### PR TITLE
openwrt: Disble wan dhcp renew for topology change

### DIFF
--- a/patches/0050-netifd-Dont-renew-dhcp-on-bridge-topo-change.patch
+++ b/patches/0050-netifd-Dont-renew-dhcp-on-bridge-topo-change.patch
@@ -1,0 +1,46 @@
+From 5380b0204d97a79669243b46a8750e038e6a0a19 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Wed, 14 Apr 2021 11:14:45 -0400
+Subject: [PATCH] netifd: Dont renew dhcp on bridge topo change
+
+Do not renew the dhcp on bridge topology change
+as this causes some of the dhcp servers to fail.
+This occurs when many interfaces are added on to
+a bridge and for every interface there is a dhcp
+renew. The server considers receiving renew many
+times in a quick succession as a DOS attack. So for
+now we disable dhcp lease renew when a new interface
+is added.
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ .../netifd/patches/0104-fix-dhcp-issue.patch    | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/0104-fix-dhcp-issue.patch
+
+diff --git a/package/network/config/netifd/patches/0104-fix-dhcp-issue.patch b/package/network/config/netifd/patches/0104-fix-dhcp-issue.patch
+new file mode 100644
+index 0000000000..6f1d2e708e
+--- /dev/null
++++ b/package/network/config/netifd/patches/0104-fix-dhcp-issue.patch
+@@ -0,0 +1,17 @@
++Index: netifd-2019-08-05-5e02f944/interface.c
++===================================================================
++--- netifd-2019-08-05-5e02f944.orig/interface.c
+++++ netifd-2019-08-05-5e02f944/interface.c
++@@ -424,7 +424,11 @@ interface_main_dev_cb(struct device_user
++ 		interface_set_link_state(iface, false);
++ 		break;
++ 	case DEV_EVENT_TOPO_CHANGE:
++-		interface_proto_event(iface->proto, PROTO_CMD_RENEW, false);
+++	/* This renews the dhcp lease when the bridge adds/deletes a
+++	 * new interface. It causes some dhcp servers to fail in
+++	 * case where there are many interfaces being added to the
+++	 * bridge frequently. Disabling this for now. */
+++	/*	interface_proto_event(iface->proto, PROTO_CMD_RENEW, false); */
++ 		return;
++ 	default:
++ 		break;
+-- 
+2.25.1
+


### PR DESCRIPTION
check for no-renew flag in dhcp.sh before
renewing dhcp lease. Renewing dhcp lease
every time a new interface is added (topology change)
to the wan is causing trouble with some dhcp servers
as they consider receiving renew many times in
a quick succession as a DOS attack. So for now
we disable dhcp lease renew when a new interface
is added.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>