### PR TITLE
WIFI-2691: Enable proxy arp by default

### DIFF
--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -529,7 +529,7 @@ hostapd_set_bss_options() {
 	set_default signal_poll_time 5
 	set_default signal_drop_reason 3
 	set_default signal_strikes 3
-	set_default proxy_arp 0
+	set_default proxy_arp 1
 	set_default multicast_to_unicast 0
 
 


### PR DESCRIPTION
wifi6 AP does not forward broadcast ARP request sent from one wifi
client to another wifi client.  Enable proxy arp by default to have the
AP respond to ARP requests on behalf of the client.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>