### PR TITLE
apc: Add Access Point coordinator choosing algorithm

### DIFF
--- a/feeds/wlan-ap/apc/Makefile
+++ b/feeds/wlan-ap/apc/Makefile
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=apc
+PKG_RELEASE:=1.0.0
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/apc
+  SECTION:=base
+  DEPENDS:=+libev +libinterapcomm
+  CATEGORY:=Base system
+  TITLE:=Access Point Coordinator
+endef
+
+define Package/apc/description
+ Access Point Coordinator.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	[ ! -d ./src/ ] || $(CP) ./src/* $(PKG_BUILD_DIR)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/apc $(1)/usr/bin
+endef
+
+define Package/apc/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/apc $(1)/usr/bin
+endef
+$(eval $(call BuildPackage,apc))

--- a/feeds/wlan-ap/apc/src/Makefile
+++ b/feeds/wlan-ap/apc/src/Makefile
@@ -1,0 +1,31 @@
+#/* SPDX-License-Identifier: BSD-3-Clause */
+srcdir ?= .
+VPATH ?= $(srcdir)/src
+
+
+LIBS = -lpthread -lrt -linterapcomm -lev
+$(call output,usr/sbin/wc-apc)
+
+CFLAGS += -I./include/ \
+	-I../include/
+
+CFLAGS  += -Wall -g
+CFLAGS += -MMD -Wall -g -Wpointer-arith -Wcast-qual -Wshadow \
+				-Waggregate-return -Wnested-externs -Wstrict-prototypes \
+				-fno-omit-frame-pointer -g -rdynamic -fexceptions -funwind-tables -funsigned-char
+
+OBJS := apc_main.o \
+               hello.o iface.o neighbor.o apc.o
+
+all: apc
+
+#.c.o:
+%.o: %.c
+	$(CC) -fPIC $(CFLAGS) -c $< -o $@
+
+
+apc: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+clean:
+	$(RM) -f apc $(OBJS)

--- a/feeds/wlan-ap/apc/src/include/apc.h
+++ b/feeds/wlan-ap/apc/src/include/apc.h
@@ -1,0 +1,364 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_APC_H_
+#define _APC_APC_H_
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nest/apcn.h"
+
+#include "lib/ip.h"
+#include "lib/lists.h"
+#include "lib/timer.h"
+#include "lib/resource.h"
+#include "protocol.h"
+#include "nest/iface.h"
+
+#ifdef LOCAL_DEBUG
+#define APC_FORCE_DEBUG 1
+#else
+#define APC_FORCE_DEBUG 0
+#endif
+
+
+#define APC_IS_V2 1
+
+#define APC_PROTO 89
+
+#define LSREFRESHTIME 1800	/* 30 minutes */
+#define MINLSINTERVAL 5
+#define MINLSARRIVAL 1
+#define LSINFINITY 0xffffff
+
+#define APC_DEFAULT_TICK 1
+#define APC_DEFAULT_STUB_COST 1000
+#define APC_DEFAULT_ECMP_LIMIT 16
+#define APC_DEFAULT_TRANSINT 40
+
+#define APC_MIN_PKT_SIZE 256
+#define APC_MAX_PKT_SIZE 65535
+
+#define APC_VLINK_ID_OFFSET 0x80000000
+
+
+struct apc_config
+{
+	struct proto_config c;
+	uint tick;
+	u8 stub_router;
+	u8 instance_id;
+	u8 abr;
+	list vlink_list;		/* list of configured vlinks (struct apc_iface_patt) */
+};
+
+struct apc_area_config
+{
+	node n;
+	u32 areaid;
+	u32 default_cost;		/* Cost of default route for stub areas
+	      			   (With possible LSA_EXT3_EBIT for NSSA areas) */
+	u8 type;		/* Area type (standard, stub, NSSA), represented
+	      			   by option flags (OPT_E, OPT_N) */
+	u8 summary;			/* Import summaries to this stub/NSSA area, valid for ABR */
+	u8 default_nssa;		/* Generate default NSSA route for NSSA+summary area */
+	u8 translator;		/* Translator role, for NSSA ABR */
+	u32 transint;			/* Translator stability interval */
+	list patt_list;		/* List of iface configs (struct apc_iface_patt) */
+	list net_list;		/* List of aggregate networks for that area */
+	list enet_list;		/* List of aggregate external (NSSA) networks */
+	list stubnet_list;	/* List of stub networks added to Router LSA */
+};
+
+struct area_net_config
+{
+	node n;
+	struct prefix px;
+	u32 tag;
+	u8 hidden;
+};
+
+struct area_net
+{
+	u32 metric;	/* With possible LSA_EXT3_EBIT for NSSA area nets */
+	u32 tag;
+	u8 hidden;
+	u8 active;
+};
+
+struct apc_stubnet_config
+{
+	node n;
+	struct prefix px;
+	u32 cost;
+	u8 hidden;
+	u8 summary;
+};
+
+struct nbma_node
+{
+	node n;
+	ip_addr ip;
+	byte eligible;
+	byte found;
+};
+
+struct apc_iface_patt
+{
+	struct iface_patt i;
+	u32 type;
+	u32 stub;
+	u32 cost;
+	u32 helloint;
+	u32 rxmtint;
+	u32 pollint;
+	u32 waitint;
+	u32 deadc;
+	u32 deadint;
+	u32 priority;
+	u32 voa;
+	u32 vid;
+	int tx_tos;
+	int tx_priority;
+	u16 tx_length;
+	u16 rx_buffer;
+
+#define APC_RXBUF_MINSIZE 256	/* Minimal allowed size */
+	u8 instance_id;
+	u8 strictnbma;
+	u8 check_link;
+	u8 ecmp_weight;
+	u8 real_bcast;		/* Not really used in APCv3 */
+	u8 ttl_security;		/* bool + 2 for TX only */
+	u8 bfd;
+	u8 bsd_secondary;
+};
+
+/* Default values for interface parameters */
+#define COST_D 10
+#define RXMTINT_D 5
+#define INFTRANSDELAY_D 1
+#define PRIORITY_D 1
+#define HELLOINT_D 10
+#define POLLINT_D 20
+#define DEADC_D 4
+#define WAIT_DMH 4
+  /* Value of Wait timer - not found it in RFC * - using 4*HELLO */
+
+
+struct apc_proto
+{
+	struct proto p;
+	timer * disp_timer; /* APC proto dispatcher */
+	uint tick;
+	list iface_list;    /* List of APC interfaces (struct apc_iface) */
+	int padj;           /* Number of neighbors in Exchange or Loading state */
+	byte stub_router;   /* Do not forward transit traffic */
+	u32 router_id;
+};
+
+
+struct apc_iface
+{
+	node n;
+	struct iface *iface;		/* Nest's iface (NULL for vlinks) */
+	struct ifa *addr;		/* IP prefix associated with that APC iface */
+	struct apc_iface_patt *cf;
+	char *ifname;			/* Interface name (iface->name), new one for vlinks */
+	
+	list neigh_list;		/* List of neighbors (struct apc_neighbor) */
+	u32 cost;			/* Cost of iface */
+	u32 waitint;			/* number of sec before changing state from wait */
+	u32 rxmtint;			/* number of seconds between LSA retransmissions */
+	u32 pollint;			/* Poll interval */
+	u32 deadint;			/* after "deadint" missing hellos is router dead */
+	u32 iface_id;			/* Interface ID (iface->index or new value for vlinks) */
+	u32 vid;			/* ID of peer of virtual link */
+	ip_addr vip;			/* IP of peer of virtual link */
+	struct apc_iface *vifa;	/* APC iface which the vlink goes through */
+	u16 helloint;			/* number of seconds between hello sending */
+	u32 csn;                      /* Last used crypt seq number */
+	time_t csn_use;         /* Last time when packet with that CSN was sent */
+	ip_addr all_routers;		/* Multicast (or broadcast) address for all routers */
+	ip_addr des_routers;		/* Multicast (or NULL) address for designated routers */
+	ip_addr drip;			/* Designated router IP */
+	ip_addr bdrip;		/* Backup DR IP */
+	u32 drid;			/* DR Router ID */
+	u32 bdrid;			/* BDR Router ID */
+	u32 dr_iface_id;		/* if drid is valid, this is iface_id of DR (for connecting network) */
+	u8 instance_id;		/* Used to differentiate between more APC
+	      			   instances on one interface */
+	u8 type;			/* APC view of type (APC_IT_*) */
+	u8 strictnbma;		/* Can I talk with unknown neighbors? */
+	u8 stub;			/* Inactive interface */
+	u8 state;			/* Interface state machine (APC_IS_*) */
+	timer *wait_timer;		/* WAIT timer */
+	timer *hello_timer;		/* HELLOINT timer */
+	timer *poll_timer;		/* Poll Interval - for NBMA */
+	
+	int fadj;			/* Number of fully adjacent neighbors */
+	u8 priority;			/* A router priority for DR election */
+	u8 ioprob;
+#define APC_I_OK 0		/* Everything OK */
+#define APC_I_SK 1		/* Socket open failed */
+#define APC_I_LL 2		/* Missing link-local address (APCv3) */
+	u8 sk_dr;			/* Socket is a member of designated routers group */
+	u8 marked;			/* Used in APC reconfigure, 2 for force restart */
+	u16 rxbuf;			/* Buffer size */
+	u16 tx_length;		/* Soft TX packet length limit, usually MTU */
+	u8 check_link;		/* Whether iface link change is used */
+	u8 ecmp_weight;		/* Weight used for ECMP */
+	u8 check_ttl;			/* Check incoming packets for TTL 255 */
+	u8 bfd;			/* Use BFD on iface */
+};
+
+struct apc_neighbor
+{
+	node n;
+	struct apc_iface *ifa;
+	u8 state;
+	timer *inactim;		/* Inactivity timer */
+	u8 imms;			/* I, M, Master/slave received */
+	u8 myimms;			/* I, M Master/slave */
+	u32 dds;			/* DD Sequence number being sent */
+	u32 ddr;			/* last Dat Des packet received */
+	
+	u32 rid;			/* Router ID */
+	ip_addr ip;			/* IP of it's interface */
+	u8 priority;			/* Priority */
+	u8 adj;			/* built adjacency? */
+	u32 options;			/* Options received */
+
+	/* Entries dr and bdr store IP addresses in APCv2 and router IDs in
+	APCv3, we use the same type to simplify handling */
+	u32 dr;			/* Neighbor's idea of DR */
+	u32 bdr;		/* Neighbor's idea of BDR */
+	u32 iface_id;		/* ID of Neighbour's iface connected to common network */
+
+	list ackl[2];
+#define ACKL_DIRECT 0
+#define ACKL_DELAY 1
+	timer *ackd_timer;		/* Delayed ack timer */
+	struct bfd_request *bfd_req;	/* BFD request, if BFD is used */
+	void *ldd_buffer;		/* Last database description packet */
+	u32 ldd_bsize;		/* Buffer size for ldd_buffer */
+	u32 csn;                /* Last received crypt seq number (for MD5) */
+	u8 basic_mac[6];
+};
+
+
+/* APC interface types */
+#define APC_IT_BCAST   0
+#define APC_IT_NBMA    1
+#define APC_IT_PTP     2
+#define APC_IT_PTMP    3
+#define APC_IT_VLINK   4
+#define APC_IT_UNDEF   5
+
+/* APC interface states */
+#define APC_IS_DOWN    0   /* Not active */
+#define APC_IS_LOOP    1   /* Iface with no link */
+#define APC_IS_WAITING 2   /* Waiting for Wait timer */
+#define APC_IS_PTP     3   /* PTP operational */
+#define APC_IS_DROTHER 4   /* I'm on BCAST or NBMA and I'm not DR */
+#define APC_IS_BACKUP  5   /* I'm BDR */
+#define APC_IS_DR      6   /* I'm DR */
+
+/* Definitions for interface state machine */
+#define ISM_UP      0   /* Interface Up */
+#define ISM_WAITF   1   /* Wait timer fired */
+#define ISM_BACKS   2   /* Backup seen */
+#define ISM_NEICH   3   /* Neighbor change */
+#define ISM_LOOP    4   /* Link down */
+#define ISM_UNLOOP  5   /* Link up */
+#define ISM_DOWN    6   /* Interface down */
+
+
+/* APC neighbor states */
+#define NEIGHBOR_DOWN       0
+#define NEIGHBOR_ATTEMPT    1
+#define NEIGHBOR_INIT       2
+#define NEIGHBOR_2WAY       3
+#define NEIGHBOR_EXSTART    4
+#define NEIGHBOR_EXCHANGE   5
+#define NEIGHBOR_LOADING    6
+#define NEIGHBOR_FULL       7
+
+/* Definitions for neighbor state machine */
+#define INM_HELLOREC	0	/* Hello Received */
+#define INM_START	1	/* Neighbor start - for NBMA */
+#define INM_2WAYREC	2	/* 2-Way received */
+#define INM_NEGDONE	3	/* Negotiation done */
+#define INM_EXDONE	4	/* Exchange done */
+#define INM_BADLSREQ	5	/* Bad LS Request */
+#define INM_LOADDONE	6	/* Load done */
+#define INM_ADJOK	7	/* AdjOK? */
+#define INM_SEQMIS	8	/* Sequence number mismatch */
+#define INM_1WAYREC	9	/* 1-Way */
+#define INM_KILLNBR	10	/* Kill Neighbor */
+#define INM_INACTTIM	11	/* Inactivity timer */
+#define INM_LLDOWN	12	/* Line down */
+
+#define TRANS_OFF	0
+#define TRANS_ON	1
+#define TRANS_WAIT	2	/* Waiting before the end of translation */
+
+#define DBDES_I		4	/* Init bit */
+#define DBDES_M		2	/* More bit */
+#define DBDES_MS	1	/* Master/Slave bit */
+#define DBDES_IMMS	(DBDES_I | DBDES_M | DBDES_MS)
+
+/* apc.c */
+#define apc_is_v2(X) APC_IS_V2
+
+/* iface.c */
+void apc_iface_chstate(struct apc_iface *ifa, u8 state);
+void apc_iface_sm(struct apc_iface *ifa, int event);
+void apc_iface_new(void);
+
+/* neighbor.c */
+struct apc_neighbor *apc_neighbor_new(struct apc_iface *ifa);
+void apc_neigh_sm(struct apc_neighbor *n, int event);
+void apc_dr_election(struct apc_iface *ifa);
+struct apc_neighbor *find_neigh_by_ip(struct apc_iface *ifa, ip_addr ip);
+
+#ifndef PARSER
+#define DROP(DSC,VAL) do { err_dsc = DSC; err_val = VAL; goto drop; } while(0)
+#endif
+
+/* hello.c */
+#define OHS_HELLO    0
+#define OHS_POLL     1
+#define OHS_SHUTDOWN 2
+
+void apc_send_hello( struct apc_iface *ifa, int kind );
+void apc_receive_hello( unsigned char *pkt, struct apc_iface *ifa, struct apc_neighbor *n, ip_addr faddr, unsigned int plen );
+
+/* apc_main.c */
+void remove_previous_radius( void );
+unsigned int set_radius_proxy( int n_peer, u32 * PeerList );
+
+/*build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/libwebsocket/include/websocke*/
+struct apc_neigh
+{
+	unsigned int Ip;
+	unsigned char BasicMac[6];
+} __attribute__((packed));
+
+#define IAC_APC_ELECTION_PORT 50010
+#define APC_UNKNOWN     0
+#define I_AM_APC        1
+#define I_AM_BAPC       2
+#define IAC_HEADER_SIZE             22
+#define APC_MAX_NEIGHBORS       100
+
+
+struct apc_spec
+{
+	unsigned int IsApc;
+	unsigned int Changed;
+	unsigned int FloatIp;
+	struct apc_neigh Neighbors[APC_MAX_NEIGHBORS];
+} __attribute__((packed));
+
+
+#endif /* _APC_APC_H_ */

