### PR TITLE
WiFi-2071. Read model info from manufacturing block

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -3,9 +3,9 @@
 . /lib/functions.sh
 
 SKU="unknown"
-MODEL="unknown"
+MODEL=""
 PLATFORM="unknown"
-SERIAL="unknown"
+SERIAL=""
 MODEL_REV="unknown"
 MODEL_DESCR="unknown"
 MANUF_NAME="unknown"
@@ -19,9 +19,12 @@ ID=""
 case "$(board_name)" in
 edgecore,ecw5211|\
 edgecore,ecw5410)
-	MODEL=$(cat /tmp/sysinfo/board_name | sed "s/edgecore,//" | tr [a-z] [A-Z])
 	PLATFORM=$(cat /tmp/sysinfo/model)
 	SERIAL=$(cat /dev/mtd5 | grep serial_number | cut -d "=" -f2)
+	MODEL=$(cat /dev/mtd5 | grep "model=" | cut -d "=" -f2)
+	if [ ! $MODEL ]; then
+		MODEL=$(cat /tmp/sysinfo/board_name | sed "s/edgecore,//" | tr [a-z] [A-Z])
+	fi
 	SKU=$(cat /dev/mtd5 | grep sku | cut -d "=" -f2)
 	CERT_REGION=$(cat /dev/mtd5 | grep certification_region | cut -d "=" -f2)
 	ID=$(cat /dev/mtd5 | grep mac_address | cut -d "=" -f2)
@@ -37,12 +40,12 @@ edgecore,ecw5410)
 	REF_DESIGN=$(cat /dev/mtd5 | grep reference_design | cut -d "=" -f2)
 	;;
 cig,wf194c)
-	MODEL=$(cat /tmp/sysinfo/board_name)
 	PLATFORM=$(cat /tmp/sysinfo/model)
 	SERIAL=$(cat /dev/mtd14 | grep serial_number | cut -d "=" -f2)
 	if [ ! $SERIAL ]; then
 		SERIAL=$(cat /dev/mtd14 | grep BaseMacAddress | cut -dx -f2)
 	fi
+	MODEL=$(cat /dev/mtd14 | grep "model=" | cut -d "=" -f2)
 	SKU=$(cat /dev/mtd14 | grep sku | cut -d "=" -f2)
 	CERT_REGION=$(cat /dev/mtd14 | grep certification_region | cut -d "=" -f2)
 	ID=$(cat /dev/mtd14 | grep mac_address | cut -d "=" -f2)
@@ -58,9 +61,9 @@ cig,wf194c)
 	REF_DESIGN=$(cat /dev/mtd14 | grep reference_design | cut -d "=" -f2)
 	;;
 cig,wf188n)
-	MODEL=$(cat /tmp/sysinfo/board_name)
 	PLATFORM=$(cat /tmp/sysinfo/model)
 	SERIAL=$(cat /dev/mtd12 | grep serial_number | cut -d "=" -f2)
+	MODEL=$(cat /dev/mtd12 | grep "model=" | cut -d "=" -f2)
 	SKU=$(cat /dev/mtd12 | grep sku | cut -d "=" -f2)
 	CERT_REGION=$(cat /dev/mtd12 | grep certification_region | cut -d "=" -f2)
 	ID=$(cat /dev/mtd12 | grep mac_address | cut -d "=" -f2)
@@ -97,9 +100,9 @@ linksys,ea8300)
 	MANUF_DATE="$DAY-$MONTH-$YEAR"
 	;;
 tp-link,ec420-g1)
-	MODEL=$(cat /tmp/sysinfo/board_name)
 	PLATFORM=$(cat /tmp/sysinfo/model)
 	SERIAL=$(cat /dev/mtd9 | grep serial_number | cut -d "=" -f2)
+	MODEL=$(cat /dev/mtd9 | grep "model=" | cut -d "=" -f2)
 	SKU=$(cat /dev/mtd9 | grep sku | cut -d "=" -f2)
 	CERT_REGION=$(cat /dev/mtd9 | grep certification_region | cut -d "=" -f2)
 	ID=$(cat /dev/mtd9 | grep mac_address | cut -d "=" -f2)
@@ -131,6 +134,11 @@ fi
 # fallback check to get the id from mac address if flash does not contain this info.
 if [ ! $ID ]; then
 	ID=$(cat /sys/class/net/eth0/address)
+fi
+
+# fallback check to get the model if flash does not contain this info.
+if [ ! $MODEL ]; then
+	MODEL=$(cat /tmp/sysinfo/board_name)
 fi
 
 uci set system.tip=tip


### PR DESCRIPTION
Reading model info from flash. If no info present in flash,
then read it from /tmp/sysinfo/boardname.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>