### PR TITLE
wifi-1514: Fix SM crash

### DIFF
--- a/feeds/wlan-ap/opensync/patches/30-fix-ipv4-string-to-bytes-conversion
+++ b/feeds/wlan-ap/opensync/patches/30-fix-ipv4-string-to-bytes-conversion
@@ -7,10 +7,10 @@
 -				ipe->ip_addr.data = malloc(16);
 -				memcpy(ipe->ip_addr.data, cs_rec->ip_event->ip_addr,16);
 -				ipe->ip_addr.len = 16;
-+				uint8_t ip[4] = {0};
++				uint8_t ip[IPV4_BYTES_LEN] = {0};
 +				sscanf(cs_rec->ip_event->ip_addr, "%hhu.%hhu.%hhu.%hhu", &ip[0], &ip[1], &ip[2], &ip[3]);
-+				ipe->ip_addr.data = ip;
-+				ipe->ip_addr.len = 4;
++				ipe->ip_addr.data = malloc(IPV4_BYTES_LEN);
++				ipe->ip_addr.len = IPV4_BYTES_LEN;
  				ipe->has_ip_addr = true;
  			}
  		}
@@ -22,10 +22,10 @@
 -				memcpy(coe->ip_addr.data, cs_rec->connect_event->ip_addr,
 -				       16);
 -				coe->ip_addr.len = 16;
-+				uint8_t ip[4] = {0};
++				uint8_t ip[IPV4_BYTES_LEN] = {0};
 +				sscanf(cs_rec->connect_event->ip_addr, "%hhu.%hhu.%hhu.%hhu", &ip[0], &ip[1], &ip[2], &ip[3]);
-+				coe->ip_addr.data = ip;
-+				coe->ip_addr.len = 4;
++				coe->ip_addr.data = malloc(IPV4_BYTES_LEN);
++				coe->ip_addr.len = IPV4_BYTES_LEN;
  				coe->has_ip_addr = true;
  			}
  

--- a/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
+++ b/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
@@ -13,6 +13,7 @@
 #define DPP_CLT_ID_LEN 129
 #define MAC_ADDRESS_STRING_LEN 17
 #define IP_ADDRESS_STRING_LEN 15
+#define IPV4_BYTES_LEN 4
 
 /* proto: EventType */
 typedef enum {


### PR DESCRIPTION
Fix for Memory corruption observed in SM.
This was also the cause for missing SSID and band reporting
inside client events.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>