### PR TITLE
opensync: enable dhcp sniffing only on bridge interface

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/inet_conf.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/inet_conf.h
@@ -9,7 +9,7 @@
 struct netifd_iface *netifd_add_inet_conf(struct schema_Wifi_Inet_Config *iconf);
 void netifd_del_inet_conf(struct schema_Wifi_Inet_Config *old_rec);
 struct netifd_iface *netifd_modify_inet_conf(struct schema_Wifi_Inet_Config *iconf);
-bool netifd_inet_config_set(struct netifd_iface *piface, struct schema_Wifi_Inet_Config *iconf);
+bool netifd_inet_config_set(struct netifd_iface *piface);
 bool netifd_inet_config_apply(struct netifd_iface *piface);
 
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/dhcp_fingerprint.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/dhcp_fingerprint.c
@@ -10,7 +10,7 @@ bool dhcp_fp_db_lookup (dhcp_fp_data_t *fp_data, char *option_seq)
 	FILE *fp = NULL;
 	char *line = NULL;
 	int i, rd, rt, found = 0;
-	size_t len;
+	size_t len = 0;
 	int dev_type, dev_manufid = 0;
 
 	memset(fp_data, 0, sizeof(dhcp_fp_data_t));
@@ -119,6 +119,9 @@ bool dhcp_fp_db_lookup (dhcp_fp_data_t *fp_data, char *option_seq)
 	if (local_db.index >= MAX_DHCP_FINGERPRINT_LOCAL_DB)
 		local_db.index = 0;
 
+
+	fclose(fp);
+	free(line);
 	return true;
 
 db_lookup_exit:

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/inet_iface.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/inet_iface.c
@@ -104,6 +104,11 @@ inet_base_t *netifd_iface_new_inet(const char *ifname, const char *iftype)
 	memset(self, 0, sizeof(inet_base_t));
 	if((!strcmp(ifname, "wan") && !strcmp(iftype,"bridge")) || (!strcmp(ifname, "lan") && !strcmp(iftype,"bridge"))) {
 		snprintf(self->inet.in_ifname, sizeof(self->inet.in_ifname), "br-%s", ifname);
+	} else if (!strcmp(iftype,"vlan")) {
+		char name[15]= {};
+		unsigned int id = 0;
+		sscanf(ifname, "%[^_]_%d", name, &id);
+		snprintf(self->inet.in_ifname, sizeof(self->inet.in_ifname), "br-%s.%d", name, id);
 	} else {
 		STRSCPY(self->inet.in_ifname, ifname);
 	}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
@@ -393,9 +393,6 @@ static void callback_Wifi_Inet_Config(ovsdb_update_monitor_t *mon,
 		return;
 	}
 
-	netifd_inet_config_set(piface, iconf);
-	netifd_inet_config_apply(piface);
-
 	return;
 }
 


### PR DESCRIPTION
Reduce nm running memory footprint by enabling dhcp sniffing only on bridge interface.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>