### PR TITLE
Wifi-2040. ManufacturingRecord: Populate device mac in qr code.

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -128,6 +128,11 @@ if [ ! $SERIAL ]; then
 	SERIAL=$(cat /sys/class/net/eth0/address | tr -d :)
 fi
 
+# fallback check to get the id from mac address if flash does not contain this info.
+if [ ! $ID ]; then
+	ID=$(cat /sys/class/net/eth0/address)
+fi
+
 uci set system.tip=tip
 uci set system.tip.serial="${SERIAL}"
 uci set system.tip.model="${MODEL}"


### PR DESCRIPTION
Adding code to fall-back and read eth0 address incase the
manufacturing data is not present for the id/mac_address field.
The same is also populated in the qr code field of AWLAN_Node.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>