### PR TITLE
Wifi-1666 : Fix for reflecting the actual channel value in wifi radio…

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -26,6 +26,7 @@ struct wifi_phy {
 	unsigned int chanpwr[IEEE80211_CHAN_MAX];
 	unsigned int freq[IEEE80211_CHAN_MAX];
 
+	int current_channel;
 	int tx_ant, rx_ant, tx_ant_avail, rx_ant_avail;
 	int band_2g, band_5gl, band_5gu;
 };
@@ -56,6 +57,7 @@ struct wifi_station {
 };
 
 extern int radio_nl80211_init(void);
+extern void update_wiphy();
 
 extern struct wifi_phy *phy_find(const char *name);
 extern struct wifi_iface *vif_find(const char *name);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -17,5 +17,6 @@ extern int phy_get_channels_state(const char *name,
 extern int phy_get_band(const char *name, char *band);
 extern int phy_is_ready(const char *name);
 extern int phy_lookup(char *name);
+extern int get_current_channel(char *name);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -186,8 +186,11 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 	struct schema_Wifi_Radio_State  rstate;
 	char phy[6];
 	int antenna;
+	int32_t chan;
 
 	LOGT("%s: get state", s->e.name);
+
+	update_wiphy();
 
 	memset(&rstate, 0, sizeof(rstate));
 	schema_Wifi_Radio_State_mark_all_present(&rstate);
@@ -209,8 +212,13 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 		return false;
 	}
 
-	if (tb[WDEV_ATTR_CHANNEL])
-		SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	if (tb[WDEV_ATTR_CHANNEL]) {
+		chan = get_current_channel(phy);
+		if(chan)
+			SCHEMA_SET_INT(rstate.channel, chan);
+		else
+			SCHEMA_SET_INT(rstate.channel, blobmsg_get_u32(tb[WDEV_ATTR_CHANNEL]));
+	}
 
 	SCHEMA_SET_INT(rstate.enabled, 1);
 	if (!force && tb[WDEV_ATTR_DISABLED] && blobmsg_get_bool(tb[WDEV_ATTR_DISABLED]))

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -590,6 +590,15 @@ int ieee80211_channel_to_frequency(int chan)
 		return 5000 + chan * 5;
 	return 0;
 }
+int get_current_channel(char *name)
+{
+	struct wifi_phy *phy = phy_find(name);
+
+	if(phy)
+		return phy->current_channel;
+
+	return 0;
+}
 
 bool vif_get_security(struct schema_Wifi_VIF_State *vstate,  char *mode,  char *encryption, char *radiusServerIP,  char *password, char *port)
 {


### PR DESCRIPTION
 Wifi-1666

- Wifi_Radio_State table now reflects the actual value of channel rather than fetching it from uci configurations.

Wifi-1640

- Upon changing the country code in Wifi_Radio_Config table the state table gets the updated allowed,disabled and dfs channels list.

    Signed-off-by: Ammad Rehmat <ammad.rehmat@netexperience.com>
