### PR TITLE
WIFI-2626: radius proxy: fix wildcard realm config

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radius_proxy.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radius_proxy.h
@@ -33,6 +33,7 @@ extern ovsdb_table_t table_Radius_Proxy_Config;
 
 void callback_Radius_Proxy_Config(ovsdb_update_monitor_t *mon,
 		struct schema_Radius_Proxy_Config *old, struct schema_Radius_Proxy_Config *conf);
+void radius_proxy_fixup(void);
 
 #endif /* RADIUS_PROXY_H_INCLUDED */
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -1089,6 +1089,7 @@ void apc_init()
 
 static void apply_config_handler(struct timeout *timeout)
 {
+	radius_proxy_fixup();
 	uci_commit_all(uci);
 	sync();
 	LOGI("====Calling reload_config====");


### PR DESCRIPTION
Wildcard realm needs to be configured as the very last item.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>