### PR TITLE
Wifi-1623 : Any event coming from hostapd with 5G frequency will be t…

### DIFF
--- a/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
+++ b/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
@@ -140,8 +140,8 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  };
  
 +enum hostapd_ubus_chan_event_reason {
-+	HOSTAPD_UBUS_HIGH_INTERFERENCE,
-+	HOSTAPD_UBUS_DFS_SWITCH
++	HOSTAPD_UBUS_DFS_SWITCH,
++	HOSTAPD_UBUS_HIGH_INTERFERENCE
 +};
 +
  struct hostapd_ubus_request {

--- a/feeds/wlan-ap/opensync/patches/26-channel-switch-events.patch
+++ b/feeds/wlan-ap/opensync/patches/26-channel-switch-events.patch
@@ -117,7 +117,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +		assert(channel_switch);
 +		sts__event_report__channel_switch_event__init(channel_switch);
 +
-+		channel_switch->band = channel_switch_rec->band;
++		channel_switch->band = dppline_to_proto_radio(channel_switch_rec->band);
 +		channel_switch->reason = channel_switch_rec->reason;
 +		channel_switch->channel = channel_switch_rec->freq;
 +		channel_switch->timestamp_ms = channel_switch_rec->timestamp;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -12,7 +12,6 @@ extern int phy_get_tx_available_antenna(const char *name);
 extern int phy_get_rx_available_antenna(const char *name);
 extern int phy_get_max_tx_power(const char *name , int channel);
 extern int phy_get_channels(const char *name, int *channel);
-extern int phy_get_list_channels_dfs(const char *name, int *list);
 extern int phy_get_channels_state(const char *name,
 			struct schema_Wifi_Radio_State *rstate);
 extern int phy_get_band(const char *name, char *band);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
@@ -33,6 +33,7 @@ extern ovsdb_table_t table_Wifi_RRM_Config;
 
 void rrm_config_vif(struct blob_buf *b, struct blob_buf *del, 
 		const char * freq_band, const char * if_name);
+int rrm_get_backup_channel(const char * freq_band);
 void callback_Wifi_RRM_Config(ovsdb_update_monitor_t *mon,
 		struct schema_Wifi_RRM_Config *old, struct schema_Wifi_RRM_Config *conf);
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -274,7 +274,6 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 
 	char phy[6];
 	char ifname[8];
-	int list_channels[IEEE80211_CHAN_MAX] , list_channels_len = 0;
 
 	strncpy(ifname, rconf->if_name, sizeof(ifname));
 	strncpy(phy, target_map_ifname(ifname), sizeof(phy));
@@ -342,16 +341,18 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 			 LOGE("%s: failed to set ht/hwmode", rconf->if_name);
 	}
 
-	list_channels_len = phy_get_list_channels_dfs(phy, list_channels);
-	if (list_channels_len) {
-		struct blob_attr *n;
+	struct blob_attr *n;
+	int backup_channel = 0;
+	backup_channel = rrm_get_backup_channel(rconf->freq_band);
+	if(backup_channel) {
 		n = blobmsg_open_array(&b, "channels");
-		for(int i = 0; i < list_channels_len; i++)
-		{
-			blobmsg_add_u32(&b, NULL, list_channels[i]);
-		}
+		blobmsg_add_u32(&b, NULL, backup_channel);
 		blobmsg_close_array(&b, n);
-	}
+	} else {
+		n = blobmsg_open_array(&del, "channels");
+		blobmsg_add_u32(&del, NULL, backup_channel);
+		blobmsg_close_array(&del, n);
+	}	
 
 	if (changed->custom_options)
 		radio_config_custom_opt_set(&b, &del, rconf);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -310,27 +310,6 @@ int phy_get_channels_state(const char *name, struct schema_Wifi_Radio_State *rst
 	return ret;
 }
 
-int phy_get_list_channels_dfs(const char *name, int *list)
-{
-	struct wifi_phy *phy = phy_find(name);
-	int i = 0, len = 0;
-
-	if (!phy)
-		return 0;
-
-	for (i = 0; (i < IEEE80211_CHAN_MAX); i++) {
-		if (phy->chandfs[i]) {
-			list[len] = i;
-			len++;
-		} else if (phy->channel[i]) {
-			list[len] = i;
-			len++;
-		}
-	}
-
-	return len;
-}
-
 int phy_get_band(const char *name, char *band)
 {
 	struct wifi_phy *phy = phy_find(name);

--- a/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
+++ b/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
@@ -126,13 +126,13 @@ static int frequency_to_channel(int freq)
 static radio_type_t frequency_to_band(int freq)
 {
 	int chan = frequency_to_channel(freq);
-
+	/*Need to add support for differentiating between 5G,5GU and 5GL*/
 	if (chan <= 16)
 		return RADIO_TYPE_2G;
 	else if (chan >= 32 && chan <= 68)
-		return RADIO_TYPE_5GL;
+		return RADIO_TYPE_5G;
 	else if (chan >= 96)
-		return RADIO_TYPE_5GU;
+		return RADIO_TYPE_5G;
 	else
 		return RADIO_TYPE_NONE;
 }


### PR DESCRIPTION
Wifi-1623 : Any event coming from hostapd with 5G frequency will be treated as 5G radio only

-  channels list only has backup_channel in order to control which channel should the hostapd choose in case of DFS event.
-  5G frequencies are treated as only 5G radios and not 5GU/5GL

Signed-off-by: Ammad Rehmat <ammad.rehmat@connectus.ai>