### PR TITLE
wifi-3203 Fix ath10k version in the rx_bss patch

### DIFF
--- a/feeds/wifi-trunk/ath10k-ct/patches/970-add-survey-local-bss-receive-time
+++ b/feeds/wifi-trunk/ath10k-ct/patches/970-add-survey-local-bss-receive-time
@@ -1,5 +1,5 @@
---- a/ath10k-5.4/wmi.c
-+++ b/ath10k-5.4/wmi.c
+--- a/ath10k-5.7/wmi.c
++++ b/ath10k-5.7/wmi.c
 @@ -6347,16 +6347,18 @@
  
  	survey = &ar->survey[idx];


### PR DESCRIPTION
 - Fix rx_bss patch to compile for the current ath10k version used
   which is ath10k-5.7

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>