### PR TITLE
hostapd: add per phy max sta count

### DIFF
--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -97,6 +97,7 @@ hostapd_common_add_device_config() {
 	config_add_boolean country_ie doth
 	config_add_boolean spectrum_mgmt_required
 	config_add_int local_pwr_constraint
+	config_add_int maxassoc
 	config_add_string require_mode
 	config_add_boolean legacy_rates
 
@@ -117,7 +118,7 @@ hostapd_prepare_device_config() {
 	local base_cfg=
 
 	json_get_vars country country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
-		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode \
+		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode maxassoc \
 		multiple_bssid he_co_locate rnr_beacon ema
 
 	hostapd_set_log_options base_cfg
@@ -131,6 +132,7 @@ hostapd_prepare_device_config() {
 	set_default rnr_beacon 0
 	set_default he_co_locate 0
 	set_default ema 0
+	set_default maxassoc 0
 
 	[ "$hwmode" = "b" ] && legacy_rates=1
 
@@ -145,6 +147,7 @@ hostapd_prepare_device_config() {
 		[ "$hwmode" = "a" -a "$doth" -gt 0 ] && append base_cfg "ieee80211h=1" "$N"
 	}
 
+	[ "$maxassoc" -gt 0 ] && append base_cfg "global_max_num_sta=$maxassoc" "$N"
 	[ -n "$acs_chan_bias" ] && append base_cfg "acs_chan_bias=$acs_chan_bias" "$N"
 
 	local brlist= br

--- a/feeds/wifi-ax/hostapd/patches/900-max-sta-limit.patch
+++ b/feeds/wifi-ax/hostapd/patches/900-max-sta-limit.patch
@@ -1,0 +1,100 @@
+Index: hostapd-2020-06-08-5a8b3662/hostapd/config_file.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/hostapd/config_file.c
++++ hostapd-2020-06-08-5a8b3662/hostapd/config_file.c
+@@ -2909,6 +2909,11 @@ static int hostapd_config_fill(struct ho
+ 				   line);
+ 			return 1;
+ 		}
++	} else if (os_strcmp(buf, "global_max_num_sta") == 0) {
++		conf->global_max_num_sta = atoi(pos);
++		if (conf->global_max_num_sta < 0 ||
++		    conf->global_max_num_sta > MAX_STA_COUNT)
++			conf->global_max_num_sta = MAX_STA_COUNT;
+ 	} else if (os_strcmp(buf, "max_num_sta") == 0) {
+ 		bss->max_num_sta = atoi(pos);
+ 		if (bss->max_num_sta < 0 ||
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ap_config.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ap_config.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/ap_config.c
+@@ -228,6 +228,8 @@ struct hostapd_config * hostapd_config_d
+ 
+ 	conf->num_bss = 1;
+ 
++	conf->global_max_num_sta = 0;
++
+ 	conf->beacon_int = 100;
+ 	conf->rts_threshold = -2; /* use driver default: 2347 */
+ 	conf->fragm_threshold = -2; /* user driver default: 2346 */
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ap_config.h
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ap_config.h
++++ hostapd-2020-06-08-5a8b3662/src/ap/ap_config.h
+@@ -1069,6 +1069,7 @@ struct hostapd_config {
+ #define AIRTIME_MODE_MAX (__AIRTIME_MODE_MAX - 1)
+ #endif /* CONFIG_AIRTIME_POLICY */
+ 	char *config_id;
++	int global_max_num_sta;
+ };
+ 
+ 
+Index: hostapd-2020-06-08-5a8b3662/src/ap/beacon.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/beacon.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/beacon.c
+@@ -1030,7 +1030,8 @@ void handle_probe_req(struct hostapd_dat
+ 	if (hapd->conf->no_probe_resp_if_max_sta &&
+ 	    is_multicast_ether_addr(mgmt->da) &&
+ 	    is_multicast_ether_addr(mgmt->bssid) &&
+-	    hapd->num_sta >= hapd->conf->max_num_sta &&
++	    hapd_check_max_sta(hapd) &&
++//	    hapd->num_sta >= hapd->conf->max_num_sta &&
+ 	    !ap_get_sta(hapd, mgmt->sa)) {
+ 		wpa_printf(MSG_MSGDUMP, "%s: Ignore Probe Request from " MACSTR
+ 			   " since no room for additional STA",
+Index: hostapd-2020-06-08-5a8b3662/src/ap/sta_info.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/sta_info.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/sta_info.c
+@@ -705,7 +705,8 @@ struct sta_info * ap_sta_add(struct host
+ 		return sta;
+ 
+ 	wpa_printf(MSG_DEBUG, "  New STA");
+-	if (hapd->num_sta >= hapd->conf->max_num_sta) {
++	if (hapd_check_max_sta(hapd)) {
++//	if (hapd->num_sta >= hapd->conf->max_num_sta) {
+ 		/* FIX: might try to remove some old STAs first? */
+ 		wpa_printf(MSG_DEBUG, "no more room for new STAs (%d/%d)",
+ 			   hapd->num_sta, hapd->conf->max_num_sta);
+Index: hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/hostapd.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+@@ -3779,3 +3779,15 @@ void hostapd_ocv_check_csa_sa_query(void
+ 	}
+ }
+ #endif /* CONFIG_OCV */
++
++int hapd_check_max_sta(struct hostapd_data *hapd)
++{
++	int cnt = 0, i;
++
++	if (!hapd->iconf->global_max_num_sta)
++		return hapd->num_sta >= hapd->conf->max_num_sta;
++
++	for (i = 0; i < hapd->iface->num_bss; i++)
++		cnt += hapd->iface->bss[i]->num_sta;
++	return cnt >= hapd->iconf->global_max_num_sta;
++}
+Index: hostapd-2020-06-08-5a8b3662/src/ap/hostapd.h
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/hostapd.h
++++ hostapd-2020-06-08-5a8b3662/src/ap/hostapd.h
+@@ -693,4 +693,6 @@ void fst_hostapd_fill_iface_obj(struct h
+ 				struct fst_wpa_obj *iface_obj);
+ #endif /* CONFIG_FST */
+ 
++int hapd_check_max_sta(struct hostapd_data *hapd);
++
+ #endif /* HOSTAPD_H */

--- a/feeds/wifi-trunk/hostapd/files/hostapd.sh
+++ b/feeds/wifi-trunk/hostapd/files/hostapd.sh
@@ -97,6 +97,7 @@ hostapd_common_add_device_config() {
 	config_add_boolean country_ie doth
 	config_add_boolean spectrum_mgmt_required
 	config_add_int local_pwr_constraint
+	config_add_int maxassoc
 	config_add_string require_mode
 	config_add_boolean legacy_rates
 
@@ -114,7 +115,7 @@ hostapd_prepare_device_config() {
 	local base_cfg=
 
 	json_get_vars country country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
-		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode
+		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode maxassoc
 
 	hostapd_set_log_options base_cfg
 
@@ -123,6 +124,7 @@ hostapd_prepare_device_config() {
 	set_default doth 1
 	set_default legacy_rates 1
 	set_default airtime_mode 0
+	set_default maxassoc 0
 
 	[ "$hwmode" = "b" ] && legacy_rates=1
 
@@ -137,6 +139,7 @@ hostapd_prepare_device_config() {
 		[ "$hwmode" = "a" -a "$doth" -gt 0 ] && append base_cfg "ieee80211h=1" "$N"
 	}
 
+	[ "$maxassoc" -gt 0 ] && append base_cfg "global_max_num_sta=$maxassoc" "$N"
 	[ -n "$acs_chan_bias" ] && append base_cfg "acs_chan_bias=$acs_chan_bias" "$N"
 
 	local brlist= br

--- a/feeds/wifi-trunk/hostapd/patches/900-max-sta-limit.patch
+++ b/feeds/wifi-trunk/hostapd/patches/900-max-sta-limit.patch
@@ -1,0 +1,100 @@
+Index: hostapd-2020-06-08-5a8b3662/hostapd/config_file.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/hostapd/config_file.c
++++ hostapd-2020-06-08-5a8b3662/hostapd/config_file.c
+@@ -2909,6 +2909,11 @@ static int hostapd_config_fill(struct ho
+ 				   line);
+ 			return 1;
+ 		}
++	} else if (os_strcmp(buf, "global_max_num_sta") == 0) {
++		conf->global_max_num_sta = atoi(pos);
++		if (conf->global_max_num_sta < 0 ||
++		    conf->global_max_num_sta > MAX_STA_COUNT)
++			conf->global_max_num_sta = MAX_STA_COUNT;
+ 	} else if (os_strcmp(buf, "max_num_sta") == 0) {
+ 		bss->max_num_sta = atoi(pos);
+ 		if (bss->max_num_sta < 0 ||
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ap_config.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ap_config.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/ap_config.c
+@@ -228,6 +228,8 @@ struct hostapd_config * hostapd_config_d
+ 
+ 	conf->num_bss = 1;
+ 
++	conf->global_max_num_sta = 0;
++
+ 	conf->beacon_int = 100;
+ 	conf->rts_threshold = -2; /* use driver default: 2347 */
+ 	conf->fragm_threshold = -2; /* user driver default: 2346 */
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ap_config.h
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ap_config.h
++++ hostapd-2020-06-08-5a8b3662/src/ap/ap_config.h
+@@ -1069,6 +1069,7 @@ struct hostapd_config {
+ #define AIRTIME_MODE_MAX (__AIRTIME_MODE_MAX - 1)
+ #endif /* CONFIG_AIRTIME_POLICY */
+ 	char *config_id;
++	int global_max_num_sta;
+ };
+ 
+ 
+Index: hostapd-2020-06-08-5a8b3662/src/ap/beacon.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/beacon.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/beacon.c
+@@ -1030,7 +1030,8 @@ void handle_probe_req(struct hostapd_dat
+ 	if (hapd->conf->no_probe_resp_if_max_sta &&
+ 	    is_multicast_ether_addr(mgmt->da) &&
+ 	    is_multicast_ether_addr(mgmt->bssid) &&
+-	    hapd->num_sta >= hapd->conf->max_num_sta &&
++	    hapd_check_max_sta(hapd) &&
++//	    hapd->num_sta >= hapd->conf->max_num_sta &&
+ 	    !ap_get_sta(hapd, mgmt->sa)) {
+ 		wpa_printf(MSG_MSGDUMP, "%s: Ignore Probe Request from " MACSTR
+ 			   " since no room for additional STA",
+Index: hostapd-2020-06-08-5a8b3662/src/ap/sta_info.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/sta_info.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/sta_info.c
+@@ -705,7 +705,8 @@ struct sta_info * ap_sta_add(struct host
+ 		return sta;
+ 
+ 	wpa_printf(MSG_DEBUG, "  New STA");
+-	if (hapd->num_sta >= hapd->conf->max_num_sta) {
++	if (hapd_check_max_sta(hapd)) {
++//	if (hapd->num_sta >= hapd->conf->max_num_sta) {
+ 		/* FIX: might try to remove some old STAs first? */
+ 		wpa_printf(MSG_DEBUG, "no more room for new STAs (%d/%d)",
+ 			   hapd->num_sta, hapd->conf->max_num_sta);
+Index: hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/hostapd.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/hostapd.c
+@@ -3779,3 +3779,15 @@ void hostapd_ocv_check_csa_sa_query(void
+ 	}
+ }
+ #endif /* CONFIG_OCV */
++
++int hapd_check_max_sta(struct hostapd_data *hapd)
++{
++	int cnt = 0, i;
++
++	if (!hapd->iconf->global_max_num_sta)
++		return hapd->num_sta >= hapd->conf->max_num_sta;
++
++	for (i = 0; i < hapd->iface->num_bss; i++)
++		cnt += hapd->iface->bss[i]->num_sta;
++	return cnt >= hapd->iconf->global_max_num_sta;
++}
+Index: hostapd-2020-06-08-5a8b3662/src/ap/hostapd.h
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/hostapd.h
++++ hostapd-2020-06-08-5a8b3662/src/ap/hostapd.h
+@@ -693,4 +693,6 @@ void fst_hostapd_fill_iface_obj(struct h
+ 				struct fst_wpa_obj *iface_obj);
+ #endif /* CONFIG_FST */
+ 
++int hapd_check_max_sta(struct hostapd_data *hapd);
++
+ #endif /* HOSTAPD_H */


### PR DESCRIPTION
    
    Normally max_num_sta is per BSS. This patch allows setting a pre IFACE sta max.
    
    Signed-off-by: John Crispin <john@phrozen.org>
