### PR TITLE
wifi-2981: Send proper mode and freq in channel switching

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-017-ubus-add-he-chan-switch.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-017-ubus-add-he-chan-switch.patch
@@ -1,0 +1,28 @@
+Index: hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+===================================================================
+--- hostapd-2020-07-02-58b384f4.orig/src/ap/ubus.c
++++ hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+@@ -528,6 +528,7 @@ enum {
+ 	CSA_SEC_CHANNEL_OFFSET,
+ 	CSA_HT,
+ 	CSA_VHT,
++	CSA_HE,
+ 	CSA_BLOCK_TX,
+ 	__CSA_MAX
+ };
+@@ -541,6 +542,7 @@ static const struct blobmsg_policy csa_p
+ 	[CSA_SEC_CHANNEL_OFFSET] = { "sec_channel_offset", BLOBMSG_TYPE_INT32 },
+ 	[CSA_HT] = { "ht", BLOBMSG_TYPE_BOOL },
+ 	[CSA_VHT] = { "vht", BLOBMSG_TYPE_BOOL },
++	[CSA_HE] = { "he", BLOBMSG_TYPE_BOOL },
+ 	[CSA_BLOCK_TX] = { "block_tx", BLOBMSG_TYPE_BOOL },
+ };
+ 
+@@ -783,6 +785,7 @@ hostapd_switch_chan(struct ubus_context
+ 	SET_CSA_SETTING(CSA_SEC_CHANNEL_OFFSET, freq_params.sec_channel_offset, u32);
+ 	SET_CSA_SETTING(CSA_HT, freq_params.ht_enabled, bool);
+ 	SET_CSA_SETTING(CSA_VHT, freq_params.vht_enabled, bool);
++	SET_CSA_SETTING(CSA_HE, freq_params.he_enabled, bool);
+ 	SET_CSA_SETTING(CSA_BLOCK_TX, block_tx, bool);
+ 
+ 	for (i = 0; i < hapd->iface->num_bss; i++) {

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/fixup.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/fixup.h
@@ -16,4 +16,15 @@ void vif_fixup_del(char *ifname);
 bool vif_fixup_captive_enabled(void);
 bool vif_fixup_iface_captive_enabled(const char *ifname);
 void vif_fixup_set_iface_captive(const char *ifname, bool en);
+
+struct radio_fixup {
+        struct avl_node avl;
+        char rname[IF_NAMESIZE];
+        char hw_mode[8];
+};
+
+struct radio_fixup * radio_fixup_find(const char *name);
+void radio_fixup_del(char *ifname);
+void radio_fixup_set_hw_mode(const char *ifname, char *hw_mode);
+char *radio_fixup_get_hw_mode(const char *ifname);
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
@@ -31,6 +31,7 @@ void set_config_apply_timeout(ovsdb_update_monitor_t *mon);
 bool apc_read_conf(struct schema_APC_Config *apcconf);
 bool apc_read_state(struct schema_APC_State *apcst);
 int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
-			    int channel_bandwidth, int sec_chan_offset);
+			    const char *hw_mode, int channel_bandwidth,
+			    int sec_chan_offset);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -28,6 +28,7 @@
 #include "vlan.h"
 #include "radius_proxy.h"
 #include "timer.h"
+#include "fixup.h"
 
 ovsdb_table_t table_Hotspot20_Config;
 ovsdb_table_t table_Hotspot20_OSU_Providers;
