### PR TITLE
wlan-ap-config: Use qca9984 fw image for ecw5410

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/firmware/40-ct-fw-cfg
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/firmware/40-ct-fw-cfg
@@ -28,14 +28,14 @@ ath10k/fwcfg-pci-0000:01:00.0.txt)
 ath10k/fwcfg-pci-0001:01:00.0.txt)
 	case "$(board_name)" in
 	edgecore,ecw5410)
-		fwcfg_symlink qca9888
+		fwcfg_symlink qca9984
 		;;
 	esac
 	;;
 ath10k/fwcfg-pci-0002:01:00.0.txt)
 	case "$(board_name)" in
 	edgecore,ecw5410)
-		fwcfg_symlink qca9888
+		fwcfg_symlink qca9984
 		;;	
 	esac
 	;;


### PR DESCRIPTION
Signed-off-by: Arif Alam <arif.alam@connectus.ai>