### PR TITLE
WiFi-1997-LEDs-Incorrect-Service-State

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/wlan_ap_led_blink.sh
+++ b/feeds/wlan-ap/opensync/files/bin/wlan_ap_led_blink.sh
@@ -3,5 +3,3 @@
 #Blink AP's LED
 /usr/opensync/tools/ovsh insert Node_Config module:="led" key:="led_blink" value:="on"
 
-#Turnoff AP's LED
-/usr/opensync/tools/ovsh insert Node_Config module:="led" key:="led_off" value:="off"

--- a/feeds/wlan-ap/opensync/files/bin/wlan_ap_led_blink_off.sh
+++ b/feeds/wlan-ap/opensync/files/bin/wlan_ap_led_blink_off.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+#Turnoff blinking of AP's LED
+/usr/opensync/tools/ovsh insert Node_Config module:="led" key:="led_off" value:="off"
+

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/unit.mk
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/command/unit.mk
@@ -54,7 +54,7 @@ UNIT_CFLAGS := -I$(UNIT_PATH)/inc
 UNIT_CFLAGS += -Isrc/lib/common/inc/
 UNIT_CFLAGS += -Isrc/lib/version/inc/
 
-UNIT_LDFLAGS += -lev -lubox -luci -lubus -lwebsocket
+UNIT_LDFLAGS += -lev -lubox -luci -lubus -lwebsocket -lblobmsg_json
 UNIT_LDFLAGS += -lrt
 
 UNIT_EXPORT_CFLAGS := $(UNIT_CFLAGS)

--- a/patches/0054-WiFi6-APs-LED-Label-Change.patch
+++ b/patches/0054-WiFi6-APs-LED-Label-Change.patch
@@ -1,101 +1,131 @@
-From 82c689a779db76c74893be4d6249b663d70d80d8 Mon Sep 17 00:00:00 2001
+From 49bf9d17f0b3f7ebb4f9f562f10853e3fd067b7a Mon Sep 17 00:00:00 2001
 From: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
-Date: Fri, 21 May 2021 16:38:07 -0400
-Subject: [PATCH] WiFi6-APs-Label-Name-Change
+Date: Wed, 30 Jun 2021 12:46:26 -0400
+Subject: [PATCH] WiFi6 Aps LEDs Label name change
 
+This patch fixes leds incorrect state issue and also chanage the label
+names of leds
+
+Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
 ---
- .../111-WiFi6-APs-LED-Label-Name-Change.patch | 182 ++++++++++++++++++
- 1 file changed, 182 insertions(+)
- create mode 100644 target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
+ .../ipq807x/base-files/etc/board.d/01_leds    |  13 +-
+ .../111-WiFi6-Aps-LEDs-Label-Change.patch     | 183 ++++++++++++++++++
+ 2 files changed, 193 insertions(+), 3 deletions(-)
+ create mode 100644 target/linux/ipq807x/patches/111-WiFi6-Aps-LEDs-Label-Change.patch
 
-diff --git a/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch b/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
+diff --git a/target/linux/ipq807x/base-files/etc/board.d/01_leds b/target/linux/ipq807x/base-files/etc/board.d/01_leds
+index 1402a74f3e..bca3ae8daa 100755
+--- a/target/linux/ipq807x/base-files/etc/board.d/01_leds
++++ b/target/linux/ipq807x/base-files/etc/board.d/01_leds
+@@ -15,10 +15,17 @@ cig,wf194c)
+ 	ucidef_set_led_netdev "wan" "WAN" "wf194c:green:wan" "br-wan" "tx rx link"
+ 	ucidef_set_led_netdev "lan" "LAN" "wf194c:green:lan" "br-lan" "tx rx link"
+ 	;;
+-edgecore,eap101 |\
++edgecore,eap101)
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "eap101:green:wifi5g" "phy0tx"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "eap101:green:wifi2g" "phy1tx"
++	;;
+ edgecore,eap102)
+-        ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tx"
+-        ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tx"
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "eap102:green:wifi5g" "phy0tx"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "eap102:green:wifi2g" "phy1tx"
++	;;
++cig,wf188n)
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "wf188:green:wifi5g" "phy0tx"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "wf188:green:wifi2g" "phy1tx"
+ 	;;
+ esac
+ 
+diff --git a/target/linux/ipq807x/patches/111-WiFi6-Aps-LEDs-Label-Change.patch b/target/linux/ipq807x/patches/111-WiFi6-Aps-LEDs-Label-Change.patch
 new file mode 100644
-index 0000000000..2396067aac
+index 0000000000..06533425a9
 --- /dev/null
-+++ b/target/linux/ipq807x/patches/111-WiFi6-APs-LED-Label-Name-Change.patch
-@@ -0,0 +1,182 @@
++++ b/target/linux/ipq807x/patches/111-WiFi6-Aps-LEDs-Label-Change.patch
+@@ -0,0 +1,183 @@
 +Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
 +===================================================================
 +--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
 ++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188.dts
