### PR TITLE
qca-ssdk: Disable port learning (roaming fix option A)

### DIFF
--- a/feeds/ipq807x/qca-ssdk/patches/101-disable-learning.patch
+++ b/feeds/ipq807x/qca-ssdk/patches/101-disable-learning.patch
@@ -1,0 +1,20 @@
+--- a/src/init/ssdk_hppe.c
++++ b/src/init/ssdk_hppe.c
+@@ -38,7 +38,7 @@ static sw_error_t qca_hppe_fdb_hw_init(a
+ 	SW_RTN_ON_NULL(p_api->adpt_port_bridge_txmac_set);
+ 
+ 	for(port = SSDK_PHYSICAL_PORT0; port <= SSDK_PHYSICAL_PORT7; port++) {
+-		fal_fdb_port_learning_ctrl_set(dev_id, port, A_TRUE, FAL_MAC_FRWRD);
++		fal_fdb_port_learning_ctrl_set(dev_id, port, A_FALSE, FAL_MAC_FRWRD);
+ 		fal_fdb_port_stamove_ctrl_set(dev_id, port, A_TRUE, FAL_MAC_FRWRD);
+ 		fal_portvlan_member_update(dev_id, port, 0x7f);
+ 		if (port == SSDK_PHYSICAL_PORT0 || port == SSDK_PHYSICAL_PORT7) {
+@@ -50,7 +50,7 @@ static sw_error_t qca_hppe_fdb_hw_init(a
+ 	}
+ 
+ 	fal_fdb_aging_ctrl_set(dev_id, A_TRUE);
+-	fal_fdb_learning_ctrl_set(dev_id, A_TRUE);
++	fal_fdb_learning_ctrl_set(dev_id, A_FALSE);
+ 
+ 	return SW_OK;
+ }


### PR DESCRIPTION
The switch in the IPQ807x/IPQ60xx devices will automatically learn the mac addresses behind a port. But it will not unlearn this entry when some mac switches from the ethernet port to the CPU port. This will for example happens when a device roams from on AP to another AP. At least when both are APs are bridging the wifi traffic directly or indirectly (mesh) to the same ethernet broadcast domain.

As result, the roaming device can no longer receive any ethernet packets which the AP is expected to receive on the ethernet port. This state will be kept for a couple of minutes until the entry in the FDB is dropped automatically. But it is still possible for the wifi device to send data via the ethernet during this whole time.

One solution is to just disable learning on all ports. The other option would be to enable the qca bridge-mgr which takes care of gathering the events from the bridge and forwards it to the qca-ssdk (to manipulate the state of the switch). The first option was chosen here for simplicity.

This is option A. Option B can be found in #258