### PR TITLE
build: reduce sysupgrade tar file size

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -21,9 +21,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ea8300-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=IPQ40XX
-        TAR_NAME="ea8300-$TAG.tar.gz"
+        TAR_NAME="ea8300-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ea8300-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/dev/"$UPGRADE_TAR_NAME""
 
   build-ecw5410:
     runs-on: ubuntu-latest
@@ -41,9 +44,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ecw5410-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=ECW5410
-        TAR_NAME="ecw5410-$TAG.tar.gz"
+        TAR_NAME="ecw5410-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq806x/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ecw5410-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq806x/generic $(find openwrt/bin/targets/ipq806x/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/dev/"$UPGRADE_TAR_NAME""
 
   build-ap2220:
     runs-on: ubuntu-latest
@@ -61,9 +67,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ap2220-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=AP2220
-        TAR_NAME="ap2220-$TAG.tar.gz"
+        TAR_NAME="ap2220-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ap2220-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/dev/"$UPGRADE_TAR_NAME""
 
   build-ecw5211:
     runs-on: ubuntu-latest
@@ -81,9 +90,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ecw5211-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=ECW5211
-        TAR_NAME="ecw5211-$TAG.tar.gz"
+        TAR_NAME="ecw5211-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ecw5211-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/dev/"$UPGRADE_TAR_NAME""
 
   build-ec420:
     runs-on: ubuntu-latest
@@ -101,9 +113,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ec420-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EC420
-        TAR_NAME="ec420-$TAG.tar.gz"
+        TAR_NAME="ec420-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ec420-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/dev/"$UPGRADE_TAR_NAME""
 
   build-eap101:
     runs-on: ubuntu-latest
@@ -121,9 +136,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "eap101-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EAP101
-        TAR_NAME="eap101-$TAG.tar.gz"
+        TAR_NAME="eap101-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap101/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap101/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="eap101-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx $(find openwrt/bin/targets/ipq807x/ipq60xx -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap101/dev/"$UPGRADE_TAR_NAME""
 
   build-eap102:
     runs-on: ubuntu-latest
@@ -141,9 +159,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "eap102-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EAP102
-        TAR_NAME="eap102-$TAG.tar.gz"
+        TAR_NAME="eap102-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap102/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap102/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="eap102-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap102/dev/"$UPGRADE_TAR_NAME""
 
   build-wf188n:
     runs-on: ubuntu-latest
@@ -161,9 +182,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "wf188n-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=WF188N
-        TAR_NAME="wf188n-$TAG.tar.gz"
+        TAR_NAME="wf188n-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf188n/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf188n/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf188n-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx $(find openwrt/bin/targets/ipq807x/ipq60xx -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf188n/dev/"$UPGRADE_TAR_NAME""
 
   build-wf194c:
     runs-on: ubuntu-latest
@@ -181,9 +205,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "wf194c-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=WF194C
-        TAR_NAME="wf194c-$TAG.tar.gz"
+        TAR_NAME="wf194c-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf194c/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf194c/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf194c-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf194c/dev/"$UPGRADE_TAR_NAME""
 
   build-wf610d:
     runs-on: ubuntu-latest
@@ -201,9 +228,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "wf610d-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=WF610D
-        TAR_NAME="wf610d-$TAG.tar.gz"
+        TAR_NAME="wf610d-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf610d-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/dev/"$UPGRADE_TAR_NAME""
 
   build-ex227:
     runs-on: ubuntu-latest
@@ -221,9 +251,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ex227-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EX227
-        TAR_NAME="ex227-$TAG.tar.gz"
+        TAR_NAME="ex227-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex227/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex227/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ex227-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex227/dev/"$UPGRADE_TAR_NAME""
 
   build-ex447:
     runs-on: ubuntu-latest
@@ -241,8 +274,11 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)
         echo "ex447-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EX447
-        TAR_NAME="ex447-$TAG.tar.gz"
+        TAR_NAME="ex447-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex447/dev/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex447/dev/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ex447-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex447/dev/"$UPGRADE_TAR_NAME""
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "ea8300-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=IPQ40XX
-        TAR_NAME="ea8300-$TAG.tar.gz"
+        TAR_NAME="ea8300-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ea8300-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ea8300/trunk/"$UPGRADE_TAR_NAME""
 
   build-ecw5410:
     runs-on: ubuntu-latest
