### PR TITLE
NETEXP-898: Increase the waiting time before terminating the websocket

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/inc/redirclient.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/inc/redirclient.h
@@ -6,7 +6,7 @@
 #define MAX_REDIR_CLIENTS   5
 
 #define WS_PING_INTERVAL            20  // in seconds
-#define WS_RESET_LINK_INTERVAL      (3*WS_PING_INTERVAL)
+#define WS_RESET_LINK_INTERVAL      (6*WS_PING_INTERVAL)
 #define WS_DEFAULT_PORT             7681
 #define REDIR_RCV_ARRAY_MAX         10
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/redirmain.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/redirmain.c
@@ -89,7 +89,7 @@ int port_forwarding(char *ipAddress, char *port)
 	    LOG(ERR, "could not resolve address");
             return( -1 );
         }
-        if( !result ){
+        if( result ){
             freeaddrinfo( result );
 	}
     } while( waitForAddrInfo );


### PR DESCRIPTION
NETEXP-898: Increase the waiting time before terminating the websocket

Signed-off-by: Ammad Rehmat <ammad.rehmat@connectus.ai>