-+@@ -309,26 +309,26 @@
++@@ -309,28 +309,28 @@
 + 		pinctrl-names = "default";
 + 
 + 		led@25 {
 +-			label = "led_5g";
-+-			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
-+-			linux,default-trigger = "wf188:green:5g";
 ++			label = "wf188:green:wifi5g";
-++			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:5g";
 ++			linux,default-trigger = "wf188:green:wifi5g";
 + 			default-state = "off";
 + 		};
 + 		led@24 {
 +-			label = "led_2g";
-+-			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
-+-			linux,default-trigger = "wf188:green:2g";
 ++			label = "wf188:green:wifi2g";
-++			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:2g";
 ++			linux,default-trigger = "wf188:green:wifi2g";
 + 			default-state = "off";
 + 		};
 + 		led@18 {
 +-			label = "led_eth";
-+-			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
 ++			label = "wf188:green:eth";
-++			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
 + 			linux,default-trigger = "wf188:green:eth";
-+ 			default-state = "off";
++-			default-state = "off";
+++			default-state = "on";
 + 		};
 +                 led_power: led@16 {
 +-                        label = "led_pwr";
-+-                        gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
 ++                        label = "wf188:green:power";
-++                        gpios = <&tlmm 16 GPIO_ACTIVE_LOW>;
++                         gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
 +                         linux,default-trigger = "wf188:green:power";
-+ 			default-state = "off";
++-			default-state = "off";
+++			default-state = "on";
 + 		};
++ 	};
++ 
 +Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
 +===================================================================
 +--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
 ++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-cig-wf188n.dts
-+@@ -309,26 +309,26 @@
++@@ -309,28 +309,28 @@
 + 		pinctrl-names = "default";
 + 
 + 		led@25 {
 +-			label = "led_5g";
-+-			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
-+-			linux,default-trigger = "wf188:green:5g";
 ++			label = "wf188:green:wifi5g";
-++			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:5g";
 ++			linux,default-trigger = "wf188:green:wifi5g";
 + 			default-state = "off";
 + 		};
 + 		led@24 {
 +-			label = "led_2g";
-+-			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
-+-			linux,default-trigger = "wf188:green:2g";
 ++			label = "wf188:green:wifi2g";
-++			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
++-			linux,default-trigger = "wf188:green:2g";
 ++			linux,default-trigger = "wf188:green:wifi2g";
 + 			default-state = "off";
 + 		};
 + 		led@18 {
 +-			label = "led_eth";
-+-			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
 ++			label = "wf188:green:eth";
-++			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
++ 			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
 + 			linux,default-trigger = "wf188:green:eth";
-+ 			default-state = "off";
++-			default-state = "off";
+++			default-state = "on";
 + 		};
 +                 led_power: led@16 {
 +-                        label = "led_pwr";
-+-                        gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
 ++                        label = "wf188:green:power";
-++                        gpios = <&tlmm 16 GPIO_ACTIVE_LOW>;
++                         gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
 +                         linux,default-trigger = "wf188:green:power";
-+ 			default-state = "off";
++-			default-state = "off";
+++			default-state = "on";
 + 		};
++ 	};
++ 
 +Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq6018-edgecore-eap101.dts
 +===================================================================
 +--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq6018-edgecore-eap101.dts
@@ -105,26 +135,27 @@ index 0000000000..2396067aac
 + 
 + 		led@25 {
 +-			label = "green:wifi5";
-++			label = "eap101:green:wifi5g";
-+ 			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
++-			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
 +-			linux,default-trigger = "wf188:green:5g";
+++			label = "eap101:green:wifi5g";
+++			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
 ++			linux,default-trigger = "eap101:green:wifi5g";
 + 			default-state = "off";
 + 		};
 + 		led@24 {
 +-			label = "green:wifi2";
-++			label = "eap101:green:wifi2g";
-+ 			gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
++-			gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
 +-			linux,default-trigger = "wf188:green:2g";
+++			label = "eap101:green:wifi2g";
+++			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
 ++			linux,default-trigger = "eap101:green:wifi2g";
 + 			default-state = "off";
 + 		};
 +                 led_power: led@16 {
 +-                        label = "led_pwr";
-+-                        gpios = <&tlmm 74 GPIO_ACTIVE_HIGH>;
-+-                        linux,default-trigger = "green:power";
 ++                        label = "eap101:green:power";
-++                        gpios = <&tlmm 74 GPIO_ACTIVE_LOW>;
++                         gpios = <&tlmm 74 GPIO_ACTIVE_HIGH>;
++-                        linux,default-trigger = "green:power";
 ++                        linux,default-trigger = "eap101:green:power";
 + 			default-state = "off";
 + 		};
@@ -133,7 +164,7 @@ index 0000000000..2396067aac
 +===================================================================
 +--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
 ++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
-+@@ -671,29 +671,27 @@
++@@ -671,29 +671,29 @@
 + 		pinctrl-names = "default";
 + 
 + 			led_power: led_pwr {
@@ -142,31 +173,31 @@ index 0000000000..2396067aac
 + 				gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
 + 				default-state = "on";
 +-				linux,default-trigger = "led_pwr";
+++				linux,default-trigger = "eap102:green:power";
 + 			};
 + 
 + 			led_2g {
 +-				label = "green:wifi2";
 ++				label = "eap102:green:wifi2g";
 + 				gpio = <&tlmm 47 GPIO_ACTIVE_HIGH>;
-+-				default-state = "off";
-++				default-state = "on";
++ 				default-state = "off";
 + 			};
 + 
 + 			led_5g {
 +-				label = "green:wifi5";
 ++				label = "eap102:green:wifi5g";
 + 				gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
-+-				default-state = "off";
-++				default-state = "on";
++ 				default-state = "off";
 + 			};
 + 
 + 			led_bt {
-++				label = "eap102:green:bt";
 + 				gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
 +-				label = "green:bt";
 +-				default-state = "off";
 +-				linux,default-trigger = "led_bt";
+++				label = "eap102:green:bt";
 ++				default-state = "on";
+++				linux,default-trigger = "eap102:green:bt";
 + 			};
 + 	};
 + 	nss-macsec0 {


### PR DESCRIPTION
This Patch fixes leds incorrect service state issue, and correct the
label names for all wifi6 APs

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>