### PR TITLE
Wifi-4469. Set registered flag before config QDSS

### DIFF
--- a/feeds/wifi-ax/mac80211/patches/qca/226-ath11k-set-registered-flag-before-qdss-config.patch
+++ b/feeds/wifi-ax/mac80211/patches/qca/226-ath11k-set-registered-flag-before-qdss-config.patch
@@ -1,0 +1,11 @@
+diff -Naur a/drivers/net/wireless/ath/ath11k/core.c b/drivers/net/wireless/ath/ath11k/core.c
+--- a/drivers/net/wireless/ath/ath11k/core.c	2021-09-30 09:44:22.861587609 -0400
++++ b/drivers/net/wireless/ath/ath11k/core.c	2021-09-30 09:45:18.361000898 -0400
+@@ -847,6 +847,7 @@
+ #endif
+ 	ath11k_hif_irq_enable(ab);
+ 
++	set_bit(ATH11K_FLAG_REGISTERED, &ab->dev_flags);
+ 	ath11k_config_qdss(ab);
+ 
+ 	if (ab->hw_params.ce_fwlog_enable) {


### PR DESCRIPTION
The QDSS config takes long time to complete and puts the kernel
thread to freeze for a while. This lets the kernel run other
threads which leads to country code command execution without
the ATH11K_FLAG_REGISTERED flag set, which inturn leads to
failure of Country code configuration.

Updating the ATH11K_FLAG_REGISTERED flag before calling QDSS
config seems to help driver configure the Country code successfully.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>