### PR TITLE
WIFI-1940: Enable IEEE802.1X with SHA-256 AKM suite for WPA3-Enterpri…

### DIFF
--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -49,6 +49,7 @@ hostapd_append_wpa_key_mgmt() {
 		;;
 		eap192)
 			append wpa_key_mgmt "WPA-EAP-SUITE-B-192"
+			[ "${ieee80211w:-0}" -gt 0 ] && append wpa_key_mgmt "WPA-EAP-SHA256"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-EAP"
 		;;
 		eap-eap192)

--- a/feeds/wifi-trunk/hostapd/files/hostapd.sh
+++ b/feeds/wifi-trunk/hostapd/files/hostapd.sh
@@ -49,6 +49,7 @@ hostapd_append_wpa_key_mgmt() {
 		;;
 		eap192)
 			append wpa_key_mgmt "WPA-EAP-SUITE-B-192"
+			[ "${ieee80211w:-0}" -gt 0 ] && append wpa_key_mgmt "WPA-EAP-SHA256"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-EAP"
 		;;
 		eap-eap192)


### PR DESCRIPTION
…se Only mode

WPA3-Enterprise Only mode requires that the AP enables at least
AKM suite selector 00-0F-AC:5 (IEEE 802.1X with SHA-256) and not
enable AKM suite selector: 00-0F-AC:1 (IEEE 802.1X with SHA-1).

Signed-off-by: Arif Alam <arif.alam@netexperience.com>