--- a/feeds/wlan-ap/apc/src/include/conf/types.h
+++ b/feeds/wlan-ap/apc/src/include/conf/types.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+typedef long long s64;
+
+typedef unsigned short u16;
+typedef unsigned short word;
+
+typedef short s16;
+
+typedef unsigned int u32;
+
+typedef int s32;
+
+typedef unsigned char byte;
+typedef unsigned char u8;
+
+typedef char s8;

--- a/feeds/wlan-ap/apc/src/include/lib/apclib.h
+++ b/feeds/wlan-ap/apc/src/include/lib/apclib.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_LIB_H_
+#define _APC_LIB_H_
+
+#include "conf/types.h"
+#include "timer.h"
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#else
+#include <stdlib.h>
+#endif
+
+/* Ugly structure offset handling macros */
+
+#define OFFSETOF(s, i) ((size_t) &((s *)0)->i)
+#define SKIP_BACK(s, i, p) ((s *)((char *)p - OFFSETOF(s, i)))
+
+/* Utility macros */
+
+#define MIN_(a,b) (((a)<(b))?(a):(b))
+#define MAX_(a,b) (((a)>(b))?(a):(b))
+
+#ifndef PARSER
+#undef MIN
+#undef MAX
+#define MIN(a,b) MIN_(a,b)
+#define MAX(a,b) MAX_(a,b)
+#endif
+
+#define ABS(a)   ((a)>=0 ? (a) : -(a))
+
+#ifndef NULL
+#define NULL ((void *) 0)
+#endif
+
+#define IP_VERSION 4
+
+/* Macros for gcc attributes */
+
+#define NORET __attribute__((noreturn))
+#define UNUSED __attribute__((unused))
+
+
+/* Microsecond time */
+
+typedef s64 btime;
+
+#define S_	*1000000
+#define MS_	*1000
+#define US_	*1
+#define TO_S	/1000000
+#define TO_MS	/1000
+#define TO_US	/1
+
+#ifndef PARSER
+#define S	S_
+#define MS	MS_
+#define US	US_
+#endif
+
+/* Pseudorandom numbers */
+
+u32 random_u32(void);
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/lib/bitops.h
+++ b/feeds/wlan-ap/apc/src/include/lib/bitops.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_BITOPTS_H_
+#define _APC_BITOPTS_H_
+
+/*
+ *	Bit mask operations:
+ *
+ *	u32_mkmask	Make bit mask consisting of <n> consecutive ones
+ *			from the left and the rest filled with zeroes.
+ *			E.g., u32_mkmask(5) = 0xf8000000.
+ *	u32_masklen	Inverse operation to u32_mkmask, -1 if not a bitmask.
+ */
+
+u32 u32_mkmask(unsigned n);
+int u32_masklen(u32 x);
+
+#endif
+

--- a/feeds/wlan-ap/apc/src/include/lib/endian.h
+++ b/feeds/wlan-ap/apc/src/include/lib/endian.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_ENDIAN_H_
+#define _APC_ENDIAN_H_
+
+/* hton[sl] and ntoh[sl] are defined here */
+
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <stdint.h>
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/lib/ip.h
+++ b/feeds/wlan-ap/apc/src/include/lib/ip.h
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_IP_H_
+#define _APC_IP_H_
+
+#include "lib/endian.h"
+#include "lib/bitops.h"
+
+
+#define IP4_NONE		_MI4(0)
+
+
+typedef u32 ip4_addr;
+
+#define _MI4(x) (x)
+#define _I(x) (x)
+
+
+/* Provisionary ip_addr definition same as ip4_addr */
+typedef ip4_addr ip_addr;
+#define IPA_NONE IP4_NONE
+
+#define ipa_to_ip4(x) x
+#define ipa_to_u32(x) ip4_to_u32(ipa_to_ip4(x))
+
+/*
+ *	Public constructors
+ */
+
+#define ip4_to_u32(x) _I(x)
+
+/*
+ *	Basic algebraic functions
+ */
+
+static inline int ip4_equal(ip4_addr a, ip4_addr b)
+{ return _I(a) == _I(b); }
+
+static inline int ip4_nonzero(ip4_addr a)
+{ return _I(a) != 0; }
+
+#define ipa_equal(x,y) ip4_equal(x,y)
+#define ipa_nonzero(x) ip4_nonzero(x)
+
+/*
+ *	Miscellaneous
+ */
+
+struct prefix {
+  ip_addr addr;
+  unsigned int len;
+};
+
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/lib/lists.c
+++ b/feeds/wlan-ap/apc/src/include/lib/lists.c
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#define _APC_LISTS_C_
+
+#include "nest/apcn.h"
+#include "lib/lists.h"
+
+/**
+ * add_tail - append a node to a list
+ * @l: linked list
+ * @n: list node
+ *
+ * add_tail() takes a node @n and appends it at the end of the list @l.
+ */
+LIST_INLINE void add_tail( list *l, node *n )
+{
+    node *z = l->tail;
+
+    n->next = (node *) &l->null;
+    n->prev = z;
+    z->next = n;
+    l->tail = n;
+}
+
+
+/**
+ * add_head - prepend a node to a list
+ * @l: linked list
+ * @n: list node
+ *
+ * add_head() takes a node @n and prepends it at the start of the list @l.
+ */
+LIST_INLINE void add_head( list *l, node *n )
+{
+    node *z = l->head;
+
+    n->next = z;
+    n->prev = (node *) &l->head;
+    z->prev = n;
+    l->head = n;
+}
+
+
+/**
+ * insert_node - insert a node to a list
+ * @n: a new list node
+ * @after: a node of a list
+ *
+ * Inserts a node @n to a linked list after an already inserted
+ * node @after.
+ */
+LIST_INLINE void insert_node( node *n, node *after )
+{
+    node *z = after->next;
+
+    n->next = z;
+    n->prev = after;
+    after->next = n;
+    z->prev = n;
+}
+
+
+/**
+ * rem_node - remove a node from a list
+ * @n: node to be removed
+ *
+ * Removes a node @n from the list it's linked in.
+ */
+LIST_INLINE void rem_node( node *n )
+{
+    node *z = n->prev;
+    node *x = n->next;
+
+    z->next = x;
+    x->prev = z;
+}
+
+
+/**
+ * rem2_node - remove a node from a list, with cleanup
+ * @n: node to be removed
+ *
+ * Removes a node @n from the list it's linked in and resets its pointers to NULL.
+ * Useful if you want to distinguish between linked and unlinked nodes.
+ */
+LIST_INLINE void rem2_node( node *n )
+{
+    node *z = n->prev;
+    node *x = n->next;
+
+    z->next = x;
+    x->prev = z;
+    n->next = NULL;
+    n->prev = NULL;
+}
+
+
+/**
+ * replace_node - replace a node in a list with another one
+ * @old: node to be removed
+ * @new: node to be inserted
+ *
+ * Replaces node @old in the list it's linked in with node @new.  Node
+ * @old may be a copy of the original node, which is not accessed
+ * through the list. The function could be called with @old == @new,
+ * which just fixes neighbors' pointers in the case that the node
+ * was reallocated.
+ */
+LIST_INLINE void replace_node( node *old, node *new )
+{
+    old->next->prev = new;
+    old->prev->next = new;
+
+    new->prev = old->prev;
+    new->next = old->next;
+}
+
+
+/**
+ * init_list - create an empty list
+ * @l: list
+ *
+ * init_list() takes a &list structure and initializes its
+ * fields, so that it represents an empty list.
+ */
+LIST_INLINE void init_list( list *l )
+{
+    l->head = (node *) &l->null;
+    l->null = NULL;
+    l->tail = (node *) &l->head;
+}
+
+
+/**
+ * add_tail_list - concatenate two lists
+ * @to: destination list
+ * @l: source list
+ *
+ * This function appends all elements of the list @l to
+ * the list @to in constant time.
+ */
+LIST_INLINE void add_tail_list( list *to, list *l )
+{
+    node *p = to->tail;
+    node *q = l->head;
+
+    p->next = q;
+    q->prev = p;
+    q = l->tail;
+    q->next = (node *) &to->null;
+    to->tail = q;
+}
+

