### PR TITLE
opensync: Add support for dynamic vlan in custom_options

### DIFF
--- a/feeds/wlan-ap/opensync/patches/27-dynamic-vlan-consts.patch
+++ b/feeds/wlan-ap/opensync/patches/27-dynamic-vlan-consts.patch
@@ -1,0 +1,13 @@
+Index: opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/schema/inc/schema_consts.h
++++ opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+@@ -153,7 +153,7 @@ typedef enum {
+ #define SCHEMA_CONSTS_DTIM_PERIOD	"dtim_period"
+ #define SCHEMA_CONSTS_DISABLE_B_RATES	"disable_b_rates"
+ #define SCHEMA_CONSTS_IEEE80211k	"ieee80211k"
+-
++#define SCHEMA_CONSTS_DYNAMIC_VLAN	"dynamic_vlan"
+ /* Captive Portal */
+ #define SCHEMA_CONSTS_SESSION_TIMEOUT              "session_timeout"
+ #define SCHEMA_CONSTS_BROWSER_TITLE                "browser_title"


### PR DESCRIPTION
Add support for dynamic vlan in custom_options:
dynamic_vlan (values 0 1 and 2)
0 - disabled
1 - enabled
2 - enabled and reject if Radius server doesnt have Dynamic VLAN

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>