### PR TITLE
Fix for wifi6 Crash in nft in ssidratelimit hotplug

### DIFF
--- a/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/40-rlimit-ssid
+++ b/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/40-rlimit-ssid
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 [ "$ACTION" = "add" ] || exit 0
+phy=$(cat /sys/class/net/${DEVICENAME}/phy80211/name)
+
 rlimit=$(uci get wireless.${DEVICENAME}.rlimit)
 
+[ -z "$rlimit" -o -z "$phy" ] && exit 0
 /etc/init.d/nft-qos restart
 exit 0


### PR DESCRIPTION
Fixes crash in kernel due to nft accessing
kernel in hotplug code early on.