### PR TITLE
opensync: remove stale clients

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -52,6 +52,7 @@ struct wifi_station {
 	uint32_t tx_packets;
 	uint32_t rx_bytes;
 	uint32_t tx_bytes;
+	time_t last_update;
 };
 
 extern int radio_nl80211_init(void);


### PR DESCRIPTION
Remove stale clients from client list in case disconnect event was
not received.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>