### PR TITLE
opensync: Fix events timestamp

### DIFF
--- a/feeds/wifi-trunk/hostapd/patches/900-hapd-netlink-ubus-bridge.patch
+++ b/feeds/wifi-trunk/hostapd/patches/900-hapd-netlink-ubus-bridge.patch
@@ -184,7 +184,7 @@
  
  static inline struct hapd_interfaces *get_hapd_interfaces_from_object(struct ubus_object *obj)
  {
-@@ -63,6 +66,16 @@ static void hostapd_ubus_connection_lost
+@@ -63,6 +66,21 @@ static void hostapd_ubus_connection_lost
  	eloop_register_timeout(1, 0, ubus_reconnect_timeout, ctx, NULL);
  }
  
@@ -198,10 +198,15 @@
 +		return *id1 > *id2;
 +}
 +
++uint64_t get_time_in_ms(struct timespec *ts)
++{
++    return (uint64_t) ts->tv_sec * 1000 + ts->tv_nsec / 1000000;
++}
++
  static bool hostapd_ubus_init(void)
  {
  	if (ctx)
-@@ -525,6 +538,177 @@ static const struct blobmsg_policy csa_p
+@@ -525,6 +543,177 @@ static const struct blobmsg_policy csa_p
  };
  
  #ifdef NEED_AP_MLME
@@ -297,7 +302,7 @@
 +				struct client_auth_event *p = &c_rec->u.auth;
 +				t_msg = blobmsg_open_table(&b_ev, "ClientAuthEvent");
 +				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
-+				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_u64(&b_ev, "timestamp", c_rec->timestamp);
 +				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
 +				blobmsg_add_u32(&b_ev, "band", p->band);
 +				blobmsg_add_u32(&b_ev, "auth_status", p->auth_status);
@@ -311,7 +316,7 @@
 +				struct client_assoc_event *p = &c_rec->u.assoc;
 +				t_msg = blobmsg_open_table(&b_ev, "ClientAssocEvent");
 +				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
-+				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_u64(&b_ev, "timestamp", c_rec->timestamp);
 +				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
 +				blobmsg_add_u32(&b_ev, "band", p->band);
 +				blobmsg_add_u32(&b_ev, "assoc_type", 0);
@@ -330,7 +335,7 @@
 +				struct client_disassoc_event *p = &c_rec->u.disassoc;
 +				t_msg = blobmsg_open_table(&b_ev, "ClientDisconnectEvent");
 +				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
-+				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_u64(&b_ev, "timestamp", c_rec->timestamp);
 +				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
 +				blobmsg_add_u32(&b_ev, "band", p->band);
 +				blobmsg_add_u32(&b_ev, "rssi", p->rssi);
@@ -345,7 +350,7 @@
 +				struct client_fdata_event *p = &c_rec->u.fdata;
 +				t_msg = blobmsg_open_table(&b_ev, "ClientFirstDataEvent");
 +				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
-+				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_u64(&b_ev, "timestamp", c_rec->timestamp);
 +				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
 +				blobmsg_add_u64(&b_ev, "fdata_tx_up_ts_in_us", p->tx_ts.tv_sec * (uint64_t)1000000);
 +				blobmsg_add_u64(&b_ev, "fdata_rx_up_ts_in_us", p->rx_ts.tv_sec * (uint64_t)1000000);
@@ -358,7 +363,7 @@
 +				struct client_ip_event *p = &c_rec->u.ip;
 +				t_msg = blobmsg_open_table(&b_ev, "ClientIpEvent");
 +				blobmsg_add_u64(&b_ev, "session_id", rec->session_id);
-+				blobmsg_add_u32(&b_ev, "timestamp", c_rec->ts.tv_sec);
++				blobmsg_add_u64(&b_ev, "timestamp", c_rec->timestamp);
 +				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
 +				blobmsg_add_string(&b_ev, "ip_address", p->ip_addr);
 +				blobmsg_close_table(&b_ev, t_msg);
