### PR TITLE
ipq807x: Fix dtc host build with GCC 10

### DIFF
--- a/patches/ipq807x/0011-ipq807x-Fix-dtc-host-build-with-GCC-10.patch
+++ b/patches/ipq807x/0011-ipq807x-Fix-dtc-host-build-with-GCC-10.patch
@@ -1,0 +1,35 @@
+From b0192e711ace4680b757bb75fdf079028174aee7 Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 25 Aug 2020 14:27:20 +0200
+Subject: [PATCH] ipq807x: Fix dtc host build with GCC 10
+
+The dtc binary has to be compiled using the host GCC and not the target
+cross compiler GCC. And GCC 10 is using by default -fno-common which
+inhibits the merging of tentative definitions by the linker.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+---
+ .../ipq807x/patches/105-fix-dtc-gcc10-build.patch     | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+ create mode 100644 target/linux/ipq807x/patches/105-fix-dtc-gcc10-build.patch
+
+diff --git a/target/linux/ipq807x/patches/105-fix-dtc-gcc10-build.patch b/target/linux/ipq807x/patches/105-fix-dtc-gcc10-build.patch
+new file mode 100644
+index 0000000000..f91601ec59
+--- /dev/null
++++ b/target/linux/ipq807x/patches/105-fix-dtc-gcc10-build.patch
+@@ -0,0 +1,11 @@
++--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
++@@ -637,7 +637,7 @@ char *yytext;
++ #include "srcpos.h"
++ #include "dtc-parser.tab.h"
++ 
++-YYLTYPE yylloc;
+++extern YYLTYPE yylloc;
++ extern bool treesource_error;
++ 
++ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.28.0
+


### PR DESCRIPTION
The dtc binary has to be compiled using the host GCC and not the target cross compiler GCC. And GCC 10 is using by default -fno-common which inhibits the merging of tentative definitions by the linker.