### PR TITLE
Wifi-3309: Fix Tx power reporting

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
@@ -6,6 +6,7 @@
 #include <libubox/blobmsg.h>
 
 #define min(a,b) (((a) < (b)) ? (a) : (b))
+#define ATH_DRIVER_NAME_LEN 16
 
 struct mode_map {
 	int fiveg;
@@ -44,4 +45,5 @@ extern char* get_max_channel_bw_channel(int channel_freq, const char* htmode);
 int phy_find_hwmon_helper(char *dir, char *file, char *hwmon);
 extern double dBm_to_mwatts(double dBm);
 extern double mWatts_to_dBm(double mW);
+extern int phy_get_ath_driver_name(char *phy, char *ath_driver);
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -418,6 +418,22 @@ int phy_lookup(char *name)
 	return atoi(buf);
 }
 
+int phy_get_ath_driver_name(char *phy, char *ath_driver)
+{
+	glob_t gl;
+	char path[128];
+	snprintf(path, sizeof(path),
+			"/sys/kernel/debug/ieee80211/%s/[ath]*", phy);
+	if (glob(path, GLOB_NOSORT | GLOB_MARK, NULL, &gl))
+		return -1;
+	if (gl.gl_pathc) {
+		memset(ath_driver, '\0', ATH_DRIVER_NAME_LEN);
+		strncpy(ath_driver, basename(gl.gl_pathv[0]), ATH_DRIVER_NAME_LEN - 1);
+	}
+	globfree(&gl);
+	return 0;
+}
+
 int vif_get_mac(char *vap, char *mac)
 {
 	int sz = ETH_ALEN * 3;


### PR DESCRIPTION
 - AP was not reporting the Channel Tx power currently set in
   the firmware. This patch reads the Tx power from debugFS stats
   and reports it to cloud through Wifi_Radio_State table

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>