### PR TITLE
wifi-1727: hostapd: Fix RRM channel switch issues

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-011-ubus-multi-bss-chan-switch.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-011-ubus-multi-bss-chan-switch.patch
@@ -1,0 +1,24 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -722,6 +722,7 @@ hostapd_switch_chan(struct ubus_context
+ 	struct blob_attr *tb[__CSA_MAX];
+ 	struct hostapd_data *hapd = get_hapd_from_object(obj);
+ 	struct csa_settings css;
++	int i;
+ 
+ 	blobmsg_parse(csa_policy, __CSA_MAX, tb, blob_data(msg), blob_len(msg));
+ 
+@@ -746,9 +747,10 @@ hostapd_switch_chan(struct ubus_context
+ 	SET_CSA_SETTING(CSA_VHT, freq_params.vht_enabled, bool);
+ 	SET_CSA_SETTING(CSA_BLOCK_TX, block_tx, bool);
+ 
+-
+-	if (hostapd_switch_channel(hapd, &css) != 0)
+-		return UBUS_STATUS_NOT_SUPPORTED;
++	for (i = 0; i < hapd->iface->num_bss; i++) {
++		if (hostapd_switch_channel(hapd->iface->bss[i], &css) != 0)
++			return UBUS_STATUS_NOT_SUPPORTED;
++	}
+ 	return UBUS_STATUS_OK;
+ #undef SET_CSA_SETTING
+ }

--- a/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
+++ b/feeds/wifi-trunk/hostapd/patches/901-hapd-ubus-channel-switch.patch
@@ -1,7 +1,5 @@
-Index: hostapd-2020-06-08-5a8b3662/src/ap/dfs.c
-===================================================================
---- hostapd-2020-06-08-5a8b3662.orig/src/ap/dfs.c
-+++ hostapd-2020-06-08-5a8b3662/src/ap/dfs.c
+--- a/src/ap/dfs.c
++++ b/src/ap/dfs.c
 @@ -18,7 +18,7 @@
  #include "drivers/driver.h"
  #include "dfs.h"
@@ -23,10 +21,8 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/dfs.c
  	if (err) {
  		wpa_printf(MSG_WARNING, "DFS failed to schedule CSA (%d) - trying fallback",
  			   err);
-Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
-===================================================================
---- hostapd-2020-06-08-5a8b3662.orig/src/ap/ubus.c
-+++ hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
 @@ -29,6 +29,8 @@ static int ctx_ref;
  static char** bss_lst = NULL;
  static size_t bss_nr = 0;
@@ -36,7 +32,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  static inline struct hapd_interfaces *get_hapd_interfaces_from_object(struct ubus_object *obj)
  {
  	return container_of(obj, struct hapd_interfaces, ubus);
-@@ -714,6 +716,43 @@ static int hostapd_sessions(struct ubus_
+@@ -714,6 +716,44 @@ static int hostapd_sessions(struct ubus_
  	return 0;
  }
  
@@ -48,7 +44,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +{
 +	void *a = NULL;
 +	void *t = NULL;
-+	struct hostapd_chan_event_list *entry;
++	struct hostapd_chan_event_list *entry, *tmp;
 +
 +	blob_buf_init(&b_ev, 0);
 +	a = blobmsg_open_table(&b_ev, "chan_switch_event");
@@ -68,9 +64,10 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
 +	/*delete list*/
 +
 +	if (!list_empty(&chan_events)) {
-+	list_for_each_entry(entry, &chan_events, list)
++	list_for_each_entry_safe(entry, tmp, &chan_events, list)
 +		{
 +			list_del(&entry->list);
++			free(entry);
 +		}
 +	}
 +
@@ -80,7 +77,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  static int
  hostapd_switch_chan(struct ubus_context *ctx, struct ubus_object *obj,
  		    struct ubus_request_data *req, const char *method,
-@@ -749,6 +788,9 @@ hostapd_switch_chan(struct ubus_context
+@@ -749,6 +789,9 @@ hostapd_switch_chan(struct ubus_context
  
  	if (hostapd_switch_channel(hapd, &css) != 0)
  		return UBUS_STATUS_NOT_SUPPORTED;
@@ -90,7 +87,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  	return UBUS_STATUS_OK;
  #undef SET_CSA_SETTING
  }
-@@ -1444,6 +1486,7 @@ static const struct ubus_method daemon_m
+@@ -1444,6 +1487,7 @@ static const struct ubus_method daemon_m
  	UBUS_METHOD("config_add", hostapd_config_add, config_add_policy),
  	UBUS_METHOD("config_remove", hostapd_config_remove, config_remove_policy),
  	UBUS_METHOD_NOARG("get_bss_list", hostapd_get_bss_list),
@@ -98,7 +95,7 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  };
  
  static struct ubus_object_type daemon_object_type =
-@@ -1507,6 +1550,28 @@ ubus_event_cb(struct ubus_notify_request
+@@ -1507,6 +1551,28 @@ ubus_event_cb(struct ubus_notify_request
  	ureq->resp = ret;
  }
  
@@ -127,10 +124,8 @@ Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
  int hostapd_ubus_handle_rt_event(struct hostapd_data *hapd,
  				 struct hostapd_ubus_request *req)
  {
-Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
-===================================================================
---- hostapd-2020-06-08-5a8b3662.orig/src/ap/ubus.h
-+++ hostapd-2020-06-08-5a8b3662/src/ap/ubus.h
+--- a/src/ap/ubus.h
++++ b/src/ap/ubus.h
 @@ -17,9 +17,15 @@ enum hostapd_ubus_event_type {
  	HOSTAPD_UBUS_DEAUTH_REQ,
  	HOSTAPD_UBUS_FDATA_REQ,

--- a/feeds/wifi-trunk/hostapd/patches/902-ubus-multi-bss-chan-switch.patch
+++ b/feeds/wifi-trunk/hostapd/patches/902-ubus-multi-bss-chan-switch.patch
@@ -1,0 +1,23 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -762,6 +762,7 @@ hostapd_switch_chan(struct ubus_context
+ 	struct blob_attr *tb[__CSA_MAX];
+ 	struct hostapd_data *hapd = get_hapd_from_object(obj);
+ 	struct csa_settings css;
++	int i;
+ 
+ 	blobmsg_parse(csa_policy, __CSA_MAX, tb, blob_data(msg), blob_len(msg));
+ 
+@@ -787,8 +788,10 @@ hostapd_switch_chan(struct ubus_context
+ 	SET_CSA_SETTING(CSA_BLOCK_TX, block_tx, bool);
+ 
+ 
+-	if (hostapd_switch_channel(hapd, &css) != 0)
+-		return UBUS_STATUS_NOT_SUPPORTED;
++	for (i = 0; i < hapd->iface->num_bss; i++) {
++		if (hostapd_switch_channel(hapd->iface->bss[i], &css) != 0)
++			return UBUS_STATUS_NOT_SUPPORTED;
++	}
+ 
+ 	hostapd_ubus_handle_channel_switch_event(hapd->iface,HOSTAPD_UBUS_HIGH_INTERFERENCE,  css.freq_params.freq);
+ 


### PR DESCRIPTION
 - Add support for multi-bss channel switch inside ubus switch_chan method
 - Fix hostapd crash occuring while sending channel switch event to cloud.
 - Fix memory leak.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>