### PR TITLE
wifi-1737: Restrict DHCP Sniffing to a max of 4 vlans

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/inet_conf.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/inet_conf.h
@@ -6,7 +6,9 @@
 #include "netifd.h"
 #include "inet_iface.h"
 
-struct netifd_iface *netifd_add_inet_conf(struct schema_Wifi_Inet_Config *iconf);
+#define DHCP_SNIFF_MAX_VLAN 4
+
+void netifd_add_inet_conf(struct schema_Wifi_Inet_Config *iconf);
 void netifd_del_inet_conf(struct schema_Wifi_Inet_Config *old_rec);
 struct netifd_iface *netifd_modify_inet_conf(struct schema_Wifi_Inet_Config *iconf);
 bool netifd_inet_config_set(struct netifd_iface *piface);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/inet_iface.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/inet_iface.c
@@ -24,8 +24,6 @@ struct netifd_iface *netifd_iface_get_by_name(char *_ifname)
 	if (piface != NULL)
 		return piface;
 
-	LOG(ERR, "netifd_iface_get_by_name: Couldn't find the interface(%s)", ifname);
-
 	return NULL;
 }
 
@@ -102,7 +100,7 @@ inet_base_t *netifd_iface_new_inet(const char *ifname, const char *iftype)
 		goto error;
 	}
 	memset(self, 0, sizeof(inet_base_t));
-	if((!strcmp(ifname, "wan") && !strcmp(iftype,"bridge")) || (!strcmp(ifname, "lan") && !strcmp(iftype,"bridge"))) {
+	if(!strcmp(iftype,"bridge")) {
 		snprintf(self->inet.in_ifname, sizeof(self->inet.in_ifname), "br-%s", ifname);
 	} else if (!strcmp(iftype,"vlan")) {
 		char name[15]= {};

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
@@ -368,16 +368,14 @@ static void callback_Wifi_Inet_Config(ovsdb_update_monitor_t *mon,
 			       struct schema_Wifi_Inet_Config *old_rec,
 			       struct schema_Wifi_Inet_Config *iconf)
 {
-	struct netifd_iface *piface = NULL;
-
 	switch (mon->mon_type) {
 	case OVSDB_UPDATE_NEW:
 		wifi_inet_conf_add(iconf);
-		piface = netifd_add_inet_conf(iconf);
+		netifd_add_inet_conf(iconf);
 		break;
 	case OVSDB_UPDATE_MODIFY:
 		wifi_inet_conf_add(iconf);
-		piface = netifd_modify_inet_conf(iconf);
+		netifd_modify_inet_conf(iconf);
 		break;
 	case OVSDB_UPDATE_DEL:
 		wifi_inet_conf_del(old_rec);
@@ -385,12 +383,6 @@ static void callback_Wifi_Inet_Config(ovsdb_update_monitor_t *mon,
 		break;
 	default:
 		LOG(ERR, "Invalid Wifi_Inet_Config mon_type(%d)", mon->mon_type);
-	}
-
-	if(!piface) {
-		LOG(ERR, "callback_Wifi_Inet_Config: Couldn't get the netifd interface(%s)",
-				iconf->if_name);
-		return;
 	}
 
 	return;


### PR DESCRIPTION
Partial fix for wifi-1737:
Use of current DHCP sniffing library from opensync increases
memory footprint of nm with increased number of vlans.
This patch restricts DHCP sniffing on a maximum of 4 vlans.
This is a workaround and actual fix would be to use a better
packet filter such as eBPF

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>