### PR TITLE
opensync: Fix SM crash during chan switch event

### DIFF
--- a/feeds/wlan-ap/opensync/patches/35-channel-switch-fix.patch
+++ b/feeds/wlan-ap/opensync/patches/35-channel-switch-fix.patch
@@ -1,0 +1,34 @@
+Index: opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/datapipeline/src/dppline.c
++++ opensync-2.0.5.0/src/lib/datapipeline/src/dppline.c
+@@ -652,8 +652,8 @@ static bool dppline_copysts(dppline_stat
+ 			dst->u.events.client_event_qty++;
+ 		}
+ 
+-		size = dst->u.events.client_event_qty * sizeof(dpp_event_record_session_t);
+-		dst->u.events.client_event_list = calloc(1, size);
++		int size_cl = dst->u.events.client_event_qty * sizeof(dpp_event_record_session_t);
++		dst->u.events.client_event_list = calloc(1, size_cl);
+ 		int count = 0;
+ 		ds_dlist_foreach(&report_data->client_event_list, result)
+ 		{
+@@ -671,8 +671,8 @@ static bool dppline_copysts(dppline_stat
+ 			dst->u.events.channel_event_qty++;
+ 		}
+ 
+-		size = dst->u.events.channel_event_qty * sizeof(dpp_event_record_channel_switch_t);
+-		dst->u.events.channel_event_list = calloc(1, size);
++		int size_ch = dst->u.events.channel_event_qty * sizeof(dpp_event_record_channel_switch_t);
++		dst->u.events.channel_event_list = calloc(1, size_ch);
+ 		ds_dlist_foreach(&report_data->channel_switch_list, channel_result)
+ 		{
+ 			assert(count < (int)dst->u.events.channel_event_qty);
+@@ -680,6 +680,7 @@ static bool dppline_copysts(dppline_stat
+ 			       sizeof(dpp_event_record_channel_switch_t));
+ 			count++;
+ 		}
++		size = size_cl + size_ch;
+ 
+ 	} break;
+ 

--- a/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
+++ b/feeds/wlan-ap/opensync/src/src/lib/datapipeline/inc/dpp_events.h
@@ -463,6 +463,19 @@ dpp_event_record_alloc()
 	return record;
 }
 
+static inline dpp_event_channel_switch_t *
+dpp_event_channel_switch_alloc()
+{
+	dpp_event_channel_switch_t *record = NULL;
+
+	record = calloc(1, sizeof(dpp_event_channel_switch_t));
+	if (record) {
+		memset(record, 0, sizeof(dpp_event_channel_switch_t));
+	}
+	return record;
+}
+
+
 static inline void
 dpp_event_channel_record_free(dpp_event_channel_switch_t *record)
 {


### PR DESCRIPTION
Fix SM crash event during chan switch event due
to global chan switch struct not being freed properly.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>