### PR TITLE
WIFI-2152: Upgrade recovery

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/flash-firmware
+++ b/feeds/wlan-ap/opensync/files/bin/flash-firmware
@@ -40,6 +40,8 @@ uci commit
 /sbin/sysupgrade $IMGFILE
 if [ "$?" != "0" ] ; then
   echo "$0: Sysupgrade failed."
+  rm /tmp/sysupgrade.meta
+  rm /tmp/upgrade.*
   exit 1
 fi
 

--- a/feeds/wlan-ap/opensync/patches/39-allow-upgrade-retry.patch
+++ b/feeds/wlan-ap/opensync/patches/39-allow-upgrade-retry.patch
@@ -1,0 +1,12 @@
+--- a/src/um/src/um_ovsdb.c
++++ b/src/um/src/um_ovsdb.c
+@@ -356,7 +356,8 @@ static void callback_AWLAN_Node(
+                 //TODO Is there something that needs to be done here?
+             }
+ 
+-            if(awlan_node->upgrade_timer_changed){
++            if(awlan_node->upgrade_timer_changed
++                || ((awlan_node->firmware_url_changed) && (strlen(awlan_node->firmware_url) > 0))) {
+                 if (awlan_node->upgrade_timer > 0)
+                 {
+                     /* if there is active timer, stop it to set new value   */


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

Made is so that when an upgrade fails (with -9 error code) the temp files are deleted afterwards since that seemed to prevent us from attempting another upgrade.

Also patched opensync so we can attempt another upgrade without changing the timer felids and only changing the url field.