### PR TITLE
WIFI-2844: Added patch from openwrt commits

### DIFF
--- a/patches/0061-fix-radio-down.patch
+++ b/patches/0061-fix-radio-down.patch
@@ -1,0 +1,37 @@
+From c3bc1c1fbc446562e46bdaeb0508fe53b2953f61 Mon Sep 17 00:00:00 2001
+From: Owen Anderson <owenthomasanderson@gmail.com>
+Date: Thu, 19 Aug 2021 14:11:41 -0400
+Subject: [PATCH] Adding changes d515f6b6cde357bf480d32a7387f07ea40e85e52 and
+ 3933e29d1b87c713167cf4730b68e5f18af4f140 from openwrt
+
+---
+ .../kernel/mac80211/files/lib/netifd/wireless/mac80211.sh   | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+index cf3e7ffbb8..a84fb8a7ae 100644
+--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
++++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+@@ -741,6 +741,8 @@ drv_mac80211_setup() {
+ 	}
+ 
+ 	wireless_set_data phy="$phy"
++	[ -z "$(uci -q -P /var/state show wireless._${phy})" ] && uci -q -P /var/state set wireless._${phy}=phy
++
+ 	mac80211_interface_cleanup "$phy"
+ 
+ 	# convert channel to frequency
+@@ -825,6 +827,10 @@ drv_mac80211_teardown() {
+ 	json_select data
+ 	json_get_vars phy
+ 	json_select ..
++	[ -n "$phy" ] || {
++		echo "Bug: PHY is undefined for device '$1'"
++		return 1
++	}
+ 
+ 	mac80211_interface_cleanup "$phy"
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
Added commits from openwrt 21.x to try and address the 5G going down issue.

https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=d515f6b6cde357bf480d32a7387f07ea40e85e52

https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=3933e29d1b87c713167cf4730b68e5f18af4f140

Doesn't seem to fix the issue where the 5G radio goes down when we update the AP's config. But Yong did notice that it helped with the situation where the 5G radio would go down when running traffic for an extended period of time.