### PR TITLE
Wifi-3522. Correcting an earlier commit for scan failures.

### DIFF
--- a/feeds/wlan-ap/opensync/patches/42-sm_dbg_log.patch
+++ b/feeds/wlan-ap/opensync/patches/42-sm_dbg_log.patch
@@ -2,20 +2,22 @@ Index: opensync-2.0.5.0/src/sm/src/sm_scan_schedule.c
 ===================================================================
 --- opensync-2.0.5.0.orig/src/sm/src/sm_scan_schedule.c
 +++ opensync-2.0.5.0/src/sm/src/sm_scan_schedule.c
-@@ -155,6 +155,12 @@ clean:
+@@ -155,6 +155,14 @@ clean:
  
      /* Remove processed context */
      ds_dlist_remove_head(&g_scan_ctx_list);
-+    LOG(DEBUG, "sm_scan_schedule_cb. Scan done. Deleting scan_ctx. %p. %s %s %d\n",
++    if (scan_ctx) {
++	LOG(DEBUG, "sm_scan_schedule_cb. Scan done. Deleting scan_ctx. %p. %s %s %d\n",
 +		scan_ctx,
 +		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
 +		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
 +		scan_ctx->scan_request.chan_list[0]);
++    }
 +
      sm_scan_ctx_free(scan_ctx);
      scan_ctx = NULL;
  
-@@ -163,6 +169,13 @@ clean:
+@@ -163,6 +171,13 @@ clean:
      if (scan_ctx)
      {
          scan_status = true;
@@ -29,7 +31,7 @@ Index: opensync-2.0.5.0/src/sm/src/sm_scan_schedule.c
          rc =
              sm_scan_schedule_process (
                      scan_ctx);
-@@ -303,6 +316,12 @@ bool sm_scan_schedule(
+@@ -303,6 +318,12 @@ bool sm_scan_schedule(
  
      if (NULL == scan_in_progress) {
          /* Trigger the scan and wait for results */


### PR DESCRIPTION
Correcting an earlier commit 4beda3ab6607825639f9c018456a83a8e79f2d72
to consider all the cases where the avl entry needs be deleted when
a scan is either completed or aborted for any reason.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>