--- a/feeds/wlan-ap/apc/src/include/lib/lists.h
+++ b/feeds/wlan-ap/apc/src/include/lib/lists.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_LISTS_H_
+#define _APC_LISTS_H_
+
+/*
+ * I admit the list structure is very tricky and also somewhat awkward,
+ * but it's both efficient and easy to manipulate once one understands the
+ * basic trick: The list head always contains two synthetic nodes which are
+ * always present in the list: the head and the tail. But as the `next'
+ * entry of the tail and the `prev' entry of the head are both NULL, the
+ * nodes can overlap each other:
+ *
+ *     head    head_node.next
+ *     null    head_node.prev  tail_node.next
+ *     tail                    tail_node.prev
+ */
+
+typedef struct node {
+  struct node *next, *prev;
+} node;
+
+typedef struct list {			/* In fact two overlayed nodes */
+  struct node *head, *null, *tail;
+} list;
+
+#define NODE (node *)
+#define HEAD(list) ((void *)((list).head))
+#define TAIL(list) ((void *)((list).tail))
+#define NODE_NEXT(n) ((void *)((NODE (n))->next))
+#define NODE_VALID(n) ((NODE (n))->next)
+#define WALK_LIST(n,list) for(n=HEAD(list); NODE_VALID(n); n=NODE_NEXT(n))
+#define WALK_LIST2(n,nn,list,pos) \
+  for(nn=(list).head; NODE_VALID(nn) && (n=SKIP_BACK(typeof(*n),pos,nn)); nn=nn->next)
+#define WALK_LIST_DELSAFE(n,nxt,list) \
+     for(n=HEAD(list); nxt=NODE_NEXT(n); n=(void *) nxt)
+/* WALK_LIST_FIRST supposes that called code removes each processed node */
+#define WALK_LIST_FIRST(n,list) \
+     while(n=HEAD(list), (NODE (n))->next)
+#define WALK_LIST_BACKWARDS(n,list) for(n=TAIL(list);(NODE (n))->prev; \
+				n=(void *)((NODE (n))->prev))
+#define WALK_LIST_BACKWARDS_DELSAFE(n,prv,list) \
+     for(n=TAIL(list); prv=(void *)((NODE (n))->prev); n=(void *) prv)
+
+#define EMPTY_LIST(list) (!(list).head->next)
+
+
+#ifndef _APC_LISTS_C_
+#define LIST_INLINE static inline
+#include "lib/lists.c"
+#undef LIST_INLINE
+
+#else
+#define LIST_INLINE
+void add_tail(list *, node *);
+void add_head(list *, node *);
+void rem_node(node *);
+void rem2_node(node *);
+void add_tail_list(list *, list *);
+void init_list(list *);
+void insert_node(node *, node *);
+#endif
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/lib/resource.h
+++ b/feeds/wlan-ap/apc/src/include/lib/resource.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_RESOURCE_H_
+#define _APC_RESOURCE_H_
+
+/* Normal memory blocks */
+
+void * mb_allocz( unsigned size );
+void mb_free( void * );
+
+#endif
+

--- a/feeds/wlan-ap/apc/src/include/lib/timer.h
+++ b/feeds/wlan-ap/apc/src/include/lib/timer.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_TIMER_H_
+#define _APC_TIMER_H_
+
+#include <time.h>
+
+#include "lib/resource.h"
+
+typedef struct _timer
+{
+    void (*hook)(struct _timer *);
+    void *data;
+    unsigned randomize; /* Amount of randomization */
+    unsigned recurrent; /* Timer recurrence */
+    time_t expires;     /* 0=inactive */
+} timer;
+
+
+timer * tm_new( void );
+void tm_start( timer *, unsigned after );
+void tm_stop( timer * );
+
+static inline timer * tm_new_set( void (*hook)(struct _timer *), void *data, unsigned rand, unsigned rec )
+{
+    timer *t = tm_new( );
+    t->hook = hook;
+    t->data = data;
+    t->randomize = rand;
+    t->recurrent = rec;
+    return t;
+}
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/nest/apcn.h
+++ b/feeds/wlan-ap/apc/src/include/nest/apcn.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_H_
+#define _APC_H_
+
+#include "lib/apclib.h"
+#include "lib/ip.h"
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/nest/iface.h
+++ b/feeds/wlan-ap/apc/src/include/nest/iface.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_IFACE_H_
+#define _APC_IFACE_H_
+
+#include "lib/lists.h"
+
+extern list iface_list;
+
+struct proto;
+
+struct ifa
+{
+    node n;
+    struct iface * iface;   /* Interface this address belongs to */
+    ip_addr ip;             /* IP address of this host */
+    ip_addr prefix;         /* Network prefix */
+    unsigned pxlen;         /* Prefix length */
+    ip_addr brd;            /* Broadcast address */
+    unsigned flags;         /* Analogous to iface->flags */
+};
+
+struct iface
+{
+    node n;
+    char name[16];
+    unsigned flags;
+    unsigned mtu;
+    unsigned index;     /* OS-dependent interface index */
+    list addrs;         /* Addresses assigned to this interface */
+    struct ifa * addr;  /* Primary address */
+    list neighbors;     /* All neighbors on this interface */
+};
+
+/* The Neighbor Cache */
+
+typedef struct neighbor
+{
+    node n;                 /* Node in global neighbor list */
+    node if_n;              /* Node in per-interface neighbor list */
+    ip_addr addr;           /* Address of the neighbor */
+    struct ifa *ifa;        /* Ifa on related iface */
+    struct iface *iface;    /* Interface it's connected to */
+    struct proto *proto;    /* Protocol this belongs to */
+    void *data;             /* Protocol-specific data */
+    unsigned flags;
+    int scope;              /* Address scope, -1 for unreachable sticky neighbors */
+} neighbor;
+
+/*
+ *	Interface Pattern Lists
+ */
+
+struct iface_patt {
+  node n;
+  list ipn_list;			/* A list of struct iface_patt_node */
+
+  /* Protocol-specific data follow after this structure */
+};
+
+#endif

