### PR TITLE
WIFI-721: Added channel_max_power map to radio state table

### DIFF
--- a/feeds/wlan-ap/opensync/patches/37-add-channel-max-power.patch
+++ b/feeds/wlan-ap/opensync/patches/37-add-channel-max-power.patch
@@ -1,0 +1,19 @@
+--- a/interfaces/opensync.ovsschema
++++ b/interfaces/opensync.ovsschema
+@@ -1880,7 +1880,15 @@
+             "min": 0,
+             "max": "unlimited"
+           }
+-        }
++        },
++        "channel_max_power": {
++          "type": {
++            "key": "integer",
++            "value": "integer",
++            "min": 0,
++            "max": "unlimited"
++          }
++        }
+       },
+       "isRoot": true,
+       "maxRows": 256

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/phy.h
@@ -12,6 +12,7 @@ extern int phy_get_tx_available_antenna(const char *name);
 extern int phy_get_rx_available_antenna(const char *name);
 extern int phy_get_max_tx_power(const char *name , int channel);
 extern int phy_get_channels(const char *name, int *channel);
+extern int phy_get_dfs_channels(const char *name, int *channel);
 extern int phy_get_channels_state(const char *name,
 			struct schema_Wifi_Radio_State *rstate);
 extern int phy_get_band(const char *name, char *band);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_nl80211.c
@@ -394,6 +394,7 @@ static void nl80211_add_phy(struct nlattr **tb, char *name)
 
 					if (tb_freq[NL80211_FREQUENCY_ATTR_RADAR]) {
 						phy->chandfs[chan] = 1;
+						phy->chanpwr[chan] = nla_get_u32(tb_freq[NL80211_FREQUENCY_ATTR_MAX_TX_POWER]);
 						phy->chandisabled[chan] = 0;
 						LOG(DEBUG, "%s: found dfs channel %d", phy->name, chan);
 						continue;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -296,6 +296,21 @@ int phy_get_channels(const char *name, int *channel)
 	return j;
 }
 
+// Gets all the dfs channels avaible for a radio
+int phy_get_dfs_channels(const char *name, int *dfs_channels)
+{
+	struct wifi_phy *phy = phy_find(name);
+	int i, j = 0;
+
+	if (!phy)
+		return 0;
+
+	for (i = 0; (i < IEEE80211_CHAN_MAX) && (j < 64); i++)
+		if (phy->chandfs[i])
+			dfs_channels[j++] = i;
+	return j;
+}
+
 static void update_channels_state(struct schema_Wifi_Radio_State *rstate,
 			int *index, const char *key, int *value, int value_len)
 {


### PR DESCRIPTION
For this PR I added a new field to the Wifi_Radio_State table and added the code to populate the map.

The key for the map represents the number for the channel and the value is the max value that the power can be set to.

This is what the Wifi_Radio_State table looks like with the change in place (EA8300):
![image](https://user-images.githubusercontent.com/5677311/119026962-c6a4d180-b973-11eb-9958-beba0e78b860.png)

And this is the same as above but just for an EX227:
![image](https://user-images.githubusercontent.com/5677311/119027018-d91f0b00-b973-11eb-8841-f6e432655c75.png)
