### PR TITLE
wifi-2069: Fix opensync vifS synchronization

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
@@ -501,25 +501,30 @@ void opennds_parameters(char *ifname)
 void opennds_section_del(char *section_name)
 {
 	struct uci_package *opennds;
+	struct uci_context *nds_ctx;
 	struct uci_element *e = NULL, *tmp = NULL;
-	int ret=0;
+	int ret = 0;
 
-	ret= uci_load(uci, "opennds", &opennds);
+	nds_ctx = uci_alloc_context();
+	ret = uci_load(nds_ctx, "opennds", &opennds);
 	if (ret) {
-		LOGD("%s: uci_load() failed with rc %d", section_name, ret);
+		LOGE("%s: %s uci_load() failed with rc %d", section_name, __func__, ret);
+		uci_free_context(nds_ctx);
 		return;
 	}
 	uci_foreach_element_safe(&opennds->sections, tmp, e) {
 		struct uci_section *s = uci_to_section(e);
 		if (!strcmp(s->e.name, section_name)) {
-			uci_section_del(uci, "vif", "opennds", (char *)s->e.name, section_name);
+			uci_section_del(nds_ctx, "vif", "opennds", (char *)s->e.name, section_name);
 		}
 		else {
 			continue;
 		}
 	}
-	uci_commit(uci, &opennds, false);
-	uci_unload(uci, opennds);
+
+	uci_commit(nds_ctx, &opennds, false);
+	uci_unload(nds_ctx, opennds);
+	uci_free_context(nds_ctx);
 	reload_config = 1;
 }
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
@@ -329,22 +329,27 @@ static bool radius_proxy_config_set(struct schema_Radius_Proxy_Config *conf )
 static bool radius_proxy_config_delete()
 {
 	struct uci_package *radsecproxy;
+	struct uci_context *rad_uci;
 	struct uci_element *e = NULL, *tmp = NULL;
-	int ret=0;
+	int ret = 0;
 
-	ret= uci_load(uci, "radsecproxy", &radsecproxy);
+	rad_uci = uci_alloc_context();
+
+	ret = uci_load(rad_uci, "radsecproxy", &radsecproxy);
 	if (ret) {
-		LOGD("%s: uci_load() failed with rc %d", __func__, ret);
+		LOGE("%s: uci_load() failed with rc %d", __func__, ret);
+		uci_free_context(rad_uci);
 		return false;
 	}
 	uci_foreach_element_safe(&radsecproxy->sections, tmp, e) {
 		struct uci_section *s = uci_to_section(e);
 		if ((s == NULL) || (s->type == NULL)) continue;
-		uci_section_del(uci, "radsecproxy", "radsecproxy",
+		uci_section_del(rad_uci, "radsecproxy", "radsecproxy",
 				(char *)s->e.name, s->type);
 	}
-	uci_commit(uci, &radsecproxy, false);
-	uci_unload(uci, radsecproxy);
+	uci_commit(rad_uci, &radsecproxy, false);
+	uci_unload(rad_uci, radsecproxy);
+	uci_free_context(rad_uci);
 	reload_config = 1;
 	return true;
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/uci.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/uci.c
@@ -210,8 +210,10 @@ int uci_section_to_blob(struct uci_context *uci, char *package, char *section,
 
 	if (uci_load(uci, package, &p))
 		p = uci_lookup_package(uci, package);
-	if (!p)
+	if (!p) {
+		uci_unload(uci, p);
 		return -1;
+	}
 	s = uci_lookup_section(uci, p, section);
 	if (!s)
 		goto out;


### PR DESCRIPTION
 - Make sure that uci_context used while loading a UCI is exclusive at
   any given time.
 - Some other improvements in the same area.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>