### PR TITLE
WIFI-3236: Channel hop event suppression when channel hop triggered from cloud

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-019-channel-switch-event.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-019-channel-switch-event.patch
@@ -1,0 +1,64 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -531,6 +531,7 @@ enum {
+ 	CSA_VHT,
+ 	CSA_HE,
+ 	CSA_BLOCK_TX,
++	CSA_REASON,
+ 	__CSA_MAX
+ };
+ 
+@@ -545,6 +546,7 @@ static const struct blobmsg_policy csa_p
+ 	[CSA_VHT] = { "vht", BLOBMSG_TYPE_BOOL },
+ 	[CSA_HE] = { "he", BLOBMSG_TYPE_BOOL },
+ 	[CSA_BLOCK_TX] = { "block_tx", BLOBMSG_TYPE_BOOL },
++	[CSA_REASON] = { "reason", BLOBMSG_TYPE_INT32 },
+ };
+ 
+ #ifdef NEED_AP_MLME
+@@ -810,7 +812,7 @@ void hostapd_dfs_csa_timeout(void *eloop
+ 		   iface->conf->ieee80211ac, iface->conf->ieee80211ax);
+ 
+ 	ret = hostapd_enable_iface(iface);
+-	if (ret == 0)
++	if (ret == 0 && css->reason == 0)
+ 		hostapd_ubus_handle_channel_switch_event(iface,
+ 						HOSTAPD_UBUS_HIGH_INTERFERENCE,
+ 						iface->freq);
+@@ -994,6 +996,7 @@ hostapd_switch_chan(struct ubus_context
+ 	SET_CSA_SETTING(CSA_VHT, freq_params.vht_enabled, bool);
+ 	SET_CSA_SETTING(CSA_HE, freq_params.he_enabled, bool);
+ 	SET_CSA_SETTING(CSA_BLOCK_TX, block_tx, bool);
++	SET_CSA_SETTING(CSA_REASON, reason, u32);
+ 
+ 	wpa_printf(MSG_INFO, "%s: CSS freq=%d chan=%d sec_chan_off=%d, width=%d, seg0=%d, seg1=%d", __func__,
+ 		css.freq_params.freq,
+@@ -1015,7 +1018,9 @@ hostapd_switch_chan(struct ubus_context
+ 			return UBUS_STATUS_NOT_SUPPORTED;
+ 	}
+ 
+-	hostapd_ubus_handle_channel_switch_event(hapd->iface, HOSTAPD_UBUS_HIGH_INTERFERENCE, css.freq_params.freq);
++	if (css.reason == 0) {
++		hostapd_ubus_handle_channel_switch_event(hapd->iface, HOSTAPD_UBUS_HIGH_INTERFERENCE, css.freq_params.freq);
++	}
+ 
+ 	return UBUS_STATUS_OK;
+ #undef SET_CSA_SETTING
+--- a/src/drivers/driver.h
++++ b/src/drivers/driver.h
+@@ -2404,6 +2404,7 @@ struct beacon_data {
+  * @freq_params: Next channel frequency parameter
+  * @beacon_csa: Beacon/probe resp/asooc resp info for CSA period
+  * @beacon_after: Next beacon/probe resp/asooc resp info
++ * @reason: The reason why we are switching the channel
+  * @counter_offset_beacon: Offset to the count field in beacon's tail
+  * @counter_offset_presp: Offset to the count field in probe resp.
+  */
+@@ -2414,6 +2415,7 @@ struct csa_settings {
+ 	struct hostapd_freq_params freq_params;
+ 	struct beacon_data beacon_csa;
+ 	struct beacon_data beacon_after;
++	u32 reason;
+ 
+ 	u16 counter_offset_beacon[2];
+ 	u16 counter_offset_presp[2];

--- a/feeds/wifi-trunk/hostapd/patches/908-channel-switch-event.patch
+++ b/feeds/wifi-trunk/hostapd/patches/908-channel-switch-event.patch
@@ -1,0 +1,64 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -530,6 +530,7 @@ enum {
+ 	CSA_HT,
+ 	CSA_VHT,
+ 	CSA_BLOCK_TX,
++	CSA_REASON,
+ 	__CSA_MAX
+ };
+ 
+@@ -543,6 +544,7 @@ static const struct blobmsg_policy csa_p
+ 	[CSA_HT] = { "ht", BLOBMSG_TYPE_BOOL },
+ 	[CSA_VHT] = { "vht", BLOBMSG_TYPE_BOOL },
+ 	[CSA_BLOCK_TX] = { "block_tx", BLOBMSG_TYPE_BOOL },
++	[CSA_REASON] = { "reason", BLOBMSG_TYPE_INT32 },
+ };
+ 
+ #ifdef NEED_AP_MLME
+@@ -810,7 +812,7 @@ void hostapd_dfs_csa_timeout(void *eloop
+ 		   iface->conf->ieee80211ac, iface->conf->ieee80211ax);
+ 
+ 	ret = hostapd_enable_iface(iface);
+-	if (ret == 0)
++	if (ret == 0 && css->reason == 0)
+ 		hostapd_ubus_handle_channel_switch_event(iface,
+ 						HOSTAPD_UBUS_HIGH_INTERFERENCE,
+ 						iface->freq);
+@@ -994,6 +996,7 @@ hostapd_switch_chan(struct ubus_context
+ 	SET_CSA_SETTING(CSA_HT, freq_params.ht_enabled, bool);
+ 	SET_CSA_SETTING(CSA_VHT, freq_params.vht_enabled, bool);
+ 	SET_CSA_SETTING(CSA_BLOCK_TX, block_tx, bool);
++	SET_CSA_SETTING(CSA_REASON, reason, u32);
+ 
+ 	wpa_printf(MSG_INFO, "%s: CSS freq=%d chan=%d sec_chan_off=%d, width=%d, seg0=%d, seg1=%d", __func__,
+ 		css.freq_params.freq,
+@@ -1015,7 +1018,9 @@ hostapd_switch_chan(struct ubus_context
+ 			return UBUS_STATUS_NOT_SUPPORTED;
+ 	}
+ 
+-	hostapd_ubus_handle_channel_switch_event(hapd->iface,HOSTAPD_UBUS_HIGH_INTERFERENCE,  css.freq_params.freq);
++	if (css.reason == 0) {
++		hostapd_ubus_handle_channel_switch_event(hapd->iface, HOSTAPD_UBUS_HIGH_INTERFERENCE, css.freq_params.freq);
++	}
+ 
+ 	return UBUS_STATUS_OK;
+ #undef SET_CSA_SETTING
+--- a/src/drivers/driver.h
++++ b/src/drivers/driver.h
+@@ -2291,6 +2291,7 @@ struct beacon_data {
+  * @freq_params: Next channel frequency parameter
+  * @beacon_csa: Beacon/probe resp/asooc resp info for CSA period
+  * @beacon_after: Next beacon/probe resp/asooc resp info
++ * @reason: The reason why we are switching the channel
+  * @counter_offset_beacon: Offset to the count field in beacon's tail
+  * @counter_offset_presp: Offset to the count field in probe resp.
+  */
+@@ -2301,6 +2302,7 @@ struct csa_settings {
+ 	struct hostapd_freq_params freq_params;
+ 	struct beacon_data beacon_csa;
+ 	struct beacon_data beacon_after;
++	u32 reason;
+ 
+ 	u16 counter_offset_beacon[2];
+ 	u16 counter_offset_presp[2];

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/radio.h
@@ -32,6 +32,6 @@ bool apc_read_conf(struct schema_APC_Config *apcconf);
 bool apc_read_state(struct schema_APC_State *apcst);
 int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
 			    const char *hw_mode, int channel_bandwidth,
-			    int sec_chan_offset);
+			    int sec_chan_offset, int reason);
 
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_ubus.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio_ubus.c
@@ -93,7 +93,7 @@ int hapd_rrm_set_neighbors(char *name, struct rrm_neighbor *neigh, int count)
 
 int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
 			    const char *hw_mode, int channel_bandwidth,
-			    int sec_chan_offset)
+			    int sec_chan_offset, int reason)
 {
 	uint32_t id;
 	char path[64];
@@ -128,6 +128,8 @@ int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
 	blobmsg_add_u32(&ub, "bcn_count", 5);
 	blobmsg_add_u32(&ub, "bandwidth", channel_bandwidth);
 	blobmsg_add_u32(&ub, "sec_channel_offset", sec_chan_offset);
+	blobmsg_add_u32(&ub, "reason", reason);
+	
 	return ubus_invoke(ubus, id, "switch_chan", ub.head, NULL, NULL, 1000);
 }
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
@@ -338,7 +338,7 @@ void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
 
 	hw_mode = radio_fixup_get_hw_mode(rconf->if_name);
 	if (hw_mode == NULL) {
-		LOGE("Falied to get hw mode");
+		LOGE("Failed to get hw mode");
 		return;
 	}
 
@@ -353,7 +353,8 @@ void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
 
 
 	ubus_set_channel_switch(wlanif, freq, hw_mode,
-				channel_bandwidth, sec_chan_offset);
+				channel_bandwidth, sec_chan_offset, 1);
+
 }
 
 static bool rrm_config_update( struct schema_Wifi_RRM_Config *conf, bool addNotDelete)

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
@@ -89,7 +89,7 @@ int rrm_setup_monitor(void);
 void rrm_channel_init(void);
 int rrm_ubus_init(struct ev_loop *loop);
 int ubus_get_noise(const char *if_name, uint32_t *noise);
-int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset);
+int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset, int reason);
 void set_rrm_parameters(rrm_entry_t *rrm_data);
 ds_tree_t* rrm_get_rrm_config_list(void);
 ds_tree_t* rrm_get_radio_list(void);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
