### PR TITLE
Wifi-2952. Fix for flooding client events for Auth and Assoc

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-016-hapd-create_new_session_if_id_is_0.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-016-hapd-create_new_session_if_id_is_0.patch
@@ -1,0 +1,14 @@
+Index: hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+===================================================================
+--- hostapd-2020-07-02-58b384f4.orig/src/ap/ubus.c
++++ hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+@@ -1655,7 +1655,8 @@ int hostapd_ubus_handle_rt_event(struct
+ 	session_id = sta->cl_session_id;
+ 
+ 	/* find by session id */
+-	rec = avl_find_element(&hapd->ubus.rt_events, &session_id, rec, avl);
++	if (session_id)
++		rec = avl_find_element(&hapd->ubus.rt_events, &session_id, rec, avl);
+ 
+ 	/* prepare rec if not found */
+ 	if (!rec) {

--- a/feeds/wifi-trunk/hostapd/patches/906-hapd-create_new_session_if_id_is_0.patch
+++ b/feeds/wifi-trunk/hostapd/patches/906-hapd-create_new_session_if_id_is_0.patch
@@ -1,0 +1,14 @@
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ubus.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
+@@ -1657,7 +1657,8 @@ int hostapd_ubus_handle_rt_event(struct
+ 	session_id = sta->cl_session_id;
+ 
+ 	/* find by session id */
+-	rec = avl_find_element(&hapd->ubus.rt_events, &session_id, rec, avl);
++	if (session_id)
++		rec = avl_find_element(&hapd->ubus.rt_events, &session_id, rec, avl);
+ 
+ 	/* prepare rec if not found */
+ 	if (!rec) {


### PR DESCRIPTION
Sometimes we see a Client session created with sessionId=0,
and this never gets deleted. The AP keep on sending this event
as long as it exist in the events list.
SessionId=0 is invalid. Adding checks to not create a session with
Id=0.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>