### PR TITLE
WIFI-1860 fix wpa3 config on wifi6 APs

### DIFF
--- a/profiles/wlan-ap.yml
+++ b/profiles/wlan-ap.yml
@@ -90,6 +90,7 @@ diffconfig: |
   CONFIG_OPENSSL_WITH_SRP=y
   CONFIG_OPENSSL_WITH_TLS13=y
   # CONFIG_PACKAGE_wpad-basic is not set
+  # CONFIG_PACKAGE_wpad is not set
   # CONFIG_PACKAGE_dnsmasq is not set 
   CONFIG_IMAGEOPT=y
   CONFIG_PREINITOPT=y


### PR DESCRIPTION
Enable sae compile option for wifi6 hostapd.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>