### PR TITLE
Wifi-1666 : Fix for reflecting the actual channel value in wifi radio…

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -26,6 +26,7 @@ struct wifi_phy {
 	unsigned int chanpwr[IEEE80211_CHAN_MAX];
 	unsigned int freq[IEEE80211_CHAN_MAX];
 
+	int current_channel;
 	int tx_ant, rx_ant, tx_ant_avail, rx_ant_avail;
 	int band_2g, band_5gl, band_5gu;
 };
@@ -56,6 +57,7 @@ struct wifi_station {
 };
 
 extern int radio_nl80211_init(void);
+extern void update_wiphy();
 
 extern struct wifi_phy *phy_find(const char *name);
 extern struct wifi_iface *vif_find(const char *name);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -18,5 +18,6 @@ extern int phy_get_channels_state(const char *name,
 extern int phy_get_band(const char *name, char *band);
 extern int phy_is_ready(const char *name);
 extern int phy_lookup(char *name);
+extern int get_current_channel(char *name);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -147,8 +147,10 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 	struct blob_attr *tb[__WDEV_ATTR_MAX] = { };
 	struct schema_Wifi_Radio_State  rstate;
 	char phy[6];
+	int32_t chan;
 
 	LOGN("%s: get state", s->e.name);
+	update_wiphy();
 
 	memset(&rstate, 0, sizeof(rstate));
 	schema_Wifi_Radio_State_mark_all_present(&rstate);
@@ -170,8 +172,13 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 		return false;
 	}
 
-	if (tb[WDEV_ATTR_CHANNEL])
-		SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	if (tb[WDEV_ATTR_CHANNEL]) {
+		chan = get_current_channel(phy);
+		if(chan)
+			SCHEMA_SET_INT(rstate.channel, chan);
+		else
+			SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	}
 
 	SCHEMA_SET_INT(rstate.enabled, 1);
 	if (!force && tb[WDEV_ATTR_DISABLED] && blobmsg_get_bool(tb[WDEV_ATTR_DISABLED]))

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
@@ -442,18 +442,20 @@ static void nl80211_add_phy(struct nlattr **tb, char *name)
 					freq = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_FREQ]);
 					chan = ieee80211_frequency_to_channel(freq);
 					if (chan >= IEEE80211_CHAN_MAX) {
-						LOGE("%s: found invalid channel %d", phy->name, chan);
+						LOG(DEBUG, "%s: found invalid channel %d", phy->name, chan);
 						continue;
 					}
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_DISABLED]) {
 						phy->chandisabled[chan] = 1;
+						phy->chandfs[chan] = 0;
 						continue;
 					}
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_RADAR]) {
 						phy->chandfs[chan] = 1;
-						LOGE("%s: found dfs channel %d", phy->name, chan);
+						phy->chandisabled[chan] = 0;
+						LOG(DEBUG, "%s: found dfs channel %d", phy->name, chan);
 						continue;
 					}
 					phy->freq[chan] = freq;
@@ -488,6 +490,17 @@ static void nl80211_del_phy(struct nlattr **tb, char *name)
 	free(phy);
 }
 
+static void nl80211_update_current_channel(struct nlattr **tb, char *name, int freq)
+{
+	struct wifi_phy *phy;
+
+	phy = avl_find_element(&phy_tree, name, phy, avl);
+	if (!phy)
+		return;
+
+	phy->current_channel = ieee80211_frequency_to_channel(freq);
+}
+
 static int nl80211_recv(struct nl_msg *msg, void *arg)
 {
 	struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
@@ -496,7 +509,7 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 	char *pif_name=NULL;
 	char phyname[IFNAMSIZ] = {};
 	int ifidx = -1, phy = -1;
-
+	int freq = 0;
 	memset(tb, 0, sizeof(tb));
 
 	nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
@@ -516,6 +529,12 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 			strncpy(phyname, nla_get_string(tb[NL80211_ATTR_WIPHY_NAME]), IFNAMSIZ);
 		else
 			snprintf(phyname, sizeof(phyname), "phy%d", phy);
+	}
+
+	if(tb[NL80211_ATTR_WIPHY_FREQ]) {
+		freq = nla_get_u32(tb[NL80211_ATTR_WIPHY_FREQ]);
+		snprintf(phyname, sizeof(phyname), "phy%d", phy);
+		nl80211_update_current_channel(tb, phyname, freq);
 	}
 
 	switch (gnlh->cmd) {
@@ -542,7 +561,6 @@ static int nl80211_recv(struct nl_msg *msg, void *arg)
 		syslog(0, "%s:%s[%d]%d\n", __FILE__, __func__, __LINE__, gnlh->cmd);
 		break;
 	}
-
 	return NL_OK;
 }
 
@@ -589,6 +607,16 @@ static void vif_poll_stations(void *arg)
 		vif_sync_stations(wif->name);
 	}
 	evsched_task_reschedule_ms(EVSCHED_SEC(STA_POLL_INTERVAL));
+}
+
+void update_wiphy()
+{
+	struct nl_msg *msg;
+
+	msg = unl_genl_msg(&unl, NL80211_CMD_GET_INTERFACE, true);
+	unl_genl_request(&unl, msg, nl80211_recv, NULL);
+	msg = unl_genl_msg(&unl, NL80211_CMD_GET_WIPHY, true);
+	unl_genl_request(&unl, msg, nl80211_recv, NULL);
 }
 
 int radio_nl80211_init(void)

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -611,6 +611,15 @@ int ieee80211_channel_to_frequency(int chan)
 		return 5000 + chan * 5;
 	return 0;
 }
+int get_current_channel(char *name)
+{
+	struct wifi_phy *phy = phy_find(name);
+
+	if(phy)
+		return phy->current_channel;
+
+	return 0;
+}
 
 bool vif_get_security(struct schema_Wifi_VIF_State *vstate,  char *mode,  char *encryption, char *radiusServerIP,  char *password, char *port)
 {


### PR DESCRIPTION
 Wifi-1666

- Wifi_Radio_State table now reflects the actual value of channel rather than fetching it from uci configurations.

Wifi-1640

- Upon changing the country code in Wifi_Radio_Config table the state table gets the updated allowed,disabled and dfs channels list.

    Signed-off-by: Ammad Rehmat <ammad.rehmat@netexperience.com>
