### PR TITLE
tplink/ap2220: update devicetree

### DIFF
--- a/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
+++ b/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
@@ -1,7 +1,7 @@
-From 7352a63c754c84a294eda639f391609deefaf87d Mon Sep 17 00:00:00 2001
+From fd1231772d2f70d1f37c2160cbf45675dc85aaf7 Mon Sep 17 00:00:00 2001
 From: Arif Alam <arif.alam@connectus.ai>
 Date: Fri, 19 Jun 2020 14:02:32 +0200
-Subject: [PATCH 7/7] ipq40xx: TP-Link AP2220 support
+Subject: [PATCH 1/2] ipq40xx: TP-Link AP2220 support
 
 Signed-off-by: Arif Alam <arif.alam@connectus.ai>
 ---
@@ -9,11 +9,11 @@ Signed-off-by: Arif Alam <arif.alam@connectus.ai>
  .../ipq-wifi/board-tp-link_ap2220.bin         | Bin 0 -> 65536 bytes
  .../ipq40xx/base-files/etc/board.d/02_network |   1 +
  .../etc/hotplug.d/firmware/11-ath10k-caldata  |   6 +-
- .../boot/dts/qcom-ipq4019-tp-link-ap2220.dts  | 277 ++++++++++++++++++
+ .../boot/dts/qcom-ipq4019-tp-link-ap2220.dts  | 279 ++++++++++++++++++
  target/linux/ipq40xx/image/Makefile           |  13 +
  .../patches-4.14/998-tp-link-ap2220.patch     |  12 +
  .../patches-4.14/999-mtd-gd25q256.patch       |  28 ++
- 8 files changed, 338 insertions(+), 3 deletions(-)
+ 8 files changed, 340 insertions(+), 3 deletions(-)
  create mode 100755 package/firmware/ipq-wifi/board-tp-link_ap2220.bin
  create mode 100755 target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
  create mode 100755 target/linux/ipq40xx/patches-4.14/998-tp-link-ap2220.patch
@@ -172,10 +172,10 @@ index 7d2e173e1a..9b11674b02 100644
  	engenius,ens620ext)
 diff --git a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
 new file mode 100755
-index 0000000000..fc35bcacbd
+index 0000000000..1746f51d54
 --- /dev/null
 +++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
-@@ -0,0 +1,277 @@
+@@ -0,0 +1,279 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 +
 +#include "qcom-ipq4019.dtsi"
@@ -231,25 +231,25 @@ index 0000000000..fc35bcacbd
 +
 +		ess-switch@c000000 {
 +			status = "okay";
-+            switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
-+            switch_initvlas = <0x0007c 0x54>; /* port0 status */
-+            switch_lan_bmp = <0x10>;
++			switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
++			witch_initvlas = <0x0007c 0x54>; /* port0 status */
++			switch_lan_bmp = <0x10>;
 +		};
 +
 +		edma@c080000 {
-+            status = "okay";
-+        };
-+    };
++			status = "okay";
++		};
++	};
 +
 +	key {
 +		compatible = "gpio-keys";
 +
 +		button@1 {
-+            label = "reset";
-+            linux,code = <KEY_RESTART>;
-+            gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
-+            linux,input-type = <1>;
-+        };
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
++			linux,input-type = <1>;
++		};
 +	};
 +
 +	leds {
@@ -281,7 +281,7 @@ index 0000000000..fc35bcacbd
 +		};
 +	};
 +    
-+    spi_0_pins: spi_0_pinmux {
++	spi_0_pins: spi_0_pinmux {
 +	    pinmux {
 +		    function = "blsp_spi0";
 +		    pins = "gpio13", "gpio14", "gpio15";
@@ -334,8 +334,8 @@ index 0000000000..fc35bcacbd
 +		reg = <0>;
 +		linux,modalias = "m25p80", "gd25q256";
 +		spi-max-frequency = <24000000>;
-+		
-+        partitions {
++
++		partitions {
 +			compatible = "fixed-partitions";
 +			#address-cells = <1>;
 +			#size-cells = <1>;
@@ -380,11 +380,14 @@ index 0000000000..fc35bcacbd
 +				reg = <0x00170000 0x00010000>;
 +				read-only;
 +			};
-+            partition8@180000 {
++			partition8@180000 {
++				label = "product_info";
++				reg = <0x00180000 0x00010000>;
++			};
++			partition8@180000 {
 +				compatible = "denx,fit";
 +				label = "firmware";
-+				//32M
-+				reg = <0x00180000 0x01e80000>;
++				reg = <0x00190000 0x01e70000>;
 +			};
 +		};
 +	};
@@ -439,20 +442,19 @@ index 0000000000..fc35bcacbd
 +	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
 +
 +	bridge@0,0 {
-+    	reg = <0x00000000 0 0 0 0>;
++		reg = <0x00000000 0 0 0 0>;
 +		#address-cells = <3>;
-+        #size-cells = <2>;
-+        ranges;
++		#size-cells = <2>;
++		ranges;
 +
-+    	wifi2: wifi@1,0 {
-+            compatible = "qcom,ath10k";
-+            status = "okay";
-+            reg = <0x00010000 0 0 0 0>;
-+            qcom,ath10k-calibration-variant = "tp-link AP2220";
-+        };
++		wifi2: wifi@1,0 {
++			compatible = "qcom,ath10k";
++			status = "okay";
++			reg = <0x00010000 0 0 0 0>;
++			qcom,ath10k-calibration-variant = "tp-link AP2220";
++		};
 +	};
 +};
-+
 diff --git a/target/linux/ipq40xx/image/Makefile b/target/linux/ipq40xx/image/Makefile
 index 921d412382..b54a287377 100644
 --- a/target/linux/ipq40xx/image/Makefile


### PR DESCRIPTION
The latest version of the board seems to have an additional partition, add this.
Cleanup the whitespace errors inside the DTS while we are at it.

Signed-off-by: John Crispin <john@phrozen.org>