### PR TITLE
ucentral: Fix bringup of encrypted meshpoint interfaces

### DIFF
--- a/profiles/ucentral-ap-light.yml
+++ b/profiles/ucentral-ap-light.yml
@@ -29,6 +29,7 @@ diffconfig: |
   CONFIG_OPENSSL_WITH_PSK=y
   CONFIG_OPENSSL_WITH_SRP=y
   CONFIG_OPENSSL_WITH_TLS13=y
+  # CONFIG_PACKAGE_wpad is not set
   # CONFIG_PACKAGE_wpad-basic-wolfssl is not set
   CONFIG_IMAGEOPT=y
   CONFIG_PREINITOPT=y

--- a/profiles/ucentral-ap.yml
+++ b/profiles/ucentral-ap.yml
@@ -55,6 +55,7 @@ diffconfig: |
   CONFIG_OPENSSL_WITH_PSK=y
   CONFIG_OPENSSL_WITH_SRP=y
   CONFIG_OPENSSL_WITH_TLS13=y
+  # CONFIG_PACKAGE_wpad is not set
   # CONFIG_PACKAGE_wpad-basic-wolfssl is not set
   # CONFIG_PACKAGE_dnsmasq is not set 
   CONFIG_IMAGEOPT=y


### PR DESCRIPTION
The encrypted mesh interfaces need a wpa_supplicant which supports SAE. This can be for example wpad-openssl or wpad-mesh-openssl. Otherwise wpa_supplicant fails with on startup:

    Line 7: invalid key_mgmt 'SAE'
    Line 7: no key_mgmt values configured.
    Line 7: failed to parse key_mgmt 'SAE'.
    Line 8: too large mode (value=5 max_value=4)
    Line 8: failed to parse mode '5'.
    Line 9: unknown network field 'mesh_fwding'.
    Line 18: failed to parse network block.

The correct package for this was already listed in the dependencies for ucentral-ap and ucentral-ap-light. But this package conflicted with the default package wpad and was therefore only build as optional package. The wpad package must therefore be deselected before selecting wpad(-mesh)-openssl.