### PR TITLE
WIFI-4209: Fix Maverick SSID

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -724,6 +724,10 @@ void radio_maverick(void *arg)
 		radio_ops->op_vconf(&conf, rconf.if_name);
 	}
 	uci_unload(uci, wireless);
+	uci_commit_all(uci);
+	sync();
+	LOGI("====Calling reload_config for Maverick ssid====");
+	system("ubus call uci reload_config");
 }
 
 


### PR DESCRIPTION
Apply maverick ssid config after timeout.

Signed-off-by: Arif Alam <arif.alam@netexperience.com>