### PR TITLE
WIFI-1664: Make some more radius proxy parameters configurable

### DIFF
--- a/feeds/wlan-ap/opensync/patches/34-radsec-schema-consts.patch
+++ b/feeds/wlan-ap/opensync/patches/34-radsec-schema-consts.patch
@@ -1,6 +1,6 @@
 --- a/interfaces/opensync.ovsschema
 +++ b/interfaces/opensync.ovsschema
-@@ -9439,6 +9439,110 @@
+@@ -9492,6 +9492,137 @@
        },
        "isRoot": true,
        "maxRows": 1
@@ -49,6 +49,33 @@
 +                  "type": "string"
 +                },
 +                "min": 1,
++                "max": 1
++              }
++            },
++            "acct_server": {
++                "type": {
++                "key": {
++                  "type": "string"
++                },
++                "min": 0,
++                "max": 1
++              }
++            },
++            "acct_port": {
++              "type": {
++                "key": {
++                  "type": "integer"
++                },
++                "min": 0,
++                "max": 1
++              }
++            },
++            "acct_secret": {
++                "type": {
++                "key": {
++                  "type": "string"
++                },
++                "min": 0,
 +                "max": 1
 +              }
 +            },


### PR DESCRIPTION
- Add config parameters for accounting server in non-TLS case
- Allow server port to be configurable
- Fix up multiple realm to server mapping config

Signed-off-by: Arif Alam <arif.alam@netexperience.com>