@@ -379,7 +384,7 @@
  static int
  hostapd_switch_chan(struct ubus_context *ctx, struct ubus_object *obj,
  		    struct ubus_request_data *req, const char *method,
-@@ -1148,6 +1332,9 @@ static const struct ubus_method bss_meth
+@@ -1148,6 +1337,9 @@ static const struct ubus_method bss_meth
  	UBUS_METHOD_NOARG("get_features", hostapd_bss_get_features),
  #ifdef NEED_AP_MLME
  	UBUS_METHOD("switch_chan", hostapd_switch_chan, csa_policy),
@@ -389,7 +394,7 @@
  #endif
  	UBUS_METHOD("set_vendor_elements", hostapd_vendor_elements, ve_policy),
  	UBUS_METHOD("notify_response", hostapd_notify_response, notify_policy),
-@@ -1187,13 +1374,17 @@ void hostapd_ubus_add_bss(struct hostapd
+@@ -1187,13 +1379,17 @@ void hostapd_ubus_add_bss(struct hostapd
  	if (asprintf(&name, "hostapd.%s", hapd->conf->iface) < 0)
  		return;
  
@@ -408,7 +413,7 @@
  	if (hapd->conf->signal_stay_min > -128)
  		eloop_register_timeout(3, 0, hostapd_bss_signal_check, NULL, hapd);  /* Start up the poll timer. */
  }
-@@ -1212,11 +1403,42 @@ void hostapd_ubus_free_bss(struct hostap
+@@ -1212,11 +1408,42 @@ void hostapd_ubus_free_bss(struct hostap
  	}
  
  	free(name);
@@ -451,7 +456,7 @@
  };
  
  static struct ubus_object_type daemon_object_type =
-@@ -1260,6 +1482,18 @@ struct ubus_event_req {
+@@ -1260,6 +1487,18 @@ struct ubus_event_req {
  	int resp;
  };
  
@@ -470,7 +475,7 @@
  static void
  ubus_event_cb(struct ubus_notify_request *req, int idx, int ret)
  {
-@@ -1268,6 +1502,221 @@ ubus_event_cb(struct ubus_notify_request
+@@ -1268,6 +1507,224 @@ ubus_event_cb(struct ubus_notify_request
  	ureq->resp = ret;
  }
  
@@ -488,7 +493,9 @@
 +	}
 +	struct hostapd_event_avl_rec *rec = NULL;
 +	struct timespec ts;
++	uint64_t timestamp = 0;
 +	clock_gettime(CLOCK_REALTIME, &ts);
++	timestamp = get_time_in_ms(&ts);
 +	uint64_t session_id = 0;
 +	uint8_t new_rec = 0;
 +	const struct ieee80211_mgmt *mgmt = req->mgmt_frame;
@@ -523,8 +530,9 @@
 +		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
 +		rp->type = CST_AUTH;
 +		rp->u.auth.session_id = rec->session_id;
++
 +		/* timestamp */
-+		rp->ts = ts;
++		rp->timestamp = timestamp;
 +		/* frequency */
 +		rp->u.auth.band = hapd->iface->freq;
 +		/* STA MAC */
@@ -553,7 +561,7 @@
 +		rp->type = CST_ASSOC;
 +		rp->u.assoc.session_id = rec->session_id;
 +		/* timestamp */
-+		rp->ts = ts;
++		rp->timestamp = timestamp;
 +		/* frequency */
 +		rp->u.assoc.band = hapd->iface->freq;
 +		/* STA MAC */
@@ -597,7 +605,7 @@
 +		rp->type = CST_DISASSOC;
 +		rp->u.disassoc.session_id = rec->session_id;
 +		/* timestamp */
-+		rp->ts = ts;
++		rp->timestamp = timestamp;
 +		/* frequency */
 +		rp->u.disassoc.band = hapd->iface->freq;
 +		/* STA MAC */
@@ -628,7 +636,7 @@
 +		rp->type = CST_FDATA;
 +		rp->u.fdata.session_id = rec->session_id;
 +		/* timestamp */
-+		rp->ts = ts;
++		rp->timestamp = timestamp;
 +		/* STA MAC */
 +		sprintf(rp->u.fdata.sta_mac, MACSTR, MAC2STR(sta->addr));
 +		/* rx ts */
@@ -656,7 +664,7 @@
 +		rp->type = CST_IP;
 +		rp->u.ip.session_id = rec->session_id;
 +		/* timestamp */
-+		rp->ts = ts;
++		rp->timestamp = timestamp;
 +		/* STA MAC */
 +		sprintf(rp->u.ip.sta_mac, MACSTR, MAC2STR(sta->addr));
 +		/* ip address */
@@ -781,7 +789,7 @@
 +
 +struct client_session_record {
 +	int type;
-+	struct timespec ts;
++	uint64_t timestamp;
 +	union {
 +		struct client_assoc_event assoc;
 +		struct client_disassoc_event disassoc;

--- a/feeds/wlan-ap/opensync/patches/19-events-protobuf-definitions.patch
+++ b/feeds/wlan-ap/opensync/patches/19-events-protobuf-definitions.patch
@@ -1,7 +1,5 @@
-Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
-===================================================================
---- opensync-2.0.5.0.orig/interfaces/opensync_stats.proto
-+++ opensync-2.0.5.0/interfaces/opensync_stats.proto
+--- a/interfaces/opensync_stats.proto
++++ b/interfaces/opensync_stats.proto
 @@ -91,15 +91,26 @@ enum BSEventType {
      CLIENT_GHOST_DEVICE_KICK                = 26;
  }
@@ -106,7 +104,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        optional bool                   using11k                            = 9;
 +        optional bool                   using11r                            = 10;
 +        optional bool                   using11v                            = 11;
-+        optional uint32                 timestamp_ms                        = 12;
++        required uint64                 timestamp_ms                        = 12;
 +    }
 +
 +    /* Client Authentication Event */
@@ -116,7 +114,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        required string                 ssid                                = 3;
 +        required RadioBandType          band                                = 4;
 +        optional uint32                 auth_status                         = 5;
-+        optional uint32                 timestamp_ms                        = 6;
++        required uint64                 timestamp_ms                        = 6;
 +    }
 +
 +    /* Client Disconnect Event */
@@ -132,7 +130,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        optional int32                  rssi                                = 9;
 +        required string                 ssid                                = 10;
 +        required RadioBandType          band                                = 11;
-+        optional uint32                 timestamp_ms                        = 12;
++        required uint64                 timestamp_ms                        = 12;
 +    }
 +
 +    /* Client Connnect Event */
@@ -157,7 +155,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        optional bool                   using11v                            = 18;
 +        optional int64                  ev_time_bootup_in_us_ip             = 19;
 +        optional int32                  assoc_rssi                          = 20;
-+        optional uint32                 timestamp_ms                        = 21;
++        required uint64                 timestamp_ms                        = 21;
 +    }
 +
 +    /* Client Failure Event */
@@ -167,7 +165,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        required string                 ssid                                = 3;
 +        optional int32                  reason_code                         = 4;
 +        optional string                 reason_str                          = 5;
-+        optional uint32                 timestamp_ms                        = 6;
++        required uint64                 timestamp_ms                        = 6;
 +    }
 +
 +    /* Client First Data Event */
@@ -176,7 +174,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        required uint64                 session_id                          = 2;
 +        optional uint64                 fdata_tx_up_ts_in_us                = 3;
 +        optional uint64                 fdata_rx_up_ts_in_us                = 4;
-+        optional uint32                 timestamp_ms                        = 5;
++        required uint64                 timestamp_ms                        = 5;
 +    }
 +
 +    /* Client Id Event */
