### PR TITLE
opensync: add timestamp_ms to protobuf and dppline

### DIFF
--- a/feeds/wlan-ap/opensync/patches/23-add-timestamp-to-events.patch
+++ b/feeds/wlan-ap/opensync/patches/23-add-timestamp-to-events.patch
@@ -1,0 +1,254 @@
+Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
+===================================================================
+--- opensync-2.0.5.0.orig/interfaces/opensync_stats.proto
++++ opensync-2.0.5.0/interfaces/opensync_stats.proto
+@@ -692,6 +692,7 @@ message EventReport {
+         optional bool                   using11k                            = 9;
+         optional bool                   using11r                            = 10;
+         optional bool                   using11v                            = 11;
++        optional uint32                 timestamp_ms                        = 12;
+     }
+ 
+     /* Client Authentication Event */
+@@ -701,6 +702,7 @@ message EventReport {
+         optional string                 ssid                                = 3;
+         optional RadioBandType          band                                = 4;
+         optional uint32                 auth_status                         = 5;
++        optional uint32                 timestamp_ms                        = 6;
+     }
+ 
+     /* Client Disconnect Event */
+@@ -716,6 +718,7 @@ message EventReport {
+         optional int32                  rssi                                = 9;
+         optional string                 ssid                                = 10;
+         optional RadioBandType          band                                = 11;
++        optional uint32                 timestamp_ms                        = 12;
+     }
+ 
+     /* Client Connnect Event */
+@@ -740,6 +743,7 @@ message EventReport {
+         optional bool                   using11v                            = 18;
+         optional int64                  ev_time_bootup_in_us_ip             = 19;
+         optional int32                  assoc_rssi                          = 20;
++        optional uint32                 timestamp_ms                        = 21;
+     }
+ 
+     /* Client Failure Event */
+@@ -749,6 +753,7 @@ message EventReport {
+         optional string                 ssid                                = 3;
+         optional int32                  reason_code                         = 4;
+         optional string                 reason_str                          = 5;
++        optional uint32                 timestamp_ms                        = 6;
+     }
+ 
+     /* Client First Data Event */
+@@ -757,6 +762,7 @@ message EventReport {
+         optional uint64                 session_id                          = 2;
+         optional uint64                 fdata_tx_up_ts_in_us                = 3;
+         optional uint64                 fdata_rx_up_ts_in_us                = 4;
++        optional uint32                 timestamp_ms                        = 5;
+     }
+ 
+     /* Client Id Event */
+@@ -764,6 +770,7 @@ message EventReport {
+         optional string                 clt_mac                             = 1;
+         optional uint64                 session_id                          = 2;
+         optional string                 clt_id                              = 3;
++        optional uint32                 timestamp_ms                        = 4;
+     }
+ 
+     /* Client IP Event */
+@@ -771,6 +778,7 @@ message EventReport {
+         optional string                 sta_mac                             = 1;
+         optional uint64                 session_id                          = 2;
+         optional bytes                  ip_addr                             = 3;
++        optional uint32                 timestamp_ms                        = 4;
+     }
+ 
+     /* Client Timeout Event */
+@@ -780,6 +788,7 @@ message EventReport {
+         optional CTReasonType           r_code                              = 3;
+         optional uint64                 last_sent_up_ts_in_us               = 4;
+         optional uint64                 last_rcv_up_ts_in_us                = 5;
++        optional uint32                 timestamp_ms                        = 6;
+     }
+ 
+     /* Client Session */
+Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/datapipeline/src/dppline.c
++++ opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
+@@ -2617,7 +2617,8 @@ static void dppline_add_stat_ucc(Sts__Re
+ 		       sizeof(ucc->record.sip_call_start.provider_domain));
+ 		sr->call_start->channel = ucc->record.sip_call_start.channel;
+ 		sr->call_start->has_channel = true;
+-		sr->call_start->band = dppline_to_proto_radio(ucc->record.sip_call_start.band);
++		sr->call_start->band =
++			dppline_to_proto_radio(ucc->record.sip_call_start.band);
+ 		break;
+ 
+ 	case PKT_TYPE_CALL_STOP:
+@@ -2652,16 +2653,18 @@ static void dppline_add_stat_ucc(Sts__Re
+ 		sr->call_stop->has_reason = true;
+ 		sr->call_stop->channel = ucc->record.sip_call_stop.channel;
+ 		sr->call_stop->has_channel = true;
+-		sr->call_stop->band = dppline_to_proto_radio(ucc->record.sip_call_stop.band);
++		sr->call_stop->band =
++			dppline_to_proto_radio(ucc->record.sip_call_stop.band);
+ 
+-		sr->call_stop->provider_domain = malloc(sizeof(ucc->record.sip_call_stop.provider_domain));
++		sr->call_stop->provider_domain = malloc(
++			sizeof(ucc->record.sip_call_stop.provider_domain));
+ 
+ 		size += sizeof(ucc->record.sip_call_stop.provider_domain);
+ 		assert(sr->call_stop->provider_domain);
+ 
+ 		memcpy(sr->call_stop->provider_domain,
+-				ucc->record.sip_call_stop.provider_domain,
+-				sizeof(ucc->record.sip_call_stop.provider_domain));
++		       ucc->record.sip_call_stop.provider_domain,
++		       sizeof(ucc->record.sip_call_stop.provider_domain));
+ 
+ 		break;
+ 
+@@ -2698,16 +2701,18 @@ static void dppline_add_stat_ucc(Sts__Re
+ 		sr->call_report->has_reason = true;
+ 		sr->call_report->channel = ucc->record.sip_call_report.channel;
+ 		sr->call_report->has_channel = true;
+-		sr->call_report->band = dppline_to_proto_radio(ucc->record.sip_call_report.band);
++		sr->call_report->band = dppline_to_proto_radio(
++			ucc->record.sip_call_report.band);
+ 
+-		sr->call_report->provider_domain = malloc(sizeof(ucc->record.sip_call_report.provider_domain));
++		sr->call_report->provider_domain = malloc(
++			sizeof(ucc->record.sip_call_report.provider_domain));
+ 
+ 		size += sizeof(ucc->record.sip_call_report.provider_domain);
+ 		assert(sr->call_report->provider_domain);
+ 
+ 		memcpy(sr->call_report->provider_domain,
+-				ucc->record.sip_call_report.provider_domain,
+-				sizeof(ucc->record.sip_call_report.provider_domain));
++		       ucc->record.sip_call_report.provider_domain,
++		       sizeof(ucc->record.sip_call_report.provider_domain));
+ 		break;
+ 
+ 	default:
+@@ -2931,6 +2936,7 @@ static void dppline_add_stat_events(Sts_
+ 				}
+ 
+ 				drx->ssid = strdup(srx->ssid);
++				LOG(INFO, "drx->ssid: %s", drx->ssid);
+ 
+ 				if (srx->band) {
+ 					drx->band = dppline_to_proto_radio(
+@@ -2974,6 +2980,13 @@ static void dppline_add_stat_events(Sts_
+ 					drx->using11v = srx->using11v;
+ 					drx->has_using11v = true;
+ 				}
++
++				LOG(INFO, "srx->timestamp: %d", srx->timestamp);
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
++				LOG(INFO, "drx->timestamp_ms: %d", drx->timestamp_ms);
+ 			}
+ 
+ 			/* Client Auth Event */
+@@ -3032,6 +3045,11 @@ static void dppline_add_stat_events(Sts_
+ 					drx->auth_status = srx->auth_status;
+ 					drx->has_auth_status = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Disconnect Event */
+@@ -3130,6 +3148,11 @@ static void dppline_add_stat_events(Sts_
+ 						srx->band);
+ 					drx->has_band = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Connect Event */
+@@ -3286,6 +3309,11 @@ static void dppline_add_stat_events(Sts_
+ 					drx->assoc_rssi = srx->assoc_rssi;
+ 					drx->has_assoc_rssi = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Failure Event */
+@@ -3344,6 +3372,11 @@ static void dppline_add_stat_events(Sts_
+ 				}
+ 
+ 				drx->reason_str = strdup(srx->reason_str);
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client First Data Event */
+@@ -3405,6 +3438,11 @@ static void dppline_add_stat_events(Sts_
+ 						srx->fdata_rx_up_ts_in_us;
+ 					drx->has_fdata_rx_up_ts_in_us = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Id Event */
+@@ -3452,6 +3490,11 @@ static void dppline_add_stat_events(Sts_
+ 				}
+ 
+ 				drx->clt_id = strdup(srx->clt_id);
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Ip Event */
+@@ -3503,6 +3546,11 @@ static void dppline_add_stat_events(Sts_
+ 					drx->ip_addr.len = 16;
+ 					drx->has_ip_addr = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 
+ 			/* Client Timeout Event */
+@@ -3571,6 +3619,11 @@ static void dppline_add_stat_events(Sts_
+ 						srx->last_recv_up_ts_in_us;
+ 					drx->has_last_rcv_up_ts_in_us = true;
+ 				}
++
++				if (srx->timestamp) {
++					drx->timestamp_ms = srx->timestamp;
++					drx->has_timestamp_ms = true;
++				}
+ 			}
+ 		}
+ 	}

--- a/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
+++ b/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
@@ -149,6 +149,7 @@ typedef struct {
 	char __barrier[46];
 	mac_address_t clt_mac;
 	uint64_t session_id;
+	uint32_t timestamp;
 	char clt_id[DPP_CLT_ID_LEN];
 
 	ds_dlist_node_t node;


### PR DESCRIPTION
- added missing timestamp field in **opensync_stats.proto**
