### PR TITLE
WiFi5-APs-LED-label-Name-Change

### DIFF
--- a/patches/0055-WiFi5-APs-LED-label-change.patch
+++ b/patches/0055-WiFi5-APs-LED-label-change.patch
@@ -1,0 +1,115 @@
+From 8091bc6a4e9167fe4dc9abea4433b4852a8a4020 Mon Sep 17 00:00:00 2001
+From: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+Date: Mon, 12 Jul 2021 14:42:44 -0400
+Subject: [PATCH] WiFI5 APs LED label change
+
+This patch will change the label names of ecw5410, ecw5211, and wf610D
+APs to follow common naming conventions
+
+Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+---
+ .../ipq40xx/base-files/etc/board.d/01_leds    |  8 ++++----
+ ...000-ecw5211-AP-LED-label-name-change.patch | 19 +++++++++++++++++++
+ .../ipq806x/base-files/etc/board.d/01_leds    |  4 ++--
+ .../arm/boot/dts/qcom-ipq8068-ecw5410.dts     |  8 ++++----
+ 4 files changed, 29 insertions(+), 10 deletions(-)
+ create mode 100644 target/linux/ipq40xx/patches-4.14/1000-ecw5211-AP-LED-label-name-change.patch
+
+diff --git a/target/linux/ipq40xx/base-files/etc/board.d/01_leds b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+index e1833ffcee..033661752c 100755
+--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+@@ -61,12 +61,12 @@ zyxel,nbg6617)
+ 	;;
+ edgecore,ecw5211 |\
+ zyxel,wre6606)
+-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy0tpt"
+-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5g" "phy1tpt"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "${boardname}:green:wifi2g" "phy0tpt"
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "${boardname}:green:wifi5g" "phy1tpt"
+ 	;;
+ cig,wf610d)
+-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "wf6203:green:wifi2g" "phy0tpt"
+-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "wf6203:green:wifi5g" "phy1tpt"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "wf6203:green:wifi2g" "phy0tpt"
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "wf6203:green:wifi5g" "phy1tpt"
+ 	;;
+ 
+ *)
+diff --git a/target/linux/ipq40xx/patches-4.14/1000-ecw5211-AP-LED-label-name-change.patch b/target/linux/ipq40xx/patches-4.14/1000-ecw5211-AP-LED-label-name-change.patch
+new file mode 100644
+index 0000000000..67664fb0fa
+--- /dev/null
++++ b/target/linux/ipq40xx/patches-4.14/1000-ecw5211-AP-LED-label-name-change.patch
+@@ -0,0 +1,19 @@
++Index: linux-4.14.187/arch/arm/boot/dts/qcom-ipq4018-ecw5211.dts
++===================================================================
++--- linux-4.14.187.orig/arch/arm/boot/dts/qcom-ipq4018-ecw5211.dts
+++++ linux-4.14.187/arch/arm/boot/dts/qcom-ipq4018-ecw5211.dts
++@@ -37,12 +37,12 @@
++ 		};
++ 
++ 		wlan2g {
++-			label = "ecw5211:green:wlan2g";
+++			label = "ecw5211:green:wifi2g";
++ 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
++ 		};
++ 
++ 		wlan5g {
++-			label = "ecw5211:green:wlan5g";
+++			label = "ecw5211:green:wifi5g";
++ 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
++ 		};
++ 	};
+diff --git a/target/linux/ipq806x/base-files/etc/board.d/01_leds b/target/linux/ipq806x/base-files/etc/board.d/01_leds
+index ffefb9e01c..809eef820a 100755
+--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
++++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
+@@ -20,8 +20,8 @@ compex,wpq864)
+ 	ucidef_set_led_usbport "pcie-usb" "PCIe USB" "wpq864:green:usb-pcie" "usb3-port1"
+ 	;;
+ edgecore,ecw5410)
+-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy1tpt"
+-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5g" "phy0tpt"
++	ucidef_set_led_wlan "wifi2g" "WIFI2G" "${boardname}:green:wifi2g" "phy1tpt"
++	ucidef_set_led_wlan "wifi5g" "WIFI5G" "${boardname}:green:wifi5g" "phy0tpt"
+ 	;;
+ nec,wg2600hp)
+ 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy1tpt"
+diff --git a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
+index 6bddc5e288..7caa1d7e0e 100644
+--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
++++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
+@@ -82,17 +82,17 @@
+ 		};
+ 
+ 		wlan2g_green {
+-			label = "ecw5410:green:wlan2g";
++			label = "ecw5410:green:wifi2g";
+ 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_LOW>;
+ 		};
+ 
+ 		wlan2g_yellow {
+-			label = "ecw5410:yellow:wlan2g";
++			label = "ecw5410:yellow:wifi2g";
+ 			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_LOW>;
+ 		};
+ 
+ 		wlan5g_green {
+-			label = "ecw5410:green:wlan5g";
++			label = "ecw5410:green:wifi5g";
+ 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+ 		};
+ 
+@@ -102,7 +102,7 @@
+ 		};
+ 
+ 		wlan5g_yellow {
+-			label = "ecw5410:yellow:wlan5g";
++			label = "ecw5410:yellow:wifi5g";
+ 			gpios = <&qcom_pinmux 59 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
+-- 
+2.25.1
+


### PR DESCRIPTION
This patch will change the ecw5410, ecw5211, and wf610D's LED label name

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>