### PR TITLE
Wifi-3237: Fix missing and duplicate client events

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-019-ubus-fix-client-events.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-019-ubus-fix-client-events.patch
@@ -1,0 +1,112 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -580,6 +580,7 @@ static int hostapd_clear_session(struct
+ 	{
+ 		if (session_id == rec->session_id) {
+ 			/* dec counter and delete */
++			wpa_printf(MSG_INFO, "%s Deleting client session with session id %llu", __func__, session_id);
+ 			cached_events_nr -= rec->rec_nr;
+ 			avl_delete(&hapd->ubus.rt_events, &rec->avl);
+ 			os_free(rec->records);
+@@ -633,6 +634,11 @@ static int hostapd_sessions(struct ubus_
+ 		/* messages for current session */
+ 		for (size_t i = 0; i < rec->rec_nr; i++) {
+ 			c_rec = &rec->records[i];
++			if (c_rec->processed) {
++				/* Record is already reported, continue */
++				continue;
++			}
++
+ 			/* check message type */
+ 			switch (c_rec->type) {
+ 			/* ClientAuthEvent */
+@@ -646,6 +652,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u32(&b_ev, "auth_status", p->auth_status);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -665,6 +672,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u8(&b_ev, "using11v", p->using11v);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -680,6 +688,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u32(&b_ev, "internal_rc", p->internal_rc);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -693,6 +702,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u64(&b_ev, "fdata_tx_up_ts_in_us", p->tx_ts.tv_sec * (uint64_t)1000000);
+ 				blobmsg_add_u64(&b_ev, "fdata_rx_up_ts_in_us", p->rx_ts.tv_sec * (uint64_t)1000000);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -705,6 +715,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
+ 				blobmsg_add_string(&b_ev, "ip_address", p->ip_addr);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -1912,6 +1923,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_AUTH;
+ 		rp->u.auth.session_id = rec->session_id;
++		rp->processed = false;
+ 
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+@@ -1942,6 +1954,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_ASSOC;
+ 		rp->u.assoc.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* frequency */
+@@ -1986,6 +1999,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_DISASSOC;
+ 		rp->u.disassoc.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* frequency */
+@@ -2017,6 +2031,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_FDATA;
+ 		rp->u.fdata.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* STA MAC */
+@@ -2045,6 +2060,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_IP;
+ 		rp->u.ip.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* STA MAC */
+--- a/src/ap/ubus.h
++++ b/src/ap/ubus.h
+@@ -110,6 +110,7 @@ struct client_ip_event {
+ };
+ 
+ struct client_session_record {
++	bool processed;
+ 	int type;
+ 	uint64_t timestamp;
+ 	union {

--- a/feeds/wifi-trunk/hostapd/patches/908-ubus-fix-client-events.patch
+++ b/feeds/wifi-trunk/hostapd/patches/908-ubus-fix-client-events.patch
@@ -1,0 +1,111 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -578,6 +578,7 @@ static int hostapd_clear_session(struct
+ 	{
+ 		if (session_id == rec->session_id) {
+ 			/* dec counter and delete */
++			wpa_printf(MSG_INFO, "%s Deleting client session with session id %llu", __func__, session_id);
+ 			cached_events_nr -= rec->rec_nr;
+ 			avl_delete(&hapd->ubus.rt_events, &rec->avl);
+ 			os_free(rec->records);
+@@ -631,6 +632,10 @@ static int hostapd_sessions(struct ubus_
+ 		/* messages for current session */
+ 		for (size_t i = 0; i < rec->rec_nr; i++) {
+ 			c_rec = &rec->records[i];
++			if (c_rec->processed) {
++				/* Record is already reported, continue */
++				continue;
++			}
+ 			/* check message type */
+ 			switch (c_rec->type) {
+ 			/* ClientAuthEvent */
+@@ -644,6 +649,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u32(&b_ev, "auth_status", p->auth_status);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -663,6 +669,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u8(&b_ev, "using11v", p->using11v);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -678,6 +685,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u32(&b_ev, "internal_rc", p->internal_rc);
+ 				blobmsg_add_string(&b_ev, "ssid", p->ssid);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -691,6 +699,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_u64(&b_ev, "fdata_tx_up_ts_in_us", p->tx_ts.tv_sec * (uint64_t)1000000);
+ 				blobmsg_add_u64(&b_ev, "fdata_rx_up_ts_in_us", p->rx_ts.tv_sec * (uint64_t)1000000);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -703,6 +712,7 @@ static int hostapd_sessions(struct ubus_
+ 				blobmsg_add_string(&b_ev, "sta_mac", p->sta_mac);
+ 				blobmsg_add_string(&b_ev, "ip_address", p->ip_addr);
+ 				blobmsg_close_table(&b_ev, t_msg);
++				c_rec->processed = true;
+ 				break;
+ 			}
+ 
+@@ -1911,6 +1921,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_AUTH;
+ 		rp->u.auth.session_id = rec->session_id;
++		rp->processed = false;
+ 
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+@@ -1941,6 +1952,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_ASSOC;
+ 		rp->u.assoc.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* frequency */
+@@ -1985,6 +1997,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_DISASSOC;
+ 		rp->u.disassoc.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* frequency */
+@@ -2016,6 +2029,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_FDATA;
+ 		rp->u.fdata.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* STA MAC */
+@@ -2044,6 +2058,7 @@ int hostapd_ubus_handle_rt_event(struct
+ 		struct client_session_record *rp = &rec->records[rec->rec_nr - 1];
+ 		rp->type = CST_IP;
+ 		rp->u.ip.session_id = rec->session_id;
++		rp->processed = false;
+ 		/* timestamp */
+ 		rp->timestamp = timestamp;
+ 		/* STA MAC */
+--- a/src/ap/ubus.h
++++ b/src/ap/ubus.h
+@@ -110,6 +110,7 @@ struct client_ip_event {
+ };
+ 
+ struct client_session_record {
++	bool processed;
+ 	int type;
+ 	uint64_t timestamp;
+ 	union {

--- a/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.h
+++ b/feeds/wlan-ap/opensync/src/src/sm/src/ubus_collector.h
@@ -31,8 +31,8 @@ void ubus_collector_cleanup(void);
 /* Poll sessions after this many seconds */
 #define UBUS_SESSIONS_POLLING_DELAY 9
 
-/* Poll the session clearing 'garbage collector' after this many seconds */
-#define UBUS_GARBAGE_COLLECTION_DELAY 1
+/* Delete session after this many seconds of receiving any first event of the session */
+#define SESSION_DELETE_TIMEOUT 30
 
 #define UBUS_OBJ_LEN 64
 


### PR DESCRIPTION
Some client events are duplicated and some of them are missing in the
client event report.

Root Cause 1: Processed clients events were not tagged in hostapd and
were thus getting duplicated during subsequent polling of client events.
Root Cause 2: Race between processing and clearing of client sessions
was leading to missing events.

Solution 1: Processed client events are tagged in hostapd and are reported only once.
Solution 2: Sessions are cleared only after they are processed by SM.

Also got rid of some unnecessary logs.

Acceptance Criteria: No duplicate client events in the mqtt report send by AP.
Sessions in the hostapd are successfully cleared after being processed by SM.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>