### PR TITLE
profiles: adding batman-adv packages

### DIFF
--- a/patches/pending/0003-profiles-add-the-wlan-ap-board-profiles.patch
+++ b/patches/pending/0003-profiles-add-the-wlan-ap-board-profiles.patch
@@ -1,4 +1,4 @@
-From eade411dfac58c87996319025aa99645d1eb1cb8 Mon Sep 17 00:00:00 2001
+From d7c6d8256bd8c89096d4abf30638ba93077fe260 Mon Sep 17 00:00:00 2001
 From: John Crispin <john@phrozen.org>
 Date: Fri, 19 Jun 2020 13:26:05 +0200
 Subject: [PATCH 01/24] profiles: add the wlan-ap board profiles
@@ -13,8 +13,8 @@ Signed-off-by: John Crispin <john@phrozen.org>
  profiles/ec420.yml   |  5 +++
  profiles/ecw5211.yml |  5 +++
  profiles/ecw5410.yml |  5 +++
- profiles/wlan-ap.yml | 89 ++++++++++++++++++++++++++++++++++++++++++++
- 6 files changed, 114 insertions(+)
+ profiles/wlan-ap.yml | 91 ++++++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 116 insertions(+)
  create mode 100644 profiles/ap2220.yml
  create mode 100644 profiles/ea8300.yml
  create mode 100644 profiles/ec420.yml
@@ -79,10 +79,10 @@ index 0000000000..d7bfba8560
 +description: Build image for the Edgecore ECW5410
 diff --git a/profiles/wlan-ap.yml b/profiles/wlan-ap.yml
 new file mode 100644
-index 0000000000..8dd37924ed
+index 0000000000..eb89c00083
 --- /dev/null
 +++ b/profiles/wlan-ap.yml
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,91 @@
 +---
 +description: Add the wlan-ap dependencies
 +feeds:
@@ -155,6 +155,8 @@ index 0000000000..8dd37924ed
 +  - ip-bridge
 +  - opennds
 +  - opensync
++  - kmod-batman-adv
++  - batctl-default
 +
 +diffconfig: |
 +  CONFIG_OPENSSL_ENGINE=y


### PR DESCRIPTION
Adding the batman-adv kernel module and the batctl userspace
configuration tool to the wlan-ap profile.

Signed-off-by: Linus Lüssing \<ll@simonwunderlich.de\>