### PR TITLE
WIFI-2671: Added codes 12 & 13 for reboot & factory reset upgrade opt…

### DIFF
--- a/feeds/wlan-ap/opensync/patches/40-reboot-factory-reset-status-codes.patch
+++ b/feeds/wlan-ap/opensync/patches/40-reboot-factory-reset-status-codes.patch
@@ -1,0 +1,32 @@
+--- a/src/um/inc/um.h
++++ b/src/um/inc/um.h
+@@ -32,6 +32,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBI
+ 
+ #define UM_STS_FW_DL_START     (10)    /* FW download started                      */
+ #define UM_STS_FW_DL_END       (11)    /* FW download successfully completed       */
++#define UM_STS_RB_END          (12)    /* Reboot has been started                  */
++#define UM_STS_FR_END          (13)    /* Factory reset has been started           */
+ #define UM_STS_FW_WR_START     (20)    /* FW write on alt partition started        */
+ #define UM_STS_FW_WR_END       (21)    /* FW image write successfully completed    */
+ #define UM_STS_FW_BC_START     (30)    /* Bootconfig partition update started      */
+--- a/src/um/src/um_ovsdb.c
++++ b/src/um/src/um_ovsdb.c
+@@ -248,8 +248,16 @@ static void cb_upg(const osp_upg_op_t op
+         case OSP_UPG_DL:
+             if (status == OSP_UPG_OK)
+             {
+-                LOG(INFO, "Download successfully completed");
+-                ret_status = UM_STS_FW_DL_END;
++                if (!strcmp(upg_url, "reboot")) {
++                    LOG(INFO, "Reboot successfully initiated");
++                    ret_status = UM_STS_RB_END;
++                } else if (!strcmp(upg_url, "factory"))  {
++                    LOG(INFO, "Factory reset successfully initiated");
++                    ret_status = UM_STS_FR_END;
++                } else {
++                    LOG(INFO, "Download successfully completed");
++                    ret_status = UM_STS_FW_DL_END;
++                }
+             }
+             else
+             {


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

We decided it would be easier for the AP to send up a different status code to the cloud instead of the cloud keeping track of what operation it started on the AP. 

A change will need to be made on the cloud side to trigger a different message box on the UI