### PR TITLE
wifi-2070: Increase CSA count

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
@@ -163,7 +163,7 @@ void rrm_nf_timer_handler(struct ev_loop *loop, ev_timer *timer, int revents)
 
 		if (nf > nf_drop_threshold)
 		{
-			LOGD("[%s] backup=%d nf=%d nf_lwm=%d drop=%d thresh=%d",
+			LOGI("Interference detected on [%s], switching to backup_channel=%d nf=%d nf_lwm=%d drop=%d thresh=%d",
 					radio->config.if_name,
 					rrm_config->rrm_data.backup_channel,
 					nf,

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
@@ -73,7 +73,7 @@ int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel
 	}
 
 	blobmsg_add_u32(&b, "freq", frequency);
-	blobmsg_add_u32(&b, "bcn_count", 1);
+	blobmsg_add_u32(&b, "bcn_count", 5);
 	blobmsg_add_u32(&b, "bandwidth", channel_bandwidth);
 	blobmsg_add_u32(&b, "sec_channel_offset", sec_chan_offset);
 	return ubus_invoke(ubus, id, "switch_chan", b.head, NULL, NULL, 1000);


### PR DESCRIPTION
 - Channel switch in case of high interference was failing
   when multiple ssids are configured. Increasing CSA count helps
   all the vifs to reserve context and get ready before CSA can be
   finalized.
 - Log when we detect high interference

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>