@@ -184,7 +182,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        required string                 clt_mac                             = 1;
 +        required uint64                 session_id                          = 2;
 +        optional string                 clt_id                              = 3;
-+        optional uint32                 timestamp_ms                        = 4;
++        required uint64                 timestamp_ms                        = 4;
 +    }
 +
 +    /* Client IP Event */
@@ -192,7 +190,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        required string                 sta_mac                             = 1;
 +        required uint64                 session_id                          = 2;
 +        optional bytes                  ip_addr                             = 3;
-+        optional uint32                 timestamp_ms                        = 4;
++        required uint64                 timestamp_ms                        = 4;
 +    }
 +
 +    /* Client Timeout Event */
@@ -202,7 +200,7 @@ Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
 +        optional CTReasonType           r_code                              = 3;
 +        optional uint64                 last_sent_up_ts_in_us               = 4;
 +        optional uint64                 last_rcv_up_ts_in_us                = 5;
-+        optional uint32                 timestamp_ms                        = 6;
++        required uint64                 timestamp_ms                        = 6;
 +    }
 +
 +    /* Client Session */

--- a/feeds/wlan-ap/opensync/patches/20-dppline-event.patch
+++ b/feeds/wlan-ap/opensync/patches/20-dppline-event.patch
@@ -1,7 +1,5 @@
-Index: opensync-2.0.5.0/src/lib/datapipeline/inc/dppline.h
-===================================================================
---- opensync-2.0.5.0.orig/src/lib/datapipeline/inc/dppline.h
-+++ opensync-2.0.5.0/src/lib/datapipeline/inc/dppline.h
+--- a/src/lib/datapipeline/inc/dppline.h
++++ b/src/lib/datapipeline/inc/dppline.h
 @@ -47,6 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBI
  #include "dpp_rssi.h"
  #include "dpp_network_probe.h"
