### PR TITLE
Staging inactive firmware

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/flash-firmware
+++ b/feeds/wlan-ap/opensync/files/bin/flash-firmware
@@ -45,6 +45,11 @@ if [ "$?" != "0" ] ; then
   exit 1
 fi
 
+# Set the current version as inactive before the upgrade
+FW_VERSION=`sed -n 's/FW_IMAGE_ACTIVE:\(.*\)/\1/p' < /usr/opensync/.versions`
+uci set system.tip.inactivefw="${FW_VERSION}"
+uci commit
+
 cd $TMPDIR
 IMGFILE=`ls *sysupgrade.bin`
 

--- a/feeds/wlan-ap/opensync/patches/10-add-fw-pkgname-ovsdb.patch
+++ b/feeds/wlan-ap/opensync/patches/10-add-fw-pkgname-ovsdb.patch
@@ -4,7 +4,7 @@
      if [ -n "${IMAGE_DEPLOYMENT_PROFILE}" -a "${IMAGE_DEPLOYMENT_PROFILE}" != "none" ]; then
          echo "FW_PROFILE:${IMAGE_DEPLOYMENT_PROFILE}"
      fi
-+    echo "FW_IMAGE_NAME:$FW_PKG_NAME"
++    echo "FW_IMAGE_ACTIVE:$FW_PKG_NAME"
      echo "DATE:${VER_DATE}"
      echo "HOST:${USERNAME}@${HOSTNAME}"
      for LAYER in .. $LAYER_LIST $SDK_DIR $SDK_BASE; do
@@ -20,3 +20,17 @@
  DIRTY_STRING=""
  if [ ${DIRTY} -ne 0 ]; then
      DIRTY_STRING="-mods"
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -178,7 +178,10 @@
+         "version_matrix": {
+           "type": {
+             "key": "string",
+-            "value": "string",
++            "value": {
++               "type": "string",
++               "maxLength": 128
++            },
+             "min": 0,
+             "max": "unlimited"
+           }


### PR DESCRIPTION
Added support to report inactive firmware version
 - Inactive firmware image version is stored over upgrade
   and is reported in AWLAN_Node table.
 - Rename FW_IMAGE_NAME to FW_IMAGE_ACTIVE

FIXES: WIFI-609