### PR TITLE
openwrt: Remove NOR factory image for tplink-ex447/ex227

### DIFF
--- a/patches/0046-Remove-NOR-factory-support-for-tplink-ex227.patch
+++ b/patches/0046-Remove-NOR-factory-support-for-tplink-ex227.patch
@@ -1,0 +1,41 @@
+From 2db87512962f81c6e6e9482136f0b17867ff0e6c Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Fri, 19 Mar 2021 10:37:11 -0400
+Subject: [PATCH] openwrt: Remove NOR factory support for tplink ex227/ex447
+
+Remove NOR factory support for tplink ex227/ex447
+as now its switched to nand based.
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ target/linux/ipq807x/image/ipq807x.mk | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/target/linux/ipq807x/image/ipq807x.mk b/target/linux/ipq807x/image/ipq807x.mk
+index a41097e08e..65bf99dd9c 100644
+--- a/target/linux/ipq807x/image/ipq807x.mk
++++ b/target/linux/ipq807x/image/ipq807x.mk
+@@ -50,10 +50,6 @@ define Device/tplink_ex227
+   DEVICE_DTS_CONFIG=config@hk07
+   SUPPORTED_DEVICES := tplink,ex227
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex227
+-  IMAGES := sysupgrade.tar nor-factory.bin nand-factory.bin
+-  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+-  IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
+-  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
+ endef
+ TARGET_DEVICES += tplink_ex227
+ 
+@@ -63,9 +59,5 @@ define Device/tplink_ex447
+   DEVICE_DTS_CONFIG=config@hk09
+   SUPPORTED_DEVICES := tplink,ex447
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex447
+-  IMAGES := sysupgrade.tar nor-factory.bin nand-factory.bin
+-  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+-  IMAGE/nor-factory.bin := qsdk-ipq-factory-nor
+-  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
+ endef
+ TARGET_DEVICES += tplink_ex447
+-- 
+2.25.1
+


### PR DESCRIPTION
Remove NOR factory image for tplink-ex447/ex227 as now its
switched to nand based image.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>