### PR TITLE
WIFI-2978 - Fix EC420 reset button

### DIFF
--- a/patches/0055-ipq40xx-fix-EC420-G1-reset-button.patch
+++ b/patches/0055-ipq40xx-fix-EC420-G1-reset-button.patch
@@ -1,0 +1,26 @@
+From 97ba6e4ba01fc7c57f769ac6d5c0e5fdf8ef0f62 Mon Sep 17 00:00:00 2001
+From: Arthur Su <arthur.su@tp-link.com>
+Date: Mon, 12 Jul 2021 02:31:13 +0000
+Subject: [PATCH] ipq40xx: fix EC420-G1 reset button
+
+Signed-off-by: Arthur Su <arthur.su@tp-link.com>
+---
+ .../arch/arm/boot/dts/qcom-ipq4019-tp-link-ec420-g1.dts         | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ec420-g1.dts b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ec420-g1.dts
+index e2062e7cd0..fc48e605d5 100755
+--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ec420-g1.dts
++++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-tp-link-ec420-g1.dts
+@@ -69,7 +69,7 @@
+ 		button@1 {
+             label = "reset";
+             linux,code = <KEY_RESTART>;
+-            gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
++            gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+             linux,input-type = <1>;
+         };
+ 	};
+-- 
+2.20.1
+


### PR DESCRIPTION
The EC420 reset button don't work, so it cannot be restarted or restored
to factory settings. The reset button is fixed to gpio18.

Signed-off-by: Arthur Su <arthur.su@tp-link.com>