@@ -22,10 +20,8 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/inc/dppline.h
  
  /*
   * Get the protobuf packed buffer
-Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
-===================================================================
---- opensync-2.0.5.0.orig/src/lib/datapipeline/src/dppline.c
-+++ opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
+--- a/src/lib/datapipeline/src/dppline.c
++++ b/src/lib/datapipeline/src/dppline.c
 @@ -44,6 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBI
  #include "dpp_capacity.h"
  #include "dpp_bs_client.h"
@@ -2996,7 +2992,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
              sizeof(s->u.capacity) + s->u.capacity.numrec * sizeof(dpp_capacity_record_t),
              sizeof(Sts__Capacity*) +
              sizeof(Sts__Capacity) +
-@@ -1714,658 +1854,1129 @@ static void dppline_add_stat_network_pro
+@@ -1714,658 +1854,1093 @@ static void dppline_add_stat_network_pro
      }
  }
  
@@ -3291,6 +3287,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			ae->sta_mac    = strdup(cs_rec->assoc_event->sta_mac);
 +			ae->ssid       = strdup(cs_rec->assoc_event->ssid);
 +			ae->band       = dppline_to_proto_radio(cs_rec->assoc_event->band);				
++			ae->timestamp_ms = cs_rec->assoc_event->timestamp;
 +
 +			if (cs_rec->assoc_event->assoc_type) {
 +				ae->assoc_type =
@@ -3328,11 +3325,6 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +				ae->using11v = cs_rec->assoc_event->using11v;
 +				ae->has_using11v = true;
 +			}
-+
-+			if (cs_rec->assoc_event->timestamp) {
-+				ae->timestamp_ms = cs_rec->assoc_event->timestamp;
-+				ae->has_timestamp_ms = true;
-+			}
 +		}
 +
 +		if(cs_rec->auth_event) {
@@ -3348,15 +3340,11 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			authe->ssid = strdup(cs_rec->auth_event->ssid);
 +			authe->band = dppline_to_proto_radio(
 +					cs_rec->auth_event->band);
++			authe->timestamp_ms = cs_rec->auth_event->timestamp;
 +
 +			if (cs_rec->auth_event->auth_status) {
 +				authe->auth_status = cs_rec->auth_event->auth_status;
 +				authe->has_auth_status = true;
-+			}
-+
-+			if (cs_rec->auth_event->timestamp) {
-+				authe->timestamp_ms = cs_rec->auth_event->timestamp;
-+				authe->has_timestamp_ms = true;
 +			}
 +		}
 +
@@ -3412,14 +3400,10 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +				de->has_rssi = true;
 +			}
 +
-+			if (cs_rec->disconnect_event->timestamp) {
-+				de->timestamp_ms = cs_rec->disconnect_event->timestamp;
-+				de->has_timestamp_ms = true;
-+			}
-+
-+				de->ssid = strdup(cs_rec->disconnect_event->ssid);
-+				de->band = dppline_to_proto_radio(
-+					cs_rec->disconnect_event->band);
++			de->ssid = strdup(cs_rec->disconnect_event->ssid);
++			de->band = dppline_to_proto_radio(
++				cs_rec->disconnect_event->band);
++			de->timestamp_ms = cs_rec->disconnect_event->timestamp;
 +		}
 +
 +		if(cs_rec->failure_event) {
@@ -3433,6 +3417,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			cfe->sta_mac = strdup(cs_rec->failure_event->sta_mac);
 +			cfe->session_id = cs_rec->failure_event->session_id;
 +			cfe->ssid = strdup(cs_rec->failure_event->ssid);
++			cfe->timestamp_ms = cs_rec->failure_event->timestamp;
 +
 +			if (cs_rec->failure_event->reason_str) {
 +			cfe->reason_str = strdup(cs_rec->failure_event->reason_str);
@@ -3441,11 +3426,6 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			if (cs_rec->failure_event->reason) {
 +				cfe->reason_code = cs_rec->failure_event->reason;
 +				cfe->has_reason_code = true;
-+			}
-+
-+			if (cs_rec->failure_event->timestamp) {
-+				cfe->timestamp_ms = cs_rec->failure_event->timestamp;
-+				cfe->has_timestamp_ms = true;
 +			}
 +		}
 +
@@ -3459,6 +3439,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +
 +			fde->sta_mac = strdup(cs_rec->first_data_event->sta_mac);
 +			fde->session_id = cs_rec->first_data_event->session_id;
++			fde->timestamp_ms = cs_rec->first_data_event->timestamp;
 +
 +			if(cs_rec->first_data_event->fdata_tx_up_ts_in_us) {
 +				fde->fdata_tx_up_ts_in_us = cs_rec->first_data_event->fdata_tx_up_ts_in_us;
@@ -3470,11 +3451,6 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +				fde->has_fdata_rx_up_ts_in_us = true;
 +			}
 +
-+			if(cs_rec->first_data_event->timestamp) {
-+				fde->timestamp_ms = cs_rec->first_data_event->timestamp;
-+				fde->has_timestamp_ms = true;
-+			}
-+			
 +		}
 +
 +		if(cs_rec->id_event) {
@@ -3488,15 +3464,11 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			ide->clt_mac = malloc(MACADDR_STR_LEN);
 +			//dpp_mac_to_str(ide->clt_mac, cs_rec->id_event->clt_mac);
 +			ide->session_id = cs_rec->id_event->session_id;
++			ide->timestamp_ms = cs_rec->id_event->timestamp;
 +
 +			if(cs_rec->id_event->clt_id) {
 +				ide->clt_id = strdup(ide->clt_id);
 +			}	
-+
-+			if(cs_rec->id_event->timestamp) {
-+				ide->timestamp_ms = cs_rec->id_event->timestamp;
-+				ide->has_timestamp_ms = true;
-+			}
 +		}
 +
 +		if(cs_rec->ip_event) {
@@ -3509,17 +3481,13 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +
 +			ipe->session_id = cs_rec->ip_event->session_id;
 +			ipe->sta_mac = strdup(cs_rec->ip_event->sta_mac);
++			ipe->timestamp_ms = cs_rec->ip_event->timestamp;
 +
 +			if (cs_rec->ip_event->ip_addr) {
 +				ipe->ip_addr.data = malloc(16);
 +				memcpy(ipe->ip_addr.data, cs_rec->ip_event->ip_addr,16);
 +				ipe->ip_addr.len = 16;
 +				ipe->has_ip_addr = true;
-+			}
-+
-+			if(cs_rec->ip_event->timestamp) {
-+				ipe->timestamp_ms = cs_rec->ip_event->timestamp;
-+				ipe->has_timestamp_ms = true;
 +			}
 +		}
 +
@@ -3533,6 +3501,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +
 +			toe->sta_mac = strdup(cs_rec->timeout_event->sta_mac);
 +			toe->session_id = cs_rec->timeout_event->session_id;
++			toe->timestamp_ms = cs_rec->timeout_event->timestamp;
 +
 +			if (cs_rec->timeout_event->r_code) {
 +				toe->r_code =
@@ -3552,11 +3521,6 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +					cs_rec->timeout_event->last_recv_up_ts_in_us;
 +					toe->has_last_rcv_up_ts_in_us = true;
 +			}
-+
-+			if(cs_rec->timeout_event->timestamp) {
-+				toe->timestamp_ms = cs_rec->timeout_event->timestamp;
-+				toe->has_timestamp_ms = true;
-+			}
 +		}
 +
 +		if(cs_rec->connect_event) {
@@ -3573,6 +3537,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			coe->session_id = cs_rec->connect_event->session_id;
 +			coe->band = dppline_to_proto_radio(
 +					cs_rec->connect_event->band);
++			coe->timestamp_ms = cs_rec->connect_event->timestamp;
 +
 +			if (cs_rec->connect_event->assoc_type) {
 +				coe->assoc_type =
@@ -3674,11 +3639,6 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +			if (cs_rec->connect_event->assoc_rssi) {
 +				coe->assoc_rssi = cs_rec->connect_event->assoc_rssi;
 +				coe->has_assoc_rssi = true;
-+			}
-+
-+			if(cs_rec->connect_event->timestamp) {
-+				coe->timestamp_ms = cs_rec->connect_event->timestamp;
-+				coe->has_timestamp_ms = true;
 +			}
 +		}		
 +
@@ -4730,7 +4690,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
  }
  
  /*
-@@ -2373,15 +2984,15 @@ bool dpp_init()
+@@ -2373,15 +2948,15 @@ bool dpp_init()
   */
  bool dpp_put_survey(dpp_survey_report_data_t *rpt)
  {
@@ -4749,7 +4709,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
  }
  
  /*
-@@ -2389,7 +3000,7 @@ bool dpp_put_capacity(dpp_capacity_repor
+@@ -2389,7 +2964,7 @@ bool dpp_put_capacity(dpp_capacity_repor
   */
  bool dpp_put_neighbor(dpp_neighbor_report_data_t *rpt)
  {
@@ -4758,7 +4718,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
  }
  
  /*
-@@ -2397,32 +3008,32 @@ bool dpp_put_neighbor(dpp_neighbor_repor
+@@ -2397,32 +2972,32 @@ bool dpp_put_neighbor(dpp_neighbor_repor
   */
  bool dpp_put_client(dpp_client_report_data_t *rpt)
  {
@@ -4801,7 +4761,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
  }
  
  /*
-@@ -2436,250 +3047,240 @@ bool dpp_put_network_probe(dpp_network_p
+@@ -2436,250 +3011,240 @@ bool dpp_put_network_probe(dpp_network_p
  /*
   * Put Video/voice stats to internal queue
   */
