### PR TITLE
interap: fix compilation error

### DIFF
--- a/feeds/wlan-ap/interAPcomm/src/include/interAPcomm.h
+++ b/feeds/wlan-ap/interAPcomm/src/include/interAPcomm.h
@@ -6,7 +6,7 @@ int interap_recv(unsigned short port, int (*recv_cb)(void *, ssize_t),
 		 unsigned int len, struct ev_loop *loop,
 		 ev_io *io);
 
-typedef int (*callback)(void *, int);
+typedef int (*callback)(void *, ssize_t);
 typedef struct recv_arg {
 	callback cb;
 	unsigned int len;


### PR DESCRIPTION
fix compilation error in interapcommlib

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>