### PR TITLE
wifi-1857: Remove redundant nl request to fetch the current channel

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -57,8 +57,6 @@ struct wifi_station {
 };
 
 extern int radio_nl80211_init(void);
-extern void update_wiphy();
-
 extern struct wifi_phy *phy_find(const char *name);
 extern struct wifi_iface *vif_find(const char *name);
 extern struct wifi_station *sta_find(const unsigned char *addr);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -190,8 +190,6 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 
 	LOGT("%s: get state", s->e.name);
 
-	update_wiphy();
-
 	memset(&rstate, 0, sizeof(rstate));
 	schema_Wifi_Radio_State_mark_all_present(&rstate);
 	rstate._partial_update = true;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
@@ -544,16 +544,6 @@ static void vif_poll_stations(void *arg)
 	evsched_task_reschedule_ms(EVSCHED_SEC(STA_POLL_INTERVAL));
 }
 
-void update_wiphy()
-{
-	struct nl_msg *msg;
-
-	msg = unl_genl_msg(&unl, NL80211_CMD_GET_INTERFACE, true);
-	unl_genl_request(&unl, msg, nl80211_recv, NULL);
-	msg = unl_genl_msg(&unl, NL80211_CMD_GET_WIPHY, true);
-	unl_genl_request(&unl, msg, nl80211_recv, NULL);
-}
-
 int radio_nl80211_init(void)
 {
 	struct nl_msg *msg;


### PR DESCRIPTION
A netlink request to fetch the current channel was leading to a race condition.
Since the current channel is already reported by nl events, the redundant code
is removed.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>