### PR TITLE
WIFI-4229-display-ssid-name-on-CP-splash-page

### DIFF
--- a/feeds/wlan-ap/opennds/patches/02-display-ssid-name-on-splash-page-instead-wlan-name.patch
+++ b/feeds/wlan-ap/opennds/patches/02-display-ssid-name-on-splash-page-instead-wlan-name.patch
@@ -1,0 +1,14 @@
+Index: openNDS-5.1.0/forward_authentication_service/libs/get_client_interface.sh
+===================================================================
+--- openNDS-5.1.0.orig/forward_authentication_service/libs/get_client_interface.sh
++++ openNDS-5.1.0/forward_authentication_service/libs/get_client_interface.sh
+@@ -68,7 +68,8 @@ for interface in $interface_list; do
+ 
+ 	if [ ! -z "$macscan" ]; then
+ 		clientmeshif=""
+-		clientlocalif=$interface
++		ssid_name=$(iw dev $interface info | awk -F 'ssid ' 'NF>1{printf $2" "}')
++		clientlocalif=$ssid_name
+ 		break
+ 	else
+ 		clientlocalip=$(ip -4 neigh | awk -F ' ' 'match($s,"'"$mac"' ")>0 {printf $1}')


### PR DESCRIPTION
This patch will add support to display ssid name on the captive portal
splash page

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>