### PR TITLE
WIFI-705: Set procd to respawn hostapd indefinitely

### DIFF
--- a/feeds/wifi-trunk/hostapd/files/wpad.init
+++ b/feeds/wifi-trunk/hostapd/files/wpad.init
@@ -11,7 +11,7 @@ start_service() {
 		mkdir -p /var/run/hostapd
 		procd_open_instance hostapd
 		procd_set_param command /usr/sbin/hostapd -s -g /var/run/hostapd/global
-		procd_set_param respawn
+		procd_set_param respawn 3600 5 0
 		procd_close_instance
 	fi
 


### PR DESCRIPTION
Procd currently only respawns hostapd five times. This commit
will ensure that hostapd is always respawned.

Signed-off-by: Arif Alam <arif.alam@connectus.ai>