### PR TITLE
wifi-4421: Fix client disconn when in DFS channel

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-021-chan-switch-check-dfs-channel-availability.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-021-chan-switch-check-dfs-channel-availability.patch
@@ -1,0 +1,29 @@
+Index: hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+===================================================================
+--- hostapd-2020-07-02-58b384f4.orig/src/ap/ubus.c
++++ hostapd-2020-07-02-58b384f4/src/ap/ubus.c
+@@ -1016,12 +1016,18 @@ hostapd_switch_chan(struct ubus_context
+ 		css.freq_params.center_freq1,
+ 		css.freq_params.center_freq2);
+ 
+-	if ((chan->flag & HOSTAPD_CHAN_RADAR) &&
+-	    ((chan->flag & HOSTAPD_CHAN_DFS_MASK)
+-	     != HOSTAPD_CHAN_DFS_AVAILABLE)) {
+-		wpa_printf(MSG_INFO, "%s: DFS chan need CAC", __func__);
+-		hostapd_switch_chan_dfs(iface, &css);
+-		return UBUS_STATUS_OK;
++	if (chan->flag & HOSTAPD_CHAN_RADAR) {
++		if ((chan->flag & HOSTAPD_CHAN_DFS_MASK) ==
++		     HOSTAPD_CHAN_DFS_UNAVAILABLE) {
++			wpa_printf(MSG_WARNING, "DFS chan %d not Available",
++				   chan->chan);
++			return UBUS_STATUS_NOT_SUPPORTED;
++		} else if ((chan->flag & HOSTAPD_CHAN_DFS_MASK)
++			!= HOSTAPD_CHAN_DFS_AVAILABLE) {
++			wpa_printf(MSG_DEBUG, "DFS chan do CAC");
++			hostapd_switch_chan_dfs(iface, &css);
++			return UBUS_STATUS_OK;
++		}
+ 	}
+ 
+ 	for (i = 0; i < hapd->iface->num_bss; i++) {

--- a/feeds/wifi-trunk/hostapd/patches/910-chan-switch-check-dfs-channel-availability.patch
+++ b/feeds/wifi-trunk/hostapd/patches/910-chan-switch-check-dfs-channel-availability.patch
@@ -1,0 +1,29 @@
+Index: hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/ubus.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/ubus.c
+@@ -1015,12 +1015,18 @@ hostapd_switch_chan(struct ubus_context
+ 		css.freq_params.center_freq1,
+ 		css.freq_params.center_freq2);
+ 
+-	if ((chan->flag & HOSTAPD_CHAN_RADAR) &&
+-	    ((chan->flag & HOSTAPD_CHAN_DFS_MASK)
+-	     != HOSTAPD_CHAN_DFS_AVAILABLE)) {
+-		wpa_printf(MSG_INFO, "%s: DFS chan need CAC", __func__);
+-		hostapd_switch_chan_dfs(iface, &css);
+-		return UBUS_STATUS_OK;
++	if (chan->flag & HOSTAPD_CHAN_RADAR) {
++		if ((chan->flag & HOSTAPD_CHAN_DFS_MASK) ==
++		     HOSTAPD_CHAN_DFS_UNAVAILABLE) {
++			wpa_printf(MSG_WARNING, "DFS chan %d not Available",
++				   chan->chan);
++			return UBUS_STATUS_NOT_SUPPORTED;
++		} else if ((chan->flag & HOSTAPD_CHAN_DFS_MASK)
++			!= HOSTAPD_CHAN_DFS_AVAILABLE) {
++			wpa_printf(MSG_DEBUG, "DFS chan do CAC");
++			hostapd_switch_chan_dfs(iface, &css);
++			return UBUS_STATUS_OK;
++		}
+ 	}
+ 
+ 	for (i = 0; i < hapd->iface->num_bss; i++) {

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/fixup.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/fixup.h
@@ -21,10 +21,13 @@ struct radio_fixup {
         struct avl_node avl;
         char rname[IF_NAMESIZE];
         char hw_mode[8];
+        int chan;
 };
 
 struct radio_fixup * radio_fixup_find(const char *name);
 void radio_fixup_del(char *ifname);
 void radio_fixup_set_hw_mode(const char *ifname, char *hw_mode);
 char *radio_fixup_get_hw_mode(const char *ifname);
+int radio_fixup_get_primary_chan(const char *ifname);
+void radio_fixup_set_primary_chan(const char *ifname, int chan);
 #endif

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/rrm_config.h
@@ -40,6 +40,6 @@ void callback_Wifi_RRM_Config(ovsdb_update_monitor_t *mon,
 		struct schema_Wifi_RRM_Config *old, struct schema_Wifi_RRM_Config *conf);
 
 
-void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf);
+int rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf);
 #endif /* RRM_CONFIG_H_INCLUDED */
 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/fixup.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/fixup.c
@@ -138,3 +138,26 @@ char * radio_fixup_get_hw_mode(const char *ifname)
 	else
 		return NULL;
 }
+
+/* primary channel */
+void radio_fixup_set_primary_chan(const char *ifname, int chan)
+{
+	struct radio_fixup * radio = NULL;
+
+	radio = radio_fixup_find(ifname);
+
+	if (radio)
+		radio->chan = chan;
+}
+
+int radio_fixup_get_primary_chan(const char *ifname)
+{
+	struct radio_fixup * radio = NULL;
+
+	radio = radio_fixup_find(ifname);
+
+	if (radio)
+		return radio->chan;
+	else
+		return -1;
+}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/rrm_config.c
@@ -319,7 +319,7 @@ void get_channel_bandwidth(const char* htmode, int *channel_bandwidth)
 		*channel_bandwidth=80;
 }
 
-void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
+int rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
 {
 	int channel_bandwidth;
 	int sec_chan_offset=0;
@@ -339,7 +339,7 @@ void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
 	hw_mode = radio_fixup_get_hw_mode(rconf->if_name);
 	if (hw_mode == NULL) {
 		LOGE("Failed to get hw mode");
-		return;
+		return -1;
 	}
 
 	m = mode_map_get_uci(rconf->freq_band, mode, hw_mode);
@@ -352,7 +352,7 @@ void rrm_radio_rebalance_channel(const struct schema_Wifi_Radio_Config *rconf)
 	get_channel_bandwidth(mode, &channel_bandwidth);
 
 
-	ubus_set_channel_switch(wlanif, freq, hw_mode,
+	return ubus_set_channel_switch(wlanif, freq, hw_mode,
 				channel_bandwidth, sec_chan_offset, 1);
 
 }


### PR DESCRIPTION
On detecting Radar on the DFS channel the radio switches
the channel to backup channel. However, the opensync tries
to set it back to the configured channel every 30 seconds, which
which would fail since the channel is in a radar NOP period, this
leads to dropping of clients.
Fix by adding a check for the configured channel's availability
before trying to change to that channel.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>