### PR TITLE
Staging wifi 1666 wifi radio state

### DIFF
--- a/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
+++ b/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
@@ -140,8 +140,8 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
  };
  
 +enum hostapd_ubus_chan_event_reason {
-+	HOSTAPD_UBUS_HIGH_INTERFERENCE,
-+	HOSTAPD_UBUS_DFS_SWITCH
++	HOSTAPD_UBUS_DFS_SWITCH,
++	HOSTAPD_UBUS_HIGH_INTERFERENCE
 +};
 +
  struct hostapd_ubus_request {

--- a/feeds/wlan-ap/opensync/patches/26-channel-switch-events.patch
+++ b/feeds/wlan-ap/opensync/patches/26-channel-switch-events.patch
@@ -117,7 +117,7 @@ Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
 +		assert(channel_switch);
 +		sts__event_report__channel_switch_event__init(channel_switch);
 +
-+		channel_switch->band = channel_switch_rec->band;
++		channel_switch->band = dppline_to_proto_radio(channel_switch_rec->band);
 +		channel_switch->reason = channel_switch_rec->reason;
 +		channel_switch->channel = channel_switch_rec->freq;
 +		channel_switch->timestamp_ms = channel_switch_rec->timestamp;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -26,6 +26,7 @@ struct wifi_phy {
 	unsigned int chanpwr[IEEE80211_CHAN_MAX];
 	unsigned int freq[IEEE80211_CHAN_MAX];
 
+	int current_channel;
 	int tx_ant, rx_ant, tx_ant_avail, rx_ant_avail;
 	int band_2g, band_5gl, band_5gu;
 };
@@ -56,6 +57,7 @@ struct wifi_station {
 };
 
 extern int radio_nl80211_init(void);
+extern void update_wiphy();
 
 extern struct wifi_phy *phy_find(const char *name);
 extern struct wifi_iface *vif_find(const char *name);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -12,7 +12,6 @@ extern int phy_get_tx_available_antenna(const char *name);
 extern int phy_get_rx_available_antenna(const char *name);
 extern int phy_get_max_tx_power(const char *name , int channel);
 extern int phy_get_channels(const char *name, int *channel);
-extern int phy_get_list_channels_dfs(const char *name, int *list);
 extern int phy_get_channels_state(const char *name,
 			struct schema_Wifi_Radio_State *rstate);
 extern int phy_get_band(const char *name, char *band);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -17,5 +17,6 @@ extern int phy_get_channels_state(const char *name,
 extern int phy_get_band(const char *name, char *band);
 extern int phy_is_ready(const char *name);
 extern int phy_lookup(char *name);
+extern int get_current_channel(char *name);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
@@ -33,6 +33,7 @@ extern ovsdb_table_t table_Wifi_RRM_Config;
 
 void rrm_config_vif(struct blob_buf *b, struct blob_buf *del, 
 		const char * freq_band, const char * if_name);
+int rrm_get_backup_channel(const char * freq_band);
 void callback_Wifi_RRM_Config(ovsdb_update_monitor_t *mon,
 		struct schema_Wifi_RRM_Config *old, struct schema_Wifi_RRM_Config *conf);
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -147,8 +147,10 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 	struct blob_attr *tb[__WDEV_ATTR_MAX] = { };
 	struct schema_Wifi_Radio_State  rstate;
 	char phy[6];
+	int32_t chan;
 
 	LOGN("%s: get state", s->e.name);
+	update_wiphy();
 
 	memset(&rstate, 0, sizeof(rstate));
 	schema_Wifi_Radio_State_mark_all_present(&rstate);
@@ -170,8 +172,13 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 		return false;
 	}
 
-	if (tb[WDEV_ATTR_CHANNEL])
-		SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	if (tb[WDEV_ATTR_CHANNEL]) {
+		chan = get_current_channel(phy);
+		if(chan)
+			SCHEMA_SET_INT(rstate.channel, chan);
+		else
+			SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	}
 
 	SCHEMA_SET_INT(rstate.enabled, 1);
 	if (!force && tb[WDEV_ATTR_DISABLED] && blobmsg_get_bool(tb[WDEV_ATTR_DISABLED]))

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -274,7 +274,6 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 
 	char phy[6];
 	char ifname[8];
-	int list_channels[IEEE80211_CHAN_MAX] , list_channels_len = 0;
 
 	strncpy(ifname, rconf->if_name, sizeof(ifname));
 	strncpy(phy, target_map_ifname(ifname), sizeof(phy));
@@ -342,16 +341,18 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 			 LOGE("%s: failed to set ht/hwmode", rconf->if_name);
 	}
 
-	list_channels_len = phy_get_list_channels_dfs(phy, list_channels);
-	if (list_channels_len) {
-		struct blob_attr *n;
+	struct blob_attr *n;
+	int backup_channel = 0;
+	backup_channel = rrm_get_backup_channel(rconf->freq_band);
+	if(backup_channel) {
 		n = blobmsg_open_array(&b, "channels");
-		for(int i = 0; i < list_channels_len; i++)
-		{
-			blobmsg_add_u32(&b, NULL, list_channels[i]);
-		}
+		blobmsg_add_u32(&b, NULL, backup_channel);
 		blobmsg_close_array(&b, n);
-	}
+	} else {
+		n = blobmsg_open_array(&del, "channels");
+		blobmsg_add_u32(&del, NULL, backup_channel);
+		blobmsg_close_array(&del, n);
+	}	
 
 	if (changed->custom_options)
 		radio_config_custom_opt_set(&b, &del, rconf);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
