### PR TITLE
wifi-3888: Fix for Client Local access enable/disable

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-020-dont-enable-hairpin-in-x_snoop.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-020-dont-enable-hairpin-in-x_snoop.patch
@@ -1,0 +1,22 @@
+Index: hostapd-2020-07-02-58b384f4/src/ap/x_snoop.c
+===================================================================
+--- hostapd-2020-07-02-58b384f4.orig/src/ap/x_snoop.c
++++ hostapd-2020-07-02-58b384f4/src/ap/x_snoop.c
+@@ -31,12 +31,17 @@ int x_snoop_init(struct hostapd_data *ha
+ 		return -1;
+ 	}
+ 
++	/* This code overwrites the setting done by netifd for isolation mode,
++	 * which makes the clients of wlan bridge port talk to each other even
++	 * when isolation is enabled on the wlan interface. Hence disabling it
++	 * to avoid that race between netifd and hostapd.
+ 	if (hostapd_drv_br_port_set_attr(hapd, DRV_BR_PORT_ATTR_HAIRPIN_MODE,
+ 					 1)) {
+ 		wpa_printf(MSG_DEBUG,
+ 			   "x_snoop: Failed to enable hairpin_mode on the bridge port");
+ 		return -1;
+ 	}
++	*/
+ 
+ 	if (hostapd_drv_br_port_set_attr(hapd, DRV_BR_PORT_ATTR_PROXYARP, 1)) {
+ 		wpa_printf(MSG_DEBUG,

--- a/feeds/wifi-trunk/hostapd/patches/909-dont-enable-hairpin-in-x_snoop.patch
+++ b/feeds/wifi-trunk/hostapd/patches/909-dont-enable-hairpin-in-x_snoop.patch
@@ -1,0 +1,22 @@
+Index: hostapd-2020-06-08-5a8b3662/src/ap/x_snoop.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/x_snoop.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/x_snoop.c
+@@ -31,12 +31,17 @@ int x_snoop_init(struct hostapd_data *ha
+ 		return -1;
+ 	}
+ 
++	/* This code overwrites the setting done by netifd for isolation mode,
++	 * which makes the clients of wlan bridge port talk to each other even
++	 * when isolation is enabled on the wlan interface. Hence disabling it
++	 * to avoid that race between netifd and hostapd.
+ 	if (hostapd_drv_br_port_set_attr(hapd, DRV_BR_PORT_ATTR_HAIRPIN_MODE,
+ 					 1)) {
+ 		wpa_printf(MSG_DEBUG,
+ 			   "x_snoop: Failed to enable hairpin_mode on the bridge port");
+ 		return -1;
+ 	}
++	*/
+ 
+ 	if (hostapd_drv_br_port_set_attr(hapd, DRV_BR_PORT_ATTR_PROXYARP, 1)) {
+ 		wpa_printf(MSG_DEBUG,


### PR DESCRIPTION
Dont enable hairpin mode from hostapd (x_snoop) as it overwrites
the set value by netifd to enable/disable client isolation.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>