### PR TITLE
hostapd: ClientIpEvent

### DIFF
--- a/feeds/wifi-trunk/hostapd/patches/900-hapd-netlink-ubus-bridge.patch
+++ b/feeds/wifi-trunk/hostapd/patches/900-hapd-netlink-ubus-bridge.patch
@@ -116,36 +116,6 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ieee802_11.c
  	return ret;
  }
  
-@@ -5487,6 +5528,14 @@ void hostapd_tx_status(struct hostapd_da
- 	}
- 
- 	ieee802_1x_tx_status(hapd, sta, buf, len, ack);
-+	/* ubus request */
-+	if (!sta->fdata) {
-+		struct hostapd_ubus_request req = {
-+			.type = HOSTAPD_UBUS_FDATA_REQ,
-+			.sta = sta
-+		};
-+		hostapd_ubus_handle_rt_event(hapd, &req);
-+	}
- }
- 
- 
-@@ -5514,6 +5563,14 @@ void hostapd_eapol_tx_status(struct host
- 	}
- 
- 	ieee802_1x_eapol_tx_status(hapd, sta, data, len, ack);
-+	/* ubus request */
-+	if (!sta->fdata) {
-+		struct hostapd_ubus_request req = {
-+			.type = HOSTAPD_UBUS_FDATA_REQ,
-+			.sta = sta
-+		};
-+		hostapd_ubus_handle_rt_event(hapd, &req);
-+	}
- }
- 
- 
 Index: hostapd-2020-06-08-5a8b3662/src/ap/sta_info.c
 ===================================================================
 --- hostapd-2020-06-08-5a8b3662.orig/src/ap/sta_info.c
@@ -201,12 +171,13 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/sta_info.h
 ===================================================================
 --- hostapd-2020-06-08-5a8b3662.orig/src/ap/sta_info.h
 +++ hostapd-2020-06-08-5a8b3662/src/ap/sta_info.h
-@@ -77,6 +77,8 @@ struct sta_info {
+@@ -77,6 +77,9 @@ struct sta_info {
  	u8 supported_rates[WLAN_SUPP_RATES_MAX];
  	int supported_rates_len;
  	u8 qosinfo; /* Valid when WLAN_STA_WMM is set */
 +	u64 cl_session_id; /* client fnv1a 64bit session id */
 +	u8 fdata; /* client first data flag */
++	u8 first_ip; /* client first ip flag */
  
  #ifdef CONFIG_MESH
  	enum mesh_plink_state plink_state;
@@ -242,7 +213,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  static bool hostapd_ubus_init(void)
  {
  	if (ctx)
-@@ -525,6 +538,164 @@ static const struct blobmsg_policy csa_p
+@@ -525,6 +538,177 @@ static const struct blobmsg_policy csa_p
  };
  
  #ifdef NEED_AP_MLME
@@ -393,6 +364,19 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +				blobmsg_close_table(&b_ev, t_msg);
 +				break;
 +			}
++
++			/* ClientIpEvent */
++			case CST_IP: {
++				struct client_ip_event *p = &c_rec->u.ip;
++				t_msg = blobmsg_open_table(&b_ev, "ClientIpEvent");
++				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
++				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
++				blobmsg_add_string(&b_ev, "ip_address", p->ip_addr);
++				blobmsg_close_table(&b_ev, t_msg);
++				break;
++			}
++
 +			default:
 +				break;
 +			}
