### PR TITLE
Staging maclist blacklist whitelist

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
@@ -110,12 +110,18 @@ bool target_stats_clients_convert(radio_entry_t *radio_cfg, target_client_record
 				  target_client_record_t *data_old, dpp_client_record_t *client_record)
 {
 	memcpy(client_record->info.mac, data_new->info.mac, sizeof(data_new->info.mac));
+	memcpy(client_record->info.essid, radio_cfg->if_name, sizeof(radio_cfg->if_name));
 
-	client_record->stats.bytes_tx   = data_new->stats.bytes_tx;
-	client_record->stats.bytes_rx   = data_new->stats.bytes_rx;
 	client_record->stats.rssi       = data_new->stats.rssi;
 	client_record->stats.rate_tx    = data_new->stats.rate_tx;
 	client_record->stats.rate_rx    = data_new->stats.rate_rx;
+	client_record->stats.bytes_tx   = data_new->stats.bytes_tx   - data_old->stats.bytes_tx;
+	client_record->stats.bytes_rx   = data_new->stats.bytes_rx   - data_old->stats.bytes_rx;
+	client_record->stats.frames_tx  = data_new->stats.frames_tx  - data_old->stats.frames_tx;
+	client_record->stats.frames_rx  = data_new->stats.frames_rx  - data_old->stats.frames_rx;
+	client_record->stats.retries_tx = data_new->stats.retries_tx - data_old->stats.retries_tx;
+	client_record->stats.errors_tx  = data_new->stats.errors_tx  - data_old->stats.errors_tx;
+	client_record->stats.errors_rx  = data_new->stats.errors_rx  - data_old->stats.errors_rx;
 
 	return true;
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
@@ -78,6 +78,7 @@ static int nl80211_assoclist_recv(struct nl_msg *msg, void *arg)
 		[NL80211_STA_INFO_TX_BYTES]      = { .type = NLA_U32    },
 		[NL80211_STA_INFO_TX_RETRIES]    = { .type = NLA_U32    },
 		[NL80211_STA_INFO_TX_FAILED]     = { .type = NLA_U32    },
+		[NL80211_STA_INFO_RX_DROP_MISC]  = { .type = NLA_U64    },
 		[NL80211_STA_INFO_T_OFFSET]      = { .type = NLA_U64    },
 		[NL80211_STA_INFO_STA_FLAGS] =
 			{ .minlen = sizeof(struct nl80211_sta_flag_update) },
@@ -113,7 +114,7 @@ static int nl80211_assoclist_recv(struct nl_msg *msg, void *arg)
 	client_entry = target_client_record_alloc();
 	client_entry->info.type = nl_call_param->type;
 	memcpy(client_entry->info.mac, nla_data(tb[NL80211_ATTR_MAC]), ETH_ALEN);
-	memcpy(client_entry->info.ifname,
+	memcpy(client_entry->info.essid,
 	       target_unmap_ifname(nl_call_param->ifname),
 	       sizeof(client_entry->info.ifname));
 
@@ -136,9 +137,19 @@ static int nl80211_assoclist_recv(struct nl_msg *msg, void *arg)
 				client_entry->stats.rate_tx = nla_get_u32(rinfo[NL80211_RATE_INFO_BITRATE32]) * 100;
 			else if (rinfo[NL80211_RATE_INFO_BITRATE])
 				client_entry->stats.rate_tx = nla_get_u32(rinfo[NL80211_RATE_INFO_BITRATE]) * 100;
-	}
+		}
 	if (sinfo[NL80211_STA_INFO_SIGNAL])
 		client_entry->stats.rssi = (signed char)nla_get_u8(sinfo[NL80211_STA_INFO_SIGNAL]);
+	if (sinfo[NL80211_STA_INFO_TX_PACKETS])
+		client_entry->stats.frames_tx = nla_get_u32(sinfo[NL80211_STA_INFO_TX_PACKETS]);
+	if (sinfo[NL80211_STA_INFO_RX_PACKETS])
+		client_entry->stats.frames_rx = nla_get_u32(sinfo[NL80211_STA_INFO_RX_PACKETS]);
+	if (sinfo[NL80211_STA_INFO_TX_RETRIES])
+		client_entry->stats.retries_tx = nla_get_u32(sinfo[NL80211_STA_INFO_TX_RETRIES]);
+	if (sinfo[NL80211_STA_INFO_TX_FAILED])
+		client_entry->stats.errors_tx = nla_get_u32(sinfo[NL80211_STA_INFO_TX_FAILED]);
+	if (sinfo[NL80211_STA_INFO_RX_DROP_MISC])
+		client_entry->stats.errors_rx = nla_get_u64(sinfo[NL80211_STA_INFO_RX_DROP_MISC]);
 
 	ds_dlist_insert_tail(nl_call_param->list, client_entry);
 

--- a/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
+++ b/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
@@ -233,6 +233,7 @@ index 0000000000..1746f51d54
 +			status = "okay";
 +			switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
 +			switch_initvlas = <0x0007c 0x54>; /* port0 status */
++			witch_initvlas = <0x0007c 0x54>; /* port0 status */
 +			switch_lan_bmp = <0x10>;
 +		};
 +

--- a/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
+++ b/patches/wlan-ap/0007-ipq40xx-TP-Link-AP2220-support.patch
@@ -1,7 +1,7 @@
-From 7352a63c754c84a294eda639f391609deefaf87d Mon Sep 17 00:00:00 2001
+From fd1231772d2f70d1f37c2160cbf45675dc85aaf7 Mon Sep 17 00:00:00 2001
 From: Arif Alam <arif.alam@connectus.ai>
 Date: Fri, 19 Jun 2020 14:02:32 +0200
