### PR TITLE
Staging dfs channel list

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/redirclient.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/redirclient.c
@@ -232,7 +232,7 @@ static int redirLinkClientPongReceiveHandler(struct lws *wsi, struct per_session
 	l = 0;
 
 	while (shift >= 0) {
-		l |= (*p++) << shift;
+		l |= ((unsigned long)(*p++)) << shift;
 		shift -= 8;
 	}
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -12,6 +12,7 @@ extern int phy_get_tx_available_antenna(const char *name);
 extern int phy_get_rx_available_antenna(const char *name);
 extern int phy_get_max_tx_power(const char *name , int channel);
 extern int phy_get_channels(const char *name, int *channel);
+extern int phy_get_list_channels_dfs(const char *name, int *list);
 extern int phy_get_channels_state(const char *name,
 			struct schema_Wifi_Radio_State *rstate);
 extern int phy_get_band(const char *name, char *band);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
@@ -370,8 +370,8 @@ void splash_page_logo(char* dest_file, char* src_url)
 	imagefile = fopen(dest_file, "wb");
 	if(imagefile == NULL){
 		LOG(ERR, "fopen failed");
-		fclose(headerfile);
-		fclose(imagefile);
+		if(headerfile)
+			fclose(headerfile);
 		return;
 	}
 	curl = curl_easy_init();

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -310,6 +310,27 @@ int phy_get_channels_state(const char *name, struct schema_Wifi_Radio_State *rst
 	return ret;
 }
 
+int phy_get_list_channels_dfs(const char *name, int *list)
+{
+	struct wifi_phy *phy = phy_find(name);
+	int i = 0, len = 0;
+
+	if (!phy)
+		return 0;
+
+	for (i = 0; (i < IEEE80211_CHAN_MAX); i++) {
+		if (phy->chandfs[i]) {
+			list[len] = i;
+			len++;
+		} else if (phy->channel[i]) {
+			list[len] = i;
+			len++;
+		}
+	}
+
+	return len;
+}
+
 int phy_get_band(const char *name, char *band)
 {
 	struct wifi_phy *phy = phy_find(name);


### PR DESCRIPTION
Wifi-1502 : Hostapd has the list of channels it can switch to in case of DFS event

- One commit makes changes for removing static analysis failure after switching from cppcheck version 1.82 to 1.90-4
- The other commit makes it possible for DFS channel switching mechanism to be complete by providing a list of channels to which hosatpd can switch on DFS event.

