### PR TITLE
WIFI-2426: start radius proxy service independent of ssid profile config

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -31,6 +31,7 @@
 ovsdb_table_t table_Hotspot20_Config;
 ovsdb_table_t table_Hotspot20_OSU_Providers;
 ovsdb_table_t table_Hotspot20_Icon_Config;
+ovsdb_table_t table_Radius_Proxy_Config;
 
 ovsdb_table_t table_APC_Config;
 ovsdb_table_t table_APC_State;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
@@ -27,7 +27,6 @@
 #include "utils.h"
 #include "radius_proxy.h"
 
-ovsdb_table_t table_Radius_Proxy_Config;
 struct blob_buf uci_buf = {};
 struct blob_attr *n;
 extern ovsdb_table_t table_APC_State;
@@ -397,10 +396,12 @@ void callback_Radius_Proxy_Config(ovsdb_update_monitor_t *self,
 	case OVSDB_UPDATE_NEW:
 	case OVSDB_UPDATE_MODIFY:
 		(void) radius_proxy_config_set(conf);
+		vif_check_radius_proxy();
 		break;
 
 	case OVSDB_UPDATE_DEL:
 		(void) radius_proxy_config_delete();
+		vif_check_radius_proxy();
 		break;
 
 	default:


### PR DESCRIPTION
Proxy service is started only if
- Radius_Proxy_Config ovsdb table is present
- APC elects AP as DR

Also fixes WIFI-2377

Signed-off-by: Arif Alam <arif.alam@netexperience.com>