### PR TITLE
Wifi-3246. Add chan_info data to existing survey info data

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
@@ -275,6 +275,21 @@ bool target_stats_survey_convert(radio_entry_t *radio_cfg, radio_scan_type_t sca
 {
 	target_survey_record_t delta;
 
+	if (data_new->info.chan != data_old->info.chan) {
+		/* Do not consider the old channel's data */
+		memset(data_old, 0, sizeof(*data_old));
+	} else if ((data_new->duration_ms <= data_old->duration_ms) &&
+			(data_new->chan_busy <= data_old->chan_busy)) {
+		/*
+		 * Take care of survey data from CHAN_INFO events which are Read-On-Clear
+		 * in nature, whereas survey data from BSS_CHAN_INFO events are Read only.
+		 * Chan_info event down in the driver updates only the duration, noise floor
+		 * and the chan_busy data.
+		 */
+		data_new->duration_ms += data_old->duration_ms;
+		data_new->chan_busy += data_old->chan_busy;
+	}
+
 	LOGD("Survey convert scan_type %d chan %d duration_new:%llu duration_old:%llu "
 	     "busy_new %llu busy_old:%llu tx_new %llu tx_old:%llu rx_new %llu rx_old:%llu "
 	     "rx_self_new %llu rx_self_old:%llu",


### PR DESCRIPTION
The data from the chan_info events were overwriting the data
to the existing survey info counters. The data in the chan_info
events were Read-On-Clear where as the Survey info was maintained
as incremental stats and the application in the User space
performs the calculations based on incremental survey info stats.
As an example, the survey->time was always stored as 150 due to
chan_info event's Clear-On-Read nature. And this lead to the
difference calcuation as 0 at the User space application.
Solution is to add the incoming chan_info data to the existing
survey info stats, instead of replacing the existing data with new.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>