### PR TITLE
Wifi-2542. Fix for populating correct ID in AWLAN_Node

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -86,7 +86,9 @@ linksys,ea8300)
 	MODEL_DESCR=$(cat /dev/mtd9 | grep modelDescription | cut -d "=" -f2 | tr -d '\r\n')
 	MANUF_URL=$(cat /dev/mtd9 | grep manufacturerURL | cut -d "=" -f2 | tr -d '\r\n')
 	CERT_REGION=$(cat /dev/mtd9 | grep cert_region | cut -d "=" -f2 | tr -d '\r\n')
-	ID=$(cat /dev/mtd9 | grep hw_mac_addr | cut -d "=" -f2 | tr -d '\r\n')
+	# Commenting out below, because hw_mac_addr is used for eth0/LAN interface
+	# whereas ID corresponds to the mac address of WAN interface.
+	#ID=$(cat /dev/mtd9 | grep hw_mac_addr | cut -d "=" -f2 | tr -d '\r\n')
 	MANUF_NAME=$(cat /dev/mtd9 | grep "manufacturer=" | cut -d "=" -f2 | tr -d '\r\n')
 	if [ ! $MANUF_NAME ]; then
 		MANUF_NAME="Linksys"
@@ -133,7 +135,11 @@ fi
 
 # fallback check to get the id from mac address if flash does not contain this info.
 if [ ! $ID ]; then
-	ID=$(cat /sys/class/net/eth0/address)
+	if [ $(board_name) == "cig,wf194c" ] || [ $(board_name) == "edgecore,eap102" ] || [ $(board_name) == "linksys,ea8300" ]; then
+		ID=$(cat /sys/class/net/eth1/address)
+	else
+		ID=$(cat /sys/class/net/eth0/address)
+	fi
 fi
 
 # fallback check to get the model if flash does not contain this info.


### PR DESCRIPTION
This fix applies to EA8300, WF194c and EAP102. For these APs,
the br-wan is mapped to eth1 instead of eth0. Adding fix to
use the mac address from eth1 as ID for these particular APs.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>