### PR TITLE
opensync: Update ovsdb schema to support 11ax

### DIFF
--- a/feeds/wlan-ap/opensync/patches/28-add-11ax-mode
+++ b/feeds/wlan-ap/opensync/patches/28-add-11ax-mode
@@ -1,0 +1,22 @@
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -2045,7 +2045,8 @@
+                   "11g",
+                   "11a",
+                   "11n",
+-                  "11ac"
++                  "11ac",
++                  "11ax"    
+                 ]
+               ]
+             },
+@@ -2437,7 +2438,8 @@
+                   "11g",
+                   "11a",
+                   "11n",
+-                  "11ac"
++                  "11ac",
++                  "11ax"
+                 ]
+               ]
+             },


### PR DESCRIPTION
Ovsdb schema for VIF_Config/State is updated to support 11ax as min_hw_mode

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>