### PR TITLE
build: generate sysupgrade.bin instead of sysupgrade.tar for AX images

### DIFF
--- a/patches/0027-ipq807x-add-the-Qualcomm-AX-target-support.patch
+++ b/patches/0027-ipq807x-add-the-Qualcomm-AX-target-support.patch
@@ -7324,8 +7324,8 @@ index 0000000000..3a219e6d6c
 +  ROOTFSNAME_IN_UBI := ubi_rootfs
 +  BLOCKSIZE := 128k
 +  PAGESIZE := 2048
-+  IMAGES := sysupgrade.tar nand-factory.bin
-+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
++  IMAGES := sysupgrade.bin nand-factory.bin
++  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 +  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
 +  KERNEL_NAME := Image
 +  KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
@@ -7348,8 +7348,8 @@ index 0000000000..c536a174f8
 +  DEVICE_DTS := qcom-ipq6018-cig-wf188
 +  DEVICE_DTS_CONFIG := config@cp03-c1
 +  SUPPORTED_DEVICES := cig,wf188
-+  IMAGES := sysupgrade.tar
-+  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
++  IMAGES := sysupgrade.bin
++  IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 +  DEVICE_PACKAGES := ath11k-wifi-cig-wf188 uboot-env
 +endef
 +TARGET_DEVICES += cig_wf188
@@ -7446,8 +7446,8 @@ index 0000000000..eb23ca2e3a
 +  DEVICE_DTS_CONFIG=config@hk07
 +  SUPPORTED_DEVICES := tplinl,ex227
 +  DEVICE_PACKAGES := ath11k-wifi-tplink-ex227
-+  IMAGES := sysupgrade.tar nor-factory.bin
-+  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
++  IMAGES := sysupgrade.bin nor-factory.bin
++  IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 +  IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
 +endef
 +TARGET_DEVICES += tplink_ex227
@@ -7458,8 +7458,8 @@ index 0000000000..eb23ca2e3a
 +  DEVICE_DTS_CONFIG=config@hk09
 +  SUPPORTED_DEVICES := tplinl,ex447
 +  DEVICE_PACKAGES := ath11k-wifi-tplink-ex447
-+  IMAGES := sysupgrade.tar nor-factory.bin
-+  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
++  IMAGES := sysupgrade.bin nor-factory.bin
++  IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 +  IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
 +endef
 +TARGET_DEVICES += tplink_ex447


### PR DESCRIPTION
Generate sysupgrade.bin to be consistant with sysupgrade image naming.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>