### PR TITLE
opensync: fix a memleak

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/uci_helper.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/uci_helper.c
@@ -368,7 +368,7 @@ int wifi_getTxChainMask(int radioIndex, int *txChainMask)
 	point = strstr(buffer, "0x");
 	point = point + 2;
         sscanf(point, "%d", txChainMask);
-
+	free(buffer);
 	return true;
     }
 


### PR DESCRIPTION
This patch fixes a memlaek in the code reading out the chainmask.

Signed-off-by: John Crispin <john@phrozen.org>