-Subject: [PATCH 7/7] ipq40xx: TP-Link AP2220 support
+Subject: [PATCH 1/2] ipq40xx: TP-Link AP2220 support
 
 Signed-off-by: Arif Alam <arif.alam@connectus.ai>
 ---
@@ -9,11 +9,11 @@ Signed-off-by: Arif Alam <arif.alam@connectus.ai>
  .../ipq-wifi/board-tp-link_ap2220.bin         | Bin 0 -> 65536 bytes
  .../ipq40xx/base-files/etc/board.d/02_network |   1 +
  .../etc/hotplug.d/firmware/11-ath10k-caldata  |   6 +-
- .../boot/dts/qcom-ipq4019-tp-link-ap2220.dts  | 277 ++++++++++++++++++
+ .../boot/dts/qcom-ipq4019-tp-link-ap2220.dts  | 279 ++++++++++++++++++
  target/linux/ipq40xx/image/Makefile           |  13 +
  .../patches-4.14/998-tp-link-ap2220.patch     |  12 +
  .../patches-4.14/999-mtd-gd25q256.patch       |  28 ++
- 8 files changed, 338 insertions(+), 3 deletions(-)
+ 8 files changed, 340 insertions(+), 3 deletions(-)
  create mode 100755 package/firmware/ipq-wifi/board-tp-link_ap2220.bin
  create mode 100755 target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
  create mode 100755 target/linux/ipq40xx/patches-4.14/998-tp-link-ap2220.patch
@@ -172,10 +172,10 @@ index 7d2e173e1a..9b11674b02 100644
  	engenius,ens620ext)
 diff --git a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
 new file mode 100755
-index 0000000000..fc35bcacbd
+index 0000000000..1746f51d54
 --- /dev/null
 +++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ap2220.dts
-@@ -0,0 +1,277 @@
+@@ -0,0 +1,279 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 +
 +#include "qcom-ipq4019.dtsi"
@@ -231,25 +231,25 @@ index 0000000000..fc35bcacbd
 +
 +		ess-switch@c000000 {
 +			status = "okay";
-+            switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
-+            switch_initvlas = <0x0007c 0x54>; /* port0 status */
-+            switch_lan_bmp = <0x10>;
++			switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
++			switch_initvlas = <0x0007c 0x54>; /* port0 status */
++			switch_lan_bmp = <0x10>;
 +		};
 +
 +		edma@c080000 {
-+            status = "okay";
-+        };
-+    };
++			status = "okay";
++		};
++	};
 +
 +	key {
 +		compatible = "gpio-keys";
 +
 +		button@1 {
-+            label = "reset";
-+            linux,code = <KEY_RESTART>;
-+            gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
-+            linux,input-type = <1>;
-+        };
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
++			linux,input-type = <1>;
++		};
 +	};
 +
 +	leds {
@@ -281,7 +281,7 @@ index 0000000000..fc35bcacbd
 +		};
 +	};
 +    
-+    spi_0_pins: spi_0_pinmux {
++	spi_0_pins: spi_0_pinmux {
 +	    pinmux {
 +		    function = "blsp_spi0";
 +		    pins = "gpio13", "gpio14", "gpio15";
@@ -334,8 +334,8 @@ index 0000000000..fc35bcacbd
 +		reg = <0>;
 +		linux,modalias = "m25p80", "gd25q256";
 +		spi-max-frequency = <24000000>;
-+		
-+        partitions {
++
++		partitions {
 +			compatible = "fixed-partitions";
 +			#address-cells = <1>;
 +			#size-cells = <1>;
@@ -380,11 +380,14 @@ index 0000000000..fc35bcacbd
 +				reg = <0x00170000 0x00010000>;
 +				read-only;
 +			};
-+            partition8@180000 {
++			partition8@180000 {
++				label = "product_info";
++				reg = <0x00180000 0x00010000>;
++			};
++			partition9@190000 {
 +				compatible = "denx,fit";
 +				label = "firmware";
-+				//32M
-+				reg = <0x00180000 0x01e80000>;
++				reg = <0x00190000 0x01e70000>;
 +			};
 +		};
 +	};
@@ -439,20 +442,19 @@ index 0000000000..fc35bcacbd
 +	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
 +
 +	bridge@0,0 {
-+    	reg = <0x00000000 0 0 0 0>;
++		reg = <0x00000000 0 0 0 0>;
 +		#address-cells = <3>;
-+        #size-cells = <2>;
-+        ranges;
++		#size-cells = <2>;
++		ranges;
 +
-+    	wifi2: wifi@1,0 {
-+            compatible = "qcom,ath10k";
-+            status = "okay";
-+            reg = <0x00010000 0 0 0 0>;
-+            qcom,ath10k-calibration-variant = "tp-link AP2220";
-+        };
++		wifi2: wifi@1,0 {
++			compatible = "qcom,ath10k";
++			status = "okay";
++			reg = <0x00010000 0 0 0 0>;
++			qcom,ath10k-calibration-variant = "tp-link AP2220";
++		};
 +	};
 +};
-+
 diff --git a/target/linux/ipq40xx/image/Makefile b/target/linux/ipq40xx/image/Makefile
 index 921d412382..b54a287377 100644
 --- a/target/linux/ipq40xx/image/Makefile


### PR DESCRIPTION
Subject: Added feature so ,that the Cloud SDK can define a list of unauthorized devices by MAC address
Test Done:
1. /usr/opensync/tools/ovsh u Wifi_VIF_Config mac_list_type:=blacklist/whitelist/none mac_list:=
'["set",["aa:4e:3f:f1:c9:60","0C:2F:B0:27:0D:80"]]' -w if_name==home-ap-u50 /home-ap-24
2. uci show or cat /etc/config/wireless