### PR TITLE
TOOLS-23: static analysis

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,17 @@
+name: Run static analysis
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+    branches: [ trunk ]
+
+jobs:
+  static_analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install cppcheck
+      run: sudo apt install -y cppcheck
+    - name: Run cppcheck
+      run: cppcheck --error-exitcode=1 -j 2 --suppressions-list=.github/files/supressions_list.txt feeds/wlan-ap/opensync/src


### PR DESCRIPTION
staticanalysis: add the github CI config for static code analysis

This patch adds support for static code analysis with cppcheck inside the github CI.

Signed-off-by: Eugene Taranov <eugene@opsfleet.com>