### PR TITLE
wifi-3258: Fix bridge client traffic on same wifi interface

### DIFF
--- a/patches/0059-wifi-3258-Fix-bridge-client-traffic-on-same-wifi-interface.patch
+++ b/patches/0059-wifi-3258-Fix-bridge-client-traffic-on-same-wifi-interface.patch
@@ -1,0 +1,39 @@
+From e0c226e8f5cfa6ec3537823685a803b970297005 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Sun, 8 Aug 2021 21:38:12 -0400
+Subject: [PATCH] wifi-3258: Fix bridge client traffic on same wifi interface
+
+Allow bridging broadcast and multicast traffic within same
+bridge port if hairpinmode is enabled for that port.
+This fixes the ARP packet between clients on same wifi interface
+being dropped.
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ ...e-allow-bcast-mcast-same-port-hairpinmode.patch | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100644 target/linux/ipq807x/patches/112-bridge-allow-bcast-mcast-same-port-hairpinmode.patch
+
+diff --git a/target/linux/ipq807x/patches/112-bridge-allow-bcast-mcast-same-port-hairpinmode.patch b/target/linux/ipq807x/patches/112-bridge-allow-bcast-mcast-same-port-hairpinmode.patch
+new file mode 100644
+index 0000000000..99989b3067
+--- /dev/null
++++ b/target/linux/ipq807x/patches/112-bridge-allow-bcast-mcast-same-port-hairpinmode.patch
+@@ -0,0 +1,14 @@
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/net/bridge/br_forward.c
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/net/bridge/br_forward.c
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/net/bridge/br_forward.c
++@@ -33,8 +33,7 @@ static inline int should_deliver(const s
++ 	struct net_bridge_vlan_group *vg;
++ 
++ 	vg = nbp_vlan_group_rcu(p);
++-	return ((skb->dev != p->dev) || ((p->flags & BR_HAIRPIN_MODE) &&
++-		(!is_multicast_ether_addr(eth_hdr(skb)->h_dest)))) &&
+++	return ((skb->dev != p->dev) || (p->flags & BR_HAIRPIN_MODE)) &&
++ 		br_allowed_egress(vg, skb) && p->state == BR_STATE_FORWARDING;
++ }
++ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Allow bridging broadcast and multicast traffic within same
bridge port if hairpinmode is enabled for that port.
This fixes the ARP packet between clients on same wifi interface
being dropped.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>