### PR TITLE
opensync: Add channel & band info in voicevideo events

### DIFF
--- a/feeds/wlan-ap/modules/nf_uccdetect/src/nf_uccdetect.c
+++ b/feeds/wlan-ap/modules/nf_uccdetect/src/nf_uccdetect.c
@@ -171,6 +171,8 @@ struct mac_entry
     struct voip_flow UdpFlows[MAX_UDP_FLOWS];
     struct voip_flow TcpFlows[MAX_TCP_FLOWS];
 
+    char Url[50];
+
     uint32_t tx_packets;
     uint32_t tx_bytes;
     uint32_t tx_wraps;
@@ -312,6 +314,7 @@ struct sip_call_end
     unsigned int RtpSeqFirst;
     unsigned int RtpSeqLast;
     unsigned int SipReportIdx;
+    char Url[50];
 } __attribute__((packed));
 
 struct radio_parms
@@ -368,17 +371,19 @@ int get_if_type(char *name) {
 }
 
 /*
- * get_if_id: Get id of wifi interface
+ * get_radio_id: Get id of wifi interface
  */
-int get_if_id(char *name) {
-	char id[4] = {'\0','\0','\0','\0'};
+int get_radio_id(char *name) {
+	char id[4] = {'\0','\0','\0'};
 	long res;
 	int i;
 
 	if (!strncmp(name, "wlan", 4)) {
 		id[0] = name[4];
+
 		for (i = 0; i < 2; i++) {
-			id[i+1] = name[i+6];
+			if (id[i] != '_')
+				id[i] = name[i+4];
 		}
 		kstrtol(id, 10, &res);
 		return res;
@@ -1113,7 +1118,6 @@ void voip_generate_report_event(struct mac_entry * HashPtr,
 	struct sip_call_end SipCallEnd;
 	unsigned char Tmp[4];
 	uint64_t WiFiSessionId = 0;
-	char IfName[20];
 	int WiFiIf = 0;
 	
 	if( HashPtr->SipReportSent == (Reason+1) )
@@ -1129,7 +1133,7 @@ void voip_generate_report_event(struct mac_entry * HashPtr,
 		return;
 	}
 	
-	WiFiIf = get_if_id(Intrf->name);
+	WiFiIf = get_radio_id(Intrf->name);
 	
 	memset( &SipCallEnd, 0, sizeof( SipCallEnd ) );
 	SipCallEnd.SessionId = HashPtr->SipSessionId;
@@ -1149,6 +1153,7 @@ void voip_generate_report_event(struct mac_entry * HashPtr,
 	SipCallEnd.WifiIf = 0;
 	memcpy( SipCallEnd.Codecs, HashPtr->RtpPayload, 4 );
 	
+        memcpy(&SipCallEnd.Url[0], &HashPtr->Url[0], 50);
 	//TODO: rtp_get_stats
 	
 	capture_put((unsigned char *)&SipCallEnd, 0,
@@ -1177,6 +1182,7 @@ static void voip_generate_start_event(struct mac_entry * HashPtr,
 				(VoipCodecs[i].MacLow == HashPtr->MacLow) )
 			{
 				memcpy( &(SipCallStart.Url[0]), &(VoipCodecs[i].Url[0]), 50 );
+				memcpy( &(HashPtr->Url[0]), &(VoipCodecs[i].Url[0]), 50 );
 				memcpy( &(SipCallStart.Codecs[0][0]),
 					&(VoipCodecs[i].Codecs[0][0]), 450 );
 	
@@ -1188,12 +1194,18 @@ static void voip_generate_start_event(struct mac_entry * HashPtr,
 	}
 	else
 	{
-    if( HashPtr->SipState == VOIP_MARK_SKYPE )
+    if( HashPtr->SipState == VOIP_MARK_SKYPE ) {
+        strcpy( &(HashPtr->Url[0]), "skype" );
         strcpy( &(SipCallStart.Url[0]), "skype" );
-    if( HashPtr->SipState == VOIP_MARK_GOTOMEETING )
+    }
+    if( HashPtr->SipState == VOIP_MARK_GOTOMEETING ) {
+        strcpy( &(HashPtr->Url[0]), "gotomeeting" );
         strcpy( &(SipCallStart.Url[0]), "gotomeeting" );
-    if( HashPtr->SipState == VOIP_MARK_ZOOMMEETING )
+    }
+    if( HashPtr->SipState == VOIP_MARK_ZOOMMEETING ) {
+        strcpy( &(HashPtr->Url[0]), "zoommeeting" );
         strcpy( &(SipCallStart.Url[0]), "zoommeeting" );
+    }
 }
 
 send_event:
@@ -1210,7 +1222,6 @@ send_event:
 // TODO: rtp_get_stats
 
     voip_increment_counter(WiFiIf);
-
     capture_put((unsigned char *)&SipCallStart, 0,
                 sizeof( struct sip_call_start ), PKT_TYPE_SIP_CALL_START, 
                 0, NULL, WiFiSessionId, &WiFiIf, SipCallStart.CltMac, 0);
@@ -1225,7 +1236,7 @@ void voip_generate_end_event(struct mac_entry * HashPtr, unsigned int Reason)
 	uint64_t WiFiSessionId = 0;
 	int WiFiIf = 0;
 	
-	WiFiIf = get_if_id(HashPtr->port->name);
+	WiFiIf = get_radio_id(HashPtr->port->name);
 	
 	memset( &SipCallEnd, 0, sizeof( SipCallEnd ) );
 	SipCallEnd.SessionId = HashPtr->SipSessionId;
@@ -1245,6 +1256,8 @@ void voip_generate_end_event(struct mac_entry * HashPtr, unsigned int Reason)
 	memcpy( SipCallEnd.Codecs, HashPtr->RtpPayload, 4 );
 	if( HashPtr->VideoIsDetected )
 		SipCallEnd.VideoCodec = 1;
+
+        memcpy(&SipCallEnd.Url[0], &HashPtr->Url[0], 50);
 
 	// TODO:rtp_get_stats
 
@@ -1626,7 +1639,7 @@ int voip_sip_packet_analyze(unsigned char * Message, unsigned char * EndPtr,
             hashEntry->RtpIpTo           = HashPtr->RtpIpTo;
         }
 
-    	WiFiIf = get_if_id(HashPtr->port->name);
+    	WiFiIf = get_radio_id(HashPtr->port->name);
 /*
         iac_send_message
 */
@@ -1757,7 +1770,7 @@ void voip_heuristic_flow_call_start(struct mac_entry * hash_ptr,
 	struct voip_session VoipSession;
 	int WiFiIf = 0, CalType = VOIP_MARK_SKYPE;
 
-	WiFiIf = get_if_id(hash_ptr->port->name);
+	WiFiIf = get_radio_id(hash_ptr->port->name);
 
 	if( IsTcp )
 	{

--- a/feeds/wlan-ap/opensync/patches/20-new-voice-video-detect-params.patch
+++ b/feeds/wlan-ap/opensync/patches/20-new-voice-video-detect-params.patch
@@ -1,0 +1,261 @@
+--- a/src/sm/src/ucc_report.c
++++ b/src/sm/src/ucc_report.c
+@@ -21,6 +21,7 @@
+ #include "nl_ucc.h"
+ 
+ #define MODULE_ID LOG_MODULE_ID_MAIN
++#define IFNAME_LEN (8)
+ 
+ /* new part */
+ typedef struct
+@@ -42,6 +43,16 @@ static sm_ucc_ctx_t              g_sm_uc
+ /******************************************************************************
+  *  PROTECTED definitions
+  *****************************************************************************/
++/*
++ * get_if_name: Get ifname of wifi interface
++ */
++void get_if_name(unsigned int id, char *ifname) {
++
++    snprintf(ifname, IFNAME_LEN, "wlan%d", id);
++//    memcpy(ifname, itoa(id));
++
++}
++
+ static
+ void sm_ucc_report(struct wc_capture_buf *rbuf)
+ {
+@@ -52,9 +63,29 @@ void sm_ucc_report(struct wc_capture_buf
+     struct sip_call_start *SipCallStart = NULL;
+     struct sip_call_end *SipCallEnd = NULL;
+     struct sip_call_report *SipCallReport = NULL;
++    unsigned int chan = 0;
++    radio_type_t band = 0;
++
++    char *ifname = (char *)malloc(IFNAME_LEN);
+ 
+     /* Get ucc stats */
+ 
++    /* Get channel and radio type */
++
++    memset(ifname, 0, IFNAME_LEN);
++    if (rbuf->wifiIf >= 0) {
++        get_if_name(rbuf->wifiIf, ifname);
++
++        if(target_stats_channel_get(ifname, &chan)) {
++            if (chan <= 16)
++                band = RADIO_TYPE_2G;
++            else if (chan >= 32 && chan <= 68)
++                band = RADIO_TYPE_5GL;
++            else if (chan >= 96)
++                band = RADIO_TYPE_5GU;
++        }
++    }
++
+     /* Report_timestamp is base-timestamp + relative start time offset */
+     report_ctx->timestamp_ms =
+         request_ctx->reporting_timestamp - ucc_ctx->report_ts +
+@@ -78,6 +109,8 @@ void sm_ucc_report(struct wc_capture_buf
+         memcpy( &(report_ctx->record.sip_call_start.provider_domain[0]),
+                &(SipCallStart->Url[0]), 50 );
+ 
++        report_ctx->record.sip_call_start.channel = chan;
++        report_ctx->record.sip_call_start.band = band;
+ 	break;
+ 
+     case PKT_TYPE_CALL_STOP:
+@@ -94,6 +127,12 @@ void sm_ucc_report(struct wc_capture_buf
+         report_ctx->record.sip_call_stop.reason = SipCallEnd->Reason;
+ 
+         report_ctx->record.sip_call_stop.session_id = SipCallEnd->SessionId;
++        report_ctx->record.sip_call_stop.channel = chan;
++        report_ctx->record.sip_call_stop.band = band;
++        memcpy(&(report_ctx->record.sip_call_stop.provider_domain[0]),
++               &(SipCallEnd->Url[0]), 50);
++        memcpy( &(report_ctx->record.sip_call_stop.codecs[0]),
++               &(SipCallEnd->codecs[0]), 4 );
+ 
+         /* Stats Currently unimplemented */
+         report_ctx->record.sip_call_stop.call_duration = 0;
+@@ -127,6 +166,12 @@ void sm_ucc_report(struct wc_capture_buf
+         report_ctx->record.sip_call_report.stats.jitter = SipCallReport->Jitter;
+         report_ctx->record.sip_call_report.stats.packet_loss_consec = SipCallReport->PacketLoss;
+         report_ctx->record.sip_call_report.stats.MOSx100 = SipCallReport->Mos;
++        report_ctx->record.sip_call_report.channel = chan;
++        report_ctx->record.sip_call_report.band = band;
++        memcpy(&(report_ctx->record.sip_call_report.provider_domain[0]),
++               &(SipCallReport->Url[0]), 50);
++        memcpy( &(report_ctx->record.sip_call_report.codecs[0]),
++               &(SipCallReport->codecs[0]), 4 );
+ 
+         break;
+     default:
+--- a/src/lib/target/inc/target_common.h
++++ b/src/lib/target/inc/target_common.h
+@@ -879,6 +879,15 @@ bool target_set_mld_mcproxy_sys_params(s
+  */
+ bool target_get_mld_mcproxy_sys_params(struct schema_MLD_Config *iccfg);
+ 
++/******************************************************************************
++ * UCC voice video detect definitions
++ *****************************************************************************/
++
++/*
++ * @brief Get channel info
++ * @return true if successful
++ */
++bool target_stats_channel_get(char *radio_if, unsigned int *chan);
+ 
+ 
+ /******************************************************************************
+--- a/interfaces/opensync_stats.proto
++++ b/interfaces/opensync_stats.proto
+@@ -592,6 +592,8 @@ message CallStart {
+ 	repeated string codecs = 4;
+ 	optional string provider_domain = 5;
+ 	optional string device_info = 6;
++	optional uint32 channel = 7;
++	required RadioBandType  band = 8;
+ }
+ 
+ message CallStop {
+@@ -606,6 +608,10 @@ message CallStop {
+ 	optional CallStopReason reason = 4;
+ 	optional uint32 call_duration = 5;
+ 	repeated RtpFlowStats stats = 6;
++	optional uint32 channel = 7;
++	required RadioBandType  band = 8;
++	repeated string codecs = 9;
++	optional string provider_domain = 10;
+ }
+ 
+ message CallReport {
+@@ -620,6 +626,10 @@ message CallReport {
+ 	optional bytes client_mac = 3;
+ 	repeated RtpFlowStats stats = 4;
+ 	optional CallReportReason reason = 5;
++	optional uint32 channel = 6;
++	required RadioBandType  band = 7;
++	repeated string codecs = 8;
++	optional string provider_domain = 9;
+ }
+ 
+ message StreamingVideoDetectPattern {
+--- a/src/lib/datapipeline/inc/dpp_ucc.h
++++ b/src/lib/datapipeline/inc/dpp_ucc.h
+@@ -40,6 +40,8 @@ typedef struct
+     char codecs[15][30];
+     char provider_domain[50];
+     char device_info[10];
++    uint32_t channel;
++    radio_type_t band;
+ } dpp_ucc_sipcall_start_t;
+ 
+ 
+@@ -51,6 +53,10 @@ typedef struct
+     sipcall_stopreason_t reason;
+     uint32_t call_duration;  // call duration in seconds
+     rtp_flow_stats_t stats;
++    uint32_t channel;
++    radio_type_t band;
++    char codecs[4];
++    char provider_domain[50];
+ } dpp_ucc_sipcall_stop_t;
+ 
+ 
+@@ -61,6 +67,10 @@ typedef struct
+     char clt_mac[6];
+     rtp_flow_stats_t stats;
+     sip_call_report_reason_t reason;
++    uint32_t channel;
++    radio_type_t band;
++    char codecs[4];
++    char provider_domain[50];
+ } dpp_ucc_sipcall_report_t;
+ 
+ typedef struct
+--- a/src/lib/datapipeline/src/dppline.c
++++ b/src/lib/datapipeline/src/dppline.c
+@@ -2037,7 +2037,13 @@ static void dppline_add_stat_ucc(Sts__Re
+         memcpy(sr->call_start->provider_domain,
+                ucc->record.sip_call_start.provider_domain,
+                sizeof(ucc->record.sip_call_start.provider_domain));
+-            break;
++
++        sr->call_start->channel = ucc->record.sip_call_start.channel;
++        sr->call_start->has_channel = true;
++        sr->call_start->band =
++                        dppline_to_proto_radio(ucc->record.sip_call_start.band);
++
++        break;
+ 
+     case PKT_TYPE_CALL_STOP:
+         /* Call Stop report */
+@@ -2068,7 +2074,23 @@ static void dppline_add_stat_ucc(Sts__Re
+ 
+         sr->call_stop->reason = ucc->record.sip_call_stop.reason;
+         sr->call_stop->has_reason = true;
+-            break;
++
++        sr->call_stop->channel = ucc->record.sip_call_stop.channel;
++        sr->call_stop->has_channel = true;
++        sr->call_stop->band =
++                        dppline_to_proto_radio(ucc->record.sip_call_stop.band);
++
++        sr->call_stop->provider_domain =
++                    malloc(sizeof(ucc->record.sip_call_stop.provider_domain));
++
++        size += sizeof(ucc->record.sip_call_stop.provider_domain);
++        assert(sr->call_stop->provider_domain);
++
++        memcpy(sr->call_stop->provider_domain,
++               ucc->record.sip_call_stop.provider_domain,
++               sizeof(ucc->record.sip_call_stop.provider_domain));
++
++        break;
+ 
+     case PKT_TYPE_CALL_REPORT:
+         /* Call report */
+@@ -2100,6 +2122,22 @@ static void dppline_add_stat_ucc(Sts__Re
+ 
+         sr->call_report->reason = ucc->record.sip_call_report.reason;
+         sr->call_report->has_reason = true;
++
++        sr->call_report->channel = ucc->record.sip_call_report.channel;
++        sr->call_report->has_channel = true;
++        sr->call_report->band =
++                    dppline_to_proto_radio(ucc->record.sip_call_report.band);
++
++        sr->call_report->provider_domain =
++                    malloc(sizeof(ucc->record.sip_call_report.provider_domain));
++
++        size += sizeof(ucc->record.sip_call_report.provider_domain);
++        assert(sr->call_report->provider_domain);
++
++        memcpy(sr->call_report->provider_domain,
++               ucc->record.sip_call_report.provider_domain,
++               sizeof(ucc->record.sip_call_report.provider_domain));
++
+         break;
+ 
+     default:
+--- a/src/sm/src/nl_ucc.h
++++ b/src/sm/src/nl_ucc.h
+@@ -70,6 +70,8 @@ struct sip_call_end
+     unsigned int RtpSeqFirst;
+     unsigned int RtpSeqLast;
+     unsigned int SipReportIdx;
++    char Url[50];
++    char codecs[4];
+ } __attribute__((packed));
+ 
+ 
+@@ -79,6 +81,8 @@ struct sip_call_report
+     unsigned int Jitter;
+     unsigned int PacketLoss;
+     unsigned int Mos;
++    char Url[50];
++    char codecs[4];
+ } __attribute__((packed));
+ 
+ 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -74,6 +74,7 @@ typedef struct ssid_list {
 
 extern int stats_nl80211_init(void);
 extern int nl80211_get_tx_chainmask(char *name, unsigned int *mask);
+extern int nl80211_get_oper_channel(char *name, unsigned int *chan);
 extern int nl80211_get_assoclist(struct nl_call_param *nl_call_param);
 extern int nl80211_get_survey(struct nl_call_param *nl_call_param);
 extern int nl80211_scan_trigger(struct nl_call_param *nl_call_param, uint32_t *chan_list, uint32_t chan_num,

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
@@ -359,6 +359,21 @@ bool target_stats_device_fanrpm_get(uint32_t *fan_rpm)
 }
 
 /******************************************************************************
+ *  UCC Voice Video definitions
+ *****************************************************************************/
+
+bool target_stats_channel_get(char *radio_if, unsigned int *chan)
+{
+	bool ret = true;
+	if ((nl80211_get_oper_channel(radio_if, chan)) < 0)
+		ret = false;
+
+	LOGT("%s: channel %d", radio_if, *chan);
+
+	return ret;
+}
+
+/******************************************************************************
  *  NETWORK PROBE definitions
  *****************************************************************************/
 bool target_stats_network_probe_get(dpp_network_probe_record_t *network_probe_report)


### PR DESCRIPTION
Add channel and band (2G 5GL 5GU) in the voice/video detect
protobuf messages.

Signed-off-by: Chaitanya Kiran Godavarthi <chaitanya.kiran@connectus.ai>