### PR TITLE
WIFI-2085: Inconsistent beacon rates when set to "auto"

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
@@ -47,8 +47,19 @@ void rrm_config_vif(struct blob_buf *b, struct blob_buf *del, const char * freq_
 		blobmsg_add_u32(b, "rssi_ignore_probe_request", conf.probe_resp_threshold);
 		blobmsg_add_u32(b, "signal_connect", conf.client_disconnect_threshold);
 		blobmsg_add_u32(b, "signal_stay", conf.client_disconnect_threshold);
-		blobmsg_add_u32(b, "bcn_rate", conf.beacon_rate);
 		blobmsg_add_u32(b, "mcast_rate", conf.mcast_rate);
+
+		if (conf.beacon_rate == 0) {
+			// Default to the lowest possible bit rate for each frequency band
+			if (!strcmp(freq_band, "2.4G")) {
+				blobmsg_add_u32(b, "bcn_rate", 10);
+			} else {
+				blobmsg_add_u32(b, "bcn_rate", 60);
+			}
+		} else {
+			blobmsg_add_u32(b, "bcn_rate", conf.beacon_rate);
+		}
+		
 	}
 	return;
 }


### PR DESCRIPTION
This bug was caused when the cloud UI had the management data rate set to "auto" and passed a value of 0 mbps down to the AP. This value was passed all the way down to ath10k and failed in such a way where the new management data rate would not overwrite the previous value resulting in unpredictable behaviour.

To solve the issue we check if the value for beacon rate is set to 0 and if it is we instead use the lowest possible management bit rate for each frequency band (1mbps for 2.4ghz and 6mbps for 5ghz) instead of continuing to pass down 0 which caused the bug.