### PR TITLE
build.sh: add the wifi feed to default builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ AP2220)
 	;;
 esac
 cd ${BUILD_DIR}
-./scripts/gen_config.py ${TARGET} wlan-ap || exit 1
+./scripts/gen_config.py ${TARGET} wlan-ap wifi || exit 1
 cd -
 
 echo "### Building image ..."


### PR DESCRIPTION
This patch selects the wifi feed when building images in CI.
This has the effect, that backports, haps, wpas, iw, ath10k-ct will the
v5.7 version from current OpenWrt HEAD.

Signed-off-by: John Crispin <john@phrozen.org>