### PR TITLE
ipq807x: Add batman-adv for wifi-ax's mac80211

### DIFF
--- a/feeds/wifi-ax/batman-adv/Config.in
+++ b/feeds/wifi-ax/batman-adv/Config.in
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2007-2019  B.A.T.M.A.N. contributors:
+#
+# Marek Lindner, Simon Wunderlich
+
+#
+# B.A.T.M.A.N meshing protocol
+#
+
+config BATMAN_ADV_BATMAN_V
+	bool "B.A.T.M.A.N. V protocol"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables the B.A.T.M.A.N. V protocol, the successor
+	  of the currently used B.A.T.M.A.N. IV protocol. The main
+	  changes include splitting of the OGM protocol into a neighbor
+	  discovery protocol (Echo Location Protocol, ELP) and a new OGM
+	  Protocol OGMv2 for flooding protocol information through the
+	  network, as well as a throughput based metric.
+	  B.A.T.M.A.N. V is currently considered experimental and not
+	  compatible to B.A.T.M.A.N. IV networks.
+
+config BATMAN_ADV_BLA
+	bool "Bridge Loop Avoidance"
+	depends on PACKAGE_kmod-batman-adv
+	select PACKAGE_kmod-lib-crc16
+	default y
+	help
+	  This option enables BLA (Bridge Loop Avoidance), a mechanism
+	  to avoid Ethernet frames looping when mesh nodes are connected
+	  to both the same LAN and the same mesh. If you will never use
+	  more than one mesh node in the same LAN, you can safely remove
+	  this feature and save some space.
+
+config BATMAN_ADV_DAT
+	bool "Distributed ARP Table"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables DAT (Distributed ARP Table), a DHT based
+	  mechanism that increases ARP reliability on sparse wireless
+	  mesh networks. If you think that your network does not need
+	  this option you can safely remove it and save some space.
+
+config BATMAN_ADV_NC
+	bool "Network Coding"
+	depends on PACKAGE_kmod-batman-adv
+	help
+	  This option enables network coding, a mechanism that aims to
+	  increase the overall network throughput by fusing multiple
+	  packets in one transmission.
+	  Note that interfaces controlled by batman-adv must be manually
+	  configured to have promiscuous mode enabled in order to make
+	  network coding work.
+	  If you think that your network does not need this feature you
+	  can safely disable it and save some space.
+
+config BATMAN_ADV_MCAST
+	bool "Multicast optimisation"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables the multicast optimisation which aims to
+	  reduce the air overhead while improving the reliability of
+	  multicast messages.
+
+config BATMAN_ADV_DEBUGFS
+	bool "batman-adv debugfs entries"
+	depends on PACKAGE_kmod-batman-adv
+	select KERNEL_DEBUG_FS
+	help
+	  Enable this to export routing related debug tables via debugfs.
+	  The information for each soft-interface and used hard-interface can be
+	  found under batman_adv/
+
+	  If unsure, say N.
+
+config BATMAN_ADV_DEBUG
+	bool "B.A.T.M.A.N. debugging"
+	depends on PACKAGE_kmod-batman-adv
+	help
+	  This is an option for use by developers; most people should
+	  say N here. This enables compilation of support for
+	  outputting debugging information to the debugfs log or tracing
+	  buffer. The output is controlled via the batadv netdev specific
+	  log_level setting.
+
+config BATMAN_ADV_SYSFS
+	bool "batman-adv sysfs entries"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  Say Y here if you want to enable batman-adv device configuration and
+	  status interface through sysfs attributes. It is replaced by the
+	  batadv generic netlink family but still used by various userspace
+	  tools and scripts.
+
+	  If unsure, say Y.
+
+config BATMAN_ADV_TRACING
+	bool "B.A.T.M.A.N. tracing support"
+	depends on PACKAGE_kmod-batman-adv
+	select KERNEL_FTRACE
+	select KERNEL_ENABLE_DEFAULT_TRACERS
+	help
+	  This is an option for use by developers; most people should
+	  say N here. Select this option to gather traces like the debug
+	  messages using the generic tracing infrastructure of the kernel.
+	  BATMAN_ADV_DEBUG must also be selected to get trace events for
+	  batadv_dbg.

--- a/feeds/wifi-ax/batman-adv/Makefile
+++ b/feeds/wifi-ax/batman-adv/Makefile
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=batman-adv
+
+PKG_VERSION:=2019.2
+PKG_RELEASE:=9
+PKG_HASH:=70c3f6a6cf88d2b25681a76768a52ed92d9fe992ba8e358368b6a8088757adc8
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
+PKG_LICENSE:=GPL-2.0
+PKG_EXTMOD_SUBDIRS=net/batman-adv
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/batman-adv
+  URL:=https://www.open-mesh.org/
+  MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
+  SUBMENU:=Network Support
+  DEPENDS:=+BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-lib-crc32c +kmod-cfg80211 +batctl
+  TITLE:=B.A.T.M.A.N. Adv
+  FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
+  AUTOLOAD:=$(call AutoProbe,batman-adv)
+endef
+
+define KernelPackage/batman-adv/description
+B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
+a routing protocol for multi-hop ad-hoc mesh networks. The
+networks may be wired or wireless. See
+https://www.open-mesh.org/ for more information and user space
+tools. This package builds version $(PKG_VERSION) of the kernel
+module.
+endef
+
+define KernelPackage/batman-adv/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Package/kmod-batman-adv/conffiles
+/etc/config/batman-adv
+endef
+
+PKG_EXTRA_KCONFIG:= \
+	CONFIG_BATMAN_ADV=m \
+	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_BATMAN_ADV_DEBUG),y,n) \
+	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_BATMAN_ADV_DEBUGFS),y,n) \
+	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_BATMAN_ADV_BLA),y,n) \
+	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_BATMAN_ADV_DAT),y,n) \
+	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_BATMAN_ADV_MCAST),y,n) \
+	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_BATMAN_ADV_NC),y,n) \
+	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_BATMAN_ADV_BATMAN_V),y,n) \
+	CONFIG_BATMAN_ADV_SYSFS=$(if $(CONFIG_BATMAN_ADV_SYSFS),y,n) \
+	CONFIG_BATMAN_ADV_TRACING=$(if $(CONFIG_BATMAN_ADV_TRACING),y,n) \
+
+PKG_EXTRA_CFLAGS:= \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(PKG_EXTRA_KCONFIG)))) \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
+
+NOSTDINC_FLAGS = \
+	-I$(PKG_BUILD_DIR)/net/batman-adv \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-I$(PKG_BUILD_DIR)/include/ \
+	-include backport/backport.h \
+	-include $(PKG_BUILD_DIR)/compat-hacks.h \
+	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
+
+COMPAT_SOURCES = \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
+
+define Build/Compile
+	+env "batman-adv-y=$(COMPAT_SOURCES)" \
+	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
+		ARCH="$(LINUX_KARCH)" \
+		CROSS_COMPILE="$(TARGET_CROSS)" \
+		SUBDIRS="$(PKG_BUILD_DIR)/net/batman-adv" \
+		$(PKG_EXTRA_KCONFIG) \
+		EXTRA_CFLAGS="$(PKG_EXTRA_CFLAGS)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+define KernelPackage/batman-adv/install
+	$(CP) ./files/. $(1)/
+endef
+
+$(eval $(call KernelPackage,batman-adv))

--- a/feeds/wifi-ax/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
+++ b/feeds/wifi-ax/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This UCI-Defaults script will split the batadv proto network interfaces
+# in batadv_hardif and batadv proto. The configuration options from
+# /etc/config/batman-adv will be moved to the latter.
+
+. /lib/functions.sh
+
+proto_batadv_to_batadv_hardif() {
+    local section="$1"
+    local proto
+    local mesh
+    local routing_algo
+
+    config_get proto "${section}" proto
+    config_get mesh "${section}" mesh
+    config_get routing_algo "${section}" routing_algo
+
+    if [ -z "$mesh" -o "${proto}" != "batadv" ]; then
+        continue
+    fi
+
+    uci set network."${section}".proto="batadv_hardif"
+    uci rename network."${section}".mesh="master"
+    uci delete network."${section}".routing_algo
+
+    # create new section or adjust existing one
+    uci set network."${mesh}"=interface
+    uci set network."${mesh}".proto=batadv
+    [ -n "${routing_algo}" ]  && uci set network."${mesh}".routing_algo="${routing_algo}"
+}
+
+mv_batadv_config_section() {
+    local section="$1"
+    local aggregated_ogms
+    local ap_isolation
+    local bonding
+    local bridge_loop_avoidance
+    local distributed_arp_table
+    local fragmentation
+    local gw_bandwidth
+    local gw_mode
+    local gw_sel_class
+    local hop_penalty
+    local isolation_mark
+    local log_level
+    local multicast_mode
+    local network_coding
+    local orig_interval
+
+    config_get aggregated_ogms "${section}" aggregated_ogms
+    config_get ap_isolation "${section}" ap_isolation
+    config_get bonding "${section}" bonding
+    config_get bridge_loop_avoidance "${section}" bridge_loop_avoidance
+    config_get distributed_arp_table "${section}" distributed_arp_table
+    config_get fragmentation "${section}" fragmentation
+    config_get gw_bandwidth "${section}" gw_bandwidth
+    config_get gw_mode "${section}" gw_mode
+    config_get gw_sel_class "${section}" gw_sel_class
+    config_get hop_penalty "${section}" hop_penalty
+    config_get isolation_mark "${section}" isolation_mark
+    config_get log_level "${section}" log_level
+    config_get multicast_mode "${section}" multicast_mode
+    config_get network_coding "${section}" network_coding
+    config_get orig_interval "${section}" orig_interval
+
+    # update section in case it exists
+    [ -n "${aggregated_ogms}" ]  && uci set network."${section}".aggregated_ogms="${aggregated_ogms}"
+    [ -n "${ap_isolation}" ]  && uci set network."${section}".ap_isolation="${ap_isolation}"
+    [ -n "${bonding}" ]  && uci set network."${section}".bonding="${bonding}"
+    [ -n "${bridge_loop_avoidance}" ]  && uci set network."${section}".bridge_loop_avoidance="${bridge_loop_avoidance}"
+    [ -n "${distributed_arp_table}" ]  && uci set network."${section}".distributed_arp_table="${distributed_arp_table}"
+    [ -n "${fragmentation}" ]  && uci set network."${section}".fragmentation="${fragmentation}"
+    [ -n "${gw_bandwidth}" ]  && uci set network."${section}".gw_bandwidth="${gw_bandwidth}"
+    [ -n "${gw_mode}" ]  && uci set network."${section}".gw_mode="${gw_mode}"
+    [ -n "${gw_sel_class}" ]  && uci set network."${section}".gw_sel_class="${gw_sel_class}"
+    [ -n "${hop_penalty}" ]  && uci set network."${section}".hop_penalty="${hop_penalty}"
+    [ -n "${isolation_mark}" ]  && uci set network."${section}".isolation_mark="${isolation_mark}"
+    [ -n "${log_level}" ]  && uci set network."${section}".log_level="${log_level}"
+    [ -n "${multicast_mode}" ]  && uci set network."${section}".multicast_mode="${multicast_mode}"
+    [ -n "${network_coding}" ]  && uci set network."${section}".network_coding="${network_coding}"
+    [ -n "${orig_interval}" ]  && uci set network."${section}".orig_interval="${orig_interval}"
+}
+
+if [ -f /etc/config/batman-adv ]; then
+    config_load network
+    config_foreach proto_batadv_to_batadv_hardif 'interface'
+    uci commit network
+
+    config_load batman-adv
+    config_foreach mv_batadv_config_section 'mesh'
+    uci commit network
+
+    rm -f /etc/config/batman-adv
+fi
+
+exit 0

