### PR TITLE
Wifi-1002 correct VIF deletion function.

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -328,8 +328,7 @@ static void periodic_task(void *arg)
 		struct uci_section *s = uci_to_section(e);
 
 		if (!strcmp(s->type, "wifi-iface"))
-			if (vif_find(s->e.name))
-				vif_state_update(s, NULL);
+			vif_state_update(s, NULL);
 	}
 	uci_unload(uci, wireless);
 	LOGT("periodic: stop state update ");

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vlan.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vlan.c
@@ -40,7 +40,7 @@ int avl_intcmp(const void *k1, const void *k2, void *ptr)
 }
 
 static struct avl_tree vlan_tree = AVL_TREE_INIT(vlan_tree, avl_intcmp, false, NULL);
-static struct avl_tree vif_tree = AVL_TREE_INIT(vlan_tree, avl_strcmp, false, NULL);
+static struct avl_tree vif_tree = AVL_TREE_INIT(vif_tree, avl_strcmp, false, NULL);
 
 struct vlan *vlan_find(int vid)
 {


### PR DESCRIPTION
Report VIF state for all wifi-iface in UCI.
Report operational state as up or down.
Use ifname not UCI section name for VIF deletion.

Signed-off-by: Rick Sommerville <rick.sommerville@netexperience.com>