### PR TITLE
WIFI-3244-WF610D-Config-Reset-Over-Sysupgrade

### DIFF
--- a/patches/0060-wifi-3244-wf610d-config-reset-over-sysupgrade.patch
+++ b/patches/0060-wifi-3244-wf610d-config-reset-over-sysupgrade.patch
@@ -1,0 +1,37 @@
+From 87af8ae014551b73a51c30a0c30da2a2c666e548 Mon Sep 17 00:00:00 2001
+From: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+Date: Fri, 13 Aug 2021 11:41:25 -0400
+Subject: [PATCH] WIFI-3244-config-reset-over-sysupgrade
+
+This patch will fix configuration restore problem over sysupgrade
+on WF610D
+Even though there is a configuration data in the /dev/mtdblock12, it is getting erased while reading it beacuse of JFFS2 empty bitmask code. So I added a condition to check whether the datatype available is JFFS2 or not, and making sure it is not empty before returning the JFFS2 flag to restore the configuration.
+
+Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+---
+ .../system/fstools/patches/002-wf610d-config-reset  | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ create mode 100644 package/system/fstools/patches/002-wf610d-config-reset
+
+diff --git a/package/system/fstools/patches/002-wf610d-config-reset b/package/system/fstools/patches/002-wf610d-config-reset
+new file mode 100644
+index 0000000000..6e18f8669c
+--- /dev/null
++++ b/package/system/fstools/patches/002-wf610d-config-reset
+@@ -0,0 +1,13 @@
++Index: fstools-2020-05-12-84269037/libfstools/mtd.c
++===================================================================
++--- fstools-2020-05-12-84269037.orig/libfstools/mtd.c
+++++ fstools-2020-05-12-84269037/libfstools/mtd.c
++@@ -226,6 +226,8 @@ static int mtd_volume_identify(struct vo
++ 	if (v->type == UBIVOLUME && deadc0de == 0xffffffff) {
++ 		return FS_JFFS2;
++ 	}
+++	if (v->type == FS_JFFS2 && v->size && deadc0de == 0xffffffff)
+++		return FS_JFFS2;
++ 
++ 	return FS_NONE;
++ }
+-- 
+2.25.1
+


### PR DESCRIPTION
This patch will fix configuration restore problem over sysupgrade
on WF610D
Even though there is a configuration data in the /dev/mtdblock12, it is getting erased while reading it beacuse of JFFS2 empty bitmask code. So I added a condition to check whether the datatype available is JFFS2 or not, and making sure it is not empty before returning the JFFS2 flag to restore the configuration.
Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>