### PR TITLE
WIFI-2410: Filter out low signal SSID from SM neighbour report

### DIFF
--- a/feeds/wlan-ap/opensync/patches/44-sm_set_min_sig_neighbour_report.patch
+++ b/feeds/wlan-ap/opensync/patches/44-sm_set_min_sig_neighbour_report.patch
@@ -1,0 +1,33 @@
+--- a/src/sm/src/sm_neighbor_report.c
++++ b/src/sm/src/sm_neighbor_report.c
+@@ -43,6 +43,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBI
+ 
+ #define MODULE_ID LOG_MODULE_ID_MAIN
+ 
++#define MIN_RSSI_2G -83
++#define MIN_RSSI_5G -85
++
+ typedef struct
+ {
+     bool                            initialized;
+@@ -657,8 +660,18 @@ void sm_neighbor_stats_results(
+             }
+         }
+ 
+-        /* Filter neighbor with 0 SNR */
+-        if (scan_entry->sig == 0) {
++        /* Finding what minimum SNR level we should use */
++        int min_sig;
++        if (scan_entry->type == RADIO_TYPE_2G) {
++            // 2.4G
++            min_sig = MIN_RSSI_2G;
++        } else {
++            // 5G, 5GL, 5GU
++            min_sig = MIN_RSSI_5G;
++        }
++
++        /* Filter neighbor with 0 or too low SNR */
++        if ((scan_entry->sig == 0) || (scan_entry->sig < min_sig)) {
+             LOG(TRACE,
+                 "Remove %s %s neighbor due to signal {bssid='%s' ssid='%s' rssi=%d chan=%d}\n",
+                 radio_get_name_from_cfg(radio_cfg_ctx),


### PR DESCRIPTION
Added a check to filter out SSID's with a low signal from out neighbour reports. Removes neighbours that have a RSSI value below the minimum value for that radio type. 

Signed-off-by: Owen Anderson <owenthomasanderson@gmail.com>