### PR TITLE
WIFI-3905-WIFI6-AP does not forward dhcp broadcast offer

### DIFF
--- a/patches/0062-Allow-DHCP-Broadcast-packets.patch
+++ b/patches/0062-Allow-DHCP-Broadcast-packets.patch
@@ -1,0 +1,86 @@
+From c914392be2dbae30ceb139ed871e57c776c66f64 Mon Sep 17 00:00:00 2001
+From: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+Date: Thu, 9 Sep 2021 17:06:08 -0400
+Subject: [PATCH] WIFI-3905-AP does not forward dhcp broadcast offer
+
+This patch will add fix to allow DHCP broadcast packets, so that AP can
+forward DHCP broadcast offer to clients
+
+Cause:
+In the bridge source code, there is a mechanism to drop all the broadcast packets if the proxy arp is enabled, because of this dhcp clients which set broadcast flag to 1 while connecting toAP's interfaces are not able get an ip address hence they are not connecting
+Solution:
+Added the code to the bridge source code so that before dropping broadcast packets it first checks, whether it is dhcp broadcast packet or not. So that it won't drop dhcp braodcast packets.Hence DORA process will succeed and clients which sets broadcast flag to 1 gets an ip address even though the proxy arp is enabled.
+
+Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>
+---
+ .../113-Allow-DHCP-broadcast-packet.patch     | 58 +++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+ create mode 100644 target/linux/ipq807x/patches/113-Allow-DHCP-broadcast-packet.patch
+
+diff --git a/target/linux/ipq807x/patches/113-Allow-DHCP-broadcast-packet.patch b/target/linux/ipq807x/patches/113-Allow-DHCP-broadcast-packet.patch
+new file mode 100644
+index 0000000000..d7ffbe9be2
+--- /dev/null
++++ b/target/linux/ipq807x/patches/113-Allow-DHCP-broadcast-packet.patch
+@@ -0,0 +1,58 @@
++Index: linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/net/bridge/br_forward.c
++===================================================================
++--- linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce.orig/net/bridge/br_forward.c
+++++ linux-4.4.60-qsdk-10fd7d14853b7020b804acae690c8acec5d954ce/net/bridge/br_forward.c
++@@ -20,6 +20,39 @@
++ #include <linux/if_vlan.h>
++ #include <linux/netfilter_bridge.h>
++ #include "br_private.h"
+++#include <linux/ip.h>
+++#include <linux/udp.h>
+++
+++struct bootp_pkt {		/* BOOTP packet format */
+++	struct iphdr iph;	/* IP header */
+++	struct udphdr udph;	/* UDP header */
+++	u8 op;			/* 1=request, 2=reply */
+++	u8 htype;		/* HW address type */
+++	u8 hlen;		/* HW address length */
+++	u8 hops;		/* Used only by gateways */
+++	__be32 xid;		/* Transaction ID */
+++	__be16 secs;		/* Seconds since we started */
+++	__be16 flags;		/* Just what it says */
+++	__be32 client_ip;	/* Client's IP address if known */
+++	__be32 your_ip;		/* Assigned IP address */
+++	__be32 server_ip;	/* (Next, e.g. NFS) Server's IP address */
+++	__be32 relay_ip;	/* IP address of BOOTP relay */
+++	u8 hw_addr[16];		/* Client's HW address */
+++	u8 serv_name[64];	/* Server host name */
+++	u8 boot_file[128];	/* Name of boot file */
+++	u8 exten[312];		/* DHCP options / BOOTP vendor extensions */
+++};
+++
+++/* Before dropping broadcast packets check whether the packets are
+++ * dhcp packet or not */
+++static bool dhcp_packet_check(struct sk_buff *skb)
+++{
+++	struct bootp_pkt *b;
+++	b = (struct bootp_pkt *)skb_network_header(skb);
+++	if (b->udph.source != htons(67) || b->udph.dest != htons(68))
+++		return false;
+++	return true;
+++}
++ 
++ static int deliver_clone(const struct net_bridge_port *prev,
++ 			 struct sk_buff *skb,
++@@ -241,8 +274,12 @@ static void br_flood(struct net_bridge *
++ 		/* Do not flood to ports that enable proxy ARP */
++ 		if (p->flags & BR_PROXYARP)
++ 			continue;
+++		/** Before dropping broadcast packets, check whether the packets are dhcp packet
+++		 * or not So that dhcp packets won't drop, hence DORA process will succeed and
+++		 * dhcp clients which set broadcast flag to 1 get an ip address even though
+++		 * proxy arp is enabled */
++ 		if ((p->flags & BR_PROXYARP_WIFI) &&
++-		    BR_INPUT_SKB_CB(skb)->proxyarp_replied)
+++		    BR_INPUT_SKB_CB(skb)->proxyarp_replied && !dhcp_packet_check(skb))
++ 			continue;
++ 
++ 		prev = maybe_deliver(prev, p, skb, __packet_hook);
+-- 
+2.25.1
+


### PR DESCRIPTION
This patch will add fix to allow DHCP broadcast packets,
so that WIFI6 AP can forward DHCP broadcast offer to clients
Cause:
In the bridge source code, there is a mechanism to drop all the broadcast packets if the proxy arp is enabled, because of this dhcp clients which set broadcast flag to 1 while connecting toAP's interfaces are not able get an ip address hence they are not connecting
Solution:
Added the code to the bridge source code so that before dropping broadcast packets it first checks, whether it is dhcp broadcast packet or not. So that it won't drop dhcp braodcast packets.Hence DORA process will succeed and clients which sets broadcast flag to 1 gets an ip address even though the proxy arp is enabled.

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>