### PR TITLE
WIFI-2059: Removed if statement that blocked some ip updates

### DIFF
--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/40-fix-lan-wan-ip-conflict
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/40-fix-lan-wan-ip-conflict
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 [ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
-[ "$INTERFACE" = wan ] || exit 0
+[ "$INTERFACE" = wan ] || [ "$INTERFACE" = lan ] || exit 0
 
 conflict=0
 wan_ipaddr="$(ubus call network.interface.wan status | grep \"address\" | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"


### PR DESCRIPTION
So this error case would occur if the AP had a br-lan IP of 192.168.1.1 and the AP (while booted) would be connected to a network with that also had a DCHP range of 192.168.1.*

When this occurred the script would set the lan IP to be 192.168.0.1 as intended but at some point this would flip back to 192.168.1.1 (still not sure what causes the flip back though 😕)

This wouldn't trigger the script to update the lan ip since it would only listen for changes on the wan interface. Removing this line does mean that sometimes the script does execute sometimes when br-wan doesn't have any IP address, but this doesn't seem to cause any side effects. I also tested to ensure that the AP doesn't go into an infinite loop of going back and forth between 192.168.1.1 and 192.168.0.1.

Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>