### PR TITLE
WiFi-1827. Updates for RRM Channel Hop based on Noise Floor threshold

### DIFF
--- a/feeds/wlan-ap/opensync/patches/34-radsec-schema-consts.patch
+++ b/feeds/wlan-ap/opensync/patches/34-radsec-schema-consts.patch
@@ -1,6 +1,6 @@
 --- a/interfaces/opensync.ovsschema
 +++ b/interfaces/opensync.ovsschema
-@@ -9439,6 +9439,110 @@
+@@ -9492,6 +9492,137 @@
        },
        "isRoot": true,
        "maxRows": 1
@@ -49,6 +49,33 @@
 +                  "type": "string"
 +                },
 +                "min": 1,
++                "max": 1
++              }
++            },
++            "acct_server": {
++                "type": {
++                "key": {
++                  "type": "string"
++                },
++                "min": 0,
++                "max": 1
++              }
++            },
++            "acct_port": {
++              "type": {
++                "key": {
++                  "type": "integer"
++                },
++                "min": 0,
++                "max": 1
++              }
++            },
++            "acct_secret": {
++                "type": {
++                "key": {
++                  "type": "string"
++                },
++                "min": 0,
 +                "max": 1
 +              }
 +            },

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
@@ -41,4 +41,6 @@ extern int net_get_mtu(char *iface);
 extern int net_get_mac(char *iface, char *mac);
 extern int net_is_bridge(char *iface);
 extern char* get_max_channel_bw_channel(int channel_freq, const char* htmode);
+extern double dBm_to_mwatts(double dBm);
+extern double mWatts_to_dBm(double mW);
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
@@ -47,8 +47,19 @@ void rrm_config_vif(struct blob_buf *b, struct blob_buf *del, const char * freq_
 		blobmsg_add_u32(b, "rssi_ignore_probe_request", conf.probe_resp_threshold);
 		blobmsg_add_u32(b, "signal_connect", conf.client_disconnect_threshold);
 		blobmsg_add_u32(b, "signal_stay", conf.client_disconnect_threshold);
-		blobmsg_add_u32(b, "bcn_rate", conf.beacon_rate);
 		blobmsg_add_u32(b, "mcast_rate", conf.mcast_rate);
+
+		if (conf.beacon_rate == 0) {
+			// Default to the lowest possible bit rate for each frequency band
+			if (!strcmp(freq_band, "2.4G")) {
+				blobmsg_add_u32(b, "bcn_rate", 10);
+			} else {
+				blobmsg_add_u32(b, "bcn_rate", 60);
+			}
+		} else {
+			blobmsg_add_u32(b, "bcn_rate", conf.beacon_rate);
+		}
+		
 	}
 	return;
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include <string.h>
+#include <math.h>
 #include <glob.h>
 #include <libgen.h>
 #include <fcntl.h>
@@ -681,3 +682,14 @@ bool vif_get_key_for_key_distr(const char *secret, char *key_str)
 	fclose(fp);
 	return err;
 }
+
+double dBm_to_mwatts(double dBm)
+{
+	return (pow(10,(dBm/10)));
+}
+
+double mWatts_to_dBm(double mW)
+{
+	return (10*log10(mW));
+}
+

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
@@ -48,6 +48,12 @@ typedef struct
 	ds_tree_node_t                  node;
 } rrm_vif_state_t;
 
+#define RRM_CHANNEL_INTERVAL     15
+
+#define RRM_MAX_NF_SAMPLES 100
+#define RRM_OBSS_HOP_MODE_NON_WIFI		1
+#define RRM_OBSS_HOP_MODE_NON_WIFI_AND_OBSS	2
+
 typedef struct
 {
 	// Cached data
@@ -59,9 +65,17 @@ typedef struct
 	uint32_t min_load;
 	uint32_t beacon_rate;
 	uint32_t mcast_rate;
+	int32_t noise_floor_thresh;
+	uint32_t noise_floor_time;
+	int32_t non_wifi_thresh;
+	uint32_t non_wifi_time;
+	uint32_t obss_hop_mode;
 
 	// Internal state data
-	int32_t noise_lwm;
+	int32_t avg_nf;
+	int32_t rrm_chan_nf_samples[RRM_MAX_NF_SAMPLES];
+	int32_t rrm_chan_nf_next_el;
+	int32_t rrm_chan_nf_num_el;
 } rrm_entry_t;
 
 typedef struct
@@ -80,5 +94,6 @@ void set_rrm_parameters(rrm_entry_t *rrm_data);
 ds_tree_t* rrm_get_rrm_config_list(void);
 ds_tree_t* rrm_get_radio_list(void);
 ds_tree_t* rrm_get_vif_list(void);
+void rrm_reset_noise_floor_samples(rrm_entry_t *rrm_data);
 
 #endif /* RRM_H_INCLUDED */

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ovsdb.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ovsdb.c
@@ -124,6 +124,21 @@ void rrm_config_update(void)
 		rrm_data.min_load = rrm->schema.min_load;
 		rrm_data.beacon_rate = rrm->schema.beacon_rate;
 		rrm_data.mcast_rate = rrm->schema.mcast_rate;
+		rrm_data.noise_floor_thresh = rrm->schema.noise_floor_thresh;
+		rrm_data.noise_floor_time = rrm->schema.noise_floor_time;
+		if (rrm_data.noise_floor_time/RRM_CHANNEL_INTERVAL > RRM_MAX_NF_SAMPLES)
+		{
+			LOG(WARN, "RRM Config: Noise floor time too high."
+					" nf_time:%d, sampling_interval:%d, max_num_samples:%d",
+					rrm_data.noise_floor_time, RRM_CHANNEL_INTERVAL,
+					RRM_MAX_NF_SAMPLES);
+		}
+		rrm_data.non_wifi_thresh = rrm->schema.non_wifi_thresh;
+		rrm_data.non_wifi_time = rrm->schema.non_wifi_time;
+		rrm_data.obss_hop_mode = rrm->schema.obss_hop_mode;
+
+		rrm_data.avg_nf = 0;
+		rrm_reset_noise_floor_samples(&rrm_data);
 
 		/* Update cache config */
 		rrm->rrm_data = rrm_data;
@@ -408,13 +423,7 @@ void rrm_update_rrm_config_cb(ovsdb_update_monitor_t *self)
 			return;
 		}
 		/* Reset configuration */
-		rrm_config->schema.backup_channel = 0;
-		rrm_config->schema.min_load = 0;
-		rrm_config->schema.beacon_rate = 0;
-		rrm_config->schema.mcast_rate = 0;
-		rrm_config->schema.snr_percentage_drop = 0;
-		rrm_config->schema.client_disconnect_threshold = 0;
-		rrm_config->schema.probe_resp_threshold = 0;
+		memset(&(rrm_config->schema), 0, sizeof(rrm_config->schema));
 
 		ds_tree_remove(&rrm_config_list, rrm_config);
 		free(rrm_config);


### PR DESCRIPTION
Average Noise Floor is calcluated for the last few samples based on the
configured Noise Floor time. This calculated avg Noise Floor is compared
against the configured Noise Floor threshold to decide if a Channel hop
is required.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>