### PR TITLE
ipq807x: fix eap101 leds

### DIFF
--- a/patches/0027-ipq807x-add-the-Qualcomm-AX-target-support.patch
+++ b/patches/0027-ipq807x-add-the-Qualcomm-AX-target-support.patch
@@ -12281,14 +12281,14 @@ index 0000000000..6b0eb2f831
 ++		pinctrl-names = "default";
 ++
 ++		led@25 {
-++			label = "wifi5g";
-++			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
+++			label = "green:wifi5";
+++			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
 ++			linux,default-trigger = "wf188:green:5g";
 ++			default-state = "off";
 ++		};
 ++		led@24 {
-++			label = "wifi2g";
-++			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+++			label = "green:wifi2";
+++			gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
 ++			linux,default-trigger = "wf188:green:2g";
 ++			default-state = "off";
 ++		};


### PR DESCRIPTION
The LEDs defined in the dts did not match what UCI expected.

Signed-off-by: John Crispin <john@phrozen.org>