### PR TITLE
wifi-1614 Disable-TX_STBC-when-configuring-1x1

### DIFF
--- a/feeds/wifi-ax/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/wifi-ax/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -254,6 +254,11 @@ mac80211_hostapd_setup_base() {
 		[ "$rx_stbc" -lt "$cap_rx_stbc" ] && cap_rx_stbc="$rx_stbc"
 		ht_cap_mask="$(( ($ht_cap_mask & ~(0x300)) | ($cap_rx_stbc << 8) ))"
 
+		conf_tx_ant=$(iw phy "$phy" info | grep 'Configured Antennas:' | cut -d: -f2)
+		set -- $conf_tx_ant
+		if [ "$2" == "0x1" -o "$2" == "0x10" ]; then
+			tx_stbc=0
+		fi
 		mac80211_add_capabilities ht_capab_flags $ht_cap_mask \
 			LDPC:0x1::$ldpc \
 			GF:0x10::$greenfield \
@@ -343,6 +348,11 @@ mac80211_hostapd_setup_base() {
 		[ "$rx_stbc" -lt "$cap_rx_stbc" ] && cap_rx_stbc="$rx_stbc"
 		vht_cap="$(( ($vht_cap & ~(0x700)) | ($cap_rx_stbc << 8) ))"
 
+		conf_tx_ant=$(iw phy "$phy" info | grep 'Configured Antennas:' | cut -d: -f2)
+		set -- $conf_tx_ant
+		if [ "$2" == "0x1" -o "$2" == "0x10" ]; then
+			tx_stbc_2by1=0
+		fi
 		mac80211_add_capabilities vht_capab $vht_cap \
 			RXLDPC:0x10::$rxldpc \
 			SHORT-GI-80:0x20::$short_gi_80 \

--- a/feeds/wifi-ax/mac80211/patches/qca/224-ath11k-update-HT-cap-to-disable-TX-STBC-with-single-antenna.patch
+++ b/feeds/wifi-ax/mac80211/patches/qca/224-ath11k-update-HT-cap-to-disable-TX-STBC-with-single-antenna.patch
@@ -1,0 +1,55 @@
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -4693,7 +4693,8 @@
+ }
+ 
+ static struct ieee80211_sta_ht_cap
+-ath11k_create_ht_cap(struct ath11k *ar, u32 ar_ht_cap, u32 rate_cap_rx_chainmask)
++ath11k_create_ht_cap(struct ath11k *ar, u32 ar_ht_cap,
++		     u32 rate_cap_tx_chainmask, u32 rate_cap_rx_chainmask)
+ {
+ 	int i;
+ 	struct ieee80211_sta_ht_cap ht_cap = {0};
+@@ -4724,7 +4725,7 @@
+ 		ht_cap.cap |= smps;
+ 	}
+ 
+-	if (ar_ht_cap & WMI_HT_CAP_TX_STBC)
++	if ((ar_ht_cap & WMI_HT_CAP_TX_STBC) && (rate_cap_tx_chainmask > 1))
+ 		ht_cap.cap |= IEEE80211_HT_CAP_TX_STBC;
+ 
+ 	if (ar_ht_cap & WMI_HT_CAP_RX_STBC) {
+@@ -4903,6 +4904,7 @@
+ 		if (ht_cap_info)
+ 			*ht_cap_info = ht_cap;
+ 		band->ht_cap = ath11k_create_ht_cap(ar, ht_cap,
++						    rate_cap_tx_chainmask,
+ 						    rate_cap_rx_chainmask);
+ 
+ 		band->vht_cap = ath11k_create_vht_cap(ar, rate_cap_tx_chainmask,
+@@ -4915,10 +4917,25 @@
+ 		if (ht_cap_info)
+ 			*ht_cap_info = ht_cap;
+ 		band->ht_cap = ath11k_create_ht_cap(ar, ht_cap,
++						    rate_cap_tx_chainmask,
+ 						    rate_cap_rx_chainmask);
+ 		band->vht_cap = ath11k_create_vht_cap(ar, rate_cap_tx_chainmask,
+ 						      rate_cap_rx_chainmask);
+ 	}
++
++	if (ar->hw->wiphy->bands[NL80211_BAND_5GHZ]) {
++		ar->hw->wiphy->bands[NL80211_BAND_5GHZ]->ht_cap.cap =
++			ar->mac.sbands[NL80211_BAND_5GHZ].ht_cap.cap;
++		ar->hw->wiphy->bands[NL80211_BAND_5GHZ]->vht_cap.cap =
++			ar->mac.sbands[NL80211_BAND_5GHZ].vht_cap.cap;
++	}
++	if (ar->hw->wiphy->bands[NL80211_BAND_2GHZ]) {
++		ar->hw->wiphy->bands[NL80211_BAND_2GHZ]->ht_cap.cap =
++			ar->mac.sbands[NL80211_BAND_2GHZ].ht_cap.cap;
++		ar->hw->wiphy->bands[NL80211_BAND_2GHZ]->vht_cap.cap =
++			ar->mac.sbands[NL80211_BAND_2GHZ].vht_cap.cap;
++	}
++
+ }
+ 
+ static int ath11k_check_chain_mask(struct ath11k *ar, u32 ant, bool is_tx_ant)

--- a/feeds/wifi-trunk/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/wifi-trunk/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -174,6 +174,11 @@ mac80211_hostapd_setup_base() {
 		[ "$rx_stbc" -lt "$cap_rx_stbc" ] && cap_rx_stbc="$rx_stbc"
 		ht_cap_mask="$(( ($ht_cap_mask & ~(0x300)) | ($cap_rx_stbc << 8) ))"
 
+		conf_tx_ant=$(iw phy "$phy" info | grep 'Configured Antennas:' | cut -d: -f2)
+		set -- $conf_tx_ant
+		if [ "$2" == "0x1" -o "$2" == "0x10" ]; then
+			tx_stbc=0
+		fi
 		mac80211_add_capabilities ht_capab_flags $ht_cap_mask \
 			LDPC:0x1::$ldpc \
 			GF:0x10::$greenfield \
@@ -263,6 +268,11 @@ mac80211_hostapd_setup_base() {
 		[ "$rx_stbc" -lt "$cap_rx_stbc" ] && cap_rx_stbc="$rx_stbc"
 		vht_cap="$(( ($vht_cap & ~(0x700)) | ($cap_rx_stbc << 8) ))"
 
+		conf_tx_ant=$(iw phy "$phy" info | grep 'Configured Antennas:' | cut -d: -f2)
+		set -- $conf_tx_ant
+		if [ "$2" == "0x1" -o "$2" == "0x10" ]; then
+			tx_stbc_2by1=0
+		fi
 		mac80211_add_capabilities vht_capab $vht_cap \
 			RXLDPC:0x10::$rxldpc \
 			SHORT-GI-80:0x20::$short_gi_80 \


### PR DESCRIPTION
Added support to update the TX-STBC capability if only single Tx-antenna is available.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>