### PR TITLE
Wifi-1470 Fix missing ip string to bytes conversion

### DIFF
--- a/feeds/wlan-ap/opensync/patches/30-fix-ipv4-string-to-bytes-conversion
+++ b/feeds/wlan-ap/opensync/patches/30-fix-ipv4-string-to-bytes-conversion
@@ -1,0 +1,31 @@
+--- a/src/lib/datapipeline/src/dppline.c
++++ b/src/lib/datapipeline/src/dppline.c
+@@ -2147,9 +2147,10 @@ static void dppline_add_stat_events(Sts_
+ 			ipe->timestamp_ms = cs_rec->ip_event->timestamp;
+ 
+ 			if (cs_rec->ip_event->ip_addr) {
+-				ipe->ip_addr.data = malloc(16);
+-				memcpy(ipe->ip_addr.data, cs_rec->ip_event->ip_addr,16);
+-				ipe->ip_addr.len = 16;
++				uint8_t ip[4] = {0};
++				sscanf(cs_rec->ip_event->ip_addr, "%hhu.%hhu.%hhu.%hhu", &ip[0], &ip[1], &ip[2], &ip[3]);
++				ipe->ip_addr.data = ip;
++				ipe->ip_addr.len = 4;
+ 				ipe->has_ip_addr = true;
+ 			}
+ 		}
+@@ -2224,10 +2225,10 @@ static void dppline_add_stat_events(Sts_
+ 			}
+ 
+ 			if (cs_rec->connect_event->ip_addr) {
+-				coe->ip_addr.data = malloc(16);
+-				memcpy(coe->ip_addr.data, cs_rec->connect_event->ip_addr,
+-				       16);
+-				coe->ip_addr.len = 16;
++				uint8_t ip[4] = {0};
++				sscanf(cs_rec->connect_event->ip_addr, "%hhu.%hhu.%hhu.%hhu", &ip[0], &ip[1], &ip[2], &ip[3]);
++				coe->ip_addr.data = ip;
++				coe->ip_addr.len = 4;
+ 				coe->has_ip_addr = true;
+ 			}
+ 

--- a/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
+++ b/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
@@ -101,7 +101,7 @@ typedef struct {
 	radio_essid_t ssid;
 	sec_type_t sec_type;
 	bool fbt_used;
-	uint8_t ip_addr[16];
+	char ip_addr[IP_ADDRESS_STRING_LEN + 1];
 	char clt_id[DPP_CLT_ID_LEN];
 	int64_t ev_time_bootup_in_us_auth;
 	int64_t ev_time_bootup_in_us_assoc;
@@ -152,7 +152,7 @@ typedef struct {
 	char sta_mac[MAC_ADDRESS_STRING_LEN + 1];
 	uint64_t session_id;
 	uint64_t timestamp;
-	uint8_t ip_addr[16];
+	char ip_addr[IP_ADDRESS_STRING_LEN + 1];
 } dpp_event_record_ip_t;
 
 /* proto: ClientTimeoutEvent */


### PR DESCRIPTION
IP event protobuf expects ip address to be in the form of bytes.
Added the missing conversion.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>