### PR TITLE
WIFI-2057: Fix current operating channel reporting in radio state table

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
@@ -21,4 +21,6 @@ extern int hapd_rrm_set_neighbors(char *name, struct rrm_neighbor *neigh, int co
 
 extern void radio_maverick(void *arg);
 
+int nl80211_channel_get(char *name, unsigned int *chan);
+
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -191,7 +191,7 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 	struct schema_Wifi_Radio_State  rstate;
 	char phy[6];
 	int antenna;
-	int32_t chan;
+	uint32_t chan = 0;
 
 	LOGT("%s: get state", s->e.name);
 
@@ -216,7 +216,7 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 	}
 
 	if (tb[WDEV_ATTR_CHANNEL]) {
-		chan = get_current_channel(phy);
+		nl80211_channel_get(phy, &chan);
 		if(chan)
 			SCHEMA_SET_INT(rstate.channel, chan);
 		else


### PR DESCRIPTION
Poll driver to get current operating channel as part of radio state update.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>