@@ -41,9 +44,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "ecw5410-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=ECW5410
-        TAR_NAME="ecw5410-$TAG.tar.gz"
+        TAR_NAME="ecw5410-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq806x/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ecw5410-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq806x/generic $(find openwrt/bin/targets/ipq806x/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5410/trunk/"$UPGRADE_TAR_NAME""
 
   build-ap2220:
     runs-on: ubuntu-latest
@@ -61,9 +67,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "ap2220-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=AP2220
-        TAR_NAME="ap2220-$TAG.tar.gz"
+        TAR_NAME="ap2220-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ap2220-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ap2220/trunk/"$UPGRADE_TAR_NAME""
 
   build-ecw5211:
     runs-on: ubuntu-latest
@@ -81,9 +90,12 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "ecw5211-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=ECW5211
-        TAR_NAME="ecw5211-$TAG.tar.gz"
+        TAR_NAME="ecw5211-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ecw5211-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ecw5211/trunk/"$UPGRADE_TAR_NAME""
 
   build-ec420:
     runs-on: ubuntu-latest
@@ -101,9 +113,104 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "ec420-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=EC420
-        TAR_NAME="ec420-$TAG.tar.gz"
+        TAR_NAME="ec420-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ec420-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ec420/trunk/"$UPGRADE_TAR_NAME""
+
+  build-eap101:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for EAP101
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "eap101-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=EAP101
+        TAR_NAME="eap101-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap101/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="eap101-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx $(find openwrt/bin/targets/ipq807x/ipq60xx -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap101/trunk/"$UPGRADE_TAR_NAME""
+
+  build-eap102:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for EAP102
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "eap102-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=EAP102
+        TAR_NAME="eap102-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap102/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="eap102-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/eap102/trunk/"$UPGRADE_TAR_NAME""
+
+  build-wf188n:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for WF188n
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "wf188n-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=WF188N
+        TAR_NAME="wf188n-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf188n/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf188n-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq60xx $(find openwrt/bin/targets/ipq807x/ipq60xx -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf188n/trunk/"$UPGRADE_TAR_NAME""
+
+  build-wf194c:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for WF194C
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "wf194c-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=WF194C
+        TAR_NAME="wf194c-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf194c/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf194c-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf194c/trunk/"$UPGRADE_TAR_NAME""
 
   build-wf610d:
     runs-on: ubuntu-latest
@@ -121,8 +228,57 @@ jobs:
         TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
         echo "wf610d-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
         make TARGET=WF610D
-        TAR_NAME="wf610d-$TAG.tar.gz"
+        TAR_NAME="wf610d-artifacts-$TAG.tar.gz"
         tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic .
-        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/trunk/"$TAR_NAME""
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="wf610d-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq40xx/generic $(find openwrt/bin/targets/ipq40xx/generic -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/wf610d/trunk/"$UPGRADE_TAR_NAME""
+
+  build-ex227:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for EX227
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "ex227-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=EX227
+        TAR_NAME="ex227-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex227/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ex227-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex227/trunk/"$UPGRADE_TAR_NAME""
+
+  build-ex447:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GH_BUILD_TOKEN }}
+        submodules: true
+    - name: Build Image for EX447
+      env:
+          GH_BUILD_USERNAME: ${{ secrets.GH_BUILD_USERNAME }}
+          GH_BUILD_PASSWORD: ${{ secrets.GH_BUILD_PASSWORD }}
+      run: |
+        TAG=$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)
+        echo "ex447-$TAG" > feeds/wlan-ap/opensync/src/vendor/tip/.pkgname
+        make TARGET=EX447
+        TAR_NAME="ex447-artifacts-$TAG.tar.gz"
+        tar cfz "$TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x .
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex447/trunk/artifacts/"$TAR_NAME""
+        UPGRADE_TAR_NAME="ex447-$TAG.tar.gz"
+        tar cfz "$UPGRADE_TAR_NAME" -C openwrt/bin/targets/ipq807x/ipq807x $(find openwrt/bin/targets/ipq807x/ipq807x -type f \( -name '*sysupgrade*' -o -name 'sha256sums' \) -printf "%f\n")
+        curl -u "$GH_BUILD_USERNAME":"$GH_BUILD_PASSWORD" -T "$UPGRADE_TAR_NAME" "https://tip.jfrog.io/artifactory/tip-wlan-ap-firmware/ex447/trunk/"$UPGRADE_TAR_NAME""
 
 


### PR DESCRIPTION
- create tar that contains sysupgrade image and sha256sums file. Pushed to jfrog under dev or trunk directory.
- create tar that contains supplementary build artifacts. Pushed to jfrog under artifacts directory.

Fixes WIFI-1363

Signed-off-by: Arif Alam <arif.alam@netexperience.com>