@@ -225,7 +225,7 @@ void rrm_nf_timer_handler(struct ev_loop *loop, ev_timer *timer, int revents)
 			get_channel_bandwidth(get_max_channel_bw_channel(ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel),
 					radio->schema.ht_mode), &channel_bandwidth);
 			ubus_set_channel_switch(radio->config.if_name,
-					ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel), channel_bandwidth, sec_chan_offset);
+					ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel), channel_bandwidth, sec_chan_offset, 0);
 
 			rrm_reset_noise_floor_samples(&(rrm_config->rrm_data));
 		}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
@@ -51,7 +51,7 @@ int ubus_get_noise(const char *if_name, uint32_t *noise)
 
 }
 
-int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset)
+int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset, int reason)
 {
 	uint32_t id;
 	static struct blob_buf b;
@@ -76,6 +76,8 @@ int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel
 	blobmsg_add_u32(&b, "bcn_count", 5);
 	blobmsg_add_u32(&b, "bandwidth", channel_bandwidth);
 	blobmsg_add_u32(&b, "sec_channel_offset", sec_chan_offset);
+	blobmsg_add_u32(&b, "reason", reason);
+
 	return ubus_invoke(ubus, id, "switch_chan", b.head, NULL, NULL, 1000);
 }
 


### PR DESCRIPTION
Made it so we don't send a channel hop event to the cloud when the channel hop was triggered from the cloud side of things.

Didn't test the impact of switching channels due to interference.

The way I did this was by adding a "reason" param to the "switch_chan" ubus call. In this case a reason code of 0 means that the channel switch was triggered by high interfearence. In this case we do send the event to the cloud, but if we call the channel switch ubus call from rrm_radio_rebalance_channel we send a 1 as the reason code instead to avoid sending up the event.