@@ -5239,10 +5199,8 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +	return record;
  }
  
-Index: opensync-2.0.5.0/src/sm/src/sm.h
-===================================================================
---- opensync-2.0.5.0.orig/src/sm/src/sm.h
-+++ opensync-2.0.5.0/src/sm/src/sm.h
+--- a/src/sm/src/sm.h
++++ b/src/sm/src/sm.h
 @@ -229,6 +229,15 @@ bool ucc_report_request(sm_stats_request
  /******************************************************************************/
  
@@ -5267,10 +5225,8 @@ Index: opensync-2.0.5.0/src/sm/src/sm.h
      STS_REPORT_MAX,
      STS_REPORT_ERROR = STS_REPORT_MAX
  } sm_report_type_t;
-Index: opensync-2.0.5.0/src/sm/src/sm_ovsdb.c
-===================================================================
---- opensync-2.0.5.0.orig/src/sm/src/sm_ovsdb.c
-+++ opensync-2.0.5.0/src/sm/src/sm_ovsdb.c
+--- a/src/sm/src/sm_ovsdb.c
++++ b/src/sm/src/sm_ovsdb.c
 @@ -63,6 +63,7 @@ char *sm_report_type_str[STS_REPORT_MAX]
      "rssi",
      "network_probe",
@@ -5305,10 +5261,8 @@ Index: opensync-2.0.5.0/src/sm/src/sm_ovsdb.c
          default:
              return false;
      }
