### PR TITLE
wifi-3051: Set proper mode & freq in RRM NF chan switch

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/inc/rrm.h
@@ -89,7 +89,7 @@ int rrm_setup_monitor(void);
 void rrm_channel_init(void);
 int rrm_ubus_init(struct ev_loop *loop);
 int ubus_get_noise(const char *if_name, uint32_t *noise);
-int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset, int reason);
+int ubus_set_channel_switch(const char *if_name, uint32_t frequency, const char *hw_mode, int channel_bandwidth, int sec_chan_offset, int reason);
 void set_rrm_parameters(rrm_entry_t *rrm_data);
 ds_tree_t* rrm_get_rrm_config_list(void);
 ds_tree_t* rrm_get_radio_list(void);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_channel.c
@@ -225,7 +225,7 @@ void rrm_nf_timer_handler(struct ev_loop *loop, ev_timer *timer, int revents)
 			get_channel_bandwidth(get_max_channel_bw_channel(ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel),
 					radio->schema.ht_mode), &channel_bandwidth);
 			ubus_set_channel_switch(radio->config.if_name,
-					ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel), channel_bandwidth, sec_chan_offset, 0);
+					ieee80211_channel_to_frequency(rrm_config->rrm_data.backup_channel), radio->schema.hw_mode, channel_bandwidth, sec_chan_offset, 0);
 
 			rrm_reset_noise_floor_samples(&(rrm_config->rrm_data));
 		}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/rrm/src/rrm_ubus.c
@@ -51,7 +51,9 @@ int ubus_get_noise(const char *if_name, uint32_t *noise)
 
 }
 
-int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel_bandwidth, int sec_chan_offset, int reason)
+int ubus_set_channel_switch(const char *if_name, uint32_t frequency,
+			    const char *hw_mode, int channel_bandwidth,
+			    int sec_chan_offset, int reason)
 {
 	uint32_t id;
 	static struct blob_buf b;
@@ -63,14 +65,25 @@ int ubus_set_channel_switch(const char *if_name, uint32_t frequency, int channel
 		return -1;
 	blob_buf_init(&b, 0);
 
-	if (channel_bandwidth == 20 || channel_bandwidth == 40) {
-		blobmsg_add_bool(&b, "ht", 1);
-	} else if (channel_bandwidth == 80) {
-		blobmsg_add_bool(&b, "vht", 1);
+	if (!strncmp(hw_mode, "11n", strlen("11n"))) {
+		blobmsg_add_u8(&b, "ht", 1);
+	} else if (!strncmp(hw_mode, "11ac", strlen("11ac"))) {
+		blobmsg_add_u8(&b, "ht", 1);
+		blobmsg_add_u8(&b, "vht", 1);
+	} else if (!strncmp(hw_mode, "11ax", strlen("11ax"))) {
+		blobmsg_add_u8(&b, "ht", 1);
+		blobmsg_add_u8(&b, "vht", 1);
+		blobmsg_add_u8(&b, "he", 1);
 	}
-	if (channel_bandwidth == 40 || channel_bandwidth == 80) {
+
+	if (channel_bandwidth == 40)
+		blobmsg_add_u32(&b, "center_freq1", frequency+10);
+	else if (channel_bandwidth == 80)
 		blobmsg_add_u32(&b, "center_freq1", frequency+30);
-	}
+	else if (channel_bandwidth == 20)
+		blobmsg_add_u32(&b, "center_freq1", frequency);
+	else if (channel_bandwidth == 160)
+		blobmsg_add_u32(&b, "center_freq1", frequency+70);
 
 	blobmsg_add_u32(&b, "freq", frequency);
 	blobmsg_add_u32(&b, "bcn_count", 5);


### PR DESCRIPTION
For RRM noise floor driven channel change:
1. Set HT VHT HE based on the hw_mode
2. Set secondary frequency (center_freq1) based on bandwidth

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>