### PR TITLE
openwrt: Nand images for tp-link EX447 and EX227

### DIFF
--- a/patches/0045-tp-link-ex447-ex227-factory-Nand-images.patch
+++ b/patches/0045-tp-link-ex447-ex227-factory-Nand-images.patch
@@ -1,0 +1,70 @@
+From 57a733a35f7727d2e1b786e4270de7d593d90614 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Fri, 12 Mar 2021 15:39:20 -0500
+Subject: [PATCH] openwrt: Generate factory Nand images for tp-link EX447 and
+ EX227
+
+Generate factory nand images for tp-link ex447 and ex227.
+This image is used to flash for migrating from stock qsdk
+image to tip openwrt image using the nand flash.
+---
+ target/linux/ipq807x/base-files/lib/upgrade/platform.sh | 8 ++++----
+ target/linux/ipq807x/image/ipq807x.mk                   | 6 ++++--
+ 2 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+index 9a5538aee3..59d1578925 100755
+--- a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+@@ -43,9 +43,7 @@ platform_do_upgrade() {
+ 
+ 	board=$(board_name)
+ 	case $board in
+-	cig,wf188|\
+-	tplink,ex227|\
+-	tplink,ex447)
++	cig,wf188)
+ 		qca_do_upgrade $1
+ 		;;
+ 	cig,wf188n|\
+@@ -53,7 +51,9 @@ platform_do_upgrade() {
+ 	edgecore,eap102|\
+ 	qcom,ipq6018-cp01|\
+ 	qcom,ipq807x-hk01|\
+-	sercomm,wallaby)
++	sercomm,wallaby|\
++	tplink,ex447|\
++	tplink,ex227)
+ 		nand_upgrade_tar "$1"
+ 		;;
+ 	edgecore,eap101)
+diff --git a/target/linux/ipq807x/image/ipq807x.mk b/target/linux/ipq807x/image/ipq807x.mk
+index 8f9cda14a3..a41097e08e 100644
+--- a/target/linux/ipq807x/image/ipq807x.mk
++++ b/target/linux/ipq807x/image/ipq807x.mk
+@@ -50,9 +50,10 @@ define Device/tplink_ex227
+   DEVICE_DTS_CONFIG=config@hk07
+   SUPPORTED_DEVICES := tplink,ex227
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex227
+-  IMAGES := sysupgrade.tar nor-factory.bin
++  IMAGES := sysupgrade.tar nor-factory.bin nand-factory.bin
+   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+   IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
++  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
+ endef
+ TARGET_DEVICES += tplink_ex227
+ 
+@@ -62,8 +63,9 @@ define Device/tplink_ex447
+   DEVICE_DTS_CONFIG=config@hk09
+   SUPPORTED_DEVICES := tplink,ex447
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex447
+-  IMAGES := sysupgrade.tar nor-factory.bin
++  IMAGES := sysupgrade.tar nor-factory.bin nand-factory.bin
+   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+   IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
++  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
+ endef
+ TARGET_DEVICES += tplink_ex447
+-- 
+2.25.1
+


### PR DESCRIPTION
Generate factory nand images for tp-link ex447 and ex227.
This image is used to flash for migrating from stock qsdk
image to tip openwrt image using the nand flash.