### PR TITLE
opensync: terminate all managers on service stop/restart

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
@@ -47,5 +47,5 @@ stop_service() {
     echo "Removing certificates"
     rm -rf ${CERTS_DEST_PATH}
     echo "Killing managers"
-    killall dm wm sm cm nm lm qm cmdm rrm um uccm
+    killall -s SIGKILL dm wm sm cm nm lm qm cmdm rrm um uccm
 }


### PR DESCRIPTION
Not all opensync managers were terminated on service stop/restart.
Send SIGKILL to terminate all managers.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>