@@ -407,7 +391,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  static int
  hostapd_switch_chan(struct ubus_context *ctx, struct ubus_object *obj,
  		    struct ubus_request_data *req, const char *method,
-@@ -1148,6 +1319,9 @@ static const struct ubus_method bss_meth
+@@ -1148,6 +1332,9 @@ static const struct ubus_method bss_meth
  	UBUS_METHOD_NOARG("get_features", hostapd_bss_get_features),
  #ifdef NEED_AP_MLME
  	UBUS_METHOD("switch_chan", hostapd_switch_chan, csa_policy),
@@ -417,7 +401,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  #endif
  	UBUS_METHOD("set_vendor_elements", hostapd_vendor_elements, ve_policy),
  	UBUS_METHOD("notify_response", hostapd_notify_response, notify_policy),
-@@ -1187,13 +1361,17 @@ void hostapd_ubus_add_bss(struct hostapd
+@@ -1187,13 +1374,17 @@ void hostapd_ubus_add_bss(struct hostapd
  	if (asprintf(&name, "hostapd.%s", hapd->conf->iface) < 0)
  		return;
  
@@ -436,7 +420,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  	if (hapd->conf->signal_stay_min > -128)
  		eloop_register_timeout(3, 0, hostapd_bss_signal_check, NULL, hapd);  /* Start up the poll timer. */
  }
-@@ -1212,11 +1390,42 @@ void hostapd_ubus_free_bss(struct hostap
+@@ -1212,11 +1403,42 @@ void hostapd_ubus_free_bss(struct hostap
  	}
  
  	free(name);
@@ -479,7 +463,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  };
  
  static struct ubus_object_type daemon_object_type =
-@@ -1260,6 +1469,18 @@ struct ubus_event_req {
+@@ -1260,6 +1482,18 @@ struct ubus_event_req {
  	int resp;
  };
  
@@ -498,7 +482,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  static void
  ubus_event_cb(struct ubus_notify_request *req, int idx, int ret)
  {
-@@ -1268,6 +1489,192 @@ ubus_event_cb(struct ubus_notify_request
+@@ -1268,6 +1502,221 @@ ubus_event_cb(struct ubus_notify_request
  	ureq->resp = ret;
  }
  
@@ -522,8 +506,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +	const struct ieee80211_mgmt *mgmt = req->mgmt_frame;
 +	struct sta_info *sta = req->sta ? (void *)req->sta : ap_get_sta(hapd, mgmt->sa);
 +	/* null pointer check */
-+	if (!sta)
-+		return WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA;
++	if (!sta) return WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA;
 +
 +	struct hostapd_bss_config *bss_conf = hapd->conf;
 +	session_id = sta->cl_session_id;
@@ -537,6 +520,10 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +		rec = os_zalloc(sizeof(struct hostapd_event_avl_rec));
 +		session_id = hash_fnv1a_64bit(&ts, sizeof(struct timespec));
 +	}
++	hostapd_logger(hapd, NULL, HOSTAPD_MODULE_IEEE80211,
++		       HOSTAPD_LEVEL_DEBUG,
++		       "hostapd_ubus_handle_rt_event: REQ TYPE [%d]",
++		       req->type);
 +
 +	switch (req->type) {
 +	case HOSTAPD_UBUS_AUTH_REQ: {
@@ -665,7 +652,33 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +		hostapd_logger(
 +			hapd, NULL, HOSTAPD_MODULE_IEEE80211,
 +			HOSTAPD_LEVEL_DEBUG,
-+			"hostapd_ubus_handle_rt_event:HOSTAPD_UBUS_DISASSOC_REQ");
++			"hostapd_ubus_handle_rt_event:HOSTAPD_UBUS_FDATA_REQ");
++		/* inc counter */
++		cached_events_nr++;
++		break;
++	}
++	case HOSTAPD_UBUS_IP_REQ: {
++		if(sta->first_ip) break;
++		/* session id */
++		rec->session_id = session_id;
++		rec->rec_nr++;
++		rec->records = os_realloc(rec->records,
++					  sizeof(struct client_session_record) * rec->rec_nr);
++		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
++		rp->type = CST_IP;
++		rp->u.ip.session_id = rec->session_id;
++		/* timestamp */
++		rp->ts = ts;
++		/* STA MAC */
++		sprintf(rp->u.ip.sta_mac, MACSTR, MAC2STR(sta->addr));
++		/* ip address */
++		snprintf(rp->u.ip.ip_addr, 20, "%u.%u.%u.%u",
++			 (req->ipaddr >> 24) & 0xFF,
++			 (req->ipaddr >> 16) & 0xFF,
++			 (req->ipaddr >> 8) & 0xFF,
++			 req->ipaddr & 0xFF);
++		/* single event only */
++		sta->first_ip = 1;
 +		/* inc counter */
 +		cached_events_nr++;
 +		break;
@@ -695,7 +708,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
 ===================================================================
 --- hostapd-2020-06-08-5a8b3662.orig/src/ap/ubus.h
 +++ hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
-@@ -12,6 +12,10 @@ enum hostapd_ubus_event_type {
+@@ -12,6 +12,11 @@ enum hostapd_ubus_event_type {
  	HOSTAPD_UBUS_PROBE_REQ,
  	HOSTAPD_UBUS_AUTH_REQ,
  	HOSTAPD_UBUS_ASSOC_REQ,
@@ -703,10 +716,11 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
 +	HOSTAPD_UBUS_DISASSOC_REQ,
 +	HOSTAPD_UBUS_DEAUTH_REQ,
 +	HOSTAPD_UBUS_FDATA_REQ,
++	HOSTAPD_UBUS_IP_REQ,
  	HOSTAPD_UBUS_TYPE_MAX
  };
  
-@@ -19,7 +23,9 @@ struct hostapd_ubus_request {
+@@ -19,8 +24,11 @@ struct hostapd_ubus_request {
  	enum hostapd_ubus_event_type type;
  	const struct ieee80211_mgmt *mgmt_frame;
  	const struct ieee802_11_elems *elems;
@@ -714,9 +728,11 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  	int ssi_signal; /* dBm */
 +	int reason;
  	const u8 *addr;
++	be32 ipaddr;
  };
  
-@@ -37,6 +43,72 @@ struct hostapd_ubus_bss {
+ struct hostapd_iface;
+@@ -37,6 +45,80 @@ struct hostapd_ubus_bss {
  	struct ubus_object obj;
  	struct avl_tree banned;
  	int notify_response;
@@ -727,7 +743,8 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
 +	CST_ASSOC,
 +	CST_AUTH,
 +	CST_DISASSOC,
-+	CST_FDATA
++	CST_FDATA,
++	CST_IP
 +};
 +
 +struct client_assoc_event {
@@ -770,6 +787,12 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
 +	struct timespec tx_ts;
 +};
 +
++struct client_ip_event {
++	unsigned char sta_mac[20];
++	uint64_t session_id;
++	unsigned char ip_addr[16];
++};
++
 +struct client_session_record {
 +	int type;
 +	struct timespec ts;
@@ -778,6 +801,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
 +		struct client_disassoc_event disassoc;
 +		struct client_auth_event auth;
 +		struct client_fdata_event fdata;
++		struct client_ip_event ip;
 +	} u;
 +};
 +
@@ -789,7 +813,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  };
  
  void hostapd_ubus_add_iface(struct hostapd_iface *iface);
-@@ -45,6 +117,7 @@ void hostapd_ubus_add_bss(struct hostapd
+@@ -45,6 +127,7 @@ void hostapd_ubus_add_bss(struct hostapd
  void hostapd_ubus_free_bss(struct hostapd_data *hapd);
  
  int hostapd_ubus_handle_event(struct hostapd_data *hapd, struct hostapd_ubus_request *req);
@@ -797,7 +821,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  void hostapd_ubus_notify(struct hostapd_data *hapd, const char *type, const u8 *mac);
  void hostapd_ubus_notify_beacon_report(struct hostapd_data *hapd,
  				       const u8 *addr, u8 token, u8 rep_mode,
-@@ -78,6 +151,11 @@ static inline int hostapd_ubus_handle_ev
+@@ -78,6 +161,11 @@ static inline int hostapd_ubus_handle_ev
  {
  	return 0;
  }
@@ -809,3 +833,69 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  
  static inline void hostapd_ubus_notify(struct hostapd_data *hapd, const char *type, const u8 *mac)
  {
+Index: hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/hostapd.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+@@ -1406,19 +1406,22 @@ static int hostapd_setup_bss(struct host
+ 				   "Generic snooping infrastructure initialization failed");
+ 			return -1;
+ 		}
+-
+-		if (dhcp_snoop_init(hapd)) {
+-			wpa_printf(MSG_ERROR,
+-				   "DHCP snooping initialization failed");
+-			return -1;
+-		}
+-
+ 		if (ndisc_snoop_init(hapd)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Neighbor Discovery snooping initialization failed");
+ 			return -1;
+ 		}
+ 	}
++	if (dhcp_snoop_init(hapd)) {
++		wpa_printf(MSG_ERROR,
++			   "DHCP snooping initialization failed");
++		hostapd_logger(
++			hapd, NULL, HOSTAPD_MODULE_IEEE80211,
++			HOSTAPD_LEVEL_DEBUG,
++			"dfranusic:DHCP snooping initialization failed");
++
++		return -1;
++	}
+ 
+ 	if (!hostapd_drv_none(hapd) && vlan_init(hapd)) {
+ 		wpa_printf(MSG_ERROR, "VLAN initialization failed.");
+Index: hostapd-2020-06-08-5a8b3662/src/ap/dhcp_snoop.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/dhcp_snoop.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/dhcp_snoop.c
+@@ -40,6 +40,7 @@ static void handle_dhcp(void *ctx, const
+ 	int res, msgtype = 0, prefixlen = 32;
+ 	u32 subnet_mask = 0;
+ 	u16 ip_len;
++	int ubus_resp;
+ 
+ 	exten_len = len - ETH_HLEN - (sizeof(*b) - sizeof(b->exten));
+ 	if (exten_len < 4)
+@@ -112,6 +113,19 @@ static void handle_dhcp(void *ctx, const
+ 			   ipaddr_str(be_to_host32(b->your_ip)),
+ 			   prefixlen);
+ 
++			struct hostapd_ubus_request req = {
++				.type = HOSTAPD_UBUS_IP_REQ,
++				.sta = sta,
++				.ipaddr = be_to_host32(b->your_ip)
++			};
++			ubus_resp = hostapd_ubus_handle_rt_event(hapd, &req);
++			if (ubus_resp) {
++				hostapd_logger(
++					hapd, NULL, HOSTAPD_MODULE_IEEE80211,
++					HOSTAPD_LEVEL_DEBUG,
++					"hostapd_ubus_handle_rt_event: ERROR");
++			}
++
+ 		if (sta->ipaddr == b->your_ip)
+ 			return;
+ 


### PR DESCRIPTION
### ClientIpEvent provided by hostapd's dhcp sniffer

**ubus get_sessions example:**
```
{
        "sessions": {
                "ClientSession": {
                        "session_id": -3855646661667610296,
                        "ClientAuthEvent": {
                                "session_id": -3855646661667610296,
                                "timestamp": 1606745461,
                                "sta_mac": "d6:7e:35:66:85:2e",
                                "band": 2437,
                                "auth_status": 0,
                                "ssid": "Default-SSID-2g"
                        },
                        "ClientAssocEvent": {
                                "session_id": -3855646661667610296,
                                "timestamp": 1606745461,
                                "sta_mac": "d6:7e:35:66:85:2e",
                                "band": 2437,
                                "assoc_type": 0,
                                "rssi": -52,
                                "internal_sc": 0,
                                "using11k": true,
                                "using11r": false,
                                "using11v": true,
                                "ssid": "Default-SSID-2g"
                        },
                        "ClientIpEvent": {
                                "session_id": -3855646661667610296,
                                "timestamp": 1606745465,
                                "sta_mac": "d6:7e:35:66:85:2e",
                                "ip_address": "192.168.1.162"
                        },
                        "ClientDisconnectEvent": {
                                "session_id": -3855646661667610296,
                                "timestamp": 1606745471,
                                "sta_mac": "d6:7e:35:66:85:2e",
                                "band": 2437,
                                "rssi": -51,
                                "internal_rc": 0,
                                "ssid": "Default-SSID-2g"
                        }
                }
        }
}

```