### PR TITLE
WIFI-1845: Updated rotation configuration file with new date format

### DIFF
--- a/feeds/wlan-ap/opensync/files/etc/logrotate.d/ovsdb.conf
+++ b/feeds/wlan-ap/opensync/files/etc/logrotate.d/ovsdb.conf
@@ -1,10 +1,10 @@
-/tmp/log/openvswitch/* {
+/tmp/log/openvswitch/*.log {
     daily
     rotate 5
     size 1M
     compress
     delaycompress
     dateext
-    dateformat -%d%m%Y
+    dateformat -%s
     notifempty
 }


### PR DESCRIPTION
We were experiencing an issue where the date format for the logs would collide with each other if we executed the rotation more than once per day. I've updated the date format to be unix epoch instead removing this issue. I also updated the wildcard used so it wouldn't try and rotate the rotated logs.