### PR TITLE
WIFI-2825: Suppress noisy logs

### DIFF
--- a/feeds/wlan-ap/opensync/patches/41-log-supression.patch
+++ b/feeds/wlan-ap/opensync/patches/41-log-supression.patch
@@ -1,0 +1,11 @@
+--- a/src/lib/ovsdb/src/ovsdb_table.c
++++ b/src/lib/ovsdb/src/ovsdb_table.c
+@@ -560,7 +560,7 @@ void ovsdb_table_update_cb(ovsdb_update_
+         return;
+     }
+ 
+-    LOG(INFO, "MON upd: %s table: %s row: %s", typestr, table->table_name, mon_uuid );
++    LOG(TRACE, "MON upd: %s table: %s row: %s", typestr, table->table_name, mon_uuid );
+ 
+     if (LOG_SEVERITY_TRACE <= log_module_severity_get(MODULE_ID))
+     {

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -950,7 +950,6 @@ apc_cld_mon_cb(struct schema_Manager *mgr)
 			if(!strncmp(mgr->status_keys[i] , "sec_since_connect",
 					       strlen("sec_since_connect"))) {
 				conn_since = atoi(mgr->status[i]);
-				LOGI("conn_since: %d", conn_since);
 				break;
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>

Removed the log that we have notifying us of the new value of conn_since.

I couldn't think of a practical way of just lowering the OVSDB Mon log for just this value so I lowered it to TRACE instead.