### PR TITLE
Wifi-2544. Fix for Off-chan dwell time configuration

### DIFF
--- a/feeds/wifi-ax/mac80211/patches/qca/225-ath11k-add_cmd_processing_time_for_scan_timeout.patch
+++ b/feeds/wifi-ax/mac80211/patches/qca/225-ath11k-add_cmd_processing_time_for_scan_timeout.patch
@@ -1,0 +1,22 @@
+diff -Naur a/drivers/net/wireless/ath/ath11k/mac.c b/drivers/net/wireless/ath/ath11k/mac.c
+--- a/drivers/net/wireless/ath/ath11k/mac.c	2021-06-09 10:02:12.040840722 -0400
++++ b/drivers/net/wireless/ath/ath11k/mac.c	2021-06-10 10:40:12.094003411 -0400
+@@ -3472,13 +3472,14 @@
+ 		scan_timeout = min_t(u32, arg->max_rest_time *
+ 				    (arg->chan_list.num_chan - 1) + (req->duration +
+ 				     ATH11K_SCAN_CHANNEL_SWITCH_WMI_EVT_OVERHEAD) *
+-				     arg->chan_list.num_chan, arg->max_scan_time +
+-				     ATH11K_MAC_SCAN_TIMEOUT_MSECS);
++				     arg->chan_list.num_chan, arg->max_scan_time);
+ 	} else {
+-		/* Add a 200ms margin to account for event/command processing */
+-		scan_timeout = arg->max_scan_time + ATH11K_MAC_SCAN_TIMEOUT_MSECS;
++		scan_timeout = arg->max_scan_time;
+ 	}
+ 
++	/* Add a 200ms margin to account for event/command processing */
++	scan_timeout += ATH11K_MAC_SCAN_TIMEOUT_MSECS;
++
+ 	ret = ath11k_start_scan(ar, arg);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to start hw scan: %d\n", ret);

--- a/feeds/wifi-trunk/ath10k-ct/patches/960-0012-ath10k-add_cmd_processing_time_for_scan_timeout.patch
+++ b/feeds/wifi-trunk/ath10k-ct/patches/960-0012-ath10k-add_cmd_processing_time_for_scan_timeout.patch
@@ -1,0 +1,22 @@
+diff -Naur a/ath10k-5.7/mac.c b/ath10k-5.7/mac.c
+--- a/ath10k-5.7/mac.c	2021-06-09 16:30:17.793556032 -0400
++++ b/ath10k-5.7/mac.c	2021-06-09 17:38:08.587733979 -0400
+@@ -7103,13 +7103,15 @@
+ 		scan_timeout = min_t(u32, arg.max_rest_time *
+ 				(arg.n_channels - 1) + (req->duration +
+ 				ATH10K_SCAN_CHANNEL_SWITCH_WMI_EVT_OVERHEAD) *
+-				arg.n_channels, arg.max_scan_time + 200);
++				arg.n_channels, arg.max_scan_time);
+ 
+ 	} else {
+-		/* Add a 200ms margin to account for event/command processing */
+-		scan_timeout = arg.max_scan_time + 200;
++		scan_timeout = arg.max_scan_time;
+ 	}
+ 
++	/* Add a 200ms margin to account for event/command processing */
++	scan_timeout += 200;
++
+ 	ret = ath10k_start_scan(ar, &arg);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to start hw scan: %d\n", ret);

--- a/feeds/wlan-ap/opensync/patches/38-correcting-scan-type-max-count.patch
+++ b/feeds/wlan-ap/opensync/patches/38-correcting-scan-type-max-count.patch
@@ -1,0 +1,16 @@
+Index: opensync-2.0.5.0/src/lib/datapipeline/inc/dpp_types.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/datapipeline/inc/dpp_types.h
++++ opensync-2.0.5.0/src/lib/datapipeline/inc/dpp_types.h
+@@ -148,10 +148,9 @@ typedef enum
+     RADIO_SCAN_TYPE_FULL,
+     RADIO_SCAN_TYPE_ONCHAN,
+     RADIO_SCAN_TYPE_OFFCHAN,
++    RADIO_SCAN_MAX_TYPE_QTY
+ } radio_scan_type_t;
+ 
+-#define RADIO_SCAN_MAX_TYPE_QTY       3
+-
+ typedef enum
+ {
+     RADIO_QUEUE_TYPE_VI = 0,


### PR DESCRIPTION
Applying the user configured dwell time for off-channel scan
requests. This needed driver changes to accommodate the command/event
processing time in the configured scan timeout, otherwise the scan
is aborted resulting in no off-channel survey results.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>