### PR TITLE
wifi-2075- Fix for inconsistency in applying vif configuration

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/node_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/src/node_config.c
@@ -159,7 +159,6 @@ static void syslog_handler(int type,
 	blob_to_uci_section(uci, "system", "@system[-1]", "system",
 			    b.head, &log_param, NULL);
 	uci_commit_all(uci);
-	system("/sbin/reload_config");
 	if (del)
 		node_state_del("syslog");
 	else
@@ -252,7 +251,6 @@ static void ntp_handler(int type,
 	blob_to_uci_section(uci, "system", "ntp", "timeserver",
 			    b.head, &ntp_param, NULL);
 	uci_commit_all(uci);
-	system("/sbin/reload_config");
 	ntp_state(0);
 }
 
@@ -376,7 +374,6 @@ static void led_handler(int type,
 		globfree(&gl);
 	}
 	uci_commit_all(uci);
-	system("/sbin/reload_config");
 	led_state(0);
 }
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
@@ -3,6 +3,10 @@
 #ifndef _RADIO_H__
 #define _RADIO_H__
 
+#include "ovsdb_update.h"
+
+#define CONFIG_APPLY_TIMEOUT 35
+
 struct rrm_neighbor {
 	char *mac;
 	char *ssid;
@@ -10,7 +14,6 @@ struct rrm_neighbor {
 };
 
 extern const struct target_radio_ops *radio_ops;
-extern int reload_config;
 extern struct blob_buf b;
 extern struct uci_context *uci;
 
@@ -22,5 +25,6 @@ extern int hapd_rrm_set_neighbors(char *name, struct rrm_neighbor *neigh, int co
 extern void radio_maverick(void *arg);
 
 int nl80211_channel_get(char *name, unsigned int *chan);
+void set_config_apply_timeout(ovsdb_update_monitor_t *mon);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/timer.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/timer.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef __TIMER_H__
+#define __TIMER_H__
+
+#include <sys/time.h>
+
+struct timeout;
+typedef void (*timeout_handler)(struct timeout *t);
+
+struct timeout {
+	bool pending;
+	timeout_handler cb;
+	struct timeval time;
+};
+
+int timeout_set(struct timeout *timeout, int msecs);
+void timer_expiry_check(struct timeout *timeout);
+
+#endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/override.mk
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/override.mk
@@ -47,6 +47,7 @@ UNIT_SRC_TOP += $(OVERRIDE_DIR)/src/dhcpdiscovery.c
 UNIT_SRC_TOP += $(OVERRIDE_DIR)/src/radius_probe.c
 UNIT_SRC_TOP += $(OVERRIDE_DIR)/src/rrm_config.c
 UNIT_SRC_TOP += $(OVERRIDE_DIR)/src/radius_proxy.c
+UNIT_SRC_TOP += $(OVERRIDE_DIR)/src/timer.c
 
 CONFIG_USE_KCONFIG=y
 CONFIG_INET_ETH_LINUX=y

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radius_proxy.c
@@ -365,7 +365,6 @@ static bool radius_proxy_config_set(struct schema_Radius_Proxy_Config *conf)
 		blob_to_uci_section(uci, "radsecproxy", name, "realm",
 				uci_buf.head, &radius_proxy_realm_param, NULL);
 	}
-
 	uci_commit_all(uci);
 	return true;
 }
@@ -394,7 +393,6 @@ static bool radius_proxy_config_delete()
 	uci_commit(rad_uci, &radsecproxy, false);
 	uci_unload(rad_uci, radsecproxy);
 	uci_free_context(rad_uci);
-	reload_config = 1;
 	return true;
 }
 