@@ -61,7 +62,7 @@ enum {
 	WDEV_ATTR_TX_ANTENNA,
 	WDEV_ATTR_RX_ANTENNA,
 	WDEV_ATTR_FREQ_BAND,
-	WDEV_AATR_CHANNELS,
+	WDEV_ATTR_CHANNELS,
 	WDEV_ATTR_DISABLE_B_RATES,
 	WDEV_ATTR_MAXASSOC_CLIENTS,
 	WDEV_ATTR_LOCAL_PWR_CONSTRAINT,
@@ -81,7 +82,7 @@ static const struct blobmsg_policy wifi_device_policy[__WDEV_ATTR_MAX] = {
 	[WDEV_ATTR_TX_ANTENNA] = { .name = "txantenna", .type = BLOBMSG_TYPE_INT32 },
 	[WDEV_ATTR_RX_ANTENNA] = { .name = "rxantenna", .type = BLOBMSG_TYPE_INT32 },
 	[WDEV_ATTR_FREQ_BAND] = { .name = "freq_band", .type = BLOBMSG_TYPE_STRING },
-	[WDEV_AATR_CHANNELS] = {.name = "channels", .type = BLOBMSG_TYPE_ARRAY},
+	[WDEV_ATTR_CHANNELS] = {.name = "channels", .type = BLOBMSG_TYPE_ARRAY},
 	[WDEV_ATTR_DISABLE_B_RATES] = { .name = "legacy_rates", .type = BLOBMSG_TYPE_BOOL },
 	[WDEV_ATTR_MAXASSOC_CLIENTS] = { .name = "maxassoc", .type = BLOBMSG_TYPE_INT32 },
 	[WDEV_ATTR_LOCAL_PWR_CONSTRAINT] = { .name = "local_pwr_constraint", .type = BLOBMSG_TYPE_INT32 },
@@ -313,6 +314,8 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 
 		if (m) {
 			SCHEMA_SET_STR(rstate.hw_mode, m->hwmode);
+			radio_fixup_set_hw_mode(rstate.if_name, m->hwmode);
+
 			if (m->htmode)
 				SCHEMA_SET_STR(rstate.ht_mode, m->htmode);
 			else
@@ -473,6 +476,7 @@ bool target_radio_config_set2(const struct schema_Wifi_Radio_Config *rconf,
 			blobmsg_add_string(&b, "htmode", m->ucihtmode);
 			blobmsg_add_string(&b, "hwmode", m->ucihwmode);
 			blobmsg_add_u32(&b, "chanbw", 20);
+			radio_fixup_set_hw_mode(rconf->if_name, m->hwmode);
 		} else
 			 LOGE("%s: failed to set ht/hwmode", rconf->if_name);
 	}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_ubus.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_ubus.c
@@ -11,6 +11,7 @@ extern struct ev_loop *wifihal_evloop;
 static struct ubus_context *ubus;
 extern struct ev_loop *wifihal_evloop;
 extern void apc_state_set(struct blob_attr *msg);
+struct blob_buf ub = { };
 
 int ubus_set_signal_thresholds(const char *if_name, int connect, int stay)
 {
@@ -91,7 +92,8 @@ int hapd_rrm_set_neighbors(char *name, struct rrm_neighbor *neigh, int count)
 }
 
 int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
-			    int channel_bandwidth, int sec_chan_offset)
+			    const char *hw_mode, int channel_bandwidth,
+			    int sec_chan_offset)
 {
 	uint32_t id;
 	char path[64];
@@ -100,23 +102,33 @@ int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
 
 	if (ubus_lookup_id(ubus, path, &id))
 		return -1;
-	blob_buf_init(&b, 0);
+	blob_buf_init(&ub, 0);
 
-	if (channel_bandwidth == 20 || channel_bandwidth == 40) {
-		blobmsg_add_u8(&b, "ht", 1);
-	} else if (channel_bandwidth == 80) {
-		blobmsg_add_u8(&b, "vht", 1);
+	if (!strncmp(hw_mode, "11n", strlen("11n"))) {
+		blobmsg_add_u8(&ub, "ht", 1);
+	} else if (!strncmp(hw_mode, "11ac", strlen("11ac"))) {
+		blobmsg_add_u8(&ub, "ht", 1);
+		blobmsg_add_u8(&ub, "vht", 1);
+	} else if (!strncmp(hw_mode, "11ax", strlen("11ax"))) {
+		blobmsg_add_u8(&ub, "ht", 1);
+		blobmsg_add_u8(&ub, "vht", 1);
+		blobmsg_add_u8(&ub, "he", 1);
 	}
 
-	if (channel_bandwidth == 40 || channel_bandwidth == 80) {
-		blobmsg_add_u32(&b, "center_freq1", frequency+30);
-	}
+	if (channel_bandwidth == 40)
+		blobmsg_add_u32(&ub, "center_freq1", frequency+10);
+	else if (channel_bandwidth == 80)
+		blobmsg_add_u32(&ub, "center_freq1", frequency+30);
+	else if (channel_bandwidth == 20)
+		blobmsg_add_u32(&ub, "center_freq1", frequency);
+	else if (channel_bandwidth == 160)
+		blobmsg_add_u32(&ub, "center_freq1", frequency+70);
 
-	blobmsg_add_u32(&b, "freq", frequency);
-	blobmsg_add_u32(&b, "bcn_count", 5);
-	blobmsg_add_u32(&b, "bandwidth", channel_bandwidth);
-	blobmsg_add_u32(&b, "sec_channel_offset", sec_chan_offset);
-	return ubus_invoke(ubus, id, "switch_chan", b.head, NULL, NULL, 1000);
+	blobmsg_add_u32(&ub, "freq", frequency);
+	blobmsg_add_u32(&ub, "bcn_count", 5);
+	blobmsg_add_u32(&ub, "bandwidth", channel_bandwidth);
+	blobmsg_add_u32(&ub, "sec_channel_offset", sec_chan_offset);
+	return ubus_invoke(ubus, id, "switch_chan", ub.head, NULL, NULL, 1000);
 }
 
 enum {


### PR DESCRIPTION
1. Set HT VHT HE based on the hw_mode
2. Set secondary frequency (center_freq1) based on bandwidth
3. Add HE parameter in ubus call switch_chan

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>