### PR TITLE
Add ESMT Nand support and ubi imgs

### DIFF
--- a/patches/0048-Add-ESMT-nand-support.patch
+++ b/patches/0048-Add-ESMT-nand-support.patch
@@ -1,0 +1,59 @@
+From 71f57ba133f983f059fc4daacb4bec67fb35cc09 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Tue, 30 Mar 2021 08:59:14 -0400
+Subject: [PATCH] Add ESMT nand support
+
+Add ESMT nand support
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ .../ipq807x/patches/110-add-esmt-nand.patch   | 37 +++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+ create mode 100644 target/linux/ipq807x/patches/110-add-esmt-nand.patch
+
+diff --git a/target/linux/ipq807x/patches/110-add-esmt-nand.patch b/target/linux/ipq807x/patches/110-add-esmt-nand.patch
+new file mode 100644
+index 0000000000..d47a4d0d16
+--- /dev/null
++++ b/target/linux/ipq807x/patches/110-add-esmt-nand.patch
+@@ -0,0 +1,37 @@
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/drivers/mtd/nand/nand_ids.c
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/drivers/mtd/nand/nand_ids.c
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/drivers/mtd/nand/nand_ids.c
++@@ -62,6 +62,12 @@ struct nand_flash_dev nand_flash_ids[] =
++ 	{"TH58NYG3S0H 8G 1.8V 8-bit",
++ 		{ .id = {0x98, 0xa3, 0x91, 0x26} },
++ 		  SZ_4K, SZ_1K, SZ_256K, 0, 4, 256, NAND_ECC_INFO(8, SZ_512) },
+++
+++	{"F59D2G81KA 2G 1.8V 8-bit",
+++		{ .id = {0xc8, 0x5a, 0x90, 0x04} },
+++		SZ_2K, SZ_256, SZ_128K, 0, 4, 128, NAND_ECC_INFO(8, SZ_512) },
+++
+++
++ 	LEGACY_ID_NAND("NAND 4MiB 5V 8-bit",   0x6B, 4, SZ_8K, SP_OPTIONS),
++ 	LEGACY_ID_NAND("NAND 4MiB 3,3V 8-bit", 0xE3, 4, SZ_8K, SP_OPTIONS),
++ 	LEGACY_ID_NAND("NAND 4MiB 3,3V 8-bit", 0xE5, 4, SZ_8K, SP_OPTIONS),
++@@ -190,6 +196,7 @@ struct nand_manufacturers nand_manuf_ids
++ 	{NAND_MFR_SANDISK, "SanDisk"},
++ 	{NAND_MFR_INTEL, "Intel"},
++ 	{NAND_MFR_ATO, "ATO"},
+++	{NAND_MFR_ESMT, "ESMT"},
++ 	{NAND_MFR_GIGA, "GigaDevice"},
++ 	{NAND_MFR_ATO, "ATO"},
++ 	{NAND_MFR_WINBOND, "Winbond"},
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/include/linux/mtd/nand.h
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/include/linux/mtd/nand.h
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/include/linux/mtd/nand.h
++@@ -778,6 +778,7 @@ static inline struct mtd_info *nand_to_m
++ #define NAND_MFR_ATO		0x9b
++ #define NAND_MFR_WINBOND	0xef
++ #define NAND_MFR_FIDELIX	0xe5
+++#define NAND_MFR_ESMT		0xc8
++ 
++ /* The maximum expected count of bytes in the NAND ID sequence */
++ #define NAND_MAX_ID_LEN 8
+-- 
+2.25.1
+

--- a/patches/0049-openwrt-Add-ubi-images-for-ex227-ex447.patch
+++ b/patches/0049-openwrt-Add-ubi-images-for-ex227-ex447.patch
@@ -1,0 +1,38 @@
+From 2fa0a5779dbc4a614b19cc690a8fa14f1ca33b33 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Thu, 1 Apr 2021 15:05:13 -0400
+Subject: [PATCH] openwrt: Add ubi images for ex227, ex447
+
+Add ubi images for ex227, ex447
+---
+ target/linux/ipq807x/image/ipq807x.mk | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/target/linux/ipq807x/image/ipq807x.mk b/target/linux/ipq807x/image/ipq807x.mk
+index 65bf99dd9c..7081769407 100644
+--- a/target/linux/ipq807x/image/ipq807x.mk
++++ b/target/linux/ipq807x/image/ipq807x.mk
+@@ -50,6 +50,10 @@ define Device/tplink_ex227
+   DEVICE_DTS_CONFIG=config@hk07
+   SUPPORTED_DEVICES := tplink,ex227
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex227
++  IMAGES := sysupgrade.tar nand-factory.bin nand-factory.ubi
++  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
++  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
++  IMAGE/nand-factory.ubi := append-ubi
+ endef
+ TARGET_DEVICES += tplink_ex227
+ 
+@@ -59,5 +63,9 @@ define Device/tplink_ex447
+   DEVICE_DTS_CONFIG=config@hk09
+   SUPPORTED_DEVICES := tplink,ex447
+   DEVICE_PACKAGES := ath11k-wifi-tplink-ex447
++  IMAGES := sysupgrade.tar nand-factory.bin nand-factory.ubi
++  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
++  IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
++  IMAGE/nand-factory.ubi := append-ubi
+ endef
+ TARGET_DEVICES += tplink_ex447
+-- 
+2.25.1
+


### PR DESCRIPTION
Add ESMT Nand support, required for ex227/ex447
Add ubi images for ex227, ex447

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>