@@ -442,18 +442,20 @@ static void nl80211_add_phy(struct nlattr **tb, char *name)
 					freq = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_FREQ]);
 					chan = ieee80211_frequency_to_channel(freq);
 					if (chan >= IEEE80211_CHAN_MAX) {
-						LOGE("%s: found invalid channel %d", phy->name, chan);
+						LOG(DEBUG, "%s: found invalid channel %d", phy->name, chan);
 						continue;
 					}
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_DISABLED]) {
 						phy->chandisabled[chan] = 1;
+						phy->chandfs[chan] = 0;
 						continue;
 					}
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_RADAR]) {
 						phy->chandfs[chan] = 1;
-						LOGE("%s: found dfs channel %d", phy->name, chan);
+						phy->chandisabled[chan] = 0;
+						LOG(DEBUG, "%s: found dfs channel %d", phy->name, chan);
 						continue;
 					}
 					phy->freq[chan] = freq;
@@ -488,6 +490,17 @@ static void nl80211_del_phy(struct nlattr **tb, char *name)
 	free(phy);
 }
 
+static void nl80211_update_current_channel(struct nlattr **tb, char *name, int freq)
+{
+	struct wifi_phy *phy;
+
+	phy = avl_find_element(&phy_tree, name, phy, avl);
+	if (!phy)
+		return;
+
+	phy->current_channel = ieee80211_frequency_to_channel(freq);
+}
+
 static int nl80211_recv(struct nl_msg *msg, void *arg)
 {
 	struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
@@ -496,7 +509,7 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 	char *pif_name=NULL;
 	char phyname[IFNAMSIZ] = {};
 	int ifidx = -1, phy = -1;
-
+	int freq = 0;
 	memset(tb, 0, sizeof(tb));
 
 	nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
@@ -516,6 +529,12 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 			strncpy(phyname, nla_get_string(tb[NL80211_ATTR_WIPHY_NAME]), IFNAMSIZ);
 		else
 			snprintf(phyname, sizeof(phyname), "phy%d", phy);
+	}
+
+	if(tb[NL80211_ATTR_WIPHY_FREQ]) {
+		freq = nla_get_u32(tb[NL80211_ATTR_WIPHY_FREQ]);
+		snprintf(phyname, sizeof(phyname), "phy%d", phy);
+		nl80211_update_current_channel(tb, phyname, freq);
 	}
 
 	switch (gnlh->cmd) {
@@ -542,7 +561,6 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 		syslog(0, "%s:%s[%d]%d\n", __FILE__, __func__, __LINE__, gnlh->cmd);
 		break;
 	}
-
 	return NL_OK;
 }
 
@@ -589,6 +607,16 @@ static void vif_poll_stations(void *arg)
 		vif_sync_stations(wif->name);
 	}
 	evsched_task_reschedule_ms(EVSCHED_SEC(STA_POLL_INTERVAL));
+}
+
+void update_wiphy()
+{
+	struct nl_msg *msg;
+
+	msg = unl_genl_msg(&unl, NL80211_CMD_GET_INTERFACE, true);
+	unl_genl_request(&unl, msg, nl80211_recv, NULL);
+	msg = unl_genl_msg(&unl, NL80211_CMD_GET_WIPHY, true);
+	unl_genl_request(&unl, msg, nl80211_recv, NULL);
 }
 
 int radio_nl80211_init(void)

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -590,6 +590,15 @@ int ieee80211_channel_to_frequency(int chan)
 		return 5000 + chan * 5;
 	return 0;
 }
+int get_current_channel(char *name)
+{
+	struct wifi_phy *phy = phy_find(name);
+
+	if(phy)
+		return phy->current_channel;
+
+	return 0;
+}
 
 bool vif_get_security(struct schema_Wifi_VIF_State *vstate,  char *mode,  char *encryption, char *radiusServerIP,  char *password, char *port)
 {

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -310,27 +310,6 @@ int phy_get_channels_state(const char *name, struct schema_Wifi_Radio_State *rst
 	return ret;
 }
 
-int phy_get_list_channels_dfs(const char *name, int *list)
-{
-	struct wifi_phy *phy = phy_find(name);
-	int i = 0, len = 0;
-
-	if (!phy)
-		return 0;
-
-	for (i = 0; (i < IEEE80211_CHAN_MAX); i++) {
-		if (phy->chandfs[i]) {
-			list[len] = i;
-			len++;
-		} else if (phy->channel[i]) {
-			list[len] = i;
-			len++;
-		}
-	}
-
-	return len;
-}
-
 int phy_get_band(const char *name, char *band)
 {
 	struct wifi_phy *phy = phy_find(name);

--- a/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
+++ b/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.c
@@ -126,13 +126,13 @@ static int frequency_to_channel(int freq)
 static radio_type_t frequency_to_band(int freq)
 {
 	int chan = frequency_to_channel(freq);
-
+	/*Need to add support for differentiating between 5G,5GU and 5GL*/
 	if (chan <= 16)
 		return RADIO_TYPE_2G;
 	else if (chan >= 32 && chan <= 68)
-		return RADIO_TYPE_5GL;
+		return RADIO_TYPE_5G;
 	else if (chan >= 96)
-		return RADIO_TYPE_5GU;
+		return RADIO_TYPE_5G;
 	else
 		return RADIO_TYPE_NONE;
 }


### PR DESCRIPTION
 Wifi-1666

- Wifi_Radio_State table now reflects the actual value of channel rather than fetching it from uci configurations.

Wifi-1640

- Upon changing the country code in Wifi_Radio_Config table the state table gets the updated allowed,disabled and dfs channels list.

    Signed-off-by: Ammad Rehmat <ammad.rehmat@netexperience.com>
