### PR TITLE
Add provision to set the AP LAN Ports to Bridge/NAT

### DIFF
--- a/feeds/wlan-ap/opensync/files/bin/check_wan_link.sh
+++ b/feeds/wlan-ap/opensync/files/bin/check_wan_link.sh
@@ -1,6 +1,21 @@
 #!/bin/sh
+. /usr/share/libubox/jshn.sh
 
-if="$(uci get network.wan.ifname)"
+json_init
+json_load "$(cat /etc/board.json)"
+json_select network
+	json_select "wan"
+		json_get_vars ifname
+	json_select ..
+json_select ..
+
+[ -n "$ifname" ] || {
+	ifname=$(uci get network.wan.ifname)
+	ifname=${ifname%% *}
+}
+
+
+if="$ifname"
 [ "$(cat /sys/class/net/"${if}"/carrier)" = 0 ] && {
 	return 0
 }

--- a/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/30-bridge
+++ b/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/30-bridge
@@ -1,6 +1,20 @@
 #!/bin/sh
 
+. /usr/share/libubox/jshn.sh
 [ "$ACTION" = "add" ] || exit 0
+
+json_init
+json_load "$(cat /etc/board.json)"
+json_select network
+	json_select "wan"
+		json_get_vars ifname
+	json_select ..
+json_select ..
+
+[ -n "$ifname" ] || {
+	ifname=$(uci get network.wan.ifname)
+	ifname=${ifname%% *}
+}
 
 net=$(uci get wireless.${DEVICENAME}.network)
 vid=$(uci get wireless.${DEVICENAME}.vid)
@@ -9,6 +23,6 @@ vid=$(uci get wireless.${DEVICENAME}.vid)
 
 bridge vlan add vid $vid dev br-lan self
 bridge vlan add vid $vid dev br-wan self
-bridge vlan add vid $vid dev $(uci get network.wan.ifname)
+bridge vlan add vid $vid dev $ifname
 bridge vlan add pvid $vid vid $vid dev ${DEVICENAME} untagged
 exit 0

--- a/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/60-dynamic-vlan
+++ b/feeds/wlan-ap/opensync/files/etc/hotplug.d/net/60-dynamic-vlan
@@ -1,4 +1,19 @@
+#!/bin/sh
+. /usr/share/libubox/jshn.sh
 [ "$ACTION" = "add" ] || exit 0
+
+json_init
+json_load "$(cat /etc/board.json)"
+json_select network
+	json_select "wan"
+		json_get_vars ifname
+	json_select ..
+json_select ..
+
+[ -n "$ifname" ] || {
+	ifname=$(uci get network.wan.ifname)
+	ifname=${ifname%% *}
+}
 
 dvid=`echo $DEVICENAME | awk -F "." '{ printf $2 }'`
 [ -z "$dvid" -o "$dvid" = 0 -o "$dvid" = 1 ] && exit 0
@@ -13,7 +28,7 @@ brctl delif br-wan.$dvid $DEVICENAME
 brctl addif br-wan $DEVICENAME
 
 bridge vlan add vid $dvid dev br-wan self
-bridge vlan add vid $dvid dev $(uci get network.wan.ifname)
+bridge vlan add vid $dvid dev $ifname
 bridge vlan add pvid $dvid vid $dvid dev $DEVICENAME untagged
 bridge vlan add vid $dvid dev br-lan self
 

--- a/feeds/wlan-ap/opensync/patches/44-wifi_inet_eth_ports_schema.patch
+++ b/feeds/wlan-ap/opensync/patches/44-wifi_inet_eth_ports_schema.patch
@@ -1,0 +1,45 @@
+Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
+===================================================================
+--- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
++++ opensync-2.0.5.0/interfaces/opensync.ovsschema
+@@ -900,6 +900,17 @@
+             "min": 0,
+             "max": 64
+           }
++        },
++        "eth_ports": {
++          "type": {
++            "key": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 32
++            },
++            "min": 0,
++            "max": 1
++          }
+         }
+       },
+       "isRoot": true,
+@@ -1170,6 +1181,22 @@
+             "min": 0,
+             "max": 64
+           }
++        },
++        "eth_ports": {
++          "type": {
++            "key": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 32
++            },
++            "value": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 64
++            },
++            "min": 0,
++            "max": 32
++          }
+         }
+       },
+       "isRoot": true,

