### PR TITLE
Wifi-3490. Opensync workaround for 0 NF reported.

### DIFF
--- a/feeds/wlan-ap/opensync/patches/43-sm_validate_noise_floor.patch
+++ b/feeds/wlan-ap/opensync/patches/43-sm_validate_noise_floor.patch
@@ -1,0 +1,39 @@
+Index: opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/sm/src/sm_survey_report.c
++++ opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+@@ -333,6 +333,7 @@ static
+ void sm_survery_target_validate (
+         radio_entry_t              *radio_cfg,
+         radio_scan_type_t           scan_type,
++        target_survey_record_t     *record_entry,
+         dpp_survey_record_t        *survey_record)
+ {
+     uint32_t chan_sum = survey_record->chan_rx + survey_record->chan_tx;
+@@ -366,6 +367,10 @@ void sm_survery_target_validate (
+         }
+         survey_record->chan_self = survey_record->chan_rx;
+     }
++
++    if (!survey_record->chan_noise) {
++    	survey_record->chan_noise = record_entry->chan_noise;
++    }
+ }
+ 
+ static
+@@ -723,6 +728,7 @@ bool sm_survey_update_list_cb (
+         sm_survery_target_validate (
+                 radio_cfg_ctx,
+                 scan_type,
++		record_entry,
+                 result_entry);
+ 
+         LOGD("Processed %s %s %u survey percent "
+@@ -965,6 +971,7 @@ bool sm_survey_threshold_util_cb (
+     sm_survery_target_validate (
+             radio_cfg_ctx,
+             scan_type,
++            &survey_ctx->threshold_record,
+             &result_entry);
+ 
+     /* update cache with current values */

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
@@ -200,10 +200,12 @@ static int add_chan_noise_offset(unsigned int chan, int chan_noise)
 {
 	int adjusted_chan_noise = 0;
 
-	if (chan > 13) {
-		adjusted_chan_noise = chan_noise + NF_OFFSET_5G;
-	} else {
-		adjusted_chan_noise = chan_noise + NF_OFFSET_24G;
+	if (chan_noise) {
+		if (chan > 13) {
+			adjusted_chan_noise = chan_noise + NF_OFFSET_5G;
+		} else {
+			adjusted_chan_noise = chan_noise + NF_OFFSET_24G;
+		}
 	}
 
 	return adjusted_chan_noise;


### PR DESCRIPTION
Sometimes, the driver reports 0 Noise Floor value which is
not a valid data point. Adding a workaround in Opensync layer
to consider previous recorded NF value when 0 NF is reported.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>