### PR TITLE
WIFI-1933-Blink-APs-LED

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/wlan_ap_led.sh
+++ b/feeds/wlan-ap/opensync/files/bin/wlan_ap_led.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+#Blink AP's LED
+/usr/opensync/tools/ovsh insert Node_Config module:="led" key:="led_blink" value:="on"

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/node_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/node_config.c
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include <string.h>
+#include <glob.h>
+#include <linux/limits.h>
+#include <libgen.h>
 
 #include "uci.h"
 #include "command.h"
@@ -253,6 +256,118 @@ static void ntp_handler(int type,
 	ntp_state(0);
 }
 
+enum {
+	LED_ATTR_SYSFS,
+	LED_ATTR_TRIGGER,
+	LED_ATTR_DELAYON,
+	LED_ATTR_DELAYOFF,
+	LED_ATTR_VALUE,
+	LED_ATTR_KEY,
+	__LED_ATTR_MAX,
+};
+
+static const struct blobmsg_policy led_policy[__LED_ATTR_MAX] = {
+	[LED_ATTR_SYSFS] = { .name = "sysfs", .type = BLOBMSG_TYPE_STRING },
+	[LED_ATTR_TRIGGER] = { .name = "trigger", .type = BLOBMSG_TYPE_STRING },
+	[LED_ATTR_DELAYON] = { .name = "delayon", .type = BLOBMSG_TYPE_STRING},
+	[LED_ATTR_DELAYOFF] = { .name = "delayoff", .type = BLOBMSG_TYPE_STRING},
+	[LED_ATTR_VALUE] = { .name = "value", .type = BLOBMSG_TYPE_STRING},
+	[LED_ATTR_KEY] = { .name = "key", .type = BLOBMSG_TYPE_STRING},
+};
+
+static const struct uci_blob_param_list led_param = {
+	.n_params = __LED_ATTR_MAX,
+	.params = led_policy,
+};
+
+static char led[][8]={"lan", "wan", "eth", "wifi2", "wifi5", "wlan2g", "wlan5g", "power","eth0",
+			  "status", "eth1", "wifi2g", "eth2", "wifi5g", "plug", "world", "usb", "linksys", "wps", "bt"};
+
+static void led_state(int config)
+{
+	struct blob_attr *tb[__LED_ATTR_MAX] = { };
+	struct uci_package *system;
+	struct uci_section *s = NULL;
+	struct uci_element *e = NULL;
+	char val[8];
+	char key[16];
+	blob_buf_init(&b, 0);
+	uci_load(uci, "system", &system);
+	uci_foreach_element(&system->sections, e) {
+		s = uci_to_section(e);
+		if (!strcmp(s->type, "led")) {
+			uci_to_blob(&b, s, &led_param);
+			blobmsg_parse(led_policy, __LED_ATTR_MAX, tb, blob_data(b.head), blob_len(b.head));
+			if(tb[LED_ATTR_KEY])
+				strcpy(key, blobmsg_get_string(tb[LED_ATTR_KEY]));
+			if(tb[LED_ATTR_VALUE])
+				strcpy(val, blobmsg_get_string(tb[LED_ATTR_VALUE]));
+			break;
+		}
+		s = NULL;
+	}
+	if (!s)
+		goto out;
+	if (config)
+		node_config_set("led", key, val);
+	node_state_set("led", key, val);
+out:
+	uci_unload(uci, system);
+}
+
+int available_led_check(char *led_name)
+{
+	unsigned int i;
+	for (i = 0; i < ARRAY_SIZE(led); i++) {
+		if(!strcmp(led_name,led[i])) {
+			return 1;
+		}
+	}
+	return 0;
+}
+static void led_handler(int type,
+			struct schema_Node_Config *old,
+			struct schema_Node_Config *conf)
+{
+	char led_string[32];
+	char ap_name[16];
+	char color[16];
+	char led_section[16];
+	char sys[8];
+	char class[8];
+	char leds[8];
+	char sysled[PATH_MAX];
+	glob_t gl;
+	unsigned int i;
+
+	switch (type) {
+	case OVSDB_UPDATE_NEW:
+	case OVSDB_UPDATE_MODIFY:
+		if (!strcmp(conf->key, "led_blink"))
+		{
+			if (glob("/sys/class/leds/*", GLOB_NOSORT, NULL, &gl))
+				return;
+			for (i = 0; i < gl.gl_pathc; i++) {
+				strncpy(sysled, gl.gl_pathv[i], sizeof(sysled));
+				sscanf(sysled,"/%[^/]/%[^/]/%[^/]/%s", sys, class, leds, led_string);
+				sscanf(led_string,"%[^:]:%[^:]:%s",ap_name, color, led_section);
+				if(available_led_check(led_section)) {
+					blob_buf_init(&b, 0);
+					blobmsg_add_string(&b, "sysfs", led_string);
+					blobmsg_add_string(&b, "value", "on");
+					blobmsg_add_string(&b, "key", conf->key );
+					blobmsg_add_string(&b, "trigger", "heartbeat");
+					blob_to_uci_section(uci, "system", led_section, "led", b.head, &led_param, NULL);
+				}
+			}
+		}
+		globfree(&gl);
+	}
+	uci_commit_all(uci);
+	system("/sbin/reload_config");
+	led_state(0);
+}
+
 static struct node_handler {
 	char *name;
 	void (*handler)(int type,
@@ -269,6 +384,11 @@ static struct node_handler {
 		.name = "ntp",
 		.handler = ntp_handler,
 		.state = ntp_state,
+	},
+	{
+		.name = "led",
+		.handler = led_handler,
+		.state = led_state,
 	},
 };
 

--- a/patches/0054-WiFi6-Aps-LEDs-Label-Name-Change.patch
+++ b/patches/0054-WiFi6-Aps-LEDs-Label-Name-Change.patch
@@ -1,0 +1,201 @@
+From 82c689a779db76c74893be4d6249b663d70d80d8 Mon Sep 17 00:00:00 2001
+From: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+Date: Fri, 21 May 2021 16:38:07 -0400
+Subject: [PATCH] WiFi6-APs-Label-Name-Change
+
+---
+ .../111-WiFi6-APs-LED-Label-Name-Change.patch | 182 ++++++++++++++++++
+ 1 file changed, 182 insertions(+)
+ create mode 100644 target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
+
+diff --git a/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch b/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
+new file mode 100644
+index 0000000000..2396067aac
+--- /dev/null
++++ b/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
+@@ -0,0 +1,182 @@
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
++@@ -309,26 +309,26 @@
++ 		pinctrl-names = "default";
++ 
++ 		led@25 {
++-			label = "led_5g";
++-			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:5g";
+++			label = "wf188:green:wifi5g";
+++			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+++			linux,default-trigger = "wf188:green:wifi5g";
++ 			default-state = "off";
++ 		};
++ 		led@24 {
++-			label = "led_2g";
++-			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:2g";
+++			label = "wf188:green:wifi2g";
+++			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+++			linux,default-trigger = "wf188:green:wifi2g";
++ 			default-state = "off";
++ 		};
++ 		led@18 {
++-			label = "led_eth";
++-			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+++			label = "wf188:green:eth";
+++			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
++ 			linux,default-trigger = "wf188:green:eth";
++ 			default-state = "off";
++ 		};
++                 led_power: led@16 {
++-                        label = "led_pwr";
++-                        gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
+++                        label = "wf188:green:power";
+++                        gpios = <&tlmm 16 GPIO_ACTIVE_LOW>;
++                         linux,default-trigger = "wf188:green:power";
++ 			default-state = "off";
++ 		};
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
++@@ -309,26 +309,26 @@
++ 		pinctrl-names = "default";
++ 
++ 		led@25 {
++-			label = "led_5g";
++-			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:5g";
+++			label = "wf188:green:wifi5g";
+++			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+++			linux,default-trigger = "wf188:green:wifi5g";
++ 			default-state = "off";
++ 		};
++ 		led@24 {
++-			label = "led_2g";
++-			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:2g";
+++			label = "wf188:green:wifi2g";
+++			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+++			linux,default-trigger = "wf188:green:wifi2g";
++ 			default-state = "off";
++ 		};
++ 		led@18 {
++-			label = "led_eth";
++-			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+++			label = "wf188:green:eth";
+++			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
++ 			linux,default-trigger = "wf188:green:eth";
++ 			default-state = "off";
++ 		};
++                 led_power: led@16 {
++-                        label = "led_pwr";
++-                        gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
+++                        label = "wf188:green:power";
+++                        gpios = <&tlmm 16 GPIO_ACTIVE_LOW>;
++                         linux,default-trigger = "wf188:green:power";
++ 			default-state = "off";
++ 		};
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-edgecore-eap101.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-edgecore-eap101.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-edgecore-eap101.dts
++@@ -337,21 +337,21 @@
++ 		pinctrl-names = "default";
++ 
++ 		led@25 {
++-			label = "green:wifi5";
+++			label = "eap101:green:wifi5g";
++ 			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
++-			linux,default-trigger = "wf188:green:5g";
+++			linux,default-trigger = "eap101:green:wifi5g";
++ 			default-state = "off";
++ 		};
++ 		led@24 {
++-			label = "green:wifi2";
+++			label = "eap101:green:wifi2g";
++ 			gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
++-			linux,default-trigger = "wf188:green:2g";
+++			linux,default-trigger = "eap101:green:wifi2g";
++ 			default-state = "off";
++ 		};
++                 led_power: led@16 {
++-                        label = "led_pwr";
++-                        gpios = <&tlmm 74 GPIO_ACTIVE_HIGH>;
++-                        linux,default-trigger = "green:power";
+++                        label = "eap101:green:power";
+++                        gpios = <&tlmm 74 GPIO_ACTIVE_LOW>;
+++                        linux,default-trigger = "eap101:green:power";
++ 			default-state = "off";
++ 		};
++ 	};
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
++@@ -671,29 +671,27 @@
++ 		pinctrl-names = "default";
++ 
++ 			led_power: led_pwr {
++-				label = "green:power";
+++				label = "eap102:green:power";
++ 				gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
++ 				default-state = "on";
++-				linux,default-trigger = "led_pwr";
++ 			};
++ 
++ 			led_2g {
++-				label = "green:wifi2";
+++				label = "eap102:green:wifi2g";
++ 				gpio = <&tlmm 47 GPIO_ACTIVE_HIGH>;
++-				default-state = "off";
+++				default-state = "on";
++ 			};
++ 
++ 			led_5g {
++-				label = "green:wifi5";
+++				label = "eap102:green:wifi5g";
++ 				gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
++-				default-state = "off";
+++				default-state = "on";
++ 			};
++ 
++ 			led_bt {
+++				label = "eap102:green:bt";
++ 				gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
++-				label = "green:bt";
++-				default-state = "off";
++-				linux,default-trigger = "led_bt";
+++				default-state = "on";
++ 			};
++ 	};
++ 	nss-macsec0 {
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex227.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex227.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex227.dts
++@@ -600,7 +600,7 @@
++ 		pinctrl-names = "default";
++ 
++ 		led_power {
++-			label = "led_power";
+++			label = "ex227:blue:power";
++ 			gpio = <&tlmm 42 GPIO_ACTIVE_HIGH>;
++ 			default-state = "on";
++ 		};
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex447.dts
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex447.dts
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-ex447.dts
++@@ -600,7 +600,7 @@
++ 		pinctrl-names = "default";
++ 
++ 		led_power {
++-			label = "led_power";
+++			label = "ex447:blue:power";
++ 			gpio = <&tlmm 42 GPIO_ACTIVE_HIGH>;
++ 			default-state = "on";
++ 		};
+-- 
+2.25.1
+

--- a/profiles/wlan-ap.yml
+++ b/profiles/wlan-ap.yml
@@ -81,6 +81,7 @@ packages:
   - apc
   - radsecproxy
   - logrotate
+  - kmod-ledtrig-heartbeat
 
 diffconfig: |
   CONFIG_OPENSSL_ENGINE=y


### PR DESCRIPTION
This patch will change the label names for WiFi6 APs to follow common naming convention and add support to blink all available LEDs on the AP through cloud command

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>