### PR TITLE
WIFI-1845: Added functionality to rotate the logs for ovsdb

### DIFF
--- a/feeds/wlan-ap/opensync/files/etc/logrotate.d/ovsdb.conf
+++ b/feeds/wlan-ap/opensync/files/etc/logrotate.d/ovsdb.conf
@@ -1,0 +1,10 @@
+/tmp/log/openvswitch/* {
+    daily
+    rotate 5
+    size 1M
+    compress
+    delaycompress
+    dateext
+    dateformat -%d%m%Y
+    notifempty
+}

--- a/profiles-20.x/wlan-ap.yml
+++ b/profiles-20.x/wlan-ap.yml
@@ -60,6 +60,7 @@ packages:
   - kmod-ip6-tunnel
   - kmod-iptunnel
   - kmod-iptunnel6
+  - logrotate
 
 diffconfig: |
   CONFIG_OPENSSL_ENGINE=y

--- a/profiles/wlan-ap.yml
+++ b/profiles/wlan-ap.yml
@@ -80,6 +80,7 @@ packages:
   - eapol-test
   - apc
   - radsecproxy
+  - logrotate
 
 diffconfig: |
   CONFIG_OPENSSL_ENGINE=y


### PR DESCRIPTION
This should rotate the main log file daily once it goes over 1mb, storing up to 5 rotated logfiles compressing them (except the most recent one). This should keep us inside the 5mb limit mentioned in the task for each log file.