### PR TITLE
opensync: add HE parameters to data model

### DIFF
--- a/feeds/wlan-ap/opensync/patches/23-ax-options.patch
+++ b/feeds/wlan-ap/opensync/patches/23-ax-options.patch
@@ -1,0 +1,21 @@
+Index: opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/schema/inc/schema_consts.h
++++ opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+@@ -166,4 +166,16 @@ typedef enum {
+ #define SCHEMA_CONSTS_LOGIN_SUCCESS_TEXT           "login_success_text"
+ #define SCHEMA_CONSTS_PAGE_TITLE                   "page_title"
+ #define SCHEMA_CONSTS_USERPASS_FILE                "username_password_file"
++
++/* AX options */
++#define SCHEMA_CONSTS_HE_SU_BEAMFORMER		"he_su_beamformer"
++#define SCHEMA_CONSTS_HE_MU_BEAMFORMER		"he_mu_beamformer"
++#define SCHEMA_CONSTS_HE_RTS_THRESHOLD		"he_rts_threshold"
++#define SCHEMA_CONSTS_HE_BSS_COLOR		"he_bss_color"
++#define SCHEMA_CONSTS_HE_TWT_REQUIRED		"he_twt_required"
++#define SCHEMA_CONSTS_HE_MULTIPLE_BSSID		"multiple_bssid"
++#define SCHEMA_CONSTS_HE_CO_LOCATE		"co_locate"
++#define SCHEMA_CONSTS_HE_RNR_BEACON		"rnr_beacon"
++#define SCHEMA_CONSTS_HE_EMA_BEACON		"ema_beacon"
++
+ #endif /* SCHEMA_CONSTS_H_INCLUDED */

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
@@ -66,6 +66,8 @@ enum {
 	WIF_ATTR_IEEE80211K,
 	WIF_ATTR_RTS_THRESHOLD,
 	WIF_ATTR_DTIM_PERIOD,
+	WIF_ATTR_HE_RTS_THRESHOLD,
+	WIF_ATTR_HE_TWT_REQUIRED,
 	__WIF_ATTR_MAX,
 };
 
@@ -107,6 +109,8 @@ static const struct blobmsg_policy wifi_iface_policy[__WIF_ATTR_MAX] = {
 	[WIF_ATTR_IEEE80211K] = { .name = "ieee80211k", BLOBMSG_TYPE_BOOL },
 	[WIF_ATTR_RTS_THRESHOLD] = { .name = "rts_threshold", BLOBMSG_TYPE_STRING },
 	[WIF_ATTR_DTIM_PERIOD] = { .name = "dtim_period", BLOBMSG_TYPE_STRING },
+	[WIF_ATTR_HE_RTS_THRESHOLD] = { .name = "he_rts_threshold", BLOBMSG_TYPE_STRING },
+	[WIF_ATTR_HE_TWT_REQUIRED] = { .name = "he_twt_required", BLOBMSG_TYPE_STRING },
 };
 
 const struct uci_blob_param_list wifi_iface_param = {
@@ -222,7 +226,7 @@ out_none:
 
 /* Custom options table */
 #define SCHEMA_CUSTOM_OPT_SZ            20
-#define SCHEMA_CUSTOM_OPTS_MAX          8
+#define SCHEMA_CUSTOM_OPTS_MAX          10
 
 const char custom_options_table[SCHEMA_CUSTOM_OPTS_MAX][SCHEMA_CUSTOM_OPT_SZ] =
 {
@@ -234,6 +238,8 @@ const char custom_options_table[SCHEMA_CUSTOM_OPTS_MAX][SCHEMA_CUSTOM_OPT_SZ] =
 	SCHEMA_CONSTS_IEEE80211k,
 	SCHEMA_CONSTS_RTS_THRESHOLD,
 	SCHEMA_CONSTS_DTIM_PERIOD,
+	SCHEMA_CONSTS_HE_RTS_THRESHOLD,
+	SCHEMA_CONSTS_HE_TWT_REQUIRED,
 };
 
 static void vif_config_custom_opt_set(struct blob_buf *b,
@@ -277,6 +283,10 @@ static void vif_config_custom_opt_set(struct blob_buf *b,
 			blobmsg_add_string(b, "rts_threshold", value);
 		else if (strcmp(opt, "dtim_period") == 0)
 			blobmsg_add_string(b, "dtim_period", value);
+		else if (strcmp(opt, "he_twt_required") == 0)
+			blobmsg_add_string(b, "he_twt_required", value);
+		else if (strcmp(opt, "he_rts_threshold") == 0)
+			blobmsg_add_string(b, "he_rts_threshold", value);
 
 	}
 }
@@ -364,6 +374,20 @@ static void vif_state_custom_options_get(struct schema_Wifi_VIF_State *vstate,
 		} else if (strcmp(opt, "dtim_period") == 0) {
 			if (tb[WIF_ATTR_DTIM_PERIOD]) {
 				buf = blobmsg_get_string(tb[WIF_ATTR_DTIM_PERIOD]);
+				set_custom_option_state(vstate, &index,
+						custom_options_table[i],
+						buf);
+			}
+		} else if (strcmp(opt, "he_twt_required") == 0) {
+			if (tb[WIF_ATTR_HE_TWT_REQUIRED]) {
+				buf = blobmsg_get_string(tb[WIF_ATTR_HE_TWT_REQUIRED]);
+				set_custom_option_state(vstate, &index,
+						custom_options_table[i],
+						buf);
+			}
+		} else if (strcmp(opt, "he_rts_thershold") == 0) {
+			if (tb[WIF_ATTR_HE_RTS_THRESHOLD]) {
+				buf = blobmsg_get_string(tb[WIF_ATTR_HE_RTS_THRESHOLD]);
 				set_custom_option_state(vstate, &index,
 						custom_options_table[i],
 						buf);


### PR DESCRIPTION
opensync: add HE parameters to data model
    
This patch adds support for pushing the new HE options down from the cloud
and rendering them out into uci.
    
Signed-off-by: John Crispin <john@phrozen.org>
