### PR TITLE
wifi-4651: Fix NM crash in single ethernet port APs

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
@@ -98,12 +98,12 @@ static void init_eth_ports_config(struct schema_Wifi_Inet_Config *config)
 	char *lan = NULL;
 
 	wan = get_eth_map_info("wan");
-	if (!strncmp(config->if_name, "wan", 3)) {
+	if (wan != NULL && !strncmp(config->if_name, "wan", 3)) {
 		SCHEMA_SET_STR(config->eth_ports, wan);
 	}
 
 	lan = get_eth_map_info("lan");
-	if (!strncmp(config->if_name, "lan", 3)) {
+	if (lan != NULL && !strncmp(config->if_name, "lan", 3)) {
 		SCHEMA_SET_STR(config->eth_ports, lan);
 	}
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
@@ -284,14 +284,17 @@ static void update_eth_ports_states(struct schema_Wifi_Inet_State *state)
 	char brname[IFNAMSIZ] = {'\0'};
 
 	wan = get_eth_map_info("wan");
-	update_eth_state(wan, &wanport);
+	if (wan != NULL)
+		update_eth_state(wan, &wanport);
 
 	lan = get_eth_map_info("lan");
-	eth = strtok (lan," ");
-	for (i = 0; i < MAX_ETH_PORTS && eth != NULL; i++)
-	{
-		update_eth_state(eth, &lanport[i]);
-		eth = strtok (NULL, " ");
+	if (lan != NULL) {
+		eth = strtok (lan," ");
+		for (i = 0; i < MAX_ETH_PORTS && eth != NULL; i++)
+		{
+			update_eth_state(eth, &lanport[i]);
+			eth = strtok (NULL, " ");
+		}
 	}
 
 	if (!strncmp(state->if_name, "wan", 3))


### PR DESCRIPTION
Fix by adding LAN port check in case of single ethernet
port APs where LAN port is not available.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>