### PR TITLE
Align opensync manager start order with reference design.

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
@@ -47,5 +47,5 @@ stop_service() {
     echo "Removing certificates"
     rm -rf ${CERTS_DEST_PATH}
     echo "Killing managers"
-    killall cm nm wm lm sm qm
+    killall dm wm sm cm nm lm qm cmdm rrm um uccm
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/managers.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/managers.c
@@ -34,17 +34,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 target_managers_config_t target_managers_config[] =
 {
 	{
+                .name = TARGET_MANAGER_PATH("cm"),
+                .needs_plan_b = false,
+        }, {
+                .name = TARGET_MANAGER_PATH("qm"),
+                .needs_plan_b = false,
+        }, {
+		.name = TARGET_MANAGER_PATH("sm"),
+		.needs_plan_b = false,
+	}, {
 		.name = TARGET_MANAGER_PATH("wm"),
-		.needs_plan_b = true,
+		.needs_plan_b = false,
 	}, {
 		.name = TARGET_MANAGER_PATH("nm"),
-		.needs_plan_b = true,
-	}, {
-		.name = TARGET_MANAGER_PATH("cm"),
-		.needs_plan_b = true,
+		.needs_plan_b = false,
 	}, {
 		.name = TARGET_MANAGER_PATH("lm"),
-		.needs_plan_b = true,
+		.needs_plan_b = false,
 	}, {
 		.name = TARGET_MANAGER_PATH("cmdm"),
 		.needs_plan_b = false,
@@ -52,17 +58,11 @@ target_managers_config_t target_managers_config[] =
 		.name = TARGET_MANAGER_PATH("rrm"),
 		.needs_plan_b = false,
 	}, {
-		.name = TARGET_MANAGER_PATH("sm"),
-		.needs_plan_b = false,
-	}, {
-		.name = TARGET_MANAGER_PATH("qm"),
-		.needs_plan_b = false,
-	}, {
 		.name = TARGET_MANAGER_PATH("um"),
 		.needs_plan_b = false,
 	}, {
 		.name = TARGET_MANAGER_PATH("uccm"),
-		.needs_plan_b = true,
+		.needs_plan_b = false,
 	},
 
 };


### PR DESCRIPTION
Shut-down new managers in init.d

Signed-off-by: Rick Sommerville <rick.sommerville@netexperience.com>