### PR TITLE
Wifi-3463. Fix for scan timeout with scan on same interface

### DIFF
--- a/feeds/wlan-ap/opensync/patches/42-sm_dbg_log.patch
+++ b/feeds/wlan-ap/opensync/patches/42-sm_dbg_log.patch
@@ -1,0 +1,44 @@
+Index: opensync-2.0.5.0/src/sm/src/sm_scan_schedule.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/sm/src/sm_scan_schedule.c
++++ opensync-2.0.5.0/src/sm/src/sm_scan_schedule.c
+@@ -155,6 +155,12 @@ clean:
+ 
+     /* Remove processed context */
+     ds_dlist_remove_head(&g_scan_ctx_list);
++    LOG(DEBUG, "sm_scan_schedule_cb. Scan done. Deleting scan_ctx. %p. %s %s %d\n",
++		scan_ctx,
++		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++		scan_ctx->scan_request.chan_list[0]);
++
+     sm_scan_ctx_free(scan_ctx);
+     scan_ctx = NULL;
+ 
+@@ -163,6 +169,13 @@ clean:
+     if (scan_ctx)
+     {
+         scan_status = true;
++
++	LOG(DEBUG, "sm_scan_schedule_cb. Schedule next scan request. %p. %s %s %d\n",
++		scan_ctx,
++		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++		scan_ctx->scan_request.chan_list[0]);
++
+         rc =
+             sm_scan_schedule_process (
+                     scan_ctx);
+@@ -303,6 +316,12 @@ bool sm_scan_schedule(
+ 
+     if (NULL == scan_in_progress) {
+         /* Trigger the scan and wait for results */
++	LOG(DEBUG, "sm_scan_schedule. Schedule scan request. %p. %s %s %d\n",
++		scan_ctx,
++		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++		scan_ctx->scan_request.chan_list[0]);
++
+         rc =
+             sm_scan_schedule_process(
+                     scan_ctx);


### PR DESCRIPTION
Successive scan requests on same interface cause scan timeout.
Scan requests are enqueued at the Opensync layer and is designed
to handle the requests sequentially. If there are successive
scan requests for the same interface, then we end up deleteling
an on-going scan context. This is due to the interface name being
used as key for the AVL entries, and we were trying to reuse the
AVL entry if one already exist.
Solution is to always allocate a new entry without any reuse.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>