### PR TITLE
Wifi-1914. Fix for FT-EAP roaming failure.

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
@@ -20,6 +20,7 @@ extern struct mode_map *mode_map_get_cloud(const char *htmode, const char *hwmod
 
 extern int vif_get_mac(char *vap, char *mac);
 extern int vif_is_ready(const char *name);
+bool vif_get_key_for_key_distr(const char *secret, char *key_str);
 
 #define blobmsg_add_bool blobmsg_add_u8
 extern int blobmsg_add_hex16(struct blob_buf *buf, const char *name, uint16_t val);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -624,3 +624,22 @@ bool vif_get_security(struct schema_Wifi_VIF_State *vstate,  char *mode,  char *
 	return true;
 
 }
+
+bool vif_get_key_for_key_distr(const char *secret, char *key_str)
+{
+	bool err = false;
+	FILE *fp;
+	char cmd_buf[256] = "openssl aes-128-cbc -nosalt -k ";
+
+	strcat(cmd_buf, secret);
+	strcat(cmd_buf, " -P 2>/dev/null | grep key | cut -d = -f2");
+	fp = popen(cmd_buf, "r");
+
+	
+	if (fp && fscanf(fp, "%s", key_str)) {
+		err = true;
+	}
+
+	fclose(fp);
+	return err;
+}

--- a/profiles/wlan-ap.yml
+++ b/profiles/wlan-ap.yml
@@ -39,6 +39,7 @@ packages:
   - luci-mod-simple
   - luci-theme-tip
   - nft-qos
+  - openssl-util
   - openvswitch
   - openvswitch-common
   - openvswitch-libofproto


### PR DESCRIPTION
Adding the required uci options for FT-EAP roaming.

- adding r0kh and r1kh uci options which gets propagated to hostapd.
- updating nasid with BSSID if nothing is configured from cloud. This does leave us with mismatched vifS and vifC.

With these changes, we do not see the Authentication failure anymore for mismatched PMKID. 
But we see some Roam-test failures due to Authentication timeout. Need to investigate more in that.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>