### PR TITLE
openwrt: Fix wifi leds for ecw5211 wf610d eap102

### DIFF
--- a/patches/0043-openwrt-Fix-WiFi_LEDs-for-ecw5211-wf610d-eap102.patch
+++ b/patches/0043-openwrt-Fix-WiFi_LEDs-for-ecw5211-wf610d-eap102.patch
@@ -1,0 +1,52 @@
+From d3c04cf273f39ba93f95d936faa1386131d9dfec Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Mon, 22 Feb 2021 14:05:33 -0500
+Subject: [PATCH] openwrt: Fix LEDs for 5211 and cig wf610d
+
+Fixed typo for ecw5211 and eap102 and fixed boardname
+of cig wf610d.
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ target/linux/ipq40xx/base-files/etc/board.d/01_leds | 8 ++++++--
+ target/linux/ipq807x/base-files/etc/board.d/01_leds | 2 +-
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/target/linux/ipq40xx/base-files/etc/board.d/01_leds b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+index 4cf7032500..e1833ffcee 100755
+--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+@@ -60,11 +60,15 @@ zyxel,nbg6617)
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5G" "phy1tpt"
+ 	;;
+ edgecore,ecw5211 |\
+-zyxel,wre6606) |\
+-cig,wf610d)
++zyxel,wre6606)
+ 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy0tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5g" "phy1tpt"
+ 	;;
++cig,wf610d)
++	ucidef_set_led_wlan "wlan2g" "WLAN2G" "wf6203:green:wifi2g" "phy0tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "wf6203:green:wifi5g" "phy1tpt"
++	;;
++
+ *)
+ 	;;
+ esac
+diff --git a/target/linux/ipq807x/base-files/etc/board.d/01_leds b/target/linux/ipq807x/base-files/etc/board.d/01_leds
+index 12492bf3d1..1402a74f3e 100755
+--- a/target/linux/ipq807x/base-files/etc/board.d/01_leds
++++ b/target/linux/ipq807x/base-files/etc/board.d/01_leds
+@@ -15,7 +15,7 @@ cig,wf194c)
+ 	ucidef_set_led_netdev "wan" "WAN" "wf194c:green:wan" "br-wan" "tx rx link"
+ 	ucidef_set_led_netdev "lan" "LAN" "wf194c:green:lan" "br-lan" "tx rx link"
+ 	;;
+-edgecore,eap101\
++edgecore,eap101 |\
+ edgecore,eap102)
+         ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tx"
+         ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tx"
+-- 
+2.25.1
+


### PR DESCRIPTION
Fix typo error for ecw5211 and eap102, correct
boardname for wf610d

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>