-Index: opensync-2.0.5.0/src/sm/unit.mk
-===================================================================
---- opensync-2.0.5.0.orig/src/sm/unit.mk
-+++ opensync-2.0.5.0/src/sm/unit.mk
+--- a/src/sm/unit.mk
++++ b/src/sm/unit.mk
 @@ -44,6 +44,7 @@ UNIT_SRC     += src/sm_radio_config.c
  UNIT_SRC     += src/sm_scan_schedule.c
  UNIT_SRC     += src/sm_rssi_report.c
@@ -5317,10 +5271,8 @@ Index: opensync-2.0.5.0/src/sm/unit.mk
  UNIT_SRC     += src/ucc_report.c
  UNIT_SRC     += src/sm_common.c
  
-Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
-===================================================================
---- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
-+++ opensync-2.0.5.0/interfaces/opensync.ovsschema
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
 @@ -4674,7 +4674,8 @@
                    "rssi",
                    "steering",

--- a/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
+++ b/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
@@ -47,7 +47,7 @@ typedef struct {
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
 	radio_essid_t ssid;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	radio_type_t band;
 	assoc_type_t assoc_type;
 	uint32_t status;
@@ -63,7 +63,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	radio_essid_t ssid;
 	radio_type_t band;
 	uint32_t auth_status;
@@ -74,7 +74,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	uint32_t reason;
 	device_type_t dev_type;
 	frame_type_t fr_type;
@@ -91,7 +91,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	radio_type_t band;
 	assoc_type_t assoc_type;
 	radio_essid_t ssid;
@@ -117,7 +117,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	radio_essid_t ssid;
 	int32_t reason;
 	char reason_str[DPP_REASON_STR_LEN];
@@ -128,7 +128,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	uint64_t fdata_tx_up_ts_in_us;
 	uint64_t fdata_rx_up_ts_in_us;
 } dpp_event_record_first_data_t;
