### PR TITLE
WiFi-1826. Add OVSDB params for RRM channel hop config

### DIFF
--- a/feeds/wlan-ap/opensync/patches/36-add-channel-hop-config.patch
+++ b/feeds/wlan-ap/opensync/patches/36-add-channel-hop-config.patch
@@ -1,0 +1,66 @@
+Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
+===================================================================
+--- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
++++ opensync-2.0.5.0/interfaces/opensync.ovsschema
+@@ -8982,6 +8982,61 @@
+                     "min": 0,
+                     "max": 1
+                 }
++            },
++            "noise_floor_thresh": {
++                "type": {
++                    "key": {
++                        "type": "integer",
++                        "minInteger": -90,
++                        "maxInteger": -10
++                    },
++                    "min": 0,
++                    "max": 1
++                }
++            },
++            "noise_floor_time": {
++                "type": {
++                    "key": {
++                        "type": "integer",
++                        "minInteger": 60,
++                        "maxInteger": 600
++                    },
++                    "min": 0,
++                    "max": 1
++                }
++            },
++            "non_wifi_thresh": {
++                "type": {
++                    "key": {
++                        "type": "integer",
++                        "minInteger": 0,
++                        "maxInteger": 100
++                    },
++                    "min": 0,
++                    "max": 1
++                }
++            },
++            "non_wifi_time": {
++                "type": {
++                    "key": {
++                        "type": "integer",
++                        "minInteger": 60,
++                        "maxInteger": 600
++                    },
++                    "min": 0,
++                    "max": 1
++                }
++            },
++            "obss_hop_mode": {
++                "type": {
++                    "key": {
++                        "type": "integer",
++                        "minInteger": 1,
++                        "maxInteger": 2
++                    },
++                    "min": 0,
++                    "max": 1
++                }
+             }
+         },
+         "isRoot": true


### PR DESCRIPTION
Adding Noise floor and OBSS related params to the RRM Config
OVSDB table.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>