--- a/feeds/wlan-ap/apc/src/include/protocol.h
+++ b/feeds/wlan-ap/apc/src/include/protocol.h
@@ -1,0 +1,210 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#ifndef _APC_PROTOCOL_H_
+#define _APC_PROTOCOL_H_
+
+#include "lib/lists.h"
+#include "lib/resource.h"
+#include "lib/timer.h"
+
+struct iface;
+struct ifa;
+struct neighbor;
+struct network;
+struct proto_config;
+struct proto;
+struct event;
+
+/*
+ *	Routing Protocol
+ */
+
+struct protocol {
+  node n;
+  char *name;
+  char *template;			/* Template for automatic generation of names */
+  int name_counter;			/* Counter for automatic name generation */
+  int attr_class;			/* Attribute class known to this protocol */
+  int multitable;			/* Protocol handles all announce hooks itself */
+  uint preference;			/* Default protocol preference */
+  uint config_size;			/* Size of protocol config */
+
+  void (*postconfig)(struct proto_config *);			/* After configuring each instance */
+  struct proto * (*init)(struct proto_config *);		/* Create new instance */
+  int (*reconfigure)(struct proto *, struct proto_config *);	/* Try to reconfigure instance, returns success */
+  void (*dump)(struct proto *);			/* Debugging dump */
+  int (*start)(struct proto *);			/* Start the instance */
+  int (*shutdown)(struct proto *);		/* Stop the instance */
+  void (*cleanup)(struct proto *);		/* Called after shutdown when protocol became hungry/down */
+  void (*get_status)(struct proto *, byte *buf); /* Get instance status (for `show protocols' command) */
+  void (*show_proto_info)(struct proto *);	/* Show protocol info (for `show protocols all' command) */
+  void (*copy_config)(struct proto_config *, struct proto_config *);	/* Copy config from given protocol instance */
+};
+
+
+/*
+ *	Known protocols
+ */
+
+extern struct protocol proto_apc;
+
+/*
+ *	Routing Protocol Instance
+ */
+
+struct proto_config {
+    node n;
+  struct protocol *protocol;		/* Protocol */
+  struct proto *proto;			/* Instance we've created */
+  char *name;
+  char *dsc;
+  int class;				/* SYM_PROTO or SYM_TEMPLATE */
+  u32 debug, mrtdump;			/* Debugging bitfields, both use D_* constants */
+  unsigned preference, disabled;	/* Generic parameters */
+  u32 router_id;			/* Protocol specific router ID */
+  struct rtable_config *table;		/* Table we're attached to */
+};
+
+
+struct proto {
+  node n;				/* Node in *_proto_list */
+  node glob_node;			/* Node in global proto_list */
+  struct protocol *proto;		/* Protocol */
+  struct proto_config *cf;		/* Configuration data */
+  struct proto_config *cf_new;		/* Configuration we want to switch to after shutdown (NULL=delete) */
+  struct event *attn;			/* "Pay attention" event */
+
+  char *name;				/* Name of this instance (== cf->name) */
+  u32 debug;				/* Debugging flags */
+  u32 mrtdump;				/* MRTDump flags */
+  unsigned preference;			/* Default route preference */
+  byte accept_ra_types;			/* Which types of route announcements are accepted (RA_OPTIMAL or RA_ANY) */
+  byte disabled;			/* Manually disabled */
+  byte proto_state;			/* Protocol state machine (PS_*, see below) */
+  byte core_state;			/* Core state machine (FS_*, see below) */
+  byte export_state;			/* Route export state (ES_*, see below) */
+  byte reconfiguring;			/* We're shutting down due to reconfiguration */
+  byte refeeding;			/* We are refeeding (valid only if export_state == ES_FEEDING) */
+  byte flushing;			/* Protocol is flushed in current flush loop round */
+  byte gr_recovery;			/* Protocol should participate in graceful restart recovery */
+  byte gr_lock;				/* Graceful restart mechanism should wait for this proto */
+  byte down_sched;			/* Shutdown is scheduled for later (PDS_*) */
+  byte down_code;			/* Reason for shutdown (PDC_* codes) */
+  u32 hash_key;				/* Random key used for hashing of neighbors */
+
+  struct rtable *table;			/* Our primary routing table */
+};
+
+struct proto_spec {
+  void *ptr;
+  int patt;
+};
+
+
+void proto_copy_config(struct proto_config *dest, struct proto_config *src);
+void proto_request_feeding(struct proto *p);
+
+static inline void
+proto_copy_rest(struct proto_config *dest, struct proto_config *src, unsigned size)
+{ memcpy(dest + 1, src + 1, size - sizeof(struct proto_config)); }
+
+void proto_show_basic_info(struct proto *p);
+
+static inline u32
+proto_get_router_id(struct proto_config *pc)
+{
+  return pc->router_id;
+}
+
+extern list active_proto_list;
+
+/*
+ *  Each protocol instance runs two different state machines:
+ *
+ *  [P] The protocol machine: (implemented inside protocol)
+ *
+ *		DOWN    ---->    START
+ *		  ^		   |
+ *		  |		   V
+ *		STOP    <----     UP
+ *
+ *	States:	DOWN	Protocol is down and it's waiting for the core
+ *			requesting protocol start.
+ *		START	Protocol is waiting for connection with the rest
+ *			of the network and it's not willing to accept
+ *			packets. When it connects, it goes to UP state.
+ *		UP	Protocol is up and running. When the network
+ *			connection breaks down or the core requests
+ *			protocol to be terminated, it goes to STOP state.
+ *		STOP	Protocol is disconnecting from the network.
+ *			After it disconnects, it returns to DOWN state.
+ *
+ *	In:	start()	Called in DOWN state to request protocol startup.
+ *			Returns new state: either UP or START (in this
+ *			case, the protocol will notify the core when it
+ *			finally comes UP).
+ *		stop()	Called in START, UP or STOP state to request
+ *			protocol shutdown. Returns new state: either
+ *			DOWN or STOP (in this case, the protocol will
+ *			notify the core when it finally comes DOWN).
+ *
+ *	Out:	proto_notify_state() -- called by protocol instance when
+ *			it does any state transition not covered by
+ *			return values of start() and stop(). This includes
+ *			START->UP (delayed protocol startup), UP->STOP
+ *			(spontaneous shutdown) and STOP->DOWN (delayed
+ *			shutdown).
+ */
+
+#define PS_DOWN 0
+#define PS_START 1
+#define PS_UP 2
+#define PS_STOP 3
+
+void proto_notify_state(struct proto *p, unsigned state);
+
+/*
+ *  [F] The feeder machine: (implemented in core routines)
+ *
+ *		HUNGRY    ---->   FEEDING
+ *		 ^		     |
+ *		 | 		     V
+ *		FLUSHING  <----   HAPPY
+ *
+ *	States:	HUNGRY	Protocol either administratively down (i.e.,
+ *			disabled by the user) or temporarily down
+ *			(i.e., [P] is not UP)
+ *		FEEDING	The protocol came up and we're feeding it
+ *			initial routes. [P] is UP.
+ *		HAPPY	The protocol is up and it's receiving normal
+ *			routing updates. [P] is UP.
+ *		FLUSHING The protocol is down and we're removing its
+ *			routes from the table. [P] is STOP or DOWN.
+ *
+ *	Normal lifecycle of a protocol looks like:
+ *
+ *		HUNGRY/DOWN --> HUNGRY/START --> HUNGRY/UP -->
+ *		FEEDING/UP --> HAPPY/UP --> FLUSHING/STOP|DOWN -->
+ *		HUNGRY/STOP|DOWN --> HUNGRY/DOWN
+ *
+ *	Sometimes, protocol might switch from HAPPY/UP to FEEDING/UP
+ *	if it wants to refeed the routes (for example BGP does so
+ *	as a result of received ROUTE-REFRESH request).
+ */
+
+/*
+ *	Debugging flags
+ */
+
+#define D_STATES 1		/* [core] State transitions */
+#define D_ROUTES 2		/* [core] Routes passed by the filters */
+#define D_FILTERS 4		/* [core] Routes rejected by the filters */
+#define D_IFACES 8		/* [core] Interface events */
+#define D_EVENTS 16		/* Protocol events */
+#define D_PACKETS 32		/* Packets sent/received */
+
+#ifndef PARSER
+#define TRACE(flags, msg, args...) \
+  do { if (p->p.debug & flags) log(L_TRACE "%s: " msg, p->p.name , ## args ); } while(0)
+#endif
+
+#endif

--- a/feeds/wlan-ap/apc/src/src/apc.c
+++ b/feeds/wlan-ap/apc/src/src/apc.c
@@ -1,0 +1,130 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdlib.h>
+#include "apc.h"
+
+static void apc_disp(struct _timer * tmr);
+
+static int apc_start(struct proto * P)
+{
+	struct apc_proto *p = (struct apc_proto *) P;
+	struct apc_config *c = (struct apc_config *) (P->cf);
+	
+	p->router_id = proto_get_router_id(P->cf);
+	p->stub_router = c->stub_router;
+	p->tick = c->tick;
+	p->disp_timer = tm_new_set( apc_disp, p, 0, p->tick );
+	tm_start(p->disp_timer, 1);
+	init_list(&(p->iface_list));
+	apc_iface_new( );
+	return PS_UP;
+}
+
+static void apc_dump( struct proto * P )
+{
+}
+
+static struct proto * apc_init(struct proto_config * c)
+{
+	struct proto * P = mb_allocz(sizeof(struct apc_proto));
+	
+	P->cf = c;
+	P->debug = c->debug;
+	P->mrtdump = c->mrtdump;
+	P->name = c->name;
+	P->preference = c->preference;
+	P->disabled = c->disabled;
+	P->proto = c->protocol;
+	//+P->table = c->table->table;
+	P->hash_key = 12345;//+random_u32();
+	c->proto = P;
+	
+	P->accept_ra_types = 1; //RA_OPTIMAL;
+	
+	return P;
+}
+
+
+/**
+ * apc_disp - invokes routing table calculation, aging and also area_disp()
+ * @timer: timer usually called every @apc_proto->tick second, @timer->data
+ * point to @apc_proto
+ */
+static void apc_disp( struct _timer * tmr )
+{
+	struct apc_proto *p = tmr->data;
+	
+	/* Originate or flush local topology LSAs */
+	//+apc_update_topology(p);
+}
+
+
+/**
+ * apc_shutdown - Finish of APC instance
+ * @P: APC protocol instance
+ *
+ * RFC does not define any action that should be taken before router
+ * shutdown. To make my neighbors react as fast as possible, I send
+ * them hello packet with empty neighbor list. They should start
+ * their neighbor state machine with event %NEIGHBOR_1WAY.
+ */
+static int apc_shutdown( struct proto *P )
+{
+	return PS_DOWN;
+}
+
+static void
+apc_get_status(struct proto *P, byte * buf)
+{
+	struct apc_proto *p = (struct apc_proto *) P;
+	
+	if (p->p.proto_state == PS_DOWN)
+		buf[0] = 0;
+	else
+	{
+		struct apc_iface *ifa;
+		struct apc_neighbor *n;
+		int adj = 0;
+	
+		WALK_LIST(ifa, p->iface_list)
+		WALK_LIST(n, ifa->neigh_list) if (n->state == NEIGHBOR_FULL)
+		adj = 1;
+	
+		if (adj == 0)
+			strcpy(buf, "Alone");
+		else
+			strcpy(buf, "Running");
+	}
+}
+
+
+/**
+ * apc_reconfigure - reconfiguration hook
+ * @P: current instance of protocol (with old configuration)
+ * @c: new configuration requested by user
+ *
+ * This hook tries to be a little bit intelligent. Instance of APC
+ * will survive change of many constants like hello interval,
+ * password change, addition or deletion of some neighbor on
+ * nonbroadcast network, cost of interface, etc.
+ */
+static int apc_reconfigure(struct proto *P, struct proto_config *c)
+{
+	return 1;
+}
+
+
+
+struct protocol proto_apc = {
+	.name =		"APC",
+	.template =	"apc%d",
+	.attr_class =	3, //EAP_APC,
+	.preference =	150, //DEF_PREF_APC,
+	.config_size =	sizeof(struct apc_config),
+	.init =		apc_init,
+	.dump =		apc_dump,
+	.start =	apc_start,
+	.shutdown =	apc_shutdown,
+	.reconfigure =	apc_reconfigure,
+	.get_status =	apc_get_status,
+};
+

--- a/feeds/wlan-ap/apc/src/src/apc_main.c
+++ b/feeds/wlan-ap/apc/src/src/apc_main.c
@@ -1,0 +1,330 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <pthread.h>
+#include <sys/errno.h>
+#include <getopt.h>
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <netinet/in.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <ev.h>
+#include <interap/interAPcomm.h>
+
+#include <nest/apcn.h>
+#include <apc.h>
+#include <protocol.h>
+
+static ev_io iac_io;
+static ev_timer  check_timer;
+static unsigned int CheckIp;
+static int CheckCount;
+
+
+list iface_list;
+struct apc_iface * apc_ifa = NULL;
+struct apc_proto * ApcProto;
+unsigned int MyIpAddr = 0;
+unsigned int WaitingToReelect = 0;
+unsigned int ApcGrpId = 0;
+unsigned char MyBasicMac[6];
+unsigned int FloatingIpSaved = 0;
+unsigned int RestartProxy = 0;
+struct apc_spec ApcSpecSaved;
+
+int recv_sock_fd = -1;
+
+void * mb_allocz(unsigned size)
+{
+	printf("mb_allocz %u\n", size);
+	return(calloc(1, size));
+}
+
+void mb_free(void * m)
+{
+	printf("mb_free %p\n", m);
+	free(m);
+}
+
+timer * tm_new(void)
+{
+	timer *tt = malloc(sizeof(timer));
+
+	printf("tm_new %p\n", tt);
+	return(tt);
+}
+
+#define MAX_TIM_NUM     100
+timer *Timers[MAX_TIM_NUM];
+
+void tm_start(timer *tm, unsigned after)
+{
+	int i;
+	
+	printf("tm_start %p %u (%p)\n", tm, after, tm->hook);
+	/* First, try to find if this timer was already started */
+	for(i=0; i<MAX_TIM_NUM; i++)
+	{
+		if (Timers[i] == tm)
+		{
+			tm->expires = after;
+			return;
+		}
+	}
+	/* Now, try to find empty slot */
+	for(i=0; i<MAX_TIM_NUM; i++)
+	{
+		if (Timers[i] == NULL)
+		{
+			tm->expires = after;
+			Timers[i] = tm;
+			return;
+		}
+	}
+}
+
+void tm_stop(timer * tm)
+{
+	int i;
+	
+	printf("tm_stop %p\n", tm);
+	for(i=0; i<MAX_TIM_NUM; i++)
+	{
+		if (Timers[i] == tm)
+		{
+			Timers[i] = NULL;
+			return;
+		}
+	}
+}
+
+static void timers_go(void)
+{
+	int i;
+	timer * tm;
+	
+	for(i=0; i<MAX_TIM_NUM; i++)
+	{
+		if (Timers[i])
+		{
+			tm = Timers[i];
+			tm->expires -= 1;
+			if (tm->expires == 0)
+			{
+				printf("=== calling hook %p\n", tm->hook);
+				tm->hook(tm);
+				if (tm->recurrent)
+					tm->expires = tm->recurrent;
+				else
+					Timers[i] = NULL;
+			}
+		}
+	}
+}
+
+u32 u32_mkmask(unsigned n)
+{
+	printf("u32_mkmask %u\n", n);
+	return(0xFFFFFF00);
+}
+
+int u32_masklen(u32 x)
+{
+	printf("u32_mkmask %x\n", x);
+	return(24);
+}
+
+int receive_from_socket(void *data, ssize_t n)
+{
+	unsigned char *cdata = (unsigned char *)data;
+
+	struct apc_neighbor * neigh;
+	unsigned int ipaddr;
+
+	if (!WaitingToReelect)
+	{
+		ipaddr = ntohl(*((unsigned int *)&(cdata[12])));
+		neigh = find_neigh_by_ip(apc_ifa, ipaddr);
+		
+		printf("received from IAP (%d) (%x) %x %x %x %x %x %x %x %x %x %x\n",
+			n, ipaddr, cdata[0], cdata[1], cdata[2], cdata[3],
+			cdata[4], cdata[5], cdata[6], cdata[7], cdata[8],
+			cdata[9]);
+
+		apc_receive_hello(&(cdata[0]), apc_ifa, neigh, ipaddr, n);
+	}
+	return(0);
+}
+
+int get_mac_addr(const char *iface, unsigned char *mac)
+{
+
+	struct ifreq ifr;
+	int ret = 0;
+	int fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
+
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ-1);
+	ret = ioctl(fd, SIOCGIFHWADDR, &ifr);
+
+	if (ret == 0)
+	{
+		memset(mac, 0, 6);
+		memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
+	}
+	
+	close(fd);
+	
+	return ret;
+}
+
+
+static void GetLocalIpv4Addr(unsigned char * IpAddr, const char *iface)
+{
+	int fd, rc;
+	struct ifreq ifr;
+	
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	ifr.ifr_addr.sa_family = AF_INET;
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ-1);
+	
+	rc = ioctl(fd, SIOCGIFADDR, &ifr);
+	close(fd);
+	
+	if (rc == 0)
+	{
+		/* IP address bytes will be in network order */
+		memcpy(IpAddr,
+		      &(((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr),
+			 4);
+	}
+	else
+		memset(IpAddr, 0, 4);
+
+	return;
+}
+
+/*************************************/
+/* library functions */
+/*************************************/
+int br_socket_fd = -1;
+int set_socket(void)
+{
+	if (br_socket_fd == -1)
+		br_socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+
+	if (br_socket_fd < 0)
+		return -1;
+
+	return(0);
+}
+
+/*************************************/
+
+
+static void check_timer_handler(struct ev_loop *loop, ev_timer *timer,
+				 int revents) 
+{
+	timers_go();
+	if (WaitingToReelect)
+	{
+		WaitingToReelect -= 1;
+		if (WaitingToReelect == 0);
+		{
+			apc_ifa->state = APC_IS_DOWN;
+			apc_iface_sm(apc_ifa, ISM_UP);
+		}
+	}
+
+	CheckCount += 1;
+	if (CheckCount == 10)
+	{
+		/* Check IP address periodically - if it's different from what
+		 it was on startup, exit and nanny will re-start us.*/
+		GetLocalIpv4Addr((unsigned char *)&CheckIp, "br-wan");
+		CheckIp = ntohl(CheckIp);
+		if (CheckIp && (MyIpAddr != CheckIp))
+		{
+			printf("IP address changed from %x to %x - restart APC election\n", MyIpAddr, CheckIp);
+			exit(0);
+		}
+		
+		CheckCount = 0;
+		if (ApcSpecSaved.IsApc == I_AM_APC)
+		{
+		//Radius stuff
+		}
+	}
+}
+
+int main(int argc, char *const* argv)
+{
+	struct proto_config c;
+	struct proto * apc_proto;
+	struct ev_loop *loop = EV_DEFAULT;
+
+	/*Socket*/
+	set_socket();
+
+	/*Radius stuff*/
+
+	printf("Basic MAC\n");
+	memset(MyBasicMac, 0, 6);
+	if (get_mac_addr("br-wan", MyBasicMac) == 0) {
+		printf("APC: br-wan mac:%02X:%02X:%02X:%02X:%02X:%02X\n",
+								MyBasicMac[0],
+								MyBasicMac[1],
+								MyBasicMac[2],
+								MyBasicMac[3],
+								MyBasicMac[4],
+								MyBasicMac[5]);
+	}
+	else {
+		printf("Failed to get AP br-wan mac\n");
+	}
+
+	/*get local ip of br-wan*/
+	MyIpAddr = 0;
+	while(1)
+	{
+		GetLocalIpv4Addr((unsigned char *)&MyIpAddr, "br-wan");
+		MyIpAddr = ntohl(MyIpAddr);
+		if (MyIpAddr && (MyIpAddr != 0xC0A8010A))
+			break;
+
+		sleep(1);
+	}
+
+	/*listening interAP*/
+	callback cb = receive_from_socket;
+	if (interap_recv(IAC_APC_ELECTION_PORT, cb, 1000,
+			 loop, &iac_io) < 0)
+		printf("Error: Failed InterAP receive");
+
+	memset(Timers, 0, sizeof(Timers));
+	
+	memset(&c, 0, sizeof(struct proto_config));
+	c.protocol = &proto_apc;
+	c.name = proto_apc.name;
+	c.preference = proto_apc.preference;
+	c.debug = 1;
+	c.router_id = MyIpAddr;
+	apc_proto = proto_apc.init(&c);
+	ApcProto = (struct apc_proto *)apc_proto;
+	proto_apc.start(apc_proto);
+
+	ev_timer_init(&check_timer, check_timer_handler, 1, 1);
+
+	ev_timer_start(loop, &check_timer);
+
+	ev_run(loop, 0);
+
+	return(1);
+}
+

--- a/feeds/wlan-ap/apc/src/src/hello.c
+++ b/feeds/wlan-ap/apc/src/src/hello.c
@@ -1,0 +1,356 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <apc.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <interap/interAPcomm.h>
+
+struct apc_hello2_packet
+{
+	u8 basmac[6];
+	u16 dummy1;
+	u32 grpid;
+	u32 netmask;
+	u16 helloint;
+	u8 options;
+	u8 priority;
+	u32 deadint;
+	u32 dr;
+	u32 bdr;
+	
+	u32 neighbors[APC_MAX_NEIGHBORS];
+};
+
+extern unsigned int MyIpAddr;
+extern unsigned int WaitingToReelect;
+extern unsigned int ApcGrpId;
+extern unsigned char MyBasicMac[6];
+extern unsigned int RestartProxy;
+extern unsigned int FloatingIpSaved;
+extern unsigned int BackingUpRadius;
+extern struct apc_spec ApcSpecSaved;
+static int ApcNeighborsFound[APC_MAX_NEIGHBORS];
+
+u32 DrIp = 0;
+unsigned int DrCount = 0;
+
+/* Get current ip broadcast address */
+int get_current_ip(char *ip, char *iface) {
+
+	int fd;
+	struct ifreq ifr;
+
+	if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+		printf("Error: socket failed");
+		return -1;
+	}
+
+	ifr.ifr_addr.sa_family = AF_INET;
+	strncpy(ifr.ifr_name, iface, IFNAMSIZ-1);
+
+	if ((ioctl(fd, SIOCGIFBRDADDR, &ifr)) < 0) {
+		printf("Error: ioctl failed");
+		return -1;
+	}
+
+	memcpy(ip, inet_ntoa(((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr),
+	       16);
+
+	close(fd);
+
+	return 0;
+}
+
+
+
+static int apc_check_neighbor_list(u32 Ip, u8 * Mac, int CheckForMissing )
+{
+	int i;
+
+	for(i=1; i<APC_MAX_NEIGHBORS; i++ )
+	{
+		if (CheckForMissing )
+		{
+			if (ApcSpecSaved.Neighbors[i].Ip == 0 )
+				return(0 );
+			if (!ApcNeighborsFound[i] )
+				return(1 );    /* Old list has more entries than new */
+		}
+		else
+		{
+			if (ApcSpecSaved.Neighbors[i].Ip == 0 )
+				break;
+			if (ApcSpecSaved.Neighbors[i].Ip == Ip )
+			{
+				ApcNeighborsFound[i] = 1;
+				/* Existing neighbor - check if MAC is the same */
+				if (memcmp(ApcSpecSaved.Neighbors[i].BasicMac,
+						 Mac, 6)== 0 )
+					return(0 );    /* Existing neighbor */
+				else
+					return(1 );    /* Something changed */
+			}
+		}
+	}
+	return(1 );                                /* New neighbor */
+}
+
+
+void apc_send_hello(struct apc_iface * ifa, int kind )
+{
+	int i;
+	struct apc_neighbor * neigh;
+	u32 * neighbors;
+	struct apc_hello2_packet ps;
+	unsigned int length, report = 0;
+	struct apc_spec ApcSpec;
+	
+	if (WaitingToReelect )
+		return;
+	
+	memcpy(ps.basmac, MyBasicMac, 6 );
+	ps.dummy1 = htons(0xa2a2 );
+	ps.grpid = htonl(ApcGrpId );
+	ps.netmask = htonl(MyIpAddr );
+	ps.helloint = htons(ifa->helloint );
+	ps.options = 0;
+	ps.priority = ifa->priority;
+	ps.deadint = htonl(ifa->deadint );
+	ps.dr = htonl(ipa_to_u32(ifa->drip));
+	ps.bdr = htonl(ipa_to_u32(ifa->bdrip));
+
+	if (DrIp == ifa->drip )
+		DrCount += 1;
+	else
+		DrCount = 0;
+	
+	DrIp = ifa->drip;
+	if (DrCount >= 2 )
+	{
+		report = 1;
+		memset(&ApcSpec, 0, sizeof(struct apc_spec));
+		memset(ApcNeighborsFound, 0, sizeof(ApcNeighborsFound));
+		if (ifa->drip == MyIpAddr )
+			ApcSpec.IsApc = I_AM_APC;
+		if (ifa->bdrip == MyIpAddr )
+			ApcSpec.IsApc = I_AM_BAPC;
+		ApcSpec.Neighbors[0].Ip = ifa->drip;
+	}
+	
+	length = 32;
+	neighbors = ps.neighbors;
+	
+	i = 0;
+
+	/* Fill all neighbors */
+	if (kind != OHS_SHUTDOWN)
+	{
+		WALK_LIST(neigh, ifa->neigh_list)
+		{
+			if (i == APC_MAX_NEIGHBORS)
+			{
+				printf("Too many neighbors\n" );
+				break;
+			}
+			neighbors[i] = htonl(neigh->rid );
+			if (report)
+			{
+				ApcSpec.Neighbors[i+1].Ip = neigh->rid;
+				memcpy(&(ApcSpec.Neighbors[i+1].BasicMac[0]),
+					 neigh->basic_mac, 6);
+			if (apc_check_neighbor_list(neigh->rid,
+						    neigh->basic_mac, 0))
+				ApcSpec.Changed = 1;
+			}
+			i++;
+		}
+	}
+	if (report )
+	{
+		if (apc_check_neighbor_list(0, 0, 1))
+			ApcSpec.Changed = 1;
+		if ((ApcSpec.IsApc == I_AM_APC) && (ApcSpecSaved.Neighbors[0].Ip == 0) )
+			ApcSpec.Changed = 1;   /* Single AP became APC - has no neighbors */
+		if (ApcSpec.IsApc == I_AM_APC )
+		{
+			ifa->priority = 0x22;
+			if (ApcSpec.Changed || RestartProxy )
+			{
+				int n_neigh = i+1;
+				unsigned int Neigh[APC_MAX_NEIGHBORS];
+				int ii;
+				
+				for(ii=0; ii<n_neigh; ii++ )
+					Neigh[ii] = ApcSpec.Neighbors[ii].Ip;
+				//Radius stuff
+				if (RestartProxy )
+					RestartProxy = 0;
+			}
+			else
+				ApcSpec.FloatIp = ApcSpecSaved.FloatIp;
+		}
+		else
+		{
+			ifa->priority = 0x11;
+			if ((ApcSpecSaved.IsApc == I_AM_APC) || BackingUpRadius )
+			{
+				//radius stuff
+				FloatingIpSaved = 0;
+				BackingUpRadius = 0;
+			}
+		}
+	}
+
+	length += i * sizeof(u32);
+
+	printf("HELLO packet sent via %s\n", ifa->ifname );
+	char *dst_ip = malloc(16);
+	memset(dst_ip, 0, 16);
+	if ((get_current_ip(dst_ip, IAC_IFACE)) < 0) {
+		printf("Error: Cannot get IP for %s", IAC_IFACE);
+		return;
+	}
+
+	interap_send(IAC_APC_ELECTION_PORT, dst_ip, &ps , length);
+}
+
+
+void apc_receive_hello(unsigned char *pkt, struct apc_iface *ifa,
+                        struct apc_neighbor *n, ip_addr faddr,
+			unsigned int plen)
+{
+	char * err_dsc = NULL;
+	u32 rcv_iface_id, rcv_helloint, rcv_deadint, rcv_dr, rcv_bdr, rcv_grpid;
+	u8 rcv_options, rcv_priority;
+	u32 * neighbors;
+	u32 neigh_count;
+	uint i, err_val = 0;
+	struct apc_hello2_packet * ps = (struct apc_hello2_packet *)pkt;
+	u32 rcv_rid = ntohl(ps->netmask );
+
+	/* RFC 2328 10.5 */
+	/*
+	 * We may not yet have the associate neighbor, so we use Router ID
+	   from the packet instead of one from the neighbor structure for log
+	   messages.
+	 */
+
+	rcv_iface_id = 0;
+	rcv_grpid = ntohl(ps->grpid );
+	rcv_helloint = ntohs(ps->helloint );
+	rcv_deadint = ntohl(ps->deadint );
+	rcv_dr = ntohl(ps->dr );
+	rcv_bdr = ntohl(ps->bdr );
+	rcv_options = ps->options;
+	rcv_priority = ps->priority;
+
+	if (rcv_grpid != ApcGrpId )
+		return;
+
+	neighbors = ps->neighbors;
+	neigh_count = (plen - 24) / sizeof(u32);
+	printf("HELLO packet received from nbr %x on %s (%u) %p n_c=%u prio=%u\n", rcv_rid, ifa->ifname, ifa->state, n, neigh_count, rcv_priority );
+	
+	if (rcv_helloint != ifa->helloint)
+	DROP("hello interval mismatch", rcv_helloint );
+	
+	if (rcv_deadint != ifa->deadint )
+	DROP("dead interval mismatch", rcv_deadint );
+
+	/* Check consistency of existing neighbor entry */
+	if (n)
+	{
+		uint t = ifa->type;
+		
+		if (t == APC_IT_BCAST)
+		{
+			/* Neighbor identified by IP address;
+			   Router ID may change */
+			if (n->rid != rcv_rid)
+			{
+				printf("Neighbor %x on %s changed Router ID to %x",
+				                n->rid, ifa->ifname, rcv_rid );
+				apc_neigh_sm(n, INM_KILLNBR);
+				n = NULL;
+			}
+		}
+	}
+
+	if (!n )
+	{
+		printf("New neighbor %x on %s, IP address %x\n",
+		                rcv_rid, ifa->ifname, faddr );
+		
+		n = apc_neighbor_new(ifa );
+		
+		memcpy(n->basic_mac, ps->basmac, 6 );
+		n->rid = rcv_rid;
+		n->ip = faddr;
+		n->dr = rcv_dr;
+		n->bdr = rcv_bdr;
+		n->priority = rcv_priority;
+		n->iface_id = rcv_iface_id;
+	}
+
+	u32 n_id = ipa_to_u32(n->ip );
+	
+	u32 old_dr = n->dr;
+	u32 old_bdr = n->bdr;
+	u32 old_priority = n->priority;
+	u32 old_iface_id = n->iface_id;
+	
+	n->dr = rcv_dr;
+	n->bdr = rcv_bdr;
+	n->priority = rcv_priority;
+	n->iface_id = rcv_iface_id;
+	
+	/* Update inactivity timer */
+	apc_neigh_sm(n, INM_HELLOREC);
+
+	/* Examine list of neighbors */
+	for(i = 0; i < neigh_count; i++ )
+	{
+		if (neighbors[i] == htonl(MyIpAddr))
+			goto found_self;
+	}
+	
+	apc_neigh_sm(n, INM_1WAYREC );
+	return;
+
+found_self:
+
+	apc_neigh_sm(n, INM_2WAYREC);
+	
+	if (n->iface_id != old_iface_id)
+	{
+		/* If neighbor is DR, also update cached DR interface ID */
+		if (ifa->drid == n->rid)
+			ifa->dr_iface_id = n->iface_id;
+	}
+	
+	if (ifa->state == APC_IS_WAITING)
+	{
+		/* Neighbor is declaring itself DR (and there is no BDR)
+		 or as BDR */
+		if (((n->dr == n_id) && (n->bdr == 0)) || (n->bdr == n_id))
+			apc_iface_sm(ifa, ISM_BACKS);
+	}
+	else
+		if (ifa->state >= APC_IS_DROTHER )
+		{
+			/* Neighbor changed priority or started/stopped
+			   declaring itself as DR/BDR */
+			if ((n->priority != old_priority) ||
+			    ((n->dr == n_id) && (old_dr != n_id)) ||
+			    ((n->dr != n_id) && (old_dr == n_id)) ||
+			    ((n->bdr == n_id) && (old_bdr != n_id)) ||
+			    ((n->bdr != n_id) && (old_bdr == n_id)) )
+			    apc_iface_sm(ifa, ISM_NEICH );
+		}
+	return;
+
+drop:
+
+	printf("Bad HELLO packet from nbr %x on %s - (%s) (%u)",
+                    rcv_rid, ifa->ifname, err_dsc, err_val );
+}
+

--- a/feeds/wlan-ap/apc/src/src/iface.c
+++ b/feeds/wlan-ap/apc/src/src/iface.c
@@ -1,0 +1,188 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <apc.h>
+
+const char *apc_is_names[] = {
+	"Down", "Loopback", "Waiting", "PtP", "DROther", "Backup", "DR"
+};
+
+const char *apc_ism_names[] = {
+	"InterfaceUp", "WaitTimer", "BackupSeen", "NeighborChange",
+	"LoopInd", "UnloopInd", "InterfaceDown"
+};
+
+char * IfName = "br-wan";
+
+extern struct apc_iface * apc_ifa;
+extern unsigned int MyIpAddr;
+
+
+static void hello_timer_hook(struct _timer * tmr)
+{
+	apc_send_hello(tmr->data, OHS_HELLO);
+}
+
+
+static void wait_timer_hook(struct _timer * tmr)
+{
+	struct apc_iface * ifa = (struct apc_iface *)tmr->data;
+	
+	printf("Wait timer fired on %s", ifa->ifname);
+	apc_iface_sm(ifa, ISM_WAITF);
+}
+
+
+static inline void
+apc_sk_join_dr(struct apc_iface *ifa)
+{
+	if (ifa->sk_dr)
+		return;
+	
+	ifa->sk_dr = 1;
+}
+
+static inline void
+apc_sk_leave_dr(struct apc_iface *ifa)
+{
+	if (!ifa->sk_dr)
+		return;
+	
+	ifa->sk_dr = 0;
+}
+
+
+/**
+ * apc_iface_chstate - handle changes of interface state
+ * @ifa: APC interface
+ * @state: new state
+ *
+ * Many actions must be taken according to interface state changes. New network
+ * LSAs must be originated, flushed, new multicast sockets to listen for messages for
+ * %ALLDROUTERS have to be opened, etc.
+ */
+void apc_iface_chstate(struct apc_iface * ifa, u8 state)
+{
+	u8 oldstate = ifa->state;
+	
+	if (state == oldstate)
+		return;
+	
+	printf("Interface %s changed state from %s to %s\n",
+		ifa->ifname, apc_is_names[oldstate], apc_is_names[state]);
+	
+	ifa->state = state;
+
+	if ((ifa->type == APC_IT_BCAST) && ipa_nonzero(ifa->des_routers))
+	{
+		if ((state == APC_IS_BACKUP) || (state == APC_IS_DR))
+			apc_sk_join_dr(ifa);
+		else
+			apc_sk_leave_dr(ifa);
+	}
+}
+
+
+/**
+ * apc_iface_sm - APC interface state machine
+ * @ifa: APC interface
+ * @event: event comming to state machine
+ *
+ * This fully respects 9.3 of RFC 2328 except we have slightly
+ * different handling of %DOWN and %LOOP state. We remove intefaces
+ * that are %DOWN. %DOWN state is used when an interface is waiting
+ * for a lock. %LOOP state is used when an interface does not have a
+ * link.
+ */
+void apc_iface_sm(struct apc_iface * ifa, int event)
+{
+	printf("Iface SM Event is '%s' (%u)\n", apc_ism_names[event], ifa->state);
+
+	switch(event)
+	{
+	case ISM_UP:
+		if (ifa->state <= APC_IS_LOOP)
+		{
+			if (ifa->priority == 0)
+				apc_iface_chstate( ifa, APC_IS_DROTHER );
+			else
+			{
+				apc_iface_chstate( ifa, APC_IS_WAITING );
+				if (ifa->wait_timer)
+					tm_start(ifa->wait_timer, ifa->waitint);
+			}
+		
+			if (ifa->hello_timer)
+				tm_start( ifa->hello_timer, ifa->helloint );
+			
+			if (ifa->poll_timer)
+				tm_start( ifa->poll_timer, ifa->pollint );
+			
+			apc_send_hello(ifa, OHS_HELLO);
+		}
+		break;
+
+	case ISM_BACKS:
+	case ISM_WAITF:
+		if (ifa->state == APC_IS_WAITING)
+			apc_dr_election(ifa);
+		break;
+
+	case ISM_NEICH:
+		if (ifa->state >= APC_IS_DROTHER)
+			apc_dr_election(ifa);
+		break;
+
+	case ISM_LOOP:
+		if ((ifa->state > APC_IS_LOOP) && ifa->check_link)
+			apc_iface_chstate(ifa, APC_IS_LOOP);
+		break;
+
+	case ISM_UNLOOP:
+		/* Immediate go UP */
+		if (ifa->state == APC_IS_LOOP)
+			apc_iface_sm(ifa, ISM_UP);
+		break;
+
+	case ISM_DOWN:
+		apc_iface_chstate(ifa, APC_IS_DOWN);
+		break;
+
+	default:
+		printf("APC_I_SM - Unknown event?" );
+		break;
+	}
+}
+
+
+void apc_iface_new( void )
+{
+	struct apc_iface * ifa;
+	printf("apc new iface\n");
+	ifa = mb_allocz(sizeof(struct apc_iface));
+	ifa->iface = NULL;
+	ifa->addr = NULL;
+	ifa->cf = NULL;
+	
+	ifa->iface_id = 1;
+	ifa->ifname = IfName;
+	
+	ifa->priority = 0x11;
+	ifa->drip = MyIpAddr;
+	ifa->helloint = 4;
+	ifa->deadint = 16;
+	ifa->waitint = 16;
+	
+	ifa->type = APC_IT_BCAST;
+	ifa->state = APC_IS_DOWN;
+	init_list(&(ifa->neigh_list));
+	
+	ifa->hello_timer = tm_new_set(hello_timer_hook, ifa, 0, ifa->helloint);
+	
+	ifa->wait_timer = tm_new_set(wait_timer_hook, ifa, 0, 0);
+	
+	apc_ifa = ifa;
+	
+	/* Do iface UP, unless there is no link and we use link detection */
+	apc_iface_sm(ifa, ISM_UP);
+}
+
+

--- a/feeds/wlan-ap/apc/src/src/neighbor.c
+++ b/feeds/wlan-ap/apc/src/src/neighbor.c
@@ -1,0 +1,506 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+#include <apc.h>
+
+const char *apc_ns_names[] = {
+	"Down", "Attempt", "Init", "2-Way", "ExStart", "Exchange", "Loading",
+	"Full"
+};
+
+const char *apc_inm_names[] = {
+	"HelloReceived", "Start", "2-WayReceived", "NegotiationDone",
+	"ExchangeDone",	"BadLSReq", "LoadingDone", "AdjOK?",
+	"SeqNumberMismatch", "1-WayReceived",
+	"KillNbr", "InactivityTimer", "LLDown"
+};
+
+
+static int can_do_adj(struct apc_neighbor *n);
+static void inactivity_timer_hook(struct _timer * tmr);
+
+extern struct apc_iface * apc_ifa;
+extern struct apc_proto * ApcProto;
+extern unsigned int MyIpAddr;
+extern unsigned int WaitingToReelect;
+
+unsigned int BackingUpRadius = 0;
+
+/* Resets LSA request and retransmit lists.
+ * We do not reset DB summary list iterator here,
+ * it is reset during entering EXCHANGE state.
+ */
+static void
+reset_lists(struct apc_proto *p, struct apc_neighbor *n)
+{
+}
+
+
+struct apc_neighbor * apc_neighbor_new(struct apc_iface * ifa)
+{
+	struct apc_neighbor * n = mb_allocz(sizeof(struct apc_neighbor));
+	
+	n->ifa = ifa;
+	add_tail(&ifa->neigh_list, NODE n);
+	n->adj = 0;
+	n->csn = 0;
+	n->state = NEIGHBOR_DOWN;
+	
+	init_list(&n->ackl[ACKL_DIRECT]);
+	init_list(&n->ackl[ACKL_DELAY]);
+	
+	n->inactim = tm_new_set(inactivity_timer_hook, n, 0, 0);
+	
+	return(n);
+}
+
+
+static void apc_neigh_down(struct apc_neighbor * n)
+{
+	struct apc_iface * ifa = n->ifa;
+	
+	rem_node(NODE n);
+	
+	printf("Neighbor %x on %s removed", n->rid, ifa->ifname );
+}
+
+
+/**
+ * apc_neigh_chstate - handles changes related to new or lod state of neighbor
+ * @n: APC neighbor
+ * @state: new state
+ *
+ * Many actions have to be taken acording to a change of state of a neighbor. It
+ * starts rxmt timers, call interface state machine etc.
+ */
+static void apc_neigh_chstate(struct apc_neighbor * n, u8 state)
+{
+	struct apc_iface * ifa = n->ifa;
+	struct apc_proto * p = ApcProto;
+	u8 old_state = n->state;
+	
+	if (state == old_state)
+		return;
+	
+	printf("Neighbor %x on %s changed state from %s to %s\n",
+	                n->rid, ifa->ifname, apc_ns_names[old_state], apc_ns_names[state] );
+	
+	n->state = state;
+
+	/* Increase number of partial adjacencies */
+	if ((state == NEIGHBOR_EXCHANGE) || (state == NEIGHBOR_LOADING))
+		p->padj++;
+	
+	/* Decrease number of partial adjacencies */
+	if ((old_state == NEIGHBOR_EXCHANGE) || (old_state == NEIGHBOR_LOADING))
+		p->padj--;
+	
+	/* Increase number of full adjacencies */
+	if (state == NEIGHBOR_FULL)
+		ifa->fadj++;
+	
+	/* Decrease number of full adjacencies */
+	if (old_state == NEIGHBOR_FULL)
+		ifa->fadj--;
+
+	if (state == NEIGHBOR_EXSTART)
+	{
+		/* First time adjacency */
+		if (n->adj == 0)
+			n->dds = 111;//+random_u32();
+		
+		n->dds++;
+		n->myimms = DBDES_IMMS;
+	}
+
+	if (state > NEIGHBOR_EXSTART)
+		n->myimms &= ~DBDES_I;
+	
+	/* Generate NeighborChange event if needed, see RFC 2328 9.2 */
+	if ((state == NEIGHBOR_2WAY) && (old_state < NEIGHBOR_2WAY))
+		apc_iface_sm( ifa, ISM_NEICH );
+	if ((state < NEIGHBOR_2WAY) && (old_state >= NEIGHBOR_2WAY))
+		apc_iface_sm(ifa, ISM_NEICH);
+}
+
+
+/**
+ * apc_neigh_sm - apc neighbor state machine
+ * @n: neighor
+ * @event: actual event
+ *
+ * This part implements the neighbor state machine as described in 10.3 of
+ * RFC 2328. The only difference is that state %NEIGHBOR_ATTEMPT is not
+ * used. We discover neighbors on nonbroadcast networks in the
+ * same way as on broadcast networks. The only difference is in
+ * sending hello packets. These are sent to IPs listed in
+ * @apc_iface->nbma_list .
+ */
+void apc_neigh_sm(struct apc_neighbor * n, int event)
+{
+	struct apc_proto * p = ApcProto;
+
+	printf("Neighbor state machine for %x on %s, event %s\n",
+		n->rid, n->ifa->ifname, apc_inm_names[event]);
+
+	switch(event)
+	{
+	case INM_START:
+		apc_neigh_chstate(n, NEIGHBOR_ATTEMPT);
+		/* NBMA are used different way */
+		break;
+
+	case INM_HELLOREC:
+		if(n->state < NEIGHBOR_INIT)
+			apc_neigh_chstate(n, NEIGHBOR_INIT);
+		/* Restart inactivity timer */
+		tm_start(n->inactim, n->ifa->deadint);
+		break;
+
+	case INM_2WAYREC:
+		if(n->state < NEIGHBOR_2WAY)
+			apc_neigh_chstate(n, NEIGHBOR_2WAY);
+		if((n->state == NEIGHBOR_2WAY) && can_do_adj(n))
+			apc_neigh_chstate(n, NEIGHBOR_EXSTART);
+		break;
+
+	case INM_NEGDONE:
+		if(n->state == NEIGHBOR_EXSTART)
+			apc_neigh_chstate(n, NEIGHBOR_EXCHANGE);
+		else
+			printf("NEGDONE and I'm not in EXSTART?\n" );
+		break;
+
+	case INM_EXDONE:
+		apc_neigh_chstate(n, NEIGHBOR_FULL);
+		break;
+
+	case INM_LOADDONE:
+		apc_neigh_chstate(n, NEIGHBOR_FULL);
+		break;
+
+	case INM_ADJOK:
+		/* Can In build adjacency? */
+		if ((n->state == NEIGHBOR_2WAY) && can_do_adj(n))
+		{
+			apc_neigh_chstate(n, NEIGHBOR_EXSTART);
+		}
+		else if ((n->state >= NEIGHBOR_EXSTART) && !can_do_adj(n))
+		{
+			reset_lists(p, n);
+			apc_neigh_chstate(n, NEIGHBOR_2WAY);
+		}
+		break;
+
+	case INM_SEQMIS:
+	case INM_BADLSREQ:
+		if (n->state >= NEIGHBOR_EXCHANGE)
+		{
+			reset_lists(p, n);
+			apc_neigh_chstate(n, NEIGHBOR_EXSTART);
+		}
+		break;
+	
+	case INM_KILLNBR:
+	case INM_LLDOWN:
+	case INM_INACTTIM:
+		/* No need for reset_lists() */
+		apc_neigh_chstate(n, NEIGHBOR_DOWN);
+		apc_neigh_down(n);
+		break;
+
+	case INM_1WAYREC:
+		reset_lists(p, n);
+		apc_neigh_chstate(n, NEIGHBOR_INIT);
+		break;
+	
+	default:
+		printf("%s: INM - Unknown event?\n", p->p.name);
+		break;
+	}
+}
+
+
+static int can_do_adj(struct apc_neighbor * n)
+{
+	struct apc_iface * ifa = n->ifa;
+	struct apc_proto * p = ApcProto;
+	int i = 0;
+	
+	switch(ifa->state)
+	{
+	case APC_IS_DOWN:
+	case APC_IS_LOOP:
+		printf("%s: Iface %s in down state?", p->p.name, ifa->ifname);
+		break;
+	
+	case APC_IS_WAITING:
+		printf("%s: Neighbor? on iface %s\n", p->p.name, ifa->ifname);
+		break;
+	
+	case APC_IS_DROTHER:
+		if (((n->rid == ifa->drid) || (n->rid == ifa->bdrid))
+			&& (n->state >= NEIGHBOR_2WAY))
+			i = 1;
+		break;
+	
+	case APC_IS_PTP:
+	case APC_IS_BACKUP:
+	case APC_IS_DR:
+		if (n->state >= NEIGHBOR_2WAY)
+			i = 1;
+		break;
+	
+	default:
+		printf("%s: Iface %s in unknown state?", p->p.name, ifa->ifname);
+		break;
+	}
+	printf("%s: Iface %s can_do_adj=%d\n", p->p.name, ifa->ifname, i);
+	return i;
+}
+
+
+static inline u32 neigh_get_id(struct apc_proto *p, struct apc_neighbor *n)
+{
+	return ipa_to_u32(n->ip);
+}
+
+
+static struct apc_neighbor * elect_bdr( struct apc_proto * p, list nl)
+{
+    struct apc_neighbor *neigh, *n1, *n2;
+    u32 nid;
+
+    n1 = NULL;
+    n2 = NULL;
+    WALK_LIST( neigh, nl )                      /* First try those decl. themselves */
+    {
+        nid = neigh_get_id( p, neigh );
+
+        if( neigh->state >= NEIGHBOR_2WAY )     /* Higher than 2WAY */
+            if( neigh->priority > 0 )           /* Eligible */
+                if( neigh->dr != nid )          /* And not decl. itself DR */
+                {
+                    if( neigh->bdr == nid )     /* Declaring BDR */
+                    {
+                        if( n1 != NULL )
+                        {
+                            if( neigh->priority > n1->priority )
+                                n1 = neigh;
+                            else
+                            {
+                                if( neigh->priority == n1->priority )
+                                    if( neigh->rid > n1->rid )
+                                        n1 = neigh;
+                            }
+                        }
+                        else
+                            n1 = neigh;
+                    }
+                    else                        /* And NOT declaring BDR */
+                    {
+                        if( n2 != NULL )
+                        {
+                            if( neigh->priority > n2->priority )
+                                n2 = neigh;
+                            else
+                                if( neigh->priority == n2->priority )
+                                    if( neigh->rid > n2->rid )
+                                        n2 = neigh;
+                        }
+                        else
+                            n2 = neigh;
+                    }
+                }
+    }
+    if( n1 == NULL )
+        n1 = n2;
+
+    return( n1 );
+}
+
+
+static struct apc_neighbor * elect_dr( struct apc_proto * p, list nl )
+{
+    struct apc_neighbor *neigh, *n;
+    u32 nid;
+
+    n = NULL;
+    WALK_LIST( neigh, nl )                      /* And now DR */
+    {
+        nid = neigh_get_id( p, neigh );
+
+        printf("neigh %p %x %x %x %d\n", n, neigh->dr, neigh->rid, neigh->ip, neigh->state );
+        if( neigh->state >= NEIGHBOR_2WAY )     /* Higher than 2WAY */
+            if( neigh->priority > 0 )           /* Eligible */
+                if( neigh->dr == nid )          /* And declaring itself DR */
+                {
+                    printf("el_dr %p %x %x %x\n", n, neigh->dr, neigh->rid, neigh->ip );
+                    if( n != NULL )
+                    {
+                        if( neigh->priority > n->priority )
+                            n = neigh;
+                        else
+                            if( neigh->priority == n->priority )
+                                if( neigh->rid > n->rid )
+                                    n = neigh;
+                    }
+                    else
+                        n = neigh;
+                }
+    }
+
+    return( n );
+}
+
+
+/**
+ * apc_dr_election - (Backup) Designed Router election
+ * @ifa: actual interface
+ *
+ * When the wait timer fires, it is time to elect (Backup) Designated Router.
+ * Structure describing me is added to this list so every electing router has
+ * the same list. Backup Designated Router is elected before Designated
+ * Router. This process is described in 9.4 of RFC 2328. The function is
+ * supposed to be called only from apc_iface_sm() as a part of the interface
+ * state machine.
+ */
+void apc_dr_election(struct apc_iface * ifa)
+{
+	struct apc_proto * p = ApcProto;
+	struct apc_neighbor *neigh, *ndr, *nbdr, me;
+	u32 myid = p->router_id;
+	u32 old_drid;
+	u32 old_bdrid;
+	
+	me.state = NEIGHBOR_2WAY;
+	me.rid = myid;
+	me.priority = ifa->priority;
+	me.ip = MyIpAddr;
+	
+	me.dr  = ipa_to_u32( ifa->drip );
+	me.bdr = ipa_to_u32( ifa->bdrip );
+	me.iface_id = ifa->iface_id;
+	
+	add_tail( &ifa->neigh_list, NODE & me );
+	
+	nbdr = elect_bdr( p, ifa->neigh_list );
+	ndr = elect_dr( p, ifa->neigh_list );
+	
+	printf("(B)DR election. %p %p\n", ndr, nbdr );
+
+	if (ndr == NULL)
+		ndr = nbdr;
+
+	if (ndr)
+		printf("elect %x %x %x\n", ndr->dr, ndr->rid, ndr->ip);
+	else
+		printf("elect no dr\n");
+
+	if (ndr && nbdr)
+		printf("(B)DR electionIP. %x %x\n", ndr->ip, nbdr->ip);
+
+	/* 9.4. (4) */
+	if (((ifa->drid == myid) && (ndr != &me))
+		|| ((ifa->drid != myid) && (ndr == &me))
+		|| ((ifa->bdrid == myid) && (nbdr != &me))
+		|| ((ifa->bdrid != myid) && (nbdr == &me)))
+	{
+		me.dr = ndr ? neigh_get_id(p, ndr) : 0;
+		me.bdr = nbdr ? neigh_get_id(p, nbdr) : 0;
+		
+		nbdr = elect_bdr(p, ifa->neigh_list);
+		ndr = elect_dr(p, ifa->neigh_list);
+	
+		if (ndr == NULL)
+			ndr = nbdr;
+		if (ndr)
+			printf("elect1 %x %x %x\n", ndr->dr, ndr->rid, ndr->ip);
+		else
+			printf("elect1 no dr\n");
+	}
+
+	rem_node( NODE & me );
+	
+	old_drid = ifa->drid;
+	old_bdrid = ifa->bdrid;
+	
+	ifa->drid = ndr ? ndr->rid : 0;
+	ifa->drip = ndr ? ndr->ip  : IPA_NONE;
+	ifa->dr_iface_id = ndr ? ndr->iface_id : 0;
+	
+	ifa->bdrid = nbdr ? nbdr->rid : 0;
+	ifa->bdrip = nbdr ? nbdr->ip  : IPA_NONE;
+	
+	printf("DR=%x, BDR=%x\n", ifa->drip, ifa->bdrip );
+
+	/* We are part of the interface state machine */
+	if (ifa->drid == myid)
+		apc_iface_chstate(ifa, APC_IS_DR);
+	else
+		if (ifa->bdrid == myid)
+			apc_iface_chstate(ifa, APC_IS_BACKUP);
+		else
+			apc_iface_chstate(ifa, APC_IS_DROTHER);
+
+	/* Review neighbor adjacencies if DR or BDR changed */
+	if ((ifa->drid != old_drid) || (ifa->bdrid != old_bdrid))
+	{
+		WALK_LIST(neigh, ifa->neigh_list)
+		if (neigh->state >= NEIGHBOR_2WAY)
+			apc_neigh_sm(neigh, INM_ADJOK);
+	}
+}
+
+
+struct apc_neighbor * find_neigh_by_ip(struct apc_iface * ifa, ip_addr ip)
+{
+	struct apc_neighbor * n;
+
+	WALK_LIST(n, ifa->neigh_list)
+	{
+		if (ipa_equal(n->ip, ip))
+			return n;
+	}
+	return NULL;
+}
+
+
+static void inactivity_timer_hook(struct _timer * tmr)
+{
+	struct apc_neighbor * n = (struct apc_neighbor *) tmr->data;
+
+	if (WaitingToReelect)
+		return;
+
+	if (n->rid == n->ifa->drip)
+	{
+		struct apc_spec ApcSpec;
+		unsigned int Neigh[APC_MAX_NEIGHBORS];
+		int n_neigh = 0;
+
+		WALK_LIST(n, apc_ifa->neigh_list)
+		{
+			Neigh[n_neigh] = n->rid;
+			n_neigh += 1;
+			tm_stop(n->inactim);
+			rem_node(NODE n);
+		}
+		if (MyIpAddr == apc_ifa->bdrip)
+		{
+			Neigh[n_neigh] = MyIpAddr;
+			n_neigh += 1;
+			//Radius stuff
+			BackingUpRadius = 1;
+		}
+
+		apc_ifa->drip = MyIpAddr;
+		apc_ifa->priority = 0x11;
+		apc_ifa->bdrip = 0;
+		memset(&ApcSpec, 0, sizeof(struct apc_spec));
+		WaitingToReelect = 12;
+		return;
+	}
+	printf("Inactivity timer expired for nbr %x on %s", n->rid, 
+							    n->ifa->ifname);
+	apc_neigh_sm(n, INM_INACTTIM);
+}
+

--- a/feeds/wlan-ap/interAPcomm/Makefile
+++ b/feeds/wlan-ap/interAPcomm/Makefile
@@ -22,12 +22,15 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/include/interap
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) $(PKG_BUILD_DIR)/include/* $(1)/usr/include/interap/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libinterapcomm.so $(1)/usr/lib/
 endef
 
 define Package/libinterapcomm/install
 	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libinterapcomm.so $(1)/usr/lib/
+	$(INSTALL_DATA) ./files/etc/uci-defaults/* $(1)/etc/uci-defaults/
 endef
 $(eval $(call BuildPackage,libinterapcomm))

--- a/feeds/wlan-ap/interAPcomm/files/etc/uci-defaults/10_interapcomm
+++ b/feeds/wlan-ap/interAPcomm/files/etc/uci-defaults/10_interapcomm
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+uci -q batch <<-EOF
+	add firewall rule
+	set firewall.@rule[-1].name='Allow-APC'
+	set firewall.@rule[-1].src='wan'
+	set firewall.@rule[-1].proto='udp'
+	set firewall.@rule[-1].dst_port='50010'
+	set firewall.@rule[-1].target='ACCEPT'
+	set firewall.@rule[-1].family='ipv4'
+        commit firewall
+	add firewall rule
+	set firewall.@rule[-1].name='Allow-UCC'
+	set firewall.@rule[-1].src='wan'
+	set firewall.@rule[-1].proto='udp'
+	set firewall.@rule[-1].dst_port='50000'
+	set firewall.@rule[-1].target='ACCEPT'
+	set firewall.@rule[-1].family='ipv4'
+        commit firewall
+
+EOF

--- a/feeds/wlan-ap/interAPcomm/src/include/interAPcomm.h
+++ b/feeds/wlan-ap/interAPcomm/src/include/interAPcomm.h
@@ -2,11 +2,11 @@
 #include <ev.h>
 int interap_send(unsigned short port, char *dst_ip,
 		 void *data, unsigned int len);
-int interap_recv(unsigned short port, int (*recv_cb)(void *),
+int interap_recv(unsigned short port, int (*recv_cb)(void *, ssize_t),
 		 unsigned int len, struct ev_loop *loop,
 		 ev_io *io);
 
-typedef int (*callback)(void *);
+typedef int (*callback)(void *, int);
 typedef struct recv_arg {
 	callback cb;
 	unsigned int len;

--- a/feeds/wlan-ap/interAPcomm/src/src/interAPcomm.c
+++ b/feeds/wlan-ap/interAPcomm/src/src/interAPcomm.c
@@ -16,7 +16,7 @@ recv_arg ra;
 static void receive_data(struct ev_loop *ev, ev_io *io, int event)
 {
 	void *recv_data;
-	int recv_data_len;
+	ssize_t recv_data_len;
 
 	recv_data = malloc(ra.len);
 	memset(recv_data, 0, ra.len);
@@ -24,11 +24,11 @@ static void receive_data(struct ev_loop *ev, ev_io *io, int event)
 				      0, NULL, 0)) < 0)
 		printf("recvfrom() failed");
 
-	ra.cb(recv_data);
+	ra.cb(recv_data, recv_data_len);
 
 }
 
-int interap_recv(unsigned short port, int (*recv_cb)(void *), unsigned int len,
+int interap_recv(unsigned short port, int (*recv_cb)(void *, ssize_t), unsigned int len,
 		 struct ev_loop *loop, ev_io *io)
 {
 	struct sockaddr_in addr;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/ucc_detect/src/main.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/ucc_detect/src/main.c
@@ -224,7 +224,7 @@ out:
 	return err;
 }
 
-int recv_process(void *data) {
+int recv_process(void *data, ssize_t len) {
 	struct nl_sock *nlsock;
 	unsigned int mcgroups = 0;
 


### PR DESCRIPTION
Add algorithm which chooses a APC (Access Point Coordinator) and backup APC among the APs in a subnet.

This APC can be used to perform few functions on behalf of the APs on the subnet once that functionality is added. For example it can act as a radius proxy (which is to be implemented later) for the APs in the subnet.