--- a/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv.sh
+++ b/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_batadv_init_config() {
+	no_device=1
+	available=1
+
+	proto_config_add_boolean 'aggregated_ogms:bool'
+	proto_config_add_boolean 'ap_isolation:bool'
+	proto_config_add_boolean 'bonding:bool'
+	proto_config_add_boolean 'bridge_loop_avoidance:bool'
+	proto_config_add_boolean 'distributed_arp_table:bool'
+	proto_config_add_boolean 'fragmentation:bool'
+	proto_config_add_string 'gw_bandwidth'
+	proto_config_add_string 'gw_mode'
+	proto_config_add_int 'gw_sel_class'
+	proto_config_add_int 'hop_penalty'
+	proto_config_add_string 'isolation_mark'
+	proto_config_add_string 'log_level'
+	proto_config_add_int 'multicast_fanout'
+	proto_config_add_boolean 'multicast_mode:bool'
+	proto_config_add_boolean 'network_coding:bool'
+	proto_config_add_int 'orig_interval'
+	proto_config_add_string 'routing_algo'
+}
+
+proto_batadv_setup() {
+	local config="$1"
+	local iface="$config"
+
+	local aggregated_ogms
+	local ap_isolation
+	local bonding
+	local bridge_loop_avoidance
+	local distributed_arp_table
+	local fragmentation
+	local gw_bandwidth
+	local gw_mode
+	local gw_sel_class
+	local hop_penalty
+	local isolation_mark
+	local log_level
+	local multicast_fanout
+	local multicast_mode
+	local network_coding
+	local orig_interval
+	local routing_algo
+
+	json_get_vars aggregated_ogms
+	json_get_vars ap_isolation
+	json_get_vars bonding
+	json_get_vars bridge_loop_avoidance
+	json_get_vars distributed_arp_table
+	json_get_vars fragmentation
+	json_get_vars gw_bandwidth
+	json_get_vars gw_mode
+	json_get_vars gw_sel_class
+	json_get_vars hop_penalty
+	json_get_vars isolation_mark
+	json_get_vars log_level
+	json_get_vars multicast_fanout
+	json_get_vars multicast_mode
+	json_get_vars network_coding
+	json_get_vars orig_interval
+	json_get_vars routing_algo
+
+	set_default routing_algo 'BATMAN_IV'
+
+	batctl routing_algo "$routing_algo"
+	batctl -m "$iface" interface create
+
+	[ -n "$aggregated_ogms" ] && batctl -m "$iface" aggregation "$aggregated_ogms"
+	[ -n "$ap_isolation" ] && batctl -m "$iface" ap_isolation "$ap_isolation"
+	[ -n "$bonding" ] && batctl -m "$iface" bonding "$bonding"
+	[ -n "$bridge_loop_avoidance" ] &&  batctl -m "$iface" bridge_loop_avoidance "$bridge_loop_avoidance" 2>&-
+	[ -n "$distributed_arp_table" ] && batctl -m "$iface" distributed_arp_table "$distributed_arp_table" 2>&-
+	[ -n "$fragmentation" ] && batctl -m "$iface" fragmentation "$fragmentation"
+
+	case "$gw_mode" in
+	server)
+		if [ -n "$gw_bandwidth" ]; then
+			batctl -m "$iface" gw_mode "server" "$gw_bandwidth"
+		else
+			batctl -m "$iface" gw_mode "server"
+		fi
+		;;
+	client)
+		if [ -n "$gw_sel_class" ]; then
+			batctl -m "$iface" gw_mode "client" "$gw_sel_class"
+		else
+			batctl -m "$iface" gw_mode "client"
+		fi
+		;;
+	*)
+		batctl -m "$iface" gw_mode "off"
+		;;
+	esac
+
+	[ -n "$hop_penalty" ] && batctl -m "$iface" hop_penalty "$hop_penalty"
+	[ -n "$isolation_mark" ] && batctl -m "$iface" isolation_mark "$isolation_mark"
+	[ -n "$multicast_fanout" ] && batctl -m "$iface" multicast_fanout "$multicast_fanout"
+	[ -n "$multicast_mode" ] && batctl -m "$iface" multicast_mode "$multicast_mode" 2>&-
+	[ -n "$network_coding" ] && batctl -m "$iface" network_coding "$network_coding" 2>&-
+	[ -n "$log_level" ] && batctl -m "$iface" loglevel "$log_level" 2>&-
+	[ -n "$orig_interval" ] && batctl -m "$iface" orig_interval "$orig_interval"
+
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+proto_batadv_teardown() {
+	local config="$1"
+	local iface="$config"
+
+	batctl -m "$iface" interface destroy
+}
+
+add_protocol batadv

