### PR TITLE
openwrt: Revert UBUS pending list iteration method

### DIFF
--- a/patches/0047-openwrt-Revert-UBUS-pending-list-iteration-method.patch
+++ b/patches/0047-openwrt-Revert-UBUS-pending-list-iteration-method.patch
@@ -1,0 +1,47 @@
+From 23be9eda1f87b77a772d24510d7096c565021e16 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Mon, 29 Mar 2021 19:22:55 -0400
+Subject: [PATCH] openwrt: Revert UBUS pending list iteration method
+
+This commit partially reverts the earlier patch:
+"workaround possibly false positive uses of memory after it is freed"
+
+This fixed the crash while freeing a list item in
+ubus_process_pending_msg due to a double free.
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ ...revert-pending-list-iteration-method.patch | 21 +++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+ create mode 100644 package/system/ubus/patches/revert-pending-list-iteration-method.patch
+
+diff --git a/package/system/ubus/patches/revert-pending-list-iteration-method.patch b/package/system/ubus/patches/revert-pending-list-iteration-method.patch
+new file mode 100644
+index 0000000000..ccc13fd9f2
+--- /dev/null
++++ b/package/system/ubus/patches/revert-pending-list-iteration-method.patch
+@@ -0,0 +1,21 @@
++Index: ubus-2019-12-27-041c9d1c/libubus.c
++===================================================================
++--- ubus-2019-12-27-041c9d1c.orig/libubus.c
+++++ ubus-2019-12-27-041c9d1c/libubus.c
++@@ -115,12 +115,11 @@ ubus_process_msg(struct ubus_context *ct
++ static void ubus_process_pending_msg(struct uloop_timeout *timeout)
++ {
++ 	struct ubus_context *ctx = container_of(timeout, struct ubus_context, pending_timer);
++-	struct ubus_pending_msg *pending, *tmp;
++-
++-	list_for_each_entry_safe(pending, tmp, &ctx->pending, list) {
++-		if (ctx->stack_depth)
++-			break;
+++
+++	struct ubus_pending_msg *pending;
++
+++	while (!ctx->stack_depth && !list_empty(&ctx->pending)) {
+++		pending = list_first_entry(&ctx->pending, struct ubus_pending_msg, list);
++ 		list_del(&pending->list);
++ 		ubus_process_msg(ctx, &pending->hdr, -1);
++ 		free(pending);
+--
+2.25.1
+


### PR DESCRIPTION
This commit partially reverts the earlier patch:
"workaround possibly false positive uses of memory after it is freed"

This fixed the crash while freeing a list item in
ubus_process_pending_msg due to a double free.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>