### PR TITLE
wifi-2069 Fix for vifC not getting applied to vifS

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/captive.c
@@ -525,7 +525,6 @@ void opennds_section_del(char *section_name)
 	uci_commit(nds_ctx, &opennds, false);
 	uci_unload(nds_ctx, opennds);
 	uci_free_context(nds_ctx);
-	reload_config = 1;
 }
 
 void vif_captive_portal_set(const struct schema_Wifi_VIF_Config *vconf, char *ifname)

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -463,7 +463,7 @@ static void periodic_task(void *arg)
 	}
 
 	if (reload_config) {
-		LOGT("periodic: reload config");
+		LOGD("periodic: reload_config");
 		reload_config = 0;
 		uci_commit_all(uci);
 		sync();


### PR DESCRIPTION
 - WM was getting stuck on recvmsg() while receiving netlink event notifications
   Since we are already using event loop to read data as and when it arrives, there was
   no need to keep nl_recvmsgs() in blocking mode for notifications.
   Setting socket to non-blocking mode resolves the issue.
 - Also removed a redundant reload_config call in captive.c.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>