### PR TITLE
WiFi-2594: Block lan ssh when deployed

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/lan-ssh-firewall
+++ b/feeds/wlan-ap/opensync/files/bin/lan-ssh-firewall
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters"
+    exit 1
+fi
+
+action=$1
+
+[ "$action" = "enable" ] && [ ! -f /etc/ssh-flag ] && uci set firewall.lan_ssh_rule.target='REJECT'
+[ "$action" = "disable" ] && uci set firewall.lan_ssh_rule.target='ACCEPT'
+uci commit firewall
+/etc/init.d/firewall restart
+
+exit 0

--- a/feeds/wlan-ap/opensync/files/bin/wlan_ap_redirector.sh
+++ b/feeds/wlan-ap/opensync/files/bin/wlan_ap_redirector.sh
@@ -40,6 +40,9 @@ else
   redirector_addr=$1
 fi
 
+# Enable lan ssh accsess
+lan-ssh-firewall disable
+
 echo "${redirector_addr}" > /usr/opensync/certs/redirector.txt
 /etc/init.d/uhttpd enable
 /etc/init.d/uhttpd start

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/webserver.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/webserver.c
@@ -10,6 +10,13 @@
 static ovsdb_table_t table_Manager;
 static int done;
 
+
+static void disable_ssh() 
+{
+	LOGN("Disabling LAN ssh access");
+	system("lan-ssh-firewall enable");
+}
+
 static void stop_http(void *arg)
 {
 	LOGN("Stopping webserver");
@@ -17,6 +24,8 @@ static void stop_http(void *arg)
 	system("uci commit system");
 	system("/etc/init.d/uhttpd stop");
 	system("/etc/init.d/uhttpd disable");
+
+	disable_ssh();
 }
 
 static void callback_Manager(ovsdb_update_monitor_t *mon,

--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-network
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-network
@@ -6,4 +6,15 @@ uci set network.wan.metric=1
 uci set network.lan.metric=10
 uci set network.wan.vlan_filtering=1
 uci set network.lan.vlan_filtering=1
+
+# Add LAN ssh rule
+uci set firewall.lan_ssh_rule=rule
+uci set firewall.lan_ssh_rule.src='lan'
+uci set firewall.lan_ssh_rule.target='ACCEPT'
+uci set firewall.lan_ssh_rule.proto='tcp'
+uci set firewall.lan_ssh_rule.dest_port='22'
+uci set firewall.lan_ssh_rule.name="Lan SSH Rule"
+uci commit firewall
+/etc/init.d/firewall restart
+
 exit 0


### PR DESCRIPTION
To prevent someone sshing into one of our AP's in the field we need to add some kind of firewall rule to block the port. I've made it so that when it's not connected to the cloud the ssh port is open to allow for debugging and first time setup

The script I added may be a little overkill but I needed a way to modify the existing firewall rule without creating a new one and it felt a little awkward to do it in C and then also duplicate the logic in the redirector script.