### PR TITLE
WIFI-2379: fix radius proxy config

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/vif.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/vif.h
@@ -37,5 +37,6 @@ void vif_hs20_update(struct schema_Hotspot20_Config *hs2conf);
 void vif_hs20_osu_update(struct schema_Hotspot20_OSU_Providers *hs2osuconf);
 void vif_hs20_icon_update(struct schema_Hotspot20_Icon_Config *hs2iconconf);
 void vif_section_del(char *section_name);
+void vif_check_radius_proxy(void);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -77,7 +77,7 @@ static const struct blobmsg_policy wifi_device_policy[__WDEV_ATTR_MAX] = {
 	[WDEV_ATTR_RX_ANTENNA] = { .name = "rxantenna", .type = BLOBMSG_TYPE_INT32 },
 	[WDEV_ATTR_FREQ_BAND] = { .name = "freq_band", .type = BLOBMSG_TYPE_STRING },
 	[WDEV_AATR_CHANNELS] = {.name = "channels", .type = BLOBMSG_TYPE_ARRAY},
-        [WDEV_ATTR_DISABLE_B_RATES] = { .name = "legacy_rates", .type = BLOBMSG_TYPE_BOOL },
+	[WDEV_ATTR_DISABLE_B_RATES] = { .name = "legacy_rates", .type = BLOBMSG_TYPE_BOOL },
 	[WDEV_ATTR_MAXASSOC_CLIENTS] = { .name = "maxassoc", .type = BLOBMSG_TYPE_INT32 },
 	[WDEV_ATTR_LOCAL_PWR_CONSTRAINT] = { .name = "local_pwr_constraint", .type = BLOBMSG_TYPE_INT32 },
 };
@@ -742,6 +742,10 @@ static void callback_APC_State(ovsdb_update_monitor_t *mon,
 		radproxy_apc = 0;
 		system("ubus call service event '{\"type\": \"config.change\", \"data\": { \"package\": \"wireless\" }}'");
 	}
+
+	/* APC changed: start / stop radius proxy service if needed */
+	vif_check_radius_proxy();
+
 }
 
 struct schema_APC_State apc_state;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
@@ -401,7 +401,6 @@ void callback_Radius_Proxy_Config(ovsdb_update_monitor_t *self,
 
 	case OVSDB_UPDATE_DEL:
 		(void) radius_proxy_config_delete();
-		(void) radius_proxy_config_set(conf);
 		break;
 
 	default:

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
@@ -1047,7 +1047,7 @@ void vif_section_del(char *section_name)
 	reload_config = 1;
 }
 
-static void vif_check_radius_proxy()
+void vif_check_radius_proxy()
 {
 	struct uci_context *uci_ctx;
 	struct uci_package *wireless;


### PR DESCRIPTION
Remove stale radius proxy config on ovsdb delete.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>

WIFI-2377: check radius proxy service on APC state change

Start or stop radius proxy service as needed on APC state change.

Radius proxy service is only started if:
- AP is elected as a DR (Designated Router) via APC
- radproxy is set to true in vif config custom options for any
  ssid

Signed-off-by: Arif Alam <arif.alam@netexperience.com>