### PR TITLE
WIFI-961: Fix for Command Manager Crash

### DIFF
--- a/feeds/wlan-ap/opensync/patches/08-command-table.patch
+++ b/feeds/wlan-ap/opensync/patches/08-command-table.patch
@@ -1,8 +1,6 @@
-Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
-===================================================================
---- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
-+++ opensync-2.0.5.0/interfaces/opensync.ovsschema
-@@ -8525,6 +8525,92 @@
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -8525,6 +8525,95 @@
              }
          },
          "isRoot": true
@@ -55,8 +53,11 @@ Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
 +                "type": {
 +                   "key": {
 +                     "type": "uuid",
-+                     "refTable": "Command_Config"
-+                   }
++                     "refTable": "Command_Config",
++                     "refType": "weak"
++                   },
++                   "min": 0,
++                   "max": 1
 +                }
 +             },
 +            "state": {

--- a/feeds/wlan-ap/opensync/patches/26-ovsdb-where.patch
+++ b/feeds/wlan-ap/opensync/patches/26-ovsdb-where.patch
@@ -1,0 +1,45 @@
+--- a/src/lib/ovsdb/src/ovsdb_sync_api.c
++++ b/src/lib/ovsdb/src/ovsdb_sync_api.c
+@@ -62,6 +62,10 @@ json_t* ovsdb_where_uuid(const char *col
+ {
+     return ovsdb_tran_cond(OCLM_UUID, column, OFUNC_EQ, uuid);
+ }
++json_t* ovsdb_where_timestamp(const char *column, int *timestamp)
++{
++    return ovsdb_tran_cond(OCLM_INT, column, OFUNC_EQ, timestamp);
++}
+ 
+ /* ovsdb_where_multi() combines multiple ovsdb_where_*() conditions
+  * Example:
+--- a/src/lib/ovsdb/inc/ovsdb_sync.h
++++ b/src/lib/ovsdb/inc/ovsdb_sync.h
+@@ -38,6 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBI
+ json_t* ovsdb_where_simple(const char *column, const char *value);
+ json_t* ovsdb_where_simple_typed(const char *column, const void *value, ovsdb_col_t col_type);
+ json_t* ovsdb_where_uuid(const char *column, const char *uuid);
++json_t* ovsdb_where_timestamp(const char *column, int *timestamp);
+ json_t* ovsdb_where_multi(json_t *where, ...);
+ json_t* ovsdb_mutation(const char *column, json_t *mutation, json_t *value);
+ int     ovsdb_get_update_result_count(json_t *result, const char *table, const char *oper);
+--- a/src/lib/ovsdb/src/ovsdb_method.c
++++ b/src/lib/ovsdb/src/ovsdb_method.c
+@@ -677,8 +677,9 @@ json_t * ovsdb_tran_cond(ovsdb_col_t col
+                          ovsdb_func_t func,
+                          const void * value)
+ {
+-    const json_int_t *jint = value;
++   // const json_int_t *jint = value;
+     json_t * jval = NULL;
++    const int *tsmp = value;
+     json_t * jtop;
+ 
+     /* wrap-up into additional array */
+@@ -701,7 +702,7 @@ json_t * ovsdb_tran_cond(ovsdb_col_t col
+             break;
+ 
+         case OCLM_INT:
+-            jval = json_integer(*jint);
++            jval = json_integer(*tsmp);
+             break;
+ 
+         default:

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/inc/command.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/inc/command.h
@@ -35,6 +35,7 @@ struct task {
 	pid_t pid;
 	ev_child child;
 	const char *arg;
+	int state;
 };
 
 extern char serial[64];

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/cmd_crashlog.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/cmd_crashlog.c
@@ -30,7 +30,7 @@ pid_t cmd_handler_crashlog(struct task *task)
 	pid_t pid;
 
 	if (!crash_timestamp) {
-		task_status(task, TASK_FAILED, "no crashlog found");
+		LOGI("No Crashlog Found");
 		return -1;
 	}
 
@@ -38,8 +38,7 @@ pid_t cmd_handler_crashlog(struct task *task)
 
 	_url = SCHEMA_KEY_VAL(task->conf.payload, "ul_url");
 	if (!_url) {
-		LOG(ERR, "curl: command without a valid ul_url");
-		task_status(task, TASK_FAILED, "invalid url");
+		LOGN("curl: crashlog command without a valid ul_url");
 		return -1;
 	}
 	snprintf(url, sizeof(url), "%s/%s-%lu.crashlog", _url, serial, crash_timestamp);


### PR DESCRIPTION
This patch will reslove command manager crash issue and also add support for deleting the lingering entries in
the command state table

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>