### PR TITLE
wifi-2984: tplink device mount manufacturing data and certificates

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/uci-defaults/99-tip-data
@@ -101,23 +101,56 @@ linksys,ea8300)
 	DAY=$(echo "$MANUF_DATE" | cut -d "/" -f3)
 	MANUF_DATE="$DAY-$MONTH-$YEAR"
 	;;
-tp-link,ec420-g1)
+tp-link,ec420-g1|\
+tplink,ex227|\
+tplink,ex447)
 	PLATFORM=$(cat /tmp/sysinfo/model)
-	SERIAL=$(cat /dev/mtd9 | grep serial_number | cut -d "=" -f2)
-	MODEL=$(cat /dev/mtd9 | grep "model=" | cut -d "=" -f2)
-	SKU=$(cat /dev/mtd9 | grep sku | cut -d "=" -f2)
-	CERT_REGION=$(cat /dev/mtd9 | grep certification_region | cut -d "=" -f2)
-	ID=$(cat /dev/mtd9 | grep mac_address | cut -d "=" -f2)
-	MANUF_DATE=$(cat /dev/mtd9 | grep manufacturer_date | cut -d "=" -f2)
-	MANUF_NAME=$(cat /dev/mtd9 | grep manufacturer_name | cut -d "=" -f2)
-	if [ ! $MANUF_NAME ]; then
-		MANUF_NAME="Proware (TP-Link)"
-	fi
 	MANUF_ABBR="PW"
