### PR TITLE
opensync: Fix SM schema add video-voice

### DIFF
--- a/feeds/wlan-ap/opensync/patches/18-video-voice-detect.patch
+++ b/feeds/wlan-ap/opensync/patches/18-video-voice-detect.patch
@@ -3915,3 +3915,15 @@
  UNIT_SRC     += src/sm_common.c
  
  ifeq ($(CONFIG_SM_CAPACITY_QUEUE_STATS),y)
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -4670,7 +4670,8 @@
+                   "device",
+                   "rssi",
+                   "steering",
+-                  "network_probe"
++                  "network_probe",
++                  "video_voice"
+                 ]
+               ]
+             }


### PR DESCRIPTION
Add video_voice string in the Wifi_Stats_Config schema

Signed-off-by: Chaitanya Kiran Godavarthi <chaitanya.kiran@connectus.ai>