### PR TITLE
Wifi-2635. Correcting the Model name format

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -144,7 +144,7 @@ fi
 
 # fallback check to get the model if flash does not contain this info.
 if [ ! $MODEL ]; then
-	MODEL=$(cat /tmp/sysinfo/board_name)
+	MODEL=$(cat /tmp/sysinfo/board_name | cut -d "," -f2 | awk '{print toupper($0)}')
 fi
 
 # Read the active firmware version info


### PR DESCRIPTION
When the manufacturer block does not contain the model info,
it is then extracted from /tmp/sysinfo/board_name, stripped
off the manufacturer name and converted for all upper case string.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>