### PR TITLE
WIFI-2148: Added auto value for hw_mode for configuration

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/auto-conf
+++ b/feeds/wlan-ap/opensync/files/bin/auto-conf
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Finds the highest settings an AP can support for various settings when set to "auto" in config
+
+find_auto_hwmode() {
+	# This function finds the highest mode (hw_mode) that the AP can support
+
+	# Arguments
+	device=$1
+
+	mode='11n'
+	iw phy "$device" info | grep -q 'VHT Capabilities*' && mode="11ac"
+	iw phy "$device" info | grep -q 'HE.*Capabilities' && mode="11ax"
+
+	echo "$mode"
+}
+
+find_auto_hwmode $1

--- a/feeds/wlan-ap/opensync/patches/37-add-auto-hw_mode.patch
+++ b/feeds/wlan-ap/opensync/patches/37-add-auto-hw_mode.patch
@@ -1,0 +1,12 @@
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -1357,7 +1357,8 @@
+                   "11n",
+                   "11ab",
+                   "11ac",
+-                  "11ax"
++                  "11ax",
++                  "auto"
+                 ]
+               ]
+             },

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -407,8 +407,26 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 
 	if ((changed->ht_mode) || (changed->hw_mode) || (changed->freq_band)) {
 		int channel_freq;
+		char buffer[8];
+		FILE *confFile_p;
+		const char* hw_mode = rconf->hw_mode;
+
 		channel_freq = ieee80211_channel_to_frequency(rconf->channel);
-		struct mode_map *m = mode_map_get_uci(rconf->freq_band, get_max_channel_bw_channel(channel_freq, rconf->ht_mode), rconf->hw_mode);
+		if (!strcmp(rconf->hw_mode, "auto")) {
+			char command[] = "auto-conf ";
+			strcat(command, phy);
+			confFile_p = popen(command, "r");
+			
+			if (confFile_p)
+			{
+				fgets(buffer, sizeof(buffer), confFile_p);
+				pclose(confFile_p);
+				buffer[strlen(buffer) - 1] = '\0'; // Remove extra \n that got added from 'echo' in script
+				hw_mode = buffer;
+			}
+		}
+
+		struct mode_map *m = mode_map_get_uci(rconf->freq_band, get_max_channel_bw_channel(channel_freq, rconf->ht_mode), hw_mode);
 		if (m) {
 			blobmsg_add_string(&b, "htmode", m->ucihtmode);
 			blobmsg_add_string(&b, "hwmode", m->ucihwmode);


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

This PR adds the ability to set hw_mode to auto in Wifi_Radio_Config. The AP will then find the highest value of hw_mode that it can support (11n, 11ac, 11ax) and selects that instead. This could allow to have a single shared config file in the cloud for both WiFi5 and WiFi6 AP's.