### PR TITLE
WiFi-2072. Populate the right fw version in the AWLAN_Node

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -141,11 +141,17 @@ if [ ! $MODEL ]; then
 	MODEL=$(cat /tmp/sysinfo/board_name)
 fi
 
+# Read the active firmware version info
+FIRMWARE=$(cat /usr/opensync/.versions | grep FW_IMAGE_ACTIVE | grep -o '[^-]*$')
+if [ ! $FIRMWARE ]; then
+	FIRMWARE=$(cat /usr/opensync/.versions | grep FW_VERSION | cut -d ":" -f2)
+fi
+
 uci set system.tip=tip
 uci set system.tip.serial="${SERIAL}"
 uci set system.tip.model="${MODEL}"
 uci set system.tip.platform="${PLATFORM}"
-uci set system.tip.firmware='0.1.0'
+uci set system.tip.firmware="${FIRMWARE}"
 uci set system.tip.sku_number="${SKU}"
 uci set system.tip.revision="${MODEL_REV}"
 uci set system.tip.model_description="${MODEL_DESCR}"


### PR DESCRIPTION
Populating the fw version from FW_IMAGE_ACTIVE in the
AWLAN_Node.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>