### PR TITLE
Wifi-1720. Fix for the neighbor scan failure on wifi6 APs.

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
@@ -547,7 +547,7 @@ int nl80211_scan_trigger(struct nl_call_param *nl_call_param, uint32_t *chan_lis
 {
 	struct nl_msg *msg = nl80211_call_vif(nl_call_param, NL80211_CMD_TRIGGER_SCAN, false);
 	struct nlattr *freq;
-	unsigned int i;
+	unsigned int i, flags = 0;
 	int ret = 0;
 
 	if (!msg)
@@ -555,6 +555,11 @@ int nl80211_scan_trigger(struct nl_call_param *nl_call_param, uint32_t *chan_lis
 
 	LOGT("%s: not setting dwell time\n", nl_call_param->ifname);
 	//nla_put_u16(msg, NL80211_ATTR_MEASUREMENT_DURATION, dwell_time);
+
+	/* Add the ap-force flag, otherwise the scan fails on wifi6 APs */
+	flags |= NL80211_SCAN_FLAG_AP;
+	nla_put(msg, NL80211_ATTR_SCAN_FLAGS, sizeof(uint32_t), &flags);
+
 	freq = nla_nest_start(msg, NL80211_ATTR_SCAN_FREQUENCIES);
 	for (i = 0; i < chan_num; i ++)
 		nla_put_u32(msg, i, ieee80211_channel_to_frequency(chan_list[i]));


### PR DESCRIPTION
Change contain John Crispin's patch to copy the nl80211-ax.h and use it for wifi6 APs.

Tested on WF188n (wifi6) and ECW5211 (wifi5) and EA8300 (wifi5) APs.
Checked for the scan results in EquipmentScanDetails event on the cloud.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>