### PR TITLE
ipq806x: add mtd spi-nor support for mx25u12835f

### DIFF
--- a/patches/0038-ipq806x-add-mtd-spi-nor-support-for-mx25u12835f.patch
+++ b/patches/0038-ipq806x-add-mtd-spi-nor-support-for-mx25u12835f.patch
@@ -1,0 +1,51 @@
+From de4a7d685f74fa57cf2d4ac4c6e106b359e94fff Mon Sep 17 00:00:00 2001
+From: Brian Moyle <brian.moyle@joindigital.com>
+Date: Mon, 7 Dec 2020 22:59:19 +0000
+Subject: [PATCH] ipq806x: add mtd spi-nor support for mx25u12835f
+
+Signed-off-by: Brian Moyle <brian.moyle@joindigital.com>
+---
+ ...-spi-nor-Add-support-for-mx25u12835f.patch | 32 +++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+ create mode 100644 target/linux/ipq806x/patches-4.14/450-mtd-spi-nor-Add-support-for-mx25u12835f.patch
+
+diff --git a/target/linux/ipq806x/patches-4.14/450-mtd-spi-nor-Add-support-for-mx25u12835f.patch b/target/linux/ipq806x/patches-4.14/450-mtd-spi-nor-Add-support-for-mx25u12835f.patch
+new file mode 100644
+index 0000000000..8b13ac234e
+--- /dev/null
++++ b/target/linux/ipq806x/patches-4.14/450-mtd-spi-nor-Add-support-for-mx25u12835f.patch
+@@ -0,0 +1,32 @@
++mtd: spi-nor: Add support for mx25u12835f
++
++Pull in support for the Macronix MX25U12835F spi nor flash.
++
++This patch is based on kernel.org commit 8155417, and has been
++modified to apply cleanly to the TIP "trunk" branch.
++
++Original kernel.org commit header:
++
++  From 81554171373018b83f3554b9e725d2b5bf1844a5 Mon Sep 17 00:00:00 2001
++  From: Alexander Sverdlin <alexander.sverdlin@nokia.com>
++  Date: Fri, 13 Jul 2018 15:06:46 +0200
++  Subject: [PATCH] mtd: spi-nor: Add support for mx25u12835f
++
++  This chip supports dual and quad read and uniform 4K-byte erase.
++
++  Signed-off-by: Alexander Sverdlin <alexander.sverdlin@nokia.com>
++  Reviewed-by: Tudor Ambarus <tudor.ambarus@microchip.com>
++  Signed-off-by: Boris Brezillon <boris.brezillon@bootlin.com>
++
++Modified patch:
++
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -1036,6 +1036,7 @@ static const struct flash_info spi_nor_i
++ 	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
++ 	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
++ 	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },
+++	{ "mx25u12835f", INFO(0xc22538, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++ 	{ "mx25l25635f", INFO(0xc22019, 0, 64 * 1024, 512, SECT_4K) },
++ 	{ "mx25u25635f", INFO(0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },
++ 	{ "mx25l25655e", INFO(0xc22619, 0, 64 * 1024, 512, 0) },
+--
+2.17.1


### PR DESCRIPTION
WIFI-1155 ECW5410: unsupported spi flash device

Signed-off-by: Brian Moyle <brian.moyle@joindigital.co>