### PR TITLE
WIFI-2681: Allow re-trying a failed upgrade

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/flash-firmware
+++ b/feeds/wlan-ap/opensync/files/bin/flash-firmware
@@ -24,7 +24,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-IMGFILE="$(ls ${1}.*)"
+# Get the most recent upgrade file available
+IMGFILE="$(ls -t1 ${1}.* | head -n 1)"
 
 if [ -z "$IMGFILE" ] || [ ! -f "$IMGFILE" ] ; then
   echo

--- a/feeds/wlan-ap/opensync/patches/39-allow-upgrade-retry.patch
+++ b/feeds/wlan-ap/opensync/patches/39-allow-upgrade-retry.patch
@@ -1,0 +1,12 @@
+--- a/src/um/src/um_ovsdb.c
++++ b/src/um/src/um_ovsdb.c
+@@ -356,7 +356,8 @@ static void callback_AWLAN_Node(
+                 //TODO Is there something that needs to be done here?
+             }
+ 
+-            if(awlan_node->upgrade_timer_changed){
++            if(awlan_node->upgrade_timer_changed
++                || ((awlan_node->firmware_url_changed) && (strlen(awlan_node->firmware_url) > 0))) {
+                 if (awlan_node->upgrade_timer > 0)
+                 {
+                     /* if there is active timer, stop it to set new value   */


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

Instead of deleting the left over image from the /tmp/ directory after a failed call to `sysupgrade` I've got it now that `flash-firmware` can now operate with multiple files that match the pattern `upgrade.*` and only selects the most recent one. 

This doesn't solve the root issue but does fix the worst case brick scenario and also the issue where we are unable to re-try an upgrade once one fails. More testing should be done to determine why `sysupgrade` returns a non-zero code and then upgrades anyways, which is similar [NETEXP-1938](https://connectustechnologies.atlassian.net/browse/NETEXP-1938) and has been documented before.