### PR TITLE
WIFI-2844: Removed the fallback case for when country code isn't set

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -329,8 +329,6 @@ static bool radio_state_update(struct uci_section *s, struct schema_Wifi_Radio_C
 
 	if (tb[WDEV_ATTR_COUNTRY])
 		SCHEMA_SET_STR(rstate.country, blobmsg_get_string(tb[WDEV_ATTR_COUNTRY]));
-	else
-		SCHEMA_SET_STR(rstate.country, "CA");
 
 	rstate.allowed_channels_len = phy_get_channels(phy, rstate.allowed_channels);
 	rstate.allowed_channels_present = true;


### PR DESCRIPTION
If the country code was blank in `/etc/config/wireless` this if statement would make it look like it was set to "CA" in the ovsdb tables. This means that when the cloud set it to "CA" we wouldn't update the `/etc/config/wireless` table since according to opensync it was already set to "CA". (this also meant this error would only happen if the region code was set to CA)

This fix seems to avoid the worst case scenario but the when the AP is booted with this fix (and having the country code entries removed from /etc/config/wireless) it seems to be put into backoff on it's first attempt to connect to the cloud but after that it's able to connect successfully on it's own after a little while. 