### PR TITLE
WIFI-3306: Updated the LLDP description with firmware version info an…

### DIFF
--- a/patches/0058-LLDP-firmware-version.patch
+++ b/patches/0058-LLDP-firmware-version.patch
@@ -1,0 +1,68 @@
+From 5e5917308f769f1228c572e4aed4f8f7f6434a14 Mon Sep 17 00:00:00 2001
+From: Owen Anderson <owenthomasanderson@gmail.com>
+Date: Wed, 4 Aug 2021 13:38:16 -0400
+Subject: [PATCH] Updated LLDPD version to 1.0.5 and updated config information
+
+---
+ package/network/services/lldpd/Makefile         |  4 ++--
+ package/network/services/lldpd/files/lldpd.init | 11 ++++++-----
+ 2 files changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/package/network/services/lldpd/Makefile b/package/network/services/lldpd/Makefile
+index 5b36155b71..48a3993492 100644
+--- a/package/network/services/lldpd/Makefile
++++ b/package/network/services/lldpd/Makefile
+@@ -8,12 +8,12 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=lldpd
+-PKG_VERSION:=1.0.3
++PKG_VERSION:=1.0.5
+ PKG_RELEASE:=1
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=https://media.luffy.cx/files/lldpd
+-PKG_HASH:=39fced395168015416bfe78b95414facf066f841f349024433aa20ab54e4c360
++PKG_HASH:=2dd3b212f4dbabfcbb2794c0010b245f9f8e74b387984e757be6243a74c6cb99
+ 
+ PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
+ PKG_LICENSE:=ISC
+diff --git a/package/network/services/lldpd/files/lldpd.init b/package/network/services/lldpd/files/lldpd.init
+index 64dfccfebe..66b5a74c18 100644
+--- a/package/network/services/lldpd/files/lldpd.init
++++ b/package/network/services/lldpd/files/lldpd.init
+@@ -12,11 +12,8 @@ LLDPD_CONFS_DIR=/tmp/lldpd.d
+ 
+ find_release_info()
+ {
+-	[ -s /etc/os-release ] && . /etc/os-release
+-	[ -z "$PRETTY_NAME" ] && [ -s /etc/openwrt_version ] && \
+-		PRETTY_NAME="$(cat /etc/openwrt_version)"
+-
+-	echo "${PRETTY_NAME:-Unknown OpenWrt release} @ $(cat /proc/sys/kernel/hostname)"
++	FW_VERSION=`sed -n 's/FW_IMAGE_ACTIVE:\(.*\)/\1/p' < /usr/opensync/.versions`
++	echo "${FW_VERSION:-Unknown TIP OpenAp release} @ $(cat /proc/sys/kernel/hostname)"
+ }
+ 
+ write_lldpd_conf()
+@@ -48,6 +45,8 @@ write_lldpd_conf()
+ 	[ -n "$lldp_description" ] && echo "configure system description" "\"$lldp_description\"" >> "$LLDPD_CONF"
+ 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
+ 
++	echo "configure system ip management pattern br-wan" >> "$LLDPD_CONF"
++
+ 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
+ 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
+ }
+@@ -107,6 +106,8 @@ reload_service() {
+ 		unconfigure lldp custom-tlv
+ 		unconfigure system interface pattern
+ 		unconfigure system description
++		unconfigure system hostname
++		unconfigure system ip management pattern
+ 	EOF
+ 	# Rewrite lldpd.conf
+ 	# If something changed it should be included by the lldpcli call
+-- 
+2.25.1
+


### PR DESCRIPTION
Updated the LLDPD configuration so that we use our firmware version in the description instead of the openwrt version.

Also I updated added rules so that the br-lan IP addresses aren't selected instead of the br-wan IP address since LLDPD just uses the first IP address in comes across in ifconfig. Tried with just PKG_RELEASE=1 but we need PKG_RELEASE=2 for the management pattern setting to work.

Used [this](https://github.com/openwrt/openwrt/commit/128250e8fc615aebe05642f023375dd7902808e1) openwrt commit as a reference for the wan IP change