### PR TITLE
wlan-ap-config: Fix ECW5410/ECW5211 serial and model config

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -5,8 +5,8 @@
 case "$(board_name)" in
 edgecore,ecw5211|\
 edgecore,ecw5410)
-	MODEL=$(cat /tmp/sysinfo/board_name)
-	SERIAL="$(fw_printenv SN | cut -d= -f2)"
+	MODEL=$(cat /tmp/sysinfo/board_name | sed "s/edgecore,//" | tr [a-z] [A-Z])
+	SERIAL=$(cat /sys/class/net/eth0/address | tr -d :)
 	PLATFORM=$(cat /tmp/sysinfo/model)
 	;;
 linksys,ea8300)


### PR DESCRIPTION
- Use eth0 mac address for serial number
- Fix model format

Signed-off-by: Arif Alam <arif.alam@connectus.ai>