### PR TITLE
WIFI-2410: Added patch to host-apd to fix ubus assoc validation

### DIFF
--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -214,6 +214,9 @@ hostapd_common_add_bss_config() {
 	config_add_int maxassoc max_inactivity
 	config_add_boolean disassoc_low_ack isolate short_preamble
 
+config_add_int signal_connect signal_stay signal_poll_time \
+		signal_drop_reason signal_strikes
+
 	config_add_int \
 		wep_rekey eap_reauth_period \
 		wpa_group_rekey wpa_pair_rekey wpa_master_rekey
@@ -485,6 +488,7 @@ hostapd_set_bss_options() {
 	local wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_key_mgmt
 
 	json_get_vars \
+	signal_connect signal_stay signal_poll_time signal_drop_reason signal_strikes \
 		wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_strict_rekey \
 		wpa_disable_eapol_key_retries tdls_prohibit \
 		maxassoc max_inactivity disassoc_low_ack isolate auth_cache \
@@ -520,8 +524,15 @@ hostapd_set_bss_options() {
 	set_default rssi_reject_assoc_rssi 0
 	set_default rssi_ignore_probe_request 0
 	set_default rts_threshold -1
+	set_default signal_connect -128
+	set_default signal_stay -128
+	set_default signal_poll_time 5
+	set_default signal_drop_reason 3
+	set_default signal_strikes 3
 	set_default proxy_arp 0
 	set_default multicast_to_unicast 0
+
+
 	append bss_conf "ctrl_interface=/var/run/hostapd"
 	if [ "$isolate" -gt 0 ]; then
 		append bss_conf "ap_isolate=$isolate" "$N"
@@ -549,6 +560,11 @@ hostapd_set_bss_options() {
 	append bss_conf "rssi_reject_assoc_rssi=$rssi_reject_assoc_rssi" "$N"
 	append bss_conf "rssi_ignore_probe_request=$rssi_ignore_probe_request" "$N"
 	append bss_conf "rts_threshold=$rts_threshold" "$N"
+	append bss_conf "signal_connect=$signal_connect" "$N"
+	append bss_conf "signal_stay=$signal_stay" "$N"
+	append bss_conf "signal_poll_time=$signal_poll_time" "$N"
+	append bss_conf "signal_strikes=$signal_strikes" "$N"
+	append bss_conf "signal_drop_reason=$signal_drop_reason" "$N"
 
 	[ -n "$proxy_arp" ] && append bss_conf "proxy_arp=$proxy_arp" "$N"
 	[ -n "$multicast_to_unicast" ] && append bss_conf "multicast_to_unicast=$multicast_to_unicast" "$N"

--- a/feeds/wifi-ax/hostapd/patches/f00-014-fix-ubus-assoc.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-014-fix-ubus-assoc.patch
@@ -1,0 +1,32 @@
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -4463,6 +4463,14 @@ static void handle_assoc(struct hostapd_
+ 			ieee802_11_set_beacons(hapd->iface);
+ 	}
+ 
++	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
++	if (ubus_resp) {
++		wpa_printf(MSG_DEBUG, "Station " MACSTR " assoc rejected by ubus handler.\n",
++		       MAC2STR(mgmt->sa));
++		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
++		goto fail;
++	}
++
+ 	update_ht_state(hapd, sta);
+ 
+ 	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+@@ -4568,14 +4576,6 @@ static void handle_assoc(struct hostapd_
+ 					    pos, left, rssi, omit_rsnxe);
+ 	os_free(tmp);
+ 
+-	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
+-	if (ubus_resp) {
+-		wpa_printf(MSG_DEBUG, "Station " MACSTR " assoc rejected by ubus handler.\n",
+-		       MAC2STR(mgmt->sa));
+-		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
+-		goto fail;
+-	}
+-
+ 	/*
+ 	 * Remove the station in case tranmission of a success response fails
+ 	 * (the STA was added associated to the driver) or if the station was

--- a/feeds/wifi-trunk/hostapd/patches/904-fix-ubus-assoc.patch
+++ b/feeds/wifi-trunk/hostapd/patches/904-fix-ubus-assoc.patch
@@ -1,0 +1,32 @@
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -4463,6 +4463,14 @@ static void handle_assoc(struct hostapd_
+ 			ieee802_11_set_beacons(hapd->iface);
+ 	}
+ 
++	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
++	if (ubus_resp) {
++		wpa_printf(MSG_DEBUG, "Station " MACSTR " assoc rejected by ubus handler.\n",
++		       MAC2STR(mgmt->sa));
++		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
++		goto fail;
++	}
++
+ 	update_ht_state(hapd, sta);
+ 
+ 	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
+@@ -4568,14 +4576,6 @@ static void handle_assoc(struct hostapd_
+ 					    pos, left, rssi, omit_rsnxe);
+ 	os_free(tmp);
+ 
+-	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
+-	if (ubus_resp) {
+-		wpa_printf(MSG_DEBUG, "Station " MACSTR " assoc rejected by ubus handler.\n",
+-		       MAC2STR(mgmt->sa));
+-		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
+-		goto fail;
+-	}
+-
+ 	/*
+ 	 * Remove the station in case tranmission of a success response fails
+ 	 * (the STA was added associated to the driver) or if the station was


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

Fairly small change. Just moved the code to send the assoc response to be after the ubus validation code runs instead of before it. I was unable to test this code due to the fact that the auth response also checks rrsi levels as well as the WiFi client I was using which caused it to be impossible to test (at least with my knowledge). 

But it shouldn't break anything, just possibly prevent weird edge cases with roaming