### PR TITLE
WiFi-1921. Fix for hostapd error logs when configuring 16 SSID

### DIFF
--- a/patches/0051-base-files-Increase-Socket-buffer-memory-size.patch
+++ b/patches/0051-base-files-Increase-Socket-buffer-memory-size.patch
@@ -1,0 +1,31 @@
+From 4a85624a667c4027bf09f6155fbb046ac588a20a Mon Sep 17 00:00:00 2001
+From: ravi vaishnav <ravi.vaishnav@netexperience.com>
+Date: Thu, 22 Apr 2021 16:36:52 -0400
+Subject: [PATCH] base-files: Increase Socket buffer memory size
+
+When configuring 16 VLAN, we see hostapd complaining
+about No buffer space available while handling receive
+events. Hence, increasing the socket buffer memory size
+to 512KB.
+
+Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>
+---
+ package/base-files/files/etc/sysctl.d/10-default.conf | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/package/base-files/files/etc/sysctl.d/10-default.conf b/package/base-files/files/etc/sysctl.d/10-default.conf
+index bc8c579695..aeda9153a8 100644
+--- a/package/base-files/files/etc/sysctl.d/10-default.conf
++++ b/package/base-files/files/etc/sysctl.d/10-default.conf
+@@ -25,3 +25,8 @@ net.ipv4.tcp_dsack=1
+ 
+ net.ipv6.conf.default.forwarding=1
+ net.ipv6.conf.all.forwarding=1
++
++net.core.wmem_default = 524288
++net.core.rmem_default = 524288
++net.core.wmem_max = 524288
++net.core.rmem_max = 524288
+-- 
+2.25.1
+


### PR DESCRIPTION
When configuring 16 VLAN, we see hostapd complaining
about no buffer space available while handling receive
events. Hence, increasing the socket buffer memory size
to 512KB.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>