@@ -419,7 +417,8 @@ void callback_Radius_Proxy_Config(ovsdb_update_monitor_t *self,
 		LOG(ERR, "Radius_Proxy_Config: unexpected mon_type %d %s",
 				self->mon_type, self->mon_uuid);
 		break;
-	}	
+	}
+	set_config_apply_timeout(self);
 	return;
 }
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
@@ -178,7 +178,8 @@ void callback_Wifi_RRM_Config(ovsdb_update_monitor_t *self,
 	default:
 		LOG(ERR, "Wifi_RRM_Config: unexpected mon_type %d %s", self->mon_type, self->mon_uuid);
 		break;
-	}	
+	}
+	set_config_apply_timeout(self);
 	return;
 }
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/timer.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/timer.c
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <time.h>
+
+#include "log.h"
+#include "evsched.h"
+
+#include "timer.h"
+
+static int tv_diff(struct timeval *t1, struct timeval *t2)
+{
+	return
+			(t1->tv_sec - t2->tv_sec) * 1000 +
+			(t1->tv_usec - t2->tv_usec) / 1000;
+}
+
+static void gettime(struct timeval *tv)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	tv->tv_sec = ts.tv_sec;
+	tv->tv_usec = ts.tv_nsec / 1000;
+}
+
+int timeout_set(struct timeout *timeout, int msecs)
+{
+	if (!timeout) {
+		LOGE("%s No timer data", __func__);
+		return -1;
+	}
+	struct timeval *time = &timeout->time;
+
+	if (timeout->pending)
+		timeout->pending = false;
+
+	gettime(time);
+
+	time->tv_sec += msecs / 1000;
+	time->tv_usec += (msecs % 1000) * 1000;
+
+	if (time->tv_usec > 1000000) {
+		time->tv_sec++;
+		time->tv_usec -= 1000000;
+	}
+	timeout->pending = true;
+	return 0;
+}
+
+void timer_expiry_check(struct timeout *t)
+{
+	struct timeval tv;
+	gettime(&tv);
+	if (t->pending && tv_diff(&t->time, &tv) <= 0) {
+		t->pending = false;
+		LOGI("%s Timer Expired..Executing callback", __func__);
+		if (t->cb)
+			t->cb(t);
+	}
+}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/vif.c
@@ -1034,7 +1034,8 @@ void vif_section_del(char *section_name)
 	ret= uci_load(sec_ctx, "wireless", &wireless);
 	if (ret) {
 		LOGE("%s: %s uci_load() failed with rc %d", section_name, __func__, ret);
-		uci_free_context(sec_ctx);
+		if (sec_ctx)
+			uci_free_context(sec_ctx);
 		return;
 	}
 	uci_foreach_element_safe(&wireless->sections, tmp, e) {
@@ -1049,8 +1050,8 @@ void vif_section_del(char *section_name)
 	}
 	uci_commit(sec_ctx, &wireless, false);
 	uci_unload(sec_ctx, wireless);
-	uci_free_context(sec_ctx);
-	reload_config = 1;
+	if (sec_ctx)
+		uci_free_context(sec_ctx);
 }
 
 void vif_check_radius_proxy()
@@ -1326,7 +1327,8 @@ bool target_vif_config_del(const struct schema_Wifi_VIF_Config *vconf)
 	ret= uci_load(vif_ctx, "wireless", &wireless);
 	if (ret) {
 		LOGE("%s: %s uci_load() failed with rc %d", vconf->if_name, __func__, ret);
-		uci_free_context(vif_ctx);
+		if (vif_ctx)
+			uci_free_context(vif_ctx);
 		return false;
 	}
 	uci_foreach_element_safe(&wireless->sections, tmp, e) {
@@ -1346,8 +1348,8 @@ bool target_vif_config_del(const struct schema_Wifi_VIF_Config *vconf)
 	}
 	uci_commit(vif_ctx, &wireless, false);
 	uci_unload(vif_ctx, wireless);
-	uci_free_context(vif_ctx);
-	reload_config = 1;
+	if (vif_ctx)
+		uci_free_context(vif_ctx);
 	return true;
 }
 
@@ -1402,7 +1404,7 @@ void vif_hs20_osu_update(struct schema_Hotspot20_OSU_Providers *osuconf)
 
 	blob_to_uci_section(uci, "wireless", osuconf->osu_provider_name, "osu-provider",
 			osu.head, &wifi_hs20_osu_param, NULL);
-	reload_config = 1;
+	uci_commit_all(uci);
 }
 
 
@@ -1433,7 +1435,7 @@ void vif_hs20_icon_update(struct schema_Hotspot20_Icon_Config *iconconf)
 
 		blob_to_uci_section(uci, "wireless", iconconf->icon_config_name, "hs20-icon",
 				hs20.head, &wifi_hs20_icon_param, NULL);
-		reload_config = 1;
+		uci_commit_all(uci);
 	}
 }
 
@@ -1456,9 +1458,9 @@ void vif_hs20_update(struct schema_Hotspot20_Config *hs2conf)
 			hs20_vif_config(&b, hs2conf);
 			blob_to_uci_section(uci, "wireless", vconf.if_name, "wifi-iface",
 					b.head, &wifi_iface_param, NULL);
-			reload_config = 1;
 		}
 	}
+	uci_commit_all(uci);
 }
 
 /* Mesh options table */
@@ -1526,8 +1528,7 @@ static int mesh_vif_config_set(const struct schema_Wifi_Radio_Config *rconf,
 	blobmsg_add_string(&mesh, "master", "bat0");
 	blob_to_uci_section(uci, "network", vconf->if_name, "interface",
 			mesh.head, &wifi_mesh_param, NULL);
-
-	reload_config = 1;
+	uci_commit_all(uci);
 	return 0;
 }
 
@@ -1646,8 +1647,7 @@ static int ap_vif_config_set(const struct schema_Wifi_Radio_Config *rconf,
 	{
 		vif_dhcp_opennds_allowlist_set(vconf,(char*)vconf->if_name);
 	}
-
-	reload_config = 1;
+	uci_commit_all(uci);
 	return 0;
 }
 


### PR DESCRIPTION
 - During the configuration process, AP was triggering network
   and wireless reload multiple times in a very short window
   resulting in a poorly configured hostapd. This patch makes sure
   that network/wireless is reloaded only once after all the configuration
   is committed to UCI files.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>