### PR TITLE
APC: Fix BDR takes place of DR

### DIFF
--- a/feeds/wlan-ap/apc/src/src/hello.c
+++ b/feeds/wlan-ap/apc/src/src/hello.c
@@ -189,8 +189,11 @@ void apc_send_hello(struct apc_iface * ifa, int kind )
 			else
 				ApcSpec.FloatIp = ApcSpecSaved.FloatIp;
 		}
-		else
+		else if (ApcSpec.IsApc == I_AM_BAPC )
 		{
+			ifa->priority = 0x12;
+		}
+		else {
 			ifa->priority = 0x11;
 			if ((ApcSpecSaved.IsApc == I_AM_APC) || BackingUpRadius )
 			{

--- a/feeds/wlan-ap/apc/src/src/neighbor.c
+++ b/feeds/wlan-ap/apc/src/src/neighbor.c
@@ -482,10 +482,13 @@ static void inactivity_timer_hook(struct _timer * tmr)
 			n_neigh += 1;
 			//Radius stuff
 			BackingUpRadius = 1;
+			apc_ifa->priority = 0x33;
 		}
+		else
+			apc_ifa->priority = 0x11;
+
 
 		apc_ifa->drip = MyIpAddr;
-		apc_ifa->priority = 0x11;
 		apc_ifa->bdrip = 0;
 		memset(&ApcSpec, 0, sizeof(struct apc_spec));
 		WaitingToReelect = 12;

--- a/feeds/wlan-ap/apc/src/src/ubus.c
+++ b/feeds/wlan-ap/apc/src/src/ubus.c
@@ -17,7 +17,7 @@ static struct blob_buf nb;
 static const char *ubus_path;
 timer *notify_timer;
 extern struct apc_iface * apc_ifa;
-#define APC_NOTIFY_INTERVAL 30
+#define APC_NOTIFY_INTERVAL 10
 
 struct apc_state {
 	char mode[4];
@@ -94,7 +94,7 @@ apc_info_handle(struct ubus_context *ctx, struct ubus_object *obj,
 	return 0;
 }
 
-static char apc_mode[APC_MAX_MODE][8] = {"DOWN", "LOOP", "WAITING", "PTP", "OR", "BDR", "DR"};
+static char apc_mode[APC_MAX_MODE][8] = {"DOWN", "LOOP", "WT", "PTP", "OR", "BDR", "DR"};
 void apc_update_state()
 {
 	struct in_addr dr_addr;
@@ -112,8 +112,12 @@ void apc_update_state()
 			 "%s", inet_ntoa(dr_addr));
 		snprintf(state.bdr_addr, sizeof(state.bdr_addr),
 			 "%s", inet_ntoa(bdr_addr));
-	}
-	else {
+	} else if (apc_ifa->state == APC_IS_WAITING) {
+		snprintf(state.mode, sizeof(state.mode), "%s",
+			 &apc_mode[apc_ifa->state][0]);
+		snprintf(state.dr_addr, sizeof(state.dr_addr), "0.0.0.0");
+		snprintf(state.bdr_addr, sizeof(state.bdr_addr), "0.0.0.0");
+	} else {
 		snprintf(state.mode, sizeof(state.mode), "NC");
 		snprintf(state.dr_addr, sizeof(state.dr_addr), "0.0.0.0");
 		snprintf(state.bdr_addr, sizeof(state.bdr_addr), "0.0.0.0");

--- a/feeds/wlan-ap/opensync/patches/33-add-apc-radsecproxy-schema.patch
+++ b/feeds/wlan-ap/opensync/patches/33-add-apc-radsecproxy-schema.patch
@@ -2,7 +2,7 @@ Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
 ===================================================================
 --- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
 +++ opensync-2.0.5.0/interfaces/opensync.ovsschema
-@@ -9368,6 +9368,68 @@
+@@ -9368,6 +9368,69 @@
              }
         },
        "isRoot": true
@@ -57,6 +57,7 @@ Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
 +                  "DR",
 +                  "BDR",
 +                  "OR",
++                  "WT",
 +                  "NC"
 +                ]
 +              ]

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -701,8 +701,7 @@ void APC_config_update(struct schema_APC_Config *conf)
 	apc_uci = uci_alloc_context();
 
 	blob_buf_init(&apcb, 0);
-
-	if (conf->enabled == true) {
+	if (conf && conf->enabled == true) {
 		blobmsg_add_bool(&apcb, "enabled", 1);
 		system("/etc/init.d/apc start");
 	} else {
@@ -721,7 +720,9 @@ static void callback_APC_Config(ovsdb_update_monitor_t *mon,
                                 struct schema_APC_Config *old,
                                 struct schema_APC_Config *conf)
 {
-	if (mon->mon_type != OVSDB_UPDATE_DEL)
+	if (mon->mon_type == OVSDB_UPDATE_DEL)
+		APC_config_update(NULL);
+	else
 		APC_config_update(conf);
 
 }


### PR DESCRIPTION
Raise the priority of BDR in case
when DR is inactive, so that in the
election process BDR is elected as
DR. 
Also add a new apc state WT, 
this is when its waiting for election.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>