### PR TITLE
WIFI-1458-Tx-Power-Range

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -23,7 +23,7 @@ struct wifi_phy {
 	unsigned char chandisabled[IEEE80211_CHAN_MAX];
 	unsigned char channel[IEEE80211_CHAN_MAX];
 	unsigned char chandfs[IEEE80211_CHAN_MAX];
-	unsigned char chanpwr[IEEE80211_CHAN_MAX];
+	unsigned int chanpwr[IEEE80211_CHAN_MAX];
 	unsigned int freq[IEEE80211_CHAN_MAX];
 
 	int tx_ant, rx_ant, tx_ant_avail, rx_ant_avail;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -10,6 +10,7 @@ extern int phy_get_tx_chainmask(const char *name);
 extern int phy_get_rx_chainmask(const char *name);
 extern int phy_get_tx_available_antenna(const char *name);
 extern int phy_get_rx_available_antenna(const char *name);
+extern int phy_get_max_tx_power(const char *name , int channel);
 extern int phy_get_channels(const char *name, int *channel);
 extern int phy_get_channels_state(const char *name,
 			struct schema_Wifi_Radio_State *rstate);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -282,8 +282,16 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 	if (changed->enabled)
 		blobmsg_add_u8(&b, "disabled", rconf->enabled ? 0 : 1);
 
-	if (changed->tx_power)
-		blobmsg_add_u32(&b, "txpower", rconf->tx_power);
+	if (changed->tx_power) {
+		int max_tx_power;
+		max_tx_power=phy_get_max_tx_power(phy,rconf->channel);
+		if (rconf->tx_power<=max_tx_power) {
+			blobmsg_add_u32(&b, "txpower", rconf->tx_power);
+		}
+		else {
+			blobmsg_add_u32(&b, "txpower", max_tx_power);
+		}
+	}
 
 	if (changed->tx_chainmask) {
 		int tx_ant_avail;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
@@ -461,7 +461,7 @@ static void nl80211_add_phy(struct nlattr **tb, char *name)
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_MAX_TX_POWER] &&
 					    !tb_freq[NL80211_FREQUENCY_ATTR_DISABLED])
-						phy->chanpwr[chan] = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_MAX_TX_POWER]) / 10;
+						phy->chanpwr[chan] = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_MAX_TX_POWER]);
 					if (chan <= 16)
 						phy->band_2g = 1;
 					else if (chan >= 32 && chan <= 68)

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -235,6 +235,15 @@ int phy_get_rx_available_antenna(const char *name)
 	return phy->rx_ant_avail;
 }
 
+int phy_get_max_tx_power(const char *name , int channel)
+{
+	struct wifi_phy *phy = phy_find(name);
+
+	if (!phy)
+		return 0;
+	return phy->chanpwr[channel]/100; //units to dBm
+}
+
 int phy_get_channels(const char *name, int *channel)
 {
 	struct wifi_phy *phy = phy_find(name);


### PR DESCRIPTION
This patch will resolve the radio config fail problem, when tx
power configured more than allowed operational range of AP.

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>