--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
@@ -1,0 +1,40 @@
+#!/bin/sh
+. /usr/share/libubox/jshn.sh
+[ "$ACTION" = ifup -o "$ACTION" = ifupdate  -o "$ACTION" = ifdown ] || exit 0
+
+json_init
+json_load "$(cat /etc/board.json)"
+json_select network
+	json_select "wan"
+		json_get_vars ifname
+	json_select ..
+json_select ..
+
+[ -n "$ifname" ] || {
+	ifname=$(uci get network.wan.ifname)
+	ifname=${ifname%% *}
+}
+
+if [ "$ACTION" = ifup -o "$ACTION" = ifupdate ]; then
+	vid=$(uci get network.${INTERFACE}.vid)
+	net=$(uci get network.${INTERFACE}.ifname)
+
+	[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
+
+	bridge vlan add vid $vid dev br-lan self
+	bridge vlan add vid $vid dev br-wan self
+	bridge vlan add vid $vid dev $ifname
+	bridge vlan add pvid $vid vid $vid dev $net untagged
+	exit 0
+else
+	if [ "$ACTION" = ifdown ]; then
+		vid=`echo $INTERFACE | awk -F "_" '{ print $2 }'`
+		net=`echo $INTERFACE | awk -F "_" '{ print $1 }'`
+		[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
+
+		bridge vlan del vid $vid dev $ifname
+		bridge vlan del pvid $vid vid $vid dev $net untagged
+		bridge vlan add pvid 1 vid 1 dev $net untagged
+		exit 0
+	fi
+fi

--- a/patches/0063-ubus-notify-when-ethernet-ports-change-state.patch
+++ b/patches/0063-ubus-notify-when-ethernet-ports-change-state.patch
@@ -1,0 +1,85 @@
+From b14c0b96644cf86b36b0e60da800dd11733b26a9 Mon Sep 17 00:00:00 2001
+From: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+Date: Tue, 14 Sep 2021 10:23:49 -0400
+Subject: [PATCH] ubus notify when ethernet ports change state
+
+Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>
+---
+ .../0106-add-ubus-notify-eth-state.patch      | 65 +++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/0106-add-ubus-notify-eth-state.patch
+
+diff --git a/package/network/config/netifd/patches/0106-add-ubus-notify-eth-state.patch b/package/network/config/netifd/patches/0106-add-ubus-notify-eth-state.patch
+new file mode 100644
+index 0000000000..3c8eaa530d
+--- /dev/null
++++ b/package/network/config/netifd/patches/0106-add-ubus-notify-eth-state.patch
+@@ -0,0 +1,65 @@
++Index: netifd-2019-08-05-5e02f944/device.c
++===================================================================
++--- netifd-2019-08-05-5e02f944.orig/device.c
+++++ netifd-2019-08-05-5e02f944/device.c
++@@ -29,6 +29,7 @@
++ #include "netifd.h"
++ #include "system.h"
++ #include "config.h"
+++#include "ubus.h"
++ 
++ static struct list_head devtypes = LIST_HEAD_INIT(devtypes);
++ static struct avl_tree devices;
++@@ -638,6 +639,7 @@ void device_set_present(struct device *d
++ 
++ void device_set_link(struct device *dev, bool state)
++ {
+++	ubus_link_state_notify(dev, state);
++ 	if (dev->link_active == state)
++ 		return;
++ 
++Index: netifd-2019-08-05-5e02f944/ubus.c
++===================================================================
++--- netifd-2019-08-05-5e02f944.orig/ubus.c
+++++ netifd-2019-08-05-5e02f944/ubus.c
++@@ -817,6 +817,29 @@ netifd_dump_status(struct interface *ifa
++ 		netifd_add_interface_errors(&b, iface);
++ }
++ 
+++void ubus_link_state_notify(struct device *dev, bool state)
+++{
+++	struct interface *iface = NULL; 
+++	/* proceed to notify if eth link state change and bridge change */
+++	if((strncmp(dev->ifname, "eth", 3) && (dev->link_active == state)) &&
+++	   strncmp(dev->ifname, "br-wan", 6) &&
+++	   strncmp(dev->ifname, "br-lan", 6))
+++		return;
+++	netifd_log_message(L_NOTICE, "%s:%s\n", __func__, dev->ifname);
+++
+++	vlist_for_each_element(&interfaces, iface, node) {
+++		if( !strncmp(iface->name, "wan", 3) ||
+++		    !strncmp(iface->name, "lan", 3) ||
+++		    !strncmp(iface->name, "eth", 3)) {
+++			blob_buf_init(&b, 0);
+++			blobmsg_add_string(&b, "interface", iface->name);
+++			netifd_dump_status(iface);
+++			ubus_notify(ubus_ctx, &iface->ubus, "interface.update",
+++				    b.head, -1);
+++		}
+++	}
+++}
+++
++ static int
++ netifd_handle_status(struct ubus_context *ctx, struct ubus_object *obj,
++ 		     struct ubus_request_data *req, const char *method,
++Index: netifd-2019-08-05-5e02f944/ubus.h
++===================================================================
++--- netifd-2019-08-05-5e02f944.orig/ubus.h
+++++ netifd-2019-08-05-5e02f944/ubus.h
++@@ -22,5 +22,6 @@ void netifd_ubus_add_interface(struct in
++ void netifd_ubus_remove_interface(struct interface *iface);
++ void netifd_ubus_interface_event(struct interface *iface, bool up);
++ void netifd_ubus_interface_notify(struct interface *iface, bool up);
+++void ubus_link_state_notify(struct device *dev, bool state);
++ 
++ #endif
+-- 
+2.25.1
+


### PR DESCRIPTION
1. Add provision to tag with vlan when set to Bridge mode (br-wan).
2. Add provision to set the local IP address in NAT (br-lan)
3. Display the Ethernet port status(up/down) and negotiated rate.
4. Add provision to set lan eth port to bridge/nat.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>