@@ -138,7 +138,7 @@ typedef struct {
 	char __barrier[46];
 	mac_address_t clt_mac;
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	char clt_id[DPP_CLT_ID_LEN];
 } dpp_event_record_id_t;
 
@@ -147,7 +147,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	uint8_t ip_addr[16];
 } dpp_event_record_ip_t;
 
@@ -156,7 +156,7 @@ typedef struct {
 	char __barrier[46];
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
-	uint32_t timestamp;
+	uint64_t timestamp;
 	ct_reason_t r_code;
 	uint64_t last_sent_up_ts_in_us;
 	uint64_t last_recv_up_ts_in_us;

--- a/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
+++ b/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
@@ -49,7 +49,7 @@ static const struct blobmsg_policy client_session_events_policy[__CLIENT_EVENTS_
 
 static const struct blobmsg_policy client_assoc_event_policy[__CLIENT_ASSOC_MAX] = {
 	[CLIENT_ASSOC_ASSOC_TYPE] = {.name = "assoc_type", .type = BLOBMSG_TYPE_INT32},
-	[CLIENT_ASSOC_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT32},
+	[CLIENT_ASSOC_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_ASSOC_BAND] = {.name = "band", .type = BLOBMSG_TYPE_INT32},
 	[CLIENT_ASSOC_INTERNAL_SC] = {.name = "internal_sc", .type = BLOBMSG_TYPE_INT32},
 	[CLIENT_ASSOC_RSSI] = {.name = "rssi", .type = BLOBMSG_TYPE_INT32},
@@ -63,7 +63,7 @@ static const struct blobmsg_policy client_assoc_event_policy[__CLIENT_ASSOC_MAX]
 
 static const struct blobmsg_policy client_auth_event_policy[__CLIENT_AUTH_MAX] = {
 	[CLIENT_AUTH_SESSION_ID] = {.name = "session_id", .type = BLOBMSG_TYPE_INT64},
-	[CLIENT_AUTH_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT32},
+	[CLIENT_AUTH_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_AUTH_BAND] = {.name = "band", .type = BLOBMSG_TYPE_INT32},
 	[CLIENT_AUTH_AUTH_STATUS] = {.name = "auth_status", .type = BLOBMSG_TYPE_INT32},
 	[CLIENT_AUTH_AUTH_SSID] = {.name = "ssid", .type = BLOBMSG_TYPE_STRING},
@@ -72,7 +72,7 @@ static const struct blobmsg_policy client_auth_event_policy[__CLIENT_AUTH_MAX] =
 
 static const struct blobmsg_policy client_disconnect_event_policy[__CLIENT_DISCONNECT_MAX] = {
 	[CLIENT_DISCONNECT_SESSION_ID] = {.name = "session_id", .type = BLOBMSG_TYPE_INT64},
-	[CLIENT_DISCONNECT_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT32},
+	[CLIENT_DISCONNECT_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_DISCONNECT_STA_MAC] = {.name = "sta_mac", .type = BLOBMSG_TYPE_STRING},
 	[CLIENT_DISCONNECT_BAND] = {.name = "band", .type = BLOBMSG_TYPE_INT32},
 	[CLIENT_DISCONNECT_RSSI] = {.name = "rssi", .type = BLOBMSG_TYPE_INT32},
@@ -83,14 +83,14 @@ static const struct blobmsg_policy client_disconnect_event_policy[__CLIENT_DISCO
 static const struct blobmsg_policy client_first_data_event_policy[__CLIENT_FIRST_DATA_MAX] = {
 	[CLIENT_FIRST_DATA_STA_MAC] = {.name = "sta_mac", .type = BLOBMSG_TYPE_STRING},
 	[CLIENT_FIRST_DATA_SESSION_ID] = {.name = "session_id", .type = BLOBMSG_TYPE_INT64},
-	[CLIENT_FIRST_DATA_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT32},
+	[CLIENT_FIRST_DATA_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_FIRST_DATA_TX_TIMESTAMP] = {.name = "fdata_tx_up_ts_in_us", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_FIRST_DATA_RX_TIMESTAMP] = {.name = "fdata_rx_up_ts_in_us", .type = BLOBMSG_TYPE_INT64},
 };
 
 static const struct blobmsg_policy client_ip_event_policy[__CLIENT_IP_MAX] = {
 	[CLIENT_IP_SESSION_ID] = {.name = "session_id", .type = BLOBMSG_TYPE_INT64},
-	[CLIENT_IP_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT32},
+	[CLIENT_IP_TIMESTAMP] = {.name = "timestamp", .type = BLOBMSG_TYPE_INT64},
 	[CLIENT_IP_STA_MAC] = {.name = "sta_mac", .type = BLOBMSG_TYPE_STRING},
 	[CLIENT_IP_IP_ADDRESS] = {.name = "ip_address", .type = BLOBMSG_TYPE_STRING},
 };
@@ -158,7 +158,7 @@ static int client_first_data_event_cb(struct blob_attr *msg,
 	}
 
 	if (tb_client_first_data_event[CLIENT_FIRST_DATA_TIMESTAMP])
-		dpp_session->first_data_event->timestamp = blobmsg_get_u32(tb_client_first_data_event[CLIENT_FIRST_DATA_TIMESTAMP]);
+		dpp_session->first_data_event->timestamp = blobmsg_get_u64(tb_client_first_data_event[CLIENT_FIRST_DATA_TIMESTAMP]);
 
 	if (tb_client_first_data_event[CLIENT_FIRST_DATA_TX_TIMESTAMP])
 		dpp_session->first_data_event->fdata_tx_up_ts_in_us = blobmsg_get_u64(tb_client_first_data_event[CLIENT_FIRST_DATA_TX_TIMESTAMP]);
@@ -212,7 +212,7 @@ static int client_disconnect_event_cb(struct blob_attr *msg,
 	}
 
 	if (tb_client_disconnect_event[CLIENT_DISCONNECT_TIMESTAMP])
-		dpp_session->disconnect_event->timestamp = blobmsg_get_u32(tb_client_disconnect_event[CLIENT_DISCONNECT_TIMESTAMP]);
+		dpp_session->disconnect_event->timestamp = blobmsg_get_u64(tb_client_disconnect_event[CLIENT_DISCONNECT_TIMESTAMP]);
 
 	if (tb_client_disconnect_event[CLIENT_DISCONNECT_INTERNAL_RC])
 		dpp_session->disconnect_event->internal_rc = blobmsg_get_u32(tb_client_disconnect_event[CLIENT_DISCONNECT_INTERNAL_RC]);
@@ -258,7 +258,7 @@ static int client_auth_event_cb(struct blob_attr *msg,
 	}
 
 	if (tb_client_auth_event[CLIENT_AUTH_TIMESTAMP])
-		dpp_session->auth_event->timestamp = blobmsg_get_u32(tb_client_auth_event[CLIENT_AUTH_TIMESTAMP]);
+		dpp_session->auth_event->timestamp = blobmsg_get_u64(tb_client_auth_event[CLIENT_AUTH_TIMESTAMP]);
 
 	if (tb_client_auth_event[CLIENT_AUTH_AUTH_STATUS])
 			dpp_session->auth_event->auth_status = blobmsg_get_u32(tb_client_auth_event[CLIENT_AUTH_AUTH_STATUS]);
@@ -301,7 +301,7 @@ static int client_assoc_event_cb(struct blob_attr *msg,
 	}
 
 	if (tb_client_assoc_event[CLIENT_ASSOC_TIMESTAMP])
-		dpp_session->assoc_event->timestamp = blobmsg_get_u32(tb_client_assoc_event[CLIENT_ASSOC_TIMESTAMP]);
+		dpp_session->assoc_event->timestamp = blobmsg_get_u64(tb_client_assoc_event[CLIENT_ASSOC_TIMESTAMP]);
 
 	if (tb_client_assoc_event[CLIENT_ASSOC_INTERNAL_SC])
 		dpp_session->assoc_event->internal_sc = blobmsg_get_u32(tb_client_assoc_event[CLIENT_ASSOC_INTERNAL_SC]);
@@ -362,7 +362,7 @@ static int client_ip_event_cb(struct blob_attr *msg,
 	}
 
 	if (tb_client_ip_event[CLIENT_IP_TIMESTAMP])
-		dpp_session->ip_event->timestamp = blobmsg_get_u32(tb_client_ip_event[CLIENT_IP_TIMESTAMP]);
+		dpp_session->ip_event->timestamp = blobmsg_get_u64(tb_client_ip_event[CLIENT_IP_TIMESTAMP]);
 
 	return 0;
 }


### PR DESCRIPTION
- Added milliseconds timestamp precision
- Replaced realtime clock with monotonic
- Data type changed to uint64 to hold millisecond timestamp

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>