### PR TITLE
ath10k: WIFI-2954 - Fix channel survey dump

### DIFF
--- a/feeds/wifi-trunk/ath10k-ct/patches/970-accumulate-survey-info-data
+++ b/feeds/wifi-trunk/ath10k-ct/patches/970-accumulate-survey-info-data
@@ -1,0 +1,11 @@
+--- a/ath10k-5.7/mac.c	2021-07-06 11:12:56.022146449 -0700
++++ b/ath10k-5.7/mac.c	2021-07-06 19:37:52.352753693 -0700
+@@ -8286,7 +8286,7 @@
+ 				  struct ieee80211_channel *channel)
+ {
+ 	int ret;
+-	enum wmi_bss_survey_req_type type = WMI_BSS_SURVEY_REQ_TYPE_READ_CLEAR;
++	enum wmi_bss_survey_req_type type = WMI_BSS_SURVEY_REQ_TYPE_READ;
+ 
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/target_OPENWRT.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/target_OPENWRT.h
@@ -45,14 +45,14 @@ typedef struct
 typedef struct
 {
 	DPP_TARGET_SURVEY_RECORD_COMMON_STRUCT;
-	uint32_t chan_active;
-	uint32_t chan_busy;
-	uint32_t chan_busy_ext;
-	uint32_t chan_self;
-	uint32_t chan_rx;
-	uint32_t chan_tx;
+	uint64_t chan_active;
+	uint64_t chan_busy;
+	uint64_t chan_busy_ext;
+	uint64_t chan_self;
+	uint64_t chan_rx;
+	uint64_t chan_tx;
 	uint32_t chan_noise;
-	uint32_t duration_ms;
+	uint64_t duration_ms;
 } target_survey_record_t;
 
 typedef void target_capacity_data_t;

--- a/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
+++ b/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
@@ -44,14 +44,14 @@ typedef struct
 typedef struct
 {
 	DPP_TARGET_SURVEY_RECORD_COMMON_STRUCT;
-	uint32_t chan_active;
-	uint32_t chan_busy;
-	uint32_t chan_busy_ext;
-	uint32_t chan_self;
-	uint32_t chan_rx;
-	uint32_t chan_tx;
+	uint64_t chan_active;
+	uint64_t chan_busy;
+	uint64_t chan_busy_ext;
+	uint64_t chan_self;
+	uint64_t chan_rx;
+	uint64_t chan_tx;
 	uint32_t chan_noise;
-	uint32_t duration_ms;
+	uint64_t duration_ms;
 	uint32_t chan_in_use;
 } target_survey_record_t;
 


### PR DESCRIPTION
Channel time, busy and other survey counters are showing incorrect values (less than previous or sometimes zero).
Consecutive survey dumps are expected to return monotonically increasing counter values.

Root Cause:
Clear on read in ath10k was leading to this issue.

Solution: Use the non-clearing
WMI_BSS_SURVEY_REQ_TYPE_READ wmi_bss_survey_req_type

Note: ath11k already has this fix.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>