--- a/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
+++ b/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_batadv_hardif_init_config() {
+	proto_config_add_int 'elp_interval'
+	proto_config_add_string "master"
+	proto_config_add_string 'throughput_override'
+}
+
+proto_batadv_hardif_setup() {
+	local config="$1"
+	local iface="$2"
+
+	local elp_interval
+	local master
+	local throughput_override
+
+	json_get_vars elp_interval
+	json_get_vars master
+	json_get_vars throughput_override
+
+	( proto_add_host_dependency "$config" '' "$master" )
+
+	batctl -m "$master" interface -M add "$iface"
+
+	[ -n "$elp_interval" ] && batctl -m "$master" hardif "$iface" elp_interval "$elp_interval"
+	[ -n "$throughput_override" ] && batctl -m "$master" hardif "$iface" throughput_override "$throughput_override"
+
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+proto_batadv_hardif_teardown() {
+	local config="$1"
+	local iface="$2"
+
+	local master
+
+	json_get_vars master
+
+	batctl -m "$master" interface -M del "$iface" || true
+}
+
+add_protocol batadv_hardif

--- a/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+++ b/feeds/wifi-ax/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. ../netifd-proto.sh
+init_proto "$@"
+
+proto_batadv_vlan_init_config() {
+	proto_config_add_boolean 'ap_isolation:bool'
+}
+
+proto_batadv_vlan_setup() {
+	local config="$1"
+	local iface="$2"
+
+	# batadv_vlan options
+	local ap_isolation
+
+	json_get_vars ap_isolation
+
+	[ -n "$ap_isolation" ] && batctl -m "$iface" ap_isolation "$ap_isolation"
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+add_protocol batadv_vlan

--- a/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
@@ -1,0 +1,77 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 2 Jun 2019 10:57:31 +0200
+Subject: batman-adv: Fix duplicated OGMs on NETDEV_UP
+
+The state of slave interfaces are handled differently depending on whether
+the interface is up or not. All active interfaces (IFF_UP) will transmit
+OGMs. But for B.A.T.M.A.N. IV, also non-active interfaces are scheduling
+(low TTL) OGMs on active interfaces. The code which setups and schedules
+the OGMs must therefore already be called when the interfaces gets added as
+slave interface and the transmit function must then check whether it has to
+send out the OGM or not on the specific slave interface.
+
+But the commit 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule
+API calls") moved the setup code from the enable function to the activate
+function. The latter is called either when the added slave was already up
+when batadv_hardif_enable_interface processed the new interface or when a
+NETDEV_UP event was received for this slave interfac. As result, each
+NETDEV_UP would schedule a new OGM worker for the interface and thus OGMs
+would be send a lot more than expected.
+
+Fixes: 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule API calls")
+Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c92331e0df3c0c5645ee5a897eb018c5da5e4aa5
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index bd4138ddf7e09a0020d9842d603dc98f21e225c7..240ed70912d6a014c0a48280741989133034396c 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -2337,7 +2337,7 @@ batadv_iv_ogm_neigh_is_sob(struct batadv_neigh_node *neigh1,
+ 	return ret;
+ }
+ 
+-static void batadv_iv_iface_activate(struct batadv_hard_iface *hard_iface)
++static void batadv_iv_iface_enabled(struct batadv_hard_iface *hard_iface)
+ {
+ 	/* begin scheduling originator messages on that interface */
+ 	batadv_iv_ogm_schedule(hard_iface);
+@@ -2683,8 +2683,8 @@ static void batadv_iv_gw_dump(struct sk_buff *msg, struct netlink_callback *cb,
+ static struct batadv_algo_ops batadv_batman_iv __read_mostly = {
+ 	.name = "BATMAN_IV",
+ 	.iface = {
+-		.activate = batadv_iv_iface_activate,
+ 		.enable = batadv_iv_ogm_iface_enable,
++		.enabled = batadv_iv_iface_enabled,
+ 		.disable = batadv_iv_ogm_iface_disable,
+ 		.update_mac = batadv_iv_ogm_iface_update_mac,
+ 		.primary_set = batadv_iv_ogm_primary_iface_set,
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 79d1731b83066c60f9aef958d2bc343233bce67a..3719cfd026f04093f5d86ffe1b41a41849b2af62 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -795,6 +795,9 @@ int batadv_hardif_enable_interface(struct batadv_hard_iface *hard_iface,
+ 
+ 	batadv_hardif_recalc_extra_skbroom(soft_iface);
+ 
++	if (bat_priv->algo_ops->iface.enabled)
++		bat_priv->algo_ops->iface.enabled(hard_iface);
++
+ out:
+ 	return 0;
+ 
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index 74b644738a36bfe063eef6df016278b45a1a0256..e0b25104cbfa9f715df364658621c29faa7ad637 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -2129,6 +2129,9 @@ struct batadv_algo_iface_ops {
+ 	/** @enable: init routing info when hard-interface is enabled */
+ 	int (*enable)(struct batadv_hard_iface *hard_iface);
+ 
++	/** @enabled: notification when hard-interface was enabled (optional) */
++	void (*enabled)(struct batadv_hard_iface *hard_iface);
++
+ 	/** @disable: de-init routing info when hard-interface is disabled */
+ 	void (*disable)(struct batadv_hard_iface *hard_iface);
+ 

--- a/feeds/wifi-ax/batman-adv/patches/0006-batman-adv-Fix-netlink-dumping-of-all-mcast_flags-bu.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0006-batman-adv-Fix-netlink-dumping-of-all-mcast_flags-bu.patch
@@ -1,0 +1,29 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 7 Jul 2019 22:19:22 +0200
+Subject: batman-adv: Fix netlink dumping of all mcast_flags buckets
+
+The bucket variable is only updated outside the loop over the mcast_flags
+buckets. It will only be updated during a dumping run when the dumping has
+to be interrupted and a new message has to be started.
+
+This could result in repeated or missing entries when the multicast flags
+are dumped to userspace.
+
+Fixes: 06c82b7b15b1 ("batman-adv: Add inconsistent multicast netlink dump detection")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d1de7f7aa316d6f7b3268f61afa88f5d2c1a5db5
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index ec54e236e345432496df8f55b2e00fbad92f3444..50fe9dfb088b60a911756c8c22cac1db6ef10ca4 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -1653,7 +1653,7 @@ __batadv_mcast_flags_dump(struct sk_buff *msg, u32 portid,
+ 
+ 	while (bucket_tmp < hash->size) {
+ 		if (batadv_mcast_flags_dump_bucket(msg, portid, cb, hash,
+-						   *bucket, &idx_tmp))
++						   bucket_tmp, &idx_tmp))
+ 			break;
+ 
+ 		bucket_tmp++;

--- a/feeds/wifi-ax/batman-adv/patches/0007-batman-adv-fix-uninit-value-in-batadv_netlink_get_if.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0007-batman-adv-fix-uninit-value-in-batadv_netlink_get_if.patch
@@ -1,0 +1,58 @@
+From: Eric Dumazet <edumazet@google.com>
+Date: Mon, 12 Aug 2019 04:57:27 -0700
+Subject: batman-adv: fix uninit-value in batadv_netlink_get_ifindex()
+
+batadv_netlink_get_ifindex() needs to make sure user passed
+a correct u32 attribute.
+
+syzbot reported :
+BUG: KMSAN: uninit-value in batadv_netlink_dump_hardif+0x70d/0x880 net/batman-adv/netlink.c:968
+CPU: 1 PID: 11705 Comm: syz-executor888 Not tainted 5.1.0+ #1
+Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+Call Trace:
+ __dump_stack lib/dump_stack.c:77 [inline]
+ dump_stack+0x191/0x1f0 lib/dump_stack.c:113
+ kmsan_report+0x130/0x2a0 mm/kmsan/kmsan.c:622
+ __msan_warning+0x75/0xe0 mm/kmsan/kmsan_instr.c:310
+ batadv_netlink_dump_hardif+0x70d/0x880 net/batman-adv/netlink.c:968
+ genl_lock_dumpit+0xc6/0x130 net/netlink/genetlink.c:482
+ netlink_dump+0xa84/0x1ab0 net/netlink/af_netlink.c:2253
+ __netlink_dump_start+0xa3a/0xb30 net/netlink/af_netlink.c:2361
+ genl_family_rcv_msg net/netlink/genetlink.c:550 [inline]
+ genl_rcv_msg+0xfc1/0x1a40 net/netlink/genetlink.c:627
+ netlink_rcv_skb+0x431/0x620 net/netlink/af_netlink.c:2486
+ genl_rcv+0x63/0x80 net/netlink/genetlink.c:638
+ netlink_unicast_kernel net/netlink/af_netlink.c:1311 [inline]
+ netlink_unicast+0xf3e/0x1020 net/netlink/af_netlink.c:1337
+ netlink_sendmsg+0x127e/0x12f0 net/netlink/af_netlink.c:1926
+ sock_sendmsg_nosec net/socket.c:651 [inline]
+ sock_sendmsg net/socket.c:661 [inline]
+ ___sys_sendmsg+0xcc6/0x1200 net/socket.c:2260
+ __sys_sendmsg net/socket.c:2298 [inline]
+ __do_sys_sendmsg net/socket.c:2307 [inline]
+ __se_sys_sendmsg+0x305/0x460 net/socket.c:2305
+ __x64_sys_sendmsg+0x4a/0x70 net/socket.c:2305
+ do_syscall_64+0xbc/0xf0 arch/x86/entry/common.c:291
+ entry_SYSCALL_64_after_hwframe+0x63/0xe7
+RIP: 0033:0x440209
+
+Fixes: 55d368c3a57e ("batman-adv: netlink: hardif query")
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: syzbot <syzkaller@googlegroups.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9b470b8a2b9ef4ce68d6e95febd3a0574be1ac14
+
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index daf56933223d478399c63360203bcf283d7686a3..e1978bc52a700e77ff881136c05ccb934f3b851d 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -164,7 +164,7 @@ batadv_netlink_get_ifindex(const struct nlmsghdr *nlh, int attrtype)
+ {
+ 	struct nlattr *attr = nlmsg_find_attr(nlh, GENL_HDRLEN, attrtype);
+ 
+-	return attr ? nla_get_u32(attr) : 0;
++	return (attr && nla_len(attr) == sizeof(u32)) ? nla_get_u32(attr) : 0;
+ }
+ 
+ /**

--- a/feeds/wifi-ax/batman-adv/patches/0008-batman-adv-Only-read-OGM-tvlv_len-after-buffer-len-c.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0008-batman-adv-Only-read-OGM-tvlv_len-after-buffer-len-c.patch
@@ -1,0 +1,74 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Fri, 23 Aug 2019 14:34:27 +0200
+Subject: batman-adv: Only read OGM tvlv_len after buffer len check
+
+Multiple batadv_ogm_packet can be stored in an skbuff. The functions
+batadv_iv_ogm_send_to_if()/batadv_iv_ogm_receive() use
+batadv_iv_ogm_aggr_packet() to check if there is another additional
+batadv_ogm_packet in the skb or not before they continue processing the
+packet.
+
+The length for such an OGM is BATADV_OGM_HLEN +
+batadv_ogm_packet->tvlv_len. The check must first check that at least
+BATADV_OGM_HLEN bytes are available before it accesses tvlv_len (which is
+part of the header. Otherwise it might try read outside of the currently
+available skbuff to get the content of tvlv_len.
+
+Fixes: 0b6aa0d43767 ("batman-adv: tvlv - basic infrastructure")
+Reported-by: syzbot+355cab184197dbbfa384@syzkaller.appspotmail.com
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Acked-by: Antonio Quartulli <a@unstable.cc>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/07b6051ebcfaa7ea89b4f278eca2ff4070d29e56
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index 240ed70912d6a014c0a48280741989133034396c..d78938e3e0085d9cff138b805148a0e77de3f654 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -277,17 +277,23 @@ static u8 batadv_hop_penalty(u8 tq, const struct batadv_priv *bat_priv)
+  * batadv_iv_ogm_aggr_packet() - checks if there is another OGM attached
+  * @buff_pos: current position in the skb
+  * @packet_len: total length of the skb
+- * @tvlv_len: tvlv length of the previously considered OGM
++ * @ogm_packet: potential OGM in buffer
+  *
+  * Return: true if there is enough space for another OGM, false otherwise.
+  */
+-static bool batadv_iv_ogm_aggr_packet(int buff_pos, int packet_len,
+-				      __be16 tvlv_len)
++static bool
++batadv_iv_ogm_aggr_packet(int buff_pos, int packet_len,
++			  const struct batadv_ogm_packet *ogm_packet)
+ {
+ 	int next_buff_pos = 0;
+ 
+-	next_buff_pos += buff_pos + BATADV_OGM_HLEN;
+-	next_buff_pos += ntohs(tvlv_len);
++	/* check if there is enough space for the header */
++	next_buff_pos += buff_pos + sizeof(*ogm_packet);
++	if (next_buff_pos > packet_len)
++		return false;
++
++	/* check if there is enough space for the optional TVLV */
++	next_buff_pos += ntohs(ogm_packet->tvlv_len);
+ 
+ 	return (next_buff_pos <= packet_len) &&
+ 	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
+@@ -315,7 +321,7 @@ static void batadv_iv_ogm_send_to_if(struct batadv_forw_packet *forw_packet,
+ 
+ 	/* adjust all flags and log packets */
+ 	while (batadv_iv_ogm_aggr_packet(buff_pos, forw_packet->packet_len,
+-					 batadv_ogm_packet->tvlv_len)) {
++					 batadv_ogm_packet)) {
+ 		/* we might have aggregated direct link packets with an
+ 		 * ordinary base packet
+ 		 */
+@@ -1704,7 +1710,7 @@ static int batadv_iv_ogm_receive(struct sk_buff *skb,
+ 
+ 	/* unpack the aggregated packets and process them one by one */
+ 	while (batadv_iv_ogm_aggr_packet(ogm_offset, skb_headlen(skb),
+-					 ogm_packet->tvlv_len)) {
++					 ogm_packet)) {
+ 		batadv_iv_ogm_process(skb, ogm_offset, if_incoming);
+ 
+ 		ogm_offset += BATADV_OGM_HLEN;

--- a/feeds/wifi-ax/batman-adv/patches/0009-batman-adv-Only-read-OGM2-tvlv_len-after-buffer-len-.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0009-batman-adv-Only-read-OGM2-tvlv_len-after-buffer-len-.patch
@@ -1,0 +1,62 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Fri, 23 Aug 2019 14:34:28 +0200
+Subject: batman-adv: Only read OGM2 tvlv_len after buffer len check
+
+Multiple batadv_ogm2_packet can be stored in an skbuff. The functions
+batadv_v_ogm_send_to_if() uses batadv_v_ogm_aggr_packet() to check if there
+is another additional batadv_ogm2_packet in the skb or not before they
+continue processing the packet.
+
+The length for such an OGM2 is BATADV_OGM2_HLEN +
+batadv_ogm2_packet->tvlv_len. The check must first check that at least
+BATADV_OGM2_HLEN bytes are available before it accesses tvlv_len (which is
+part of the header. Otherwise it might try read outside of the currently
+available skbuff to get the content of tvlv_len.
+
+Fixes: 667996ebeab4 ("batman-adv: OGMv2 - implement originators logic")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/18f77da3761c5550f42a2d131f0fe5cac62e022d
+
+diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
+index fad95ef64e01a9670ed66f9a81658718a14fc716..bc06e3cdfa84f63cc003867d4453a88249d3fb18 100644
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -631,17 +631,23 @@ batadv_v_ogm_process_per_outif(struct batadv_priv *bat_priv,
+  * batadv_v_ogm_aggr_packet() - checks if there is another OGM aggregated
+  * @buff_pos: current position in the skb
+  * @packet_len: total length of the skb
+- * @tvlv_len: tvlv length of the previously considered OGM
++ * @ogm2_packet: potential OGM2 in buffer
+  *
+  * Return: true if there is enough space for another OGM, false otherwise.
+  */
+-static bool batadv_v_ogm_aggr_packet(int buff_pos, int packet_len,
+-				     __be16 tvlv_len)
++static bool
++batadv_v_ogm_aggr_packet(int buff_pos, int packet_len,
++			 const struct batadv_ogm2_packet *ogm2_packet)
+ {
+ 	int next_buff_pos = 0;
+ 
+-	next_buff_pos += buff_pos + BATADV_OGM2_HLEN;
+-	next_buff_pos += ntohs(tvlv_len);
++	/* check if there is enough space for the header */
++	next_buff_pos += buff_pos + sizeof(*ogm2_packet);
++	if (next_buff_pos > packet_len)
++		return false;
++
++	/* check if there is enough space for the optional TVLV */
++	next_buff_pos += ntohs(ogm2_packet->tvlv_len);
+ 
+ 	return (next_buff_pos <= packet_len) &&
+ 	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
+@@ -818,7 +824,7 @@ int batadv_v_ogm_packet_recv(struct sk_buff *skb,
+ 	ogm_packet = (struct batadv_ogm2_packet *)skb->data;
+ 
+ 	while (batadv_v_ogm_aggr_packet(ogm_offset, skb_headlen(skb),
+-					ogm_packet->tvlv_len)) {
++					ogm_packet)) {
+ 		batadv_v_ogm_process(skb, ogm_offset, if_incoming);
+ 
+ 		ogm_offset += BATADV_OGM2_HLEN;

--- a/feeds/wifi-ax/batman-adv/patches/0010-batman-adv-Avoid-free-alloc-race-when-handling-OGM2-.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0010-batman-adv-Avoid-free-alloc-race-when-handling-OGM2-.patch
@@ -1,0 +1,119 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 3 Oct 2019 17:02:01 +0200
+Subject: batman-adv: Avoid free/alloc race when handling OGM2 buffer
+
+A B.A.T.M.A.N. V virtual interface has an OGM2 packet buffer which is
+initialized using data from the RTNL lock protected netdevice notifier and
+other rtnetlink related hooks. It is sent regularly via various slave
+interfaces of the batadv virtual interface and in this process also
+modified (realloced) to integrate additional state information via TVLV
+containers.
+
+It must be avoided that the worker item is executed without a common lock
+with the netdevice notifier/rtnetlink helpers. Otherwise it can either
+happen that half modified data is sent out or the functions modifying the
+OGM2 buffer try to access already freed memory regions.
+
+Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/14ee24576213ff02272b7f8d975c7c61d5448aa2
+
+diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
+index bc06e3cdfa84f63cc003867d4453a88249d3fb18..034bdc5e31e7b1b6f12c06da9977b3b6663da7f3 100644
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -21,6 +21,7 @@
+ #include <linux/random.h>
+ #include <linux/rculist.h>
+ #include <linux/rcupdate.h>
++#include <linux/rtnetlink.h>
+ #include <linux/skbuff.h>
+ #include <linux/slab.h>
+ #include <linux/stddef.h>
+@@ -116,14 +117,12 @@ static void batadv_v_ogm_send_to_if(struct sk_buff *skb,
+ }
+ 
+ /**
+- * batadv_v_ogm_send() - periodic worker broadcasting the own OGM
+- * @work: work queue item
++ * batadv_v_ogm_send_softif() - periodic worker broadcasting the own OGM
++ * @bat_priv: the bat priv with all the soft interface information
+  */
+-static void batadv_v_ogm_send(struct work_struct *work)
++static void batadv_v_ogm_send_softif(struct batadv_priv *bat_priv)
+ {
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_priv_bat_v *bat_v;
+-	struct batadv_priv *bat_priv;
+ 	struct batadv_ogm2_packet *ogm_packet;
+ 	struct sk_buff *skb, *skb_tmp;
+ 	unsigned char *ogm_buff;
+@@ -131,8 +130,7 @@ static void batadv_v_ogm_send(struct work_struct *work)
+ 	u16 tvlv_len = 0;
+ 	int ret;
+ 
+-	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
+-	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
++	ASSERT_RTNL();
+ 
+ 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING)
+ 		goto out;
+@@ -223,6 +221,22 @@ static void batadv_v_ogm_send(struct work_struct *work)
+ 	return;
+ }
+ 
++/**
++ * batadv_v_ogm_send() - periodic worker broadcasting the own OGM
++ * @work: work queue item
++ */
++static void batadv_v_ogm_send(struct work_struct *work)
++{
++	struct batadv_priv_bat_v *bat_v;
++	struct batadv_priv *bat_priv;
++
++	rtnl_lock();
++	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
++	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
++	batadv_v_ogm_send_softif(bat_priv);
++	rtnl_unlock();
++}
++
+ /**
+  * batadv_v_ogm_iface_enable() - prepare an interface for B.A.T.M.A.N. V
+  * @hard_iface: the interface to prepare
+@@ -249,6 +263,8 @@ void batadv_v_ogm_primary_iface_set(struct batadv_hard_iface *primary_iface)
+ 	struct batadv_priv *bat_priv = netdev_priv(primary_iface->soft_iface);
+ 	struct batadv_ogm2_packet *ogm_packet;
+ 
++	ASSERT_RTNL();
++
+ 	if (!bat_priv->bat_v.ogm_buff)
+ 		return;
+ 
+@@ -857,6 +873,8 @@ int batadv_v_ogm_init(struct batadv_priv *bat_priv)
+ 	unsigned char *ogm_buff;
+ 	u32 random_seqno;
+ 
++	ASSERT_RTNL();
++
+ 	bat_priv->bat_v.ogm_buff_len = BATADV_OGM2_HLEN;
+ 	ogm_buff = kzalloc(bat_priv->bat_v.ogm_buff_len, GFP_ATOMIC);
+ 	if (!ogm_buff)
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index e0b25104cbfa9f715df364658621c29faa7ad637..f298e9a04986faf40db04ece14180b7f43b5a7b7 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1477,10 +1477,10 @@ struct batadv_softif_vlan {
+  * struct batadv_priv_bat_v - B.A.T.M.A.N. V per soft-interface private data
+  */
+ struct batadv_priv_bat_v {
+-	/** @ogm_buff: buffer holding the OGM packet */
++	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+ 	unsigned char *ogm_buff;
+ 
+-	/** @ogm_buff_len: length of the OGM packet buffer */
++	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+ 	int ogm_buff_len;
+ 
+ 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */

--- a/feeds/wifi-ax/batman-adv/patches/0011-batman-adv-Avoid-free-alloc-race-when-handling-OGM-b.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0011-batman-adv-Avoid-free-alloc-race-when-handling-OGM-b.patch
@@ -1,0 +1,136 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 3 Oct 2019 17:02:01 +0200
+Subject: batman-adv: Avoid free/alloc race when handling OGM buffer
+
+Each slave interface of an B.A.T.M.A.N. IV virtual interface has an OGM
+packet buffer which is initialized using data from the RTNL lock protected
+netdevice notifier and other rtnetlink related hooks. It is sent regularly
+via various slave interfaces of the batadv virtual interface and in this
+process also modified (realloced) to integrate additional state information
+via TVLV containers.
+
+It must be avoided that the worker item is executed without a common lock
+with the netdevice notifier/rtnetlink helpers. Otherwise it can either
+happen that half modified/freed data is sent out or functions modifying the
+OGM buffer try to access already freed memory regions.
+
+Reported-by: syzbot+0cc629f19ccb8534935b@syzkaller.appspotmail.com
+Fixes: ea6f8d42a595 ("batman-adv: move /proc interface handling to /sys")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9b8ceef26c697d0c8319748428944c3339a498dc
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index d78938e3e0085d9cff138b805148a0e77de3f654..e20c3813182c422a52f58178f05010869c5ebe66 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -29,6 +29,7 @@
+ #include <linux/random.h>
+ #include <linux/rculist.h>
+ #include <linux/rcupdate.h>
++#include <linux/rtnetlink.h>
+ #include <linux/seq_file.h>
+ #include <linux/skbuff.h>
+ #include <linux/slab.h>
+@@ -193,6 +194,8 @@ static int batadv_iv_ogm_iface_enable(struct batadv_hard_iface *hard_iface)
+ 	unsigned char *ogm_buff;
+ 	u32 random_seqno;
+ 
++	ASSERT_RTNL();
++
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+ 	atomic_set(&hard_iface->bat_iv.ogm_seqno, random_seqno);
+@@ -217,6 +220,8 @@ static int batadv_iv_ogm_iface_enable(struct batadv_hard_iface *hard_iface)
+ 
+ static void batadv_iv_ogm_iface_disable(struct batadv_hard_iface *hard_iface)
+ {
++	ASSERT_RTNL();
++
+ 	kfree(hard_iface->bat_iv.ogm_buff);
+ 	hard_iface->bat_iv.ogm_buff = NULL;
+ }
+@@ -226,6 +231,8 @@ static void batadv_iv_ogm_iface_update_mac(struct batadv_hard_iface *hard_iface)
+ 	struct batadv_ogm_packet *batadv_ogm_packet;
+ 	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+ 
++	ASSERT_RTNL();
++
+ 	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+ 	ether_addr_copy(batadv_ogm_packet->orig,
+ 			hard_iface->net_dev->dev_addr);
+@@ -239,6 +246,8 @@ batadv_iv_ogm_primary_iface_set(struct batadv_hard_iface *hard_iface)
+ 	struct batadv_ogm_packet *batadv_ogm_packet;
+ 	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+ 
++	ASSERT_RTNL();
++
+ 	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+ 	batadv_ogm_packet->ttl = BATADV_TTL;
+ }
+@@ -753,6 +762,8 @@ static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
+ 	u16 tvlv_len = 0;
+ 	unsigned long send_time;
+ 
++	ASSERT_RTNL();
++
+ 	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
+ 	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
+ 		return;
+@@ -1643,16 +1654,12 @@ static void batadv_iv_ogm_process(const struct sk_buff *skb, int ogm_offset,
+ 	batadv_orig_node_put(orig_node);
+ }
+ 
+-static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
++static void
++batadv_iv_send_outstanding_forw_packet(struct batadv_forw_packet *forw_packet)
+ {
+-	struct delayed_work *delayed_work;
+-	struct batadv_forw_packet *forw_packet;
+ 	struct batadv_priv *bat_priv;
+ 	bool dropped = false;
+ 
+-	delayed_work = to_delayed_work(work);
+-	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+-				   delayed_work);
+ 	bat_priv = netdev_priv(forw_packet->if_incoming->soft_iface);
+ 
+ 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING) {
+@@ -1681,6 +1688,20 @@ static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+ 		batadv_forw_packet_free(forw_packet, dropped);
+ }
+ 
++static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
++{
++	struct delayed_work *delayed_work;
++	struct batadv_forw_packet *forw_packet;
++
++	delayed_work = to_delayed_work(work);
++	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
++				   delayed_work);
++
++	rtnl_lock();
++	batadv_iv_send_outstanding_forw_packet(forw_packet);
++	rtnl_unlock();
++}
++
+ static int batadv_iv_ogm_receive(struct sk_buff *skb,
+ 				 struct batadv_hard_iface *if_incoming)
+ {
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index f298e9a04986faf40db04ece14180b7f43b5a7b7..f3084b005ed641d8ab8910df542762bc7dff450a 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -71,10 +71,10 @@ enum batadv_dhcp_recipient {
+  * struct batadv_hard_iface_bat_iv - per hard-interface B.A.T.M.A.N. IV data
+  */
+ struct batadv_hard_iface_bat_iv {
+-	/** @ogm_buff: buffer holding the OGM packet */
++	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+ 	unsigned char *ogm_buff;
+ 
+-	/** @ogm_buff_len: length of the OGM packet buffer */
++	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+ 	int ogm_buff_len;
+ 
+ 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */

--- a/feeds/wifi-ax/batman-adv/patches/0012-batman-adv-Introduce-own-OGM2-buffer-mutex.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0012-batman-adv-Introduce-own-OGM2-buffer-mutex.patch
@@ -1,0 +1,138 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 13 Oct 2019 21:03:06 +0200
+Subject: batman-adv: Introduce own OGM2 buffer mutex
+
+Only a single function is currently automatically locked by the rtnl_lock
+because (unlike B.A.T.M.A.N. IV) the OGM2 buffer is independent of the hard
+interfaces on which it will be transmitted. A private mutex can be used
+instead to avoid unnecessary delays which would have been introduced by the
+global lock.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/8069c581f9097f1f9398f2d49047a1dab8093821
+
+diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
+index 034bdc5e31e7b1b6f12c06da9977b3b6663da7f3..74452e9385b1a6e81be64af259dfc371cd3e9655 100644
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -17,11 +17,12 @@
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
++#include <linux/lockdep.h>
++#include <linux/mutex.h>
+ #include <linux/netdevice.h>
+ #include <linux/random.h>
+ #include <linux/rculist.h>
+ #include <linux/rcupdate.h>
+-#include <linux/rtnetlink.h>
+ #include <linux/skbuff.h>
+ #include <linux/slab.h>
+ #include <linux/stddef.h>
+@@ -130,7 +131,7 @@ static void batadv_v_ogm_send_softif(struct batadv_priv *bat_priv)
+ 	u16 tvlv_len = 0;
+ 	int ret;
+ 
+-	ASSERT_RTNL();
++	lockdep_assert_held(&bat_priv->bat_v.ogm_buff_mutex);
+ 
+ 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING)
+ 		goto out;
+@@ -230,11 +231,12 @@ static void batadv_v_ogm_send(struct work_struct *work)
+ 	struct batadv_priv_bat_v *bat_v;
+ 	struct batadv_priv *bat_priv;
+ 
+-	rtnl_lock();
+ 	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
+ 	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
++
++	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
+ 	batadv_v_ogm_send_softif(bat_priv);
+-	rtnl_unlock();
++	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+ }
+ 
+ /**
+@@ -263,13 +265,15 @@ void batadv_v_ogm_primary_iface_set(struct batadv_hard_iface *primary_iface)
+ 	struct batadv_priv *bat_priv = netdev_priv(primary_iface->soft_iface);
+ 	struct batadv_ogm2_packet *ogm_packet;
+ 
+-	ASSERT_RTNL();
+-
++	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
+ 	if (!bat_priv->bat_v.ogm_buff)
+-		return;
++		goto unlock;
+ 
+ 	ogm_packet = (struct batadv_ogm2_packet *)bat_priv->bat_v.ogm_buff;
+ 	ether_addr_copy(ogm_packet->orig, primary_iface->net_dev->dev_addr);
++
++unlock:
++	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+ }
+ 
+ /**
+@@ -873,8 +877,6 @@ int batadv_v_ogm_init(struct batadv_priv *bat_priv)
+ 	unsigned char *ogm_buff;
+ 	u32 random_seqno;
+ 
+-	ASSERT_RTNL();
+-
+ 	bat_priv->bat_v.ogm_buff_len = BATADV_OGM2_HLEN;
+ 	ogm_buff = kzalloc(bat_priv->bat_v.ogm_buff_len, GFP_ATOMIC);
+ 	if (!ogm_buff)
+@@ -893,6 +895,8 @@ int batadv_v_ogm_init(struct batadv_priv *bat_priv)
+ 	atomic_set(&bat_priv->bat_v.ogm_seqno, random_seqno);
+ 	INIT_DELAYED_WORK(&bat_priv->bat_v.ogm_wq, batadv_v_ogm_send);
+ 
++	mutex_init(&bat_priv->bat_v.ogm_buff_mutex);
++
+ 	return 0;
+ }
+ 
+@@ -904,7 +908,11 @@ void batadv_v_ogm_free(struct batadv_priv *bat_priv)
+ {
+ 	cancel_delayed_work_sync(&bat_priv->bat_v.ogm_wq);
+ 
++	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
++
+ 	kfree(bat_priv->bat_v.ogm_buff);
+ 	bat_priv->bat_v.ogm_buff = NULL;
+ 	bat_priv->bat_v.ogm_buff_len = 0;
++
++	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+ }
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index f3084b005ed641d8ab8910df542762bc7dff450a..09f44bac693fcb3dc13c33319f4928a472a14b2e 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -16,6 +16,7 @@
+ #include <linux/compiler.h>
+ #include <linux/if_ether.h>
+ #include <linux/kref.h>
++#include <linux/mutex.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/sched.h> /* for linux/wait.h */
+@@ -1477,15 +1478,18 @@ struct batadv_softif_vlan {
+  * struct batadv_priv_bat_v - B.A.T.M.A.N. V per soft-interface private data
+  */
+ struct batadv_priv_bat_v {
+-	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
++	/** @ogm_buff: buffer holding the OGM packet */
+ 	unsigned char *ogm_buff;
+ 
+-	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
++	/** @ogm_buff_len: length of the OGM packet buffer */
+ 	int ogm_buff_len;
+ 
+ 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+ 	atomic_t ogm_seqno;
+ 
++	/** @ogm_buff_mutex: lock protecting ogm_buff and ogm_buff_len */
++	struct mutex ogm_buff_mutex;
++
+ 	/** @ogm_wq: workqueue used to schedule OGM transmissions */
+ 	struct delayed_work ogm_wq;
+ };

--- a/feeds/wifi-ax/batman-adv/patches/0013-batman-adv-Avoid-OGM-workqueue-synchronous-cancel-de.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0013-batman-adv-Avoid-OGM-workqueue-synchronous-cancel-de.patch
@@ -1,0 +1,263 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 13 Oct 2019 21:03:07 +0200
+Subject: batman-adv: Avoid OGM workqueue synchronous cancel deadlock
+
+batadv_forw_packet_list_free can be called when an interface is being
+disabled. Under this circumstance, the rntl_lock will be held and while it
+calls cancel_delayed_work_sync.
+
+cancel_delayed_work_sync will stop the execution of the current context
+when the work item is currently processed. It can now happen that the
+cancel_delayed_work_sync was called when rtnl_lock was already called in
+batadv_iv_send_outstanding_bat_ogm_packet or when it was in the process of
+calling it. In this case, batadv_iv_send_outstanding_bat_ogm_packet waits
+for the lock and cancel_delayed_work_sync (which holds the rtnl_lock) is
+waiting for batadv_iv_send_outstanding_bat_ogm_packet to finish.
+
+This can only be avoided by not using (conflicting) blocking locks while
+cancel_delayed_work_sync is called. It also has the benefit that the
+ogm scheduling functionality can avoid unnecessary delays which can be
+introduced by a global lock.
+
+Fixes: 9b8ceef26c69 ("batman-adv: Avoid free/alloc race when handling OGM buffer")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d3be478f1aa27b47f61c4a62e18eb063d47c9168
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index e20c3813182c422a52f58178f05010869c5ebe66..5b0b20e6da956b4333b118bce1c09c5acef6d66f 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -22,6 +22,8 @@
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
++#include <linux/lockdep.h>
++#include <linux/mutex.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/pkt_sched.h>
+@@ -29,7 +31,6 @@
+ #include <linux/random.h>
+ #include <linux/rculist.h>
+ #include <linux/rcupdate.h>
+-#include <linux/rtnetlink.h>
+ #include <linux/seq_file.h>
+ #include <linux/skbuff.h>
+ #include <linux/slab.h>
+@@ -194,7 +195,7 @@ static int batadv_iv_ogm_iface_enable(struct batadv_hard_iface *hard_iface)
+ 	unsigned char *ogm_buff;
+ 	u32 random_seqno;
+ 
+-	ASSERT_RTNL();
++	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+@@ -202,8 +203,10 @@ static int batadv_iv_ogm_iface_enable(struct batadv_hard_iface *hard_iface)
+ 
+ 	hard_iface->bat_iv.ogm_buff_len = BATADV_OGM_HLEN;
+ 	ogm_buff = kmalloc(hard_iface->bat_iv.ogm_buff_len, GFP_ATOMIC);
+-	if (!ogm_buff)
++	if (!ogm_buff) {
++		mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+ 		return -ENOMEM;
++	}
+ 
+ 	hard_iface->bat_iv.ogm_buff = ogm_buff;
+ 
+@@ -215,41 +218,59 @@ static int batadv_iv_ogm_iface_enable(struct batadv_hard_iface *hard_iface)
+ 	batadv_ogm_packet->reserved = 0;
+ 	batadv_ogm_packet->tq = BATADV_TQ_MAX_VALUE;
+ 
++	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
++
+ 	return 0;
+ }
+ 
+ static void batadv_iv_ogm_iface_disable(struct batadv_hard_iface *hard_iface)
+ {
+-	ASSERT_RTNL();
++	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
+ 	kfree(hard_iface->bat_iv.ogm_buff);
+ 	hard_iface->bat_iv.ogm_buff = NULL;
++
++	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+ }
+ 
+ static void batadv_iv_ogm_iface_update_mac(struct batadv_hard_iface *hard_iface)
+ {
+ 	struct batadv_ogm_packet *batadv_ogm_packet;
+-	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
++	void *ogm_buff;
+ 
+-	ASSERT_RTNL();
++	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
+-	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
++	ogm_buff = hard_iface->bat_iv.ogm_buff;
++	if (!ogm_buff)
++		goto unlock;
++
++	batadv_ogm_packet = ogm_buff;
+ 	ether_addr_copy(batadv_ogm_packet->orig,
+ 			hard_iface->net_dev->dev_addr);
+ 	ether_addr_copy(batadv_ogm_packet->prev_sender,
+ 			hard_iface->net_dev->dev_addr);
++
++unlock:
++	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+ }
+ 
+ static void
+ batadv_iv_ogm_primary_iface_set(struct batadv_hard_iface *hard_iface)
+ {
+ 	struct batadv_ogm_packet *batadv_ogm_packet;
+-	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
++	void *ogm_buff;
+ 
+-	ASSERT_RTNL();
++	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
+-	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
++	ogm_buff = hard_iface->bat_iv.ogm_buff;
++	if (!ogm_buff)
++		goto unlock;
++
++	batadv_ogm_packet = ogm_buff;
+ 	batadv_ogm_packet->ttl = BATADV_TTL;
++
++unlock:
++	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+ }
+ 
+ /* when do we schedule our own ogm to be sent */
+@@ -751,7 +772,11 @@ batadv_iv_ogm_slide_own_bcast_window(struct batadv_hard_iface *hard_iface)
+ 	}
+ }
+ 
+-static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
++/**
++ * batadv_iv_ogm_schedule_buff() - schedule submission of hardif ogm buffer
++ * @hard_iface: interface whose ogm buffer should be transmitted
++ */
++static void batadv_iv_ogm_schedule_buff(struct batadv_hard_iface *hard_iface)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(hard_iface->soft_iface);
+ 	unsigned char **ogm_buff = &hard_iface->bat_iv.ogm_buff;
+@@ -762,11 +787,7 @@ static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
+ 	u16 tvlv_len = 0;
+ 	unsigned long send_time;
+ 
+-	ASSERT_RTNL();
+-
+-	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
+-	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
+-		return;
++	lockdep_assert_held(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
+ 	/* the interface gets activated here to avoid race conditions between
+ 	 * the moment of activating the interface in
+@@ -834,6 +855,17 @@ static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
+ 		batadv_hardif_put(primary_if);
+ }
+ 
++static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
++{
++	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
++	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
++		return;
++
++	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
++	batadv_iv_ogm_schedule_buff(hard_iface);
++	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
++}
++
+ /**
+  * batadv_iv_orig_ifinfo_sum() - Get bcast_own sum for originator over iterface
+  * @orig_node: originator which reproadcasted the OGMs directly
+@@ -1654,12 +1686,16 @@ static void batadv_iv_ogm_process(const struct sk_buff *skb, int ogm_offset,
+ 	batadv_orig_node_put(orig_node);
+ }
+ 
+-static void
+-batadv_iv_send_outstanding_forw_packet(struct batadv_forw_packet *forw_packet)
++static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+ {
++	struct delayed_work *delayed_work;
++	struct batadv_forw_packet *forw_packet;
+ 	struct batadv_priv *bat_priv;
+ 	bool dropped = false;
+ 
++	delayed_work = to_delayed_work(work);
++	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
++				   delayed_work);
+ 	bat_priv = netdev_priv(forw_packet->if_incoming->soft_iface);
+ 
+ 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING) {
+@@ -1688,20 +1724,6 @@ batadv_iv_send_outstanding_forw_packet(struct batadv_forw_packet *forw_packet)
+ 		batadv_forw_packet_free(forw_packet, dropped);
+ }
+ 
+-static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+-{
+-	struct delayed_work *delayed_work;
+-	struct batadv_forw_packet *forw_packet;
+-
+-	delayed_work = to_delayed_work(work);
+-	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+-				   delayed_work);
+-
+-	rtnl_lock();
+-	batadv_iv_send_outstanding_forw_packet(forw_packet);
+-	rtnl_unlock();
+-}
+-
+ static int batadv_iv_ogm_receive(struct sk_buff *skb,
+ 				 struct batadv_hard_iface *if_incoming)
+ {
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 3719cfd026f04093f5d86ffe1b41a41849b2af62..62b926dd4aaeffd82da83654c8e568de2c3714fb 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -17,6 +17,7 @@
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
++#include <linux/mutex.h>
+ #include <linux/netdevice.h>
+ #include <linux/printk.h>
+ #include <linux/rculist.h>
+@@ -930,6 +931,7 @@ batadv_hardif_add_interface(struct net_device *net_dev)
+ 	INIT_LIST_HEAD(&hard_iface->list);
+ 	INIT_HLIST_HEAD(&hard_iface->neigh_list);
+ 
++	mutex_init(&hard_iface->bat_iv.ogm_buff_mutex);
+ 	spin_lock_init(&hard_iface->neigh_list_lock);
+ 	kref_init(&hard_iface->refcount);
+ 
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index 09f44bac693fcb3dc13c33319f4928a472a14b2e..c0ded822517b94333451deb9c0ff4037744b1fd9 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -72,14 +72,17 @@ enum batadv_dhcp_recipient {
+  * struct batadv_hard_iface_bat_iv - per hard-interface B.A.T.M.A.N. IV data
+  */
+ struct batadv_hard_iface_bat_iv {
+-	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
++	/** @ogm_buff: buffer holding the OGM packet */
+ 	unsigned char *ogm_buff;
+ 
+-	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
++	/** @ogm_buff_len: length of the OGM packet buffer */
+ 	int ogm_buff_len;
+ 
+ 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+ 	atomic_t ogm_seqno;
++
++	/** @ogm_buff_mutex: lock protecting ogm_buff and ogm_buff_len */
++	struct mutex ogm_buff_mutex;
+ };
+ 
+ /**

--- a/feeds/wifi-ax/batman-adv/patches/0014-batman-adv-Fix-DAT-candidate-selection-on-little-end.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0014-batman-adv-Fix-DAT-candidate-selection-on-little-end.patch
@@ -1,0 +1,43 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 28 Nov 2019 12:43:49 +0100
+Subject: batman-adv: Fix DAT candidate selection on little endian systems
+
+The distributed arp table is using a DHT to store and retrieve MAC address
+information for an IP address. This is done using unicast messages to
+selected peers. The potential peers are looked up using the IP address and
+the VID.
+
+While the IP address is always stored in big endian byte order, it is not
+the case of the VID. It can (depending on the host system) either be big
+endian or little endian. The host must therefore always convert it to big
+endian to ensure that all devices calculate the same peers for the same
+lookup data.
+
+Fixes: 3e26722bc9f2 ("batman-adv: make the Distributed ARP Table vlan aware")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Acked-by: Antonio Quartulli <a@unstable.cc>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/728aea06f38e0e4d70f4f7d43698187f7f7055c5
+
+diff --git a/net/batman-adv/distributed-arp-table.c b/net/batman-adv/distributed-arp-table.c
+index b0af3a11d4069cb7e44419d4494f20dd653dbca8..ec7bf5a4a9fc724b63da7bfd7ece79f32b104d99 100644
+--- a/net/batman-adv/distributed-arp-table.c
++++ b/net/batman-adv/distributed-arp-table.c
+@@ -285,6 +285,7 @@ static u32 batadv_hash_dat(const void *data, u32 size)
+ 	u32 hash = 0;
+ 	const struct batadv_dat_entry *dat = data;
+ 	const unsigned char *key;
++	__be16 vid;
+ 	u32 i;
+ 
+ 	key = (const unsigned char *)&dat->ip;
+@@ -294,7 +295,8 @@ static u32 batadv_hash_dat(const void *data, u32 size)
+ 		hash ^= (hash >> 6);
+ 	}
+ 
+-	key = (const unsigned char *)&dat->vid;
++	vid = htons(dat->vid);
++	key = (__force const unsigned char *)&vid;
+ 	for (i = 0; i < sizeof(dat->vid); i++) {
+ 		hash += key[i];
+ 		hash += (hash << 10);

--- a/feeds/wifi-ax/batman-adv/patches/0015-batman-adv-Don-t-schedule-OGM-for-disabled-interface.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0015-batman-adv-Don-t-schedule-OGM-for-disabled-interface.patch
@@ -1,0 +1,37 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 16 Feb 2020 13:02:06 +0100
+Subject: batman-adv: Don't schedule OGM for disabled interface
+
+A transmission scheduling for an interface which is currently dropped by
+batadv_iv_ogm_iface_disable could still be in progress. The B.A.T.M.A.N. V
+is simply cancelling the workqueue item in an synchronous way but this is
+not possible with B.A.T.M.A.N. IV because the OGM submissions are
+intertwined.
+
+Instead it has to stop submitting the OGM when it detect that the buffer
+pointer is set to NULL.
+
+Reported-by: syzbot+a98f2016f40b9cd3818a@syzkaller.appspotmail.com
+Reported-by: syzbot+ac36b6a33c28a491e929@syzkaller.appspotmail.com
+Fixes: c6c8fea29769 ("net: Add batman-adv meshing protocol")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Cc: Hillf Danton <hdanton@sina.com>
+Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/a089c55ca004b396d340baae58abe9a79f32cc0f
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index 5b0b20e6da956b4333b118bce1c09c5acef6d66f..d88a4de0223727d25cf36839e46d7777449f025a 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -789,6 +789,10 @@ static void batadv_iv_ogm_schedule_buff(struct batadv_hard_iface *hard_iface)
+ 
+ 	lockdep_assert_held(&hard_iface->bat_iv.ogm_buff_mutex);
+ 
++	/* interface already disabled by batadv_iv_ogm_iface_disable */
++	if (!*ogm_buff)
++		return;
++
+ 	/* the interface gets activated here to avoid race conditions between
+ 	 * the moment of activating the interface in
+ 	 * hardif_activate_interface() where the originator mac is set and

--- a/feeds/wifi-ax/batman-adv/patches/0016-batman-adv-fix-batadv_nc_random_weight_tq.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0016-batman-adv-fix-batadv_nc_random_weight_tq.patch
@@ -1,0 +1,59 @@
+From: George Spelvin <lkml@sdf.org>
+Date: Sun, 8 Mar 2020 09:44:59 -0400
+Subject: batman-adv: fix batadv_nc_random_weight_tq
+
+and change to pseudorandom numbers, as this is a traffic dithering
+operation that doesn't need crypto-grade.
+
+The previous code operated in 4 steps:
+
+1. Generate a random byte 0 <= rand_tq <= 255
+2. Multiply it by BATADV_TQ_MAX_VALUE - tq
+3. Divide by 255 (= BATADV_TQ_MAX_VALUE)
+4. Return BATADV_TQ_MAX_VALUE - rand_tq
+
+This would apperar to scale (BATADV_TQ_MAX_VALUE - tq) by a random
+value between 0/255 and 255/255.
+
+But!  The intermediate value between steps 3 and 4 is stored in a u8
+variable.  So it's truncated, and most of the time, is less than 255, after
+which the division produces 0.  Specifically, if tq is odd, the product is
+always even, and can never be 255.  If tq is even, there's exactly one
+random byte value that will produce a product byte of 255.
+
+Thus, the return value is 255 (511/512 of the time) or 254 (1/512
+of the time).
+
+If we assume that the truncation is a bug, and the code is meant to scale
+the input, a simpler way of looking at it is that it's returning a random
+value between tq and BATADV_TQ_MAX_VALUE, inclusive.
+
+Well, we have an optimized function for doing just that.
+
+Fixes: c3289f3650d3 ("batman-adv: network coding - code and transmit packets if possible")
+Signed-off-by: George Spelvin <lkml@sdf.org>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/db48c60b0edb995450ee846157364bd09bb23762
+
+diff --git a/net/batman-adv/network-coding.c b/net/batman-adv/network-coding.c
+index c5e7906045f3c62c052400c44a18bca0a38499ba..b7f3d9ef83cfcc136888cd2487dcdd88cb16d6d9 100644
+--- a/net/batman-adv/network-coding.c
++++ b/net/batman-adv/network-coding.c
+@@ -1009,15 +1009,8 @@ static struct batadv_nc_path *batadv_nc_get_path(struct batadv_priv *bat_priv,
+  */
+ static u8 batadv_nc_random_weight_tq(u8 tq)
+ {
+-	u8 rand_val, rand_tq;
+-
+-	get_random_bytes(&rand_val, sizeof(rand_val));
+-
+ 	/* randomize the estimated packet loss (max TQ - estimated TQ) */
+-	rand_tq = rand_val * (BATADV_TQ_MAX_VALUE - tq);
+-
+-	/* normalize the randomized packet loss */
+-	rand_tq /= BATADV_TQ_MAX_VALUE;
++	u8 rand_tq = prandom_u32_max(BATADV_TQ_MAX_VALUE + 1 - tq);
+ 
+ 	/* convert to (randomized) estimated tq again */
+ 	return BATADV_TQ_MAX_VALUE - rand_tq;

--- a/feeds/wifi-ax/batman-adv/patches/0017-batman-adv-Fix-refcnt-leak-in-batadv_show_throughput.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0017-batman-adv-Fix-refcnt-leak-in-batadv_show_throughput.patch
@@ -1,0 +1,38 @@
+From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Date: Wed, 15 Apr 2020 16:31:50 +0800
+Subject: batman-adv: Fix refcnt leak in batadv_show_throughput_override
+
+batadv_show_throughput_override() invokes batadv_hardif_get_by_netdev(),
+which gets a batadv_hard_iface object from net_dev with increased refcnt
+and its reference is assigned to a local pointer 'hard_iface'.
+
+When batadv_show_throughput_override() returns, "hard_iface" becomes
+invalid, so the refcount should be decreased to keep refcount balanced.
+
+The issue happens in the normal path of
+batadv_show_throughput_override(), which forgets to decrease the refcnt
+increased by batadv_hardif_get_by_netdev() before the function returns,
+causing a refcnt leak.
+
+Fix this issue by calling batadv_hardif_put() before the
+batadv_show_throughput_override() returns in the normal path.
+
+Fixes: c513176e4b7a ("batman-adv: add throughput override attribute to hard_ifaces")
+Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/f301bfed59b146a63471d0f147b767d7cafede6f
+
+diff --git a/net/batman-adv/sysfs.c b/net/batman-adv/sysfs.c
+index 80fc3253c3368e3cc356176c5ba961542de0a8c9..c20f2bab9db56021f7280ebdfc2afcfd772991bd 100644
+--- a/net/batman-adv/sysfs.c
++++ b/net/batman-adv/sysfs.c
+@@ -1189,6 +1189,7 @@ static ssize_t batadv_show_throughput_override(struct kobject *kobj,
+ 
+ 	tp_override = atomic_read(&hard_iface->bat_v.throughput_override);
+ 
++	batadv_hardif_put(hard_iface);
+ 	return sprintf(buff, "%u.%u MBit\n", tp_override / 10,
+ 		       tp_override % 10);
+ }

--- a/feeds/wifi-ax/batman-adv/patches/0018-batman-adv-Fix-refcnt-leak-in-batadv_store_throughpu.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0018-batman-adv-Fix-refcnt-leak-in-batadv_store_throughpu.patch
@@ -1,0 +1,39 @@
+From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Date: Wed, 15 Apr 2020 16:35:21 +0800
+Subject: batman-adv: Fix refcnt leak in batadv_store_throughput_override
+
+batadv_show_throughput_override() invokes batadv_hardif_get_by_netdev(),
+which gets a batadv_hard_iface object from net_dev with increased refcnt
+and its reference is assigned to a local pointer 'hard_iface'.
+
+When batadv_store_throughput_override() returns, "hard_iface" becomes
+invalid, so the refcount should be decreased to keep refcount balanced.
+
+The issue happens in one error path of
+batadv_store_throughput_override(). When batadv_parse_throughput()
+returns NULL, the refcnt increased by batadv_hardif_get_by_netdev() is
+not decreased, causing a refcnt leak.
+
+Fix this issue by jumping to "out" label when batadv_parse_throughput()
+returns NULL.
+
+Fixes: c513176e4b7a ("batman-adv: add throughput override attribute to hard_ifaces")
+Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/b69cd8bdbfd6fa7e61878c2fa9e6637406f40dd9
+
+diff --git a/net/batman-adv/sysfs.c b/net/batman-adv/sysfs.c
+index c20f2bab9db56021f7280ebdfc2afcfd772991bd..34e9948fbd45ef6f2690052a208d6a4e4a4f215b 100644
+--- a/net/batman-adv/sysfs.c
++++ b/net/batman-adv/sysfs.c
+@@ -1149,7 +1149,7 @@ static ssize_t batadv_store_throughput_override(struct kobject *kobj,
+ 	ret = batadv_parse_throughput(net_dev, buff, "throughput_override",
+ 				      &tp_override);
+ 	if (!ret)
+-		return count;
++		goto out;
+ 
+ 	old_tp_override = atomic_read(&hard_iface->bat_v.throughput_override);
+ 	if (old_tp_override == tp_override)

--- a/feeds/wifi-ax/batman-adv/patches/0019-batman-adv-Fix-refcnt-leak-in-batadv_v_ogm_process.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0019-batman-adv-Fix-refcnt-leak-in-batadv_v_ogm_process.patch
@@ -1,0 +1,39 @@
+From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Date: Mon, 20 Apr 2020 13:37:20 +0800
+Subject: batman-adv: Fix refcnt leak in batadv_v_ogm_process
+
+batadv_v_ogm_process() invokes batadv_hardif_neigh_get(), which returns
+a reference of the neighbor object to "hardif_neigh" with increased
+refcount.
+
+When batadv_v_ogm_process() returns, "hardif_neigh" becomes invalid, so
+the refcount should be decreased to keep refcount balanced.
+
+The reference counting issue happens in one exception handling paths of
+batadv_v_ogm_process(). When batadv_v_ogm_orig_get() fails to get the
+orig node and returns NULL, the refcnt increased by
+batadv_hardif_neigh_get() is not decreased, causing a refcnt leak.
+
+Fix this issue by jumping to "out" label when batadv_v_ogm_orig_get()
+fails to get the orig node.
+
+Fixes: 667996ebeab4 ("batman-adv: OGMv2 - implement originators logic")
+Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/4515f5e6a4ccbe1c563b05f2d487eb9eef3c9740
+
+diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
+index 74452e9385b1a6e81be64af259dfc371cd3e9655..9c42152829c976a2fb6c4395ab4d17c34fe47682 100644
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -723,7 +723,7 @@ static void batadv_v_ogm_process(const struct sk_buff *skb, int ogm_offset,
+ 
+ 	orig_node = batadv_v_ogm_orig_get(bat_priv, ogm_packet->orig);
+ 	if (!orig_node)
+-		return;
++		goto out;
+ 
+ 	neigh_node = batadv_neigh_node_get_or_create(orig_node, if_incoming,
+ 						     ethhdr->h_source);

--- a/feeds/wifi-ax/batman-adv/patches/0020-batman-adv-Revert-disable-ethtool-link-speed-detecti.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0020-batman-adv-Revert-disable-ethtool-link-speed-detecti.patch
@@ -1,0 +1,76 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 25 Nov 2019 10:46:50 +0100
+Subject: batman-adv: Revert "disable ethtool link speed detection when auto negotiation off"
+
+The commit d60b8fc69ef2 ("batman-adv: disable ethtool link speed detection
+when auto negotiation off") disabled the usage of ethtool's link_ksetting
+when auto negotation was enabled due to invalid values when used with
+tun/tap virtual net_devices. According to the patch, automatic measurements
+should be used for these kind of interfaces.
+
+But there are major flaws with this argumentation:
+
+* automatic measurements are not implemented
+* auto negotiation has nothing to do with the validity of the retrieved
+  values
+
+The first point has to be fixed by a longer patch series. The "validity"
+part of the second point must be addressed in the same patch series by
+dropping the usage of ethtool's link_ksetting (thus always doing automatic
+measurements over ethernet).
+
+Drop the patch again to have more default values for various net_device
+types/configurations. The user can still overwrite them using the
+batadv_hardif's BATADV_ATTR_THROUGHPUT_OVERRIDE.
+
+Reported-by: Matthias Schiffer <mschiffer@universe-factory.net>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/6e860b3d5e4147bafcda32bf9b3e769926f232c5
+
+diff --git a/compat-include/linux/ethtool.h b/compat-include/linux/ethtool.h
+index e1f39c3377febbd650a75206aafa9ae3e807762a..8dcbe02c3decf941e892af70a0a67653b010e65e 100644
+--- a/compat-include/linux/ethtool.h
++++ b/compat-include/linux/ethtool.h
+@@ -21,7 +21,6 @@ struct batadv_ethtool_link_ksettings {
+ 	struct {
+ 		__u32	speed;
+ 		__u8	duplex;
+-		__u8	autoneg;
+ 	} base;
+ };
+ 
+@@ -42,7 +41,6 @@ batadv_ethtool_get_link_ksettings(struct net_device *dev,
+ 		return ret;
+ 
+ 	link_ksettings->base.duplex = cmd.duplex;
+-	link_ksettings->base.autoneg = cmd.autoneg;
+ 	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
+index 2614a9caee008539cc489b71dabdc36ac0ae3752..a39af0eefad313101812118181ec0376b21b79bb 100644
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -120,20 +120,7 @@ static u32 batadv_v_elp_get_throughput(struct batadv_hardif_neigh_node *neigh)
+ 	rtnl_lock();
+ 	ret = __ethtool_get_link_ksettings(hard_iface->net_dev, &link_settings);
+ 	rtnl_unlock();
+-
+-	/* Virtual interface drivers such as tun / tap interfaces, VLAN, etc
+-	 * tend to initialize the interface throughput with some value for the
+-	 * sake of having a throughput number to export via ethtool. This
+-	 * exported throughput leaves batman-adv to conclude the interface
+-	 * throughput is genuine (reflecting reality), thus no measurements
+-	 * are necessary.
+-	 *
+-	 * Based on the observation that those interface types also tend to set
+-	 * the link auto-negotiation to 'off', batman-adv shall check this
+-	 * setting to differentiate between genuine link throughput information
+-	 * and placeholders installed by virtual interfaces.
+-	 */
+-	if (ret == 0 && link_settings.base.autoneg == AUTONEG_ENABLE) {
++	if (ret == 0) {
+ 		/* link characteristics might change over time */
+ 		if (link_settings.base.duplex == DUPLEX_FULL)
+ 			hard_iface->bat_v.flags |= BATADV_FULL_DUPLEX;

--- a/feeds/wifi-ax/batman-adv/patches/0021-batman-adv-Avoid-uninitialized-chaddr-when-handling-.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0021-batman-adv-Avoid-uninitialized-chaddr-when-handling-.patch
@@ -1,0 +1,42 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 22 Jul 2020 20:49:23 +0200
+Subject: batman-adv: Avoid uninitialized chaddr when handling DHCP
+
+The gateway client code can try to optimize the delivery of DHCP packets to
+avoid broadcasting them through the whole mesh. But also transmissions to
+the client can be optimized by looking up the destination via the chaddr of
+the DHCP packet.
+
+But the chaddr is currently only done when chaddr is fully inside the
+non-paged area of the skbuff. Otherwise it will not be initialized and the
+unoptimized path should have been taken.
+
+But the implementation didn't handle this correctly. It didn't retrieve the
+correct chaddr but still tried to perform the TT lookup with this
+uninitialized memory.
+
+Reported-by: syzbot+ab16e463b903f5a37036@syzkaller.appspotmail.com
+Fixes: 2d5b555644b2 ("batman-adv: send every DHCP packet as bat-unicast")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Acked-by: Antonio Quartulli <a@unstable.cc>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/fcdf008ffd749246632d1f9423163af5dc3f8c7f
+
+diff --git a/net/batman-adv/gateway_client.c b/net/batman-adv/gateway_client.c
+index 47df4c678988613f7410acb96889558eabdf396d..89c9097007c3a575836018df9e0fe97731a19619 100644
+--- a/net/batman-adv/gateway_client.c
++++ b/net/batman-adv/gateway_client.c
+@@ -703,8 +703,10 @@ batadv_gw_dhcp_recipient_get(struct sk_buff *skb, unsigned int *header_len,
+ 
+ 	chaddr_offset = *header_len + BATADV_DHCP_CHADDR_OFFSET;
+ 	/* store the client address if the message is going to a client */
+-	if (ret == BATADV_DHCP_TO_CLIENT &&
+-	    pskb_may_pull(skb, chaddr_offset + ETH_ALEN)) {
++	if (ret == BATADV_DHCP_TO_CLIENT) {
++		if (!pskb_may_pull(skb, chaddr_offset + ETH_ALEN))
++			return BATADV_DHCP_NO;
++
+ 		/* check if the DHCP packet carries an Ethernet DHCP */
+ 		p = skb->data + *header_len + BATADV_DHCP_HTYPE_OFFSET;
+ 		if (*p != BATADV_DHCP_HTYPE_ETHERNET)

--- a/feeds/wifi-ax/batman-adv/patches/0022-batman-adv-Fix-own-OGM-check-in-aggregated-OGMs.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0022-batman-adv-Fix-own-OGM-check-in-aggregated-OGMs.patch
@@ -1,0 +1,59 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Fri, 31 Jul 2020 00:22:55 +0200
+Subject: batman-adv: Fix own OGM check in aggregated OGMs
+
+The own OGM check is currently misplaced and can lead to the following
+issues:
+
+For one thing we might receive an aggregated OGM from a neighbor node
+which has our own OGM in the first place. We would then not only skip
+our own OGM but erroneously also any other, following OGM in the
+aggregate.
+
+For another, we might receive an OGM aggregate which has our own OGM in
+a place other then the first one. Then we would wrongly not skip this
+OGM, leading to populating the orginator and gateway table with ourself.
+
+The latter seems to not only be a cosmetic issue, but there were reports
+that this causes issues with various subsystems of batman-adv, too. For
+instance there were reports about issues with DAT and either disabling
+DAT or aggregation seemed to solve it.
+
+Fixing these issues by applying the own OGM check not on the first OGM
+in an aggregate but for each OGM in an aggregate instead.
+
+Fixes: 667996ebeab ("batman-adv: OGMv2 - implement originators logic")
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d41cc7cb62c184b2fb8ab97fda45815918200001
+
+diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
+index 9c42152829c976a2fb6c4395ab4d17c34fe47682..330204a73a0d3d9e4083656b82ff7b9d73a48fdc 100644
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -704,6 +704,12 @@ static void batadv_v_ogm_process(const struct sk_buff *skb, int ogm_offset,
+ 		   ntohl(ogm_packet->seqno), ogm_throughput, ogm_packet->ttl,
+ 		   ogm_packet->version, ntohs(ogm_packet->tvlv_len));
+ 
++	if (batadv_is_my_mac(bat_priv, ogm_packet->orig)) {
++		batadv_dbg(BATADV_DBG_BATMAN, bat_priv,
++			   "Drop packet: originator packet from ourself\n");
++		return;
++	}
++
+ 	/* If the throughput metric is 0, immediately drop the packet. No need
+ 	 * to create orig_node / neigh_node for an unusable route.
+ 	 */
+@@ -831,11 +837,6 @@ int batadv_v_ogm_packet_recv(struct sk_buff *skb,
+ 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+ 		goto free_skb;
+ 
+-	ogm_packet = (struct batadv_ogm2_packet *)skb->data;
+-
+-	if (batadv_is_my_mac(bat_priv, ogm_packet->orig))
+-		goto free_skb;
+-
+ 	batadv_inc_counter(bat_priv, BATADV_CNT_MGMT_RX);
+ 	batadv_add_counter(bat_priv, BATADV_CNT_MGMT_RX_BYTES,
+ 			   skb->len + ETH_HLEN);

--- a/feeds/wifi-ax/batman-adv/patches/0023-batman-adv-bla-use-netif_rx_ni-when-not-in-interrupt.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0023-batman-adv-bla-use-netif_rx_ni-when-not-in-interrupt.patch
@@ -1,0 +1,31 @@
+From: Jussi Kivilinna <jussi.kivilinna@haltian.com>
+Date: Tue, 18 Aug 2020 17:46:10 +0300
+Subject: batman-adv: bla: use netif_rx_ni when not in interrupt context
+
+batadv_bla_send_claim() gets called from worker thread context through
+batadv_bla_periodic_work(), thus netif_rx_ni needs to be used in that
+case. This fixes "NOHZ: local_softirq_pending 08" log messages seen
+when batman-adv is enabled.
+
+Fixes: a9ce0dc43e2c ("batman-adv: add basic bridge loop avoidance code")
+Signed-off-by: Jussi Kivilinna <jussi.kivilinna@haltian.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/3747f81a1380b65740fc52fc71c7a3af4c6e49de
+
+diff --git a/net/batman-adv/bridge_loop_avoidance.c b/net/batman-adv/bridge_loop_avoidance.c
+index 663a53b6d36e65508b4296d86cecdd808c653836..5f6309ade1ea19f6a0bd27e8cbc5fcfba8f7dda5 100644
+--- a/net/batman-adv/bridge_loop_avoidance.c
++++ b/net/batman-adv/bridge_loop_avoidance.c
+@@ -437,7 +437,10 @@ static void batadv_bla_send_claim(struct batadv_priv *bat_priv, u8 *mac,
+ 	batadv_add_counter(bat_priv, BATADV_CNT_RX_BYTES,
+ 			   skb->len + ETH_HLEN);
+ 
+-	netif_rx(skb);
++	if (in_interrupt())
++		netif_rx(skb);
++	else
++		netif_rx_ni(skb);
+ out:
+ 	if (primary_if)
+ 		batadv_hardif_put(primary_if);

--- a/feeds/wifi-ax/batman-adv/src/compat-hacks.h
+++ b/feeds/wifi-ax/batman-adv/src/compat-hacks.h
@@ -1,0 +1,278 @@
+/* Please avoid adding hacks here - instead add it to mac80211/backports.git */
+
+#undef CONFIG_MODULE_STRIPPED
+
+#include <linux/version.h>	/* LINUX_VERSION_CODE */
+#include <linux/types.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
+
+#define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
+
+#endif /* < KERNEL_VERSION(4, 1, 0) */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+
+#include <linux/netdevice.h>
+
+#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+	BUILD_BUG_ON(upper_priv != NULL); \
+	BUILD_BUG_ON(upper_info != NULL); \
+	BUILD_BUG_ON(extack != NULL); \
+	netdev_master_upper_dev_link(dev, upper_dev); \
+})
+
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+
+#include <linux/netdevice.h>
+
+#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+	BUILD_BUG_ON(extack != NULL); \
+	netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info); \
+})
+
+#endif /* < KERNEL_VERSION(4, 5, 0) */
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
+
+/* wild hack for batadv_getlink_net only */
+#define get_link_net get_xstats_size || 1 ? fallback_net : (struct net*)netdev->rtnl_link_ops->get_xstats_size
+
+#endif /* < KERNEL_VERSION(4, 0, 0) */
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+
+struct sk_buff *skb_checksum_trimmed(struct sk_buff *skb,
+				     unsigned int transport_len,
+				     __sum16(*skb_chkf)(struct sk_buff *skb));
+
+int ip_mc_check_igmp(struct sk_buff *skb);
+int ipv6_mc_check_mld(struct sk_buff *skb);
+
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
+
+#include_next <linux/igmp.h>
+#include_next <net/addrconf.h>
+
+static inline int batadv_ipv6_mc_check_mld1(struct sk_buff *skb)
+{
+	return ipv6_mc_check_mld(skb, NULL);
+}
+
+static inline int batadv_ipv6_mc_check_mld2(struct sk_buff *skb,
+					    struct sk_buff **skb_trimmed)
+{
+	return ipv6_mc_check_mld(skb, skb_trimmed);
+}
+
+#define ipv6_mc_check_mld_get(_1, _2, ipv6_mc_check_mld_name, ...) ipv6_mc_check_mld_name
+#define ipv6_mc_check_mld(...) \
+	ipv6_mc_check_mld_get(__VA_ARGS__, batadv_ipv6_mc_check_mld2, batadv_ipv6_mc_check_mld1)(__VA_ARGS__)
+
+static inline int batadv_ip_mc_check_igmp1(struct sk_buff *skb)
+{
+	return ip_mc_check_igmp(skb, NULL);
+}
+
+static inline int batadv_ip_mc_check_igmp2(struct sk_buff *skb,
+					   struct sk_buff **skb_trimmed)
+{
+	return ip_mc_check_igmp(skb, skb_trimmed);
+}
+
+#define ip_mc_check_igmp_get(_1, _2, ip_mc_check_igmp_name, ...) ip_mc_check_igmp_name
+#define ip_mc_check_igmp(...) \
+	ip_mc_check_igmp_get(__VA_ARGS__, batadv_ip_mc_check_igmp2, batadv_ip_mc_check_igmp1)(__VA_ARGS__)
+
+#endif /* < KERNEL_VERSION(4, 2, 0) */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+
+#define IFF_NO_QUEUE	0; dev->tx_queue_len = 0
+
+static inline bool hlist_fake(struct hlist_node *h)
+{
+	return h->pprev == &h->next;
+}
+
+#endif /* < KERNEL_VERSION(4, 3, 0) */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+
+#include <linux/ethtool.h>
+
+#define ethtool_link_ksettings batadv_ethtool_link_ksettings
+
+struct batadv_ethtool_link_ksettings {
+	struct {
+		__u32	speed;
+		__u8	duplex;
+		__u8    autoneg;
+	} base;
+};
+
+#define __ethtool_get_link_ksettings(__dev, __link_settings) \
+	batadv_ethtool_get_link_ksettings(__dev, __link_settings)
+
+static inline int
+batadv_ethtool_get_link_ksettings(struct net_device *dev,
+				  struct ethtool_link_ksettings *link_ksettings)
+{
+	struct ethtool_cmd cmd;
+	int ret;
+
+	memset(&cmd, 0, sizeof(cmd));
+	ret = __ethtool_get_settings(dev, &cmd);
+
+	if (ret != 0)
+		return ret;
+
+	link_ksettings->base.duplex = cmd.duplex;
+	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
+	link_ksettings->base.autoneg = cmd.autoneg;
+
+	return 0;
+}
+
+#endif /* < KERNEL_VERSION(4, 6, 0) */
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+
+#include_next <linux/cache.h>
+
+/* hack for netlink.c which marked the family ops as ro */
+#ifdef __ro_after_init
+#undef __ro_after_init
+#endif
+#define __ro_after_init
+
+#endif /* < KERNEL_VERSION(4, 10, 0) */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9)
+
+#include <linux/netdevice.h>
+
+/* work around missing attribute needs_free_netdev and priv_destructor in
+ * net_device
+ */
+#define ether_setup(dev) \
+	void batadv_softif_free2(struct net_device *dev) \
+	{ \
+		batadv_softif_free(dev); \
+		free_netdev(dev); \
+	} \
+	void (*t1)(struct net_device *dev) __attribute__((unused)); \
+	bool t2 __attribute__((unused)); \
+	ether_setup(dev)
+#define needs_free_netdev destructor = batadv_softif_free2; t2
+#define priv_destructor destructor = batadv_softif_free2; t1
+
+#endif /* < KERNEL_VERSION(4, 11, 9) */
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+
+#define batadv_softif_slave_add(__dev, __slave_dev, __extack) \
+	batadv_softif_slave_add(__dev, __slave_dev)
+
+#endif /* < KERNEL_VERSION(4, 15, 0) */
+
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+
+static inline int batadv_access_ok(int type, const void __user *p,
+				   unsigned long size)
+{
+	return access_ok(type, p, size);
+}
+
+#ifdef access_ok
+#undef access_ok
+#endif
+
+#define access_ok_get(_1, _2, _3 , access_ok_name, ...) access_ok_name
+#define access_ok(...) \
+	access_ok_get(__VA_ARGS__, access_ok3, access_ok2)(__VA_ARGS__)
+
+#define access_ok2(addr, size)	batadv_access_ok(VERIFY_WRITE, (addr), (size))
+#define access_ok3(type, addr, size)	batadv_access_ok((type), (addr), (size))
+
+#endif /* < KERNEL_VERSION(5, 0, 0) */
+
+/* <DECLARE_EWMA> */
+
+#include <linux/version.h>
+#include_next <linux/average.h>
+
+#include <linux/bug.h>
+
+#ifdef DECLARE_EWMA
+#undef DECLARE_EWMA
+#endif /* DECLARE_EWMA */
+
+/*
+ * Exponentially weighted moving average (EWMA)
+ *
+ * This implements a fixed-precision EWMA algorithm, with both the
+ * precision and fall-off coefficient determined at compile-time
+ * and built into the generated helper funtions.
+ *
+ * The first argument to the macro is the name that will be used
+ * for the struct and helper functions.
+ *
+ * The second argument, the precision, expresses how many bits are
+ * used for the fractional part of the fixed-precision values.
+ *
+ * The third argument, the weight reciprocal, determines how the
+ * new values will be weighed vs. the old state, new values will
+ * get weight 1/weight_rcp and old values 1-1/weight_rcp. Note
+ * that this parameter must be a power of two for efficiency.
+ */
+
+#define DECLARE_EWMA(name, _precision, _weight_rcp)			\
+	struct ewma_##name {						\
+		unsigned long internal;					\
+	};								\
+	static inline void ewma_##name##_init(struct ewma_##name *e)	\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		/*							\
+		 * Even if you want to feed it just 0/1 you should have	\
+		 * some bits for the non-fractional part...		\
+		 */							\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+		e->internal = 0;					\
+	}								\
+	static inline unsigned long					\
+	ewma_##name##_read(struct ewma_##name *e)			\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+		return e->internal >> (_precision);			\
+	}								\
+	static inline void ewma_##name##_add(struct ewma_##name *e,	\
+					     unsigned long val)		\
+	{								\
+		unsigned long internal = READ_ONCE(e->internal);	\
+		unsigned long weight_rcp = ilog2(_weight_rcp);		\
+		unsigned long precision = _precision;			\
+									\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+									\
+		WRITE_ONCE(e->internal, internal ?			\
+			(((internal << weight_rcp) - internal) +	\
+				(val << precision)) >> weight_rcp :	\
+			(val << precision));				\
+	}
+
+/* </DECLARE_EWMA> */


### PR DESCRIPTION
The batman-adv source code in openwrt-routing for OpenWrt 19.07 is expecting the backports' compat code from OpenWrt 19.07. But the mac80211 package in wifi-ax is providing the ABI (and API) from a much newer kernel.

To work around this problem, a fork of the batman-adv package from OpenWrt 19.07 without the patches 0001-0004 can be used to switch to the new netlink policy structure from newer kernel versions.