-	MANUF_URL=$(cat /dev/mtd9 | grep manufacturer_url | cut -d "=" -f2)
-	MODEL_DESCR=$(cat /dev/mtd9 | grep model_description | cut -d "=" -f2)
-	MODEL_REV=$(cat /dev/mtd9 | grep model_revision | cut -d "=" -f2)
-	REF_DESIGN=$(cat /dev/mtd9 | grep reference_design | cut -d "=" -f2)
+	# tp-link device manufacturing data and certs are stored in product_info partition
+	tip_part=$(find_mtd_part "product_info" 2> /dev/null)
+	mkdir -p /tmp/.tip
+	if mount -t squashfs $tip_part /tmp/.tip &> /dev/null; then
+		SERIAL=$(cat /tmp/.tip/serial_number)
+		MODEL=$(cat /tmp/.tip/model)
+		SKU=$(cat /tmp/.tip/sku)
+		CERT_REGION=$(cat /tmp/.tip/certification_region)
+		ID=$(cat /tmp/.tip/mac_address)
+		MANUF_DATE=$(cat /tmp/.tip/manufacturer_date)
+		MANUF_NAME=$(cat /tmp/.tip/manufacturer_name)
+		MANUF_URL=$(cat /tmp/.tip/manufacturer_url)
+		MODEL_DESCR=$(cat /tmp/.tip/model_description)
+		MODEL_REV=$(cat /tmp/.tip/model_revision)
+		REF_DESIGN=$(cat /tmp/.tip/reference_design)
+		if [ -f /tmp/.tip/certs/ca.pem ] && [ -f /tmp/.tip/certs/client.pem ] && [ -f /tmp/.tip/certs/client_dec.key ]; then
+			# If certs are default certs, and they will be replaced by manufacturing certs.
+			if cmp /usr/opensync/certs/ca.pem /rom/usr/opensync/certs/ca.pem &> /dev/null || \
+			   cmp /usr/opensync/certs/client.pem /rom/usr/opensync/certs/client.pem &> /dev/null || \
+			   cmp /usr/opensync/certs/client_dec.key /rom/usr/opensync/certs/client_dec.key &> /dev/null; then
+				cp /tmp/.tip/certs/* /usr/opensync/certs/
+			fi
+		fi
+		umount -l /tmp/.tip &> /dev/null
+
+	# for EC420-G1 DVT sample
+	elif [ $(board_name) = "tp-link,ec420-g1" ]; then
+		SERIAL=$(cat /dev/mtd9 | grep serial_number | cut -d "=" -f2)
+		MODEL=$(cat /dev/mtd9 | grep "model=" | cut -d "=" -f2)
+		SKU=$(cat /dev/mtd9 | grep sku | cut -d "=" -f2)
+		CERT_REGION=$(cat /dev/mtd9 | grep certification_region | cut -d "=" -f2)
+		ID=$(cat /dev/mtd9 | grep mac_address | cut -d "=" -f2)
+		MANUF_DATE=$(cat /dev/mtd9 | grep manufacturer_date | cut -d "=" -f2)
+		MANUF_NAME=$(cat /dev/mtd9 | grep manufacturer_name | cut -d "=" -f2)
+		if [ ! $MANUF_NAME ]; then
+			MANUF_NAME="Proware (TP-Link)"
+		fi
+		MANUF_URL=$(cat /dev/mtd9 | grep manufacturer_url | cut -d "=" -f2)
+		MODEL_DESCR=$(cat /dev/mtd9 | grep model_description | cut -d "=" -f2)
+		MODEL_REV=$(cat /dev/mtd9 | grep model_revision | cut -d "=" -f2)
+		REF_DESIGN=$(cat /dev/mtd9 | grep reference_design | cut -d "=" -f2)
+	else
+		MODEL=$(cat /tmp/sysinfo/board_name)
+		SERIAL=$(cat /sys/class/net/eth0/address | tr -d :)
+	fi
 	;;
 *)
 	MODEL=$(cat /tmp/sysinfo/board_name)

--- a/patches/0056-ipq40xx-change-EC420-G1-patch_mac-method.patch
+++ b/patches/0056-ipq40xx-change-EC420-G1-patch_mac-method.patch
@@ -1,0 +1,38 @@
+From 73bb7009f980da3e898b590be06328703235c8ee Mon Sep 17 00:00:00 2001
+From: Arthur Su <arthur.su@tp-link.com>
+Date: Fri, 16 Jul 2021 09:43:25 +0000
+Subject: [PATCH] ipq40xx: change EC420-G1 patch_mac method
+
+deprecate get_tip command, because manufacturing data aren't binrary
+raw.
+
+Signed-off-by: Arthur Su <arthur.su@tp-link.com>
+---
+ .../base-files/etc/hotplug.d/firmware/11-ath10k-caldata       | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 428002acf3..38f248fb6e 100644
+--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -129,7 +129,7 @@ case "$FIRMWARE" in
+ 	tp-link,ap2220 |\
+ 	tp-link,ec420-g1)
+ 		ath10kcal_extract "0:ART" 36864 12064
+-		ath10kcal_patch_mac_crc $(macaddr_add "$(get_tip mac_address)" 1) # 5G, wlan0
++		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 1) # 5G, wlan0
+ 		;;
+ 	esac
+ 	;;
+@@ -200,7 +200,7 @@ case "$FIRMWARE" in
+ 	tp-link,ap2220 |\
+ 	tp-link,ec420-g1)
+ 		ath10kcal_extract "0:ART" 4096 12064
+-		ath10kcal_patch_mac_crc $(macaddr_add "$(get_tip mac_address)" 9) #2.4G, wlan1
++		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 9) #2.4G, wlan1
+ 		;;
+ 	esac
+ 	;;
+-- 
+2.20.1
+

--- a/patches/0056-ipq807x-add-ath11k_generate_macs-method-for-tplink.patch
+++ b/patches/0056-ipq807x-add-ath11k_generate_macs-method-for-tplink.patch
@@ -1,0 +1,52 @@
+From efe92c7fc395794cbfc12d195dddb660be5e4f2c Mon Sep 17 00:00:00 2001
+From: Arthur Su <arthur.su@tp-link.com>
+Date: Mon, 19 Jul 2021 08:45:27 +0000
+Subject: [PATCH] ipq807x: add ath11k_generate_macs method for EX227 and EX447
+
+The ex227 and ex447 have 17 MACs,the base mac is reserved for WAN, and
+other 16 MACs are reserved for WLAN0/WALN1.
+
+Signed-off-by: Arthur Su <arthur.su@tp-link.com>
+---
+ .../etc/hotplug.d/firmware/10-ath11k-caldata   | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata b/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
+index 25b22887fe..e6eb7e2dfd 100755
+--- a/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
++++ b/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
+@@ -24,6 +24,20 @@ ath11k_generate_macs() {
+ 	done
+ }
+ 
++# The tplink device has 17 MAC addresses. The base MAC address is reserved for eth0(WAN), 
++# 8 MACs are reserved for 5G wireless(WLAN0), and the other 8 MACs are reserved for 2.4G wireless(WLAN1).
++# eth0: base_mac
++# wlan0: base_mac+1 ~ base_mac+8
++# wlan1: base_mac+9 ~ base_mac+16
++ath11k_generate_macs_for_tplink() {
++	touch /lib/firmware/ath11k-macs
++	eth=$(cat /sys/class/net/eth0/address)
++	wlan0=$(macaddr_add ${eth} 1) # 5G, wlan0
++	echo -ne \\x${wlan0//:/\\x} >> /lib/firmware/ath11k-macs
++	wlan1=$(macaddr_add ${eth} 9) # 2.4G, wlan1
++	echo -ne \\x${wlan1//:/\\x} >> /lib/firmware/ath11k-macs
++}
++
+ caldata_die() {
+         echo "caldata: " "$*"
+         exit 1
+@@ -88,6 +102,10 @@ ath11k-macs)
+ 	cig,wf188n)
+ 		ath11k_generate_macs
+ 		;;
++	tplink,ex227|\
++	tplink,ex447)
++		ath11k_generate_macs_for_tplink
++		;;
+ 	esac
+ 	;;
+ *)
+-- 
+2.20.1
+


### PR DESCRIPTION
The TP-Link device mounts the production_info partition, and apnos will
access the manufacturing data and copy the certificate to its use when
it is first booted.

Signed-off-by: Arthur Su <arthur.su@tp-link.com>