### PR TITLE
Add provision to set an ethernet lan port as vlan trunk

### DIFF
--- a/feeds/wlan-ap/opensync/patches/45-wifi_inet_eth_ports_vlan_trunk_schema.patch
+++ b/feeds/wlan-ap/opensync/patches/45-wifi_inet_eth_ports_vlan_trunk_schema.patch
@@ -1,0 +1,93 @@
+Index: opensync-2.0.5.0/interfaces/opensync.ovsschema
+===================================================================
+--- opensync-2.0.5.0.orig/interfaces/opensync.ovsschema
++++ opensync-2.0.5.0/interfaces/opensync.ovsschema
+@@ -307,7 +307,8 @@
+                   "pppoe",
+                   "softwds",
+                   "tap",
+-                  "mesh"
++                  "mesh",
++                  "vlan_trunk"
+                 ]
+               ]
+             }
+@@ -585,7 +586,8 @@
+                   "pppoe",
+                   "softwds",
+                   "tap",
+-                  "mesh"
++                  "mesh",
++                  "vlan_trunk"
+                 ]
+               ]
+             }
+@@ -911,6 +913,22 @@
+             "min": 0,
+             "max": 1
+           }
++        },
++        "vlan_trunk": {
++          "type": {
++            "key": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 32
++            },
++            "value": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 64
++            },
++            "min": 0,
++            "max": 32
++          }
+         }
+       },
+       "isRoot": true,
+@@ -951,7 +969,8 @@
+                   "pppoe",
+                   "softwds",
+                   "tap",
+-                  "mesh"
++                  "mesh",
++                  "vlan_trunk"
+                 ]
+               ]
+             }
+@@ -1186,6 +1205,22 @@
+           "type": {
+             "key": {
+                 "type": "string",
++                "minLength": 1,
++                "maxLength": 32
++            },
++            "value": {
++                "type": "string",
++                "minLength": 1,
++                "maxLength": 64
++            },
++            "min": 0,
++            "max": 32
++          }
++        },
++        "vlan_trunk": {
++          "type": {
++            "key": {
++                "type": "string",
+                 "minLength": 1,
+                 "maxLength": 32
+             },
+Index: opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/schema/inc/schema_consts.h
++++ opensync-2.0.5.0/src/lib/schema/inc/schema_consts.h
+@@ -187,4 +187,8 @@ typedef enum {
+ /* Max clients per radio */
+ #define SCHEMA_CONSTS_MAX_CLIENTS	"max_clients"
+ 
++/* VLAN Trunk options */
++#define SCHEMA_CONSTS_ALLOWED_VLANS 	"allowed_vlans"
++#define SCHEMA_CONSTS_PVID 		"pvid"
++
+ #endif /* SCHEMA_CONSTS_H_INCLUDED */

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/eth_vlan.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/inc/eth_vlan.h
@@ -1,0 +1,28 @@
+#define MAX_ETH_PORTS 5
+#define TMP_VLAN_JSON "/tmp/vlans.json"
+
+#define SCHEMA_VLAN_TRUNK_SZ            256
+#define SCHEMA_VLAN_TRUNK_MAX          2
+
+extern const char vlan_trunk_table[SCHEMA_VLAN_TRUNK_MAX][SCHEMA_VLAN_TRUNK_SZ];
+
+struct eth_port_vlans {
+	int vindex;
+	int allowed_vlans[64];
+	int pvid;
+};
+
+struct eth_port_state {
+	char ifname[8];
+	char state[8];
+	char speed[8];
+	char duplex[16];
+	char bridge[8];
+	struct eth_port_vlans vlans;
+};
+
+extern struct eth_port_state wanport;
+extern struct eth_port_state lanport[];
+
+int vlan_state_json_parse(void);
+struct eth_port_state *get_eth_port(const char *ifname);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/bridge_vlan_parse.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/bridge_vlan_parse.c
@@ -1,0 +1,167 @@
+#include "log.h"
+#include <json-c/json.h>
+#include "schema_consts.h"
+#include "eth_vlan.h"
+
+static struct eth_port_state *ethport[MAX_ETH_PORTS+1];
+static int eth_index;
+
+bool is_dup_vlan(struct eth_port_state *eps, int vlan_id)
+{
+	int i = 0;
+	for (i=0; i < eps->vlans.vindex; i++)
+		if (eps->vlans.allowed_vlans[i] == vlan_id)
+			return true;
+	return false;
+}
+
+struct eth_port_state *get_eth_port(const char *ifname)
+{
+	int i = 0;
+	if (strcmp(wanport.ifname, ifname) == 0) {
+		return &wanport;
+	}
+	for (i = 0; i < MAX_ETH_PORTS && lanport[i].ifname != NULL; i++) {
+		if (strcmp(lanport[i].ifname, ifname) == 0) {
+			return &lanport[i];
+		}
+	}
+	return NULL;
+}
+
+int parse_each_array_element(json_object *arr_json,
+			      void (*parse_func)(json_object *)) {
+	int len = 0, i = 0;
+
+	len = json_object_array_length(arr_json);
+	if (len == 0)
+		return -1;
+
+	for (i = 0; i < len; i++) {
+		json_object *tmp;
+		tmp = json_object_array_get_idx(arr_json, i);
+		if (tmp)
+			parse_func(tmp);
+		else {
+			LOGI("%s:Error: Failed to parse info",
+			     __func__);
+			continue;
+		}
+	}
+	return 0;
+}
+
+/* ["PVID","Egress Untagged"] */
+void flags_parse_element(json_object *flag_json)
+{
+	const char *flags;
+
+	flags = json_object_get_string(flag_json);
+	if (!strncmp(flags, "PVID", 4)) {
+
+	ethport[eth_index-1]->vlans.pvid = ethport[eth_index-1]->vlans.allowed_vlans[ethport[eth_index-1]->vlans.vindex];
+	}
+}
+
+/*[{"vlan":1,"flags":["PVID","Egress Untagged"]}] */
+void vlans_parse_element(json_object *vlans_json) 
+{
+	int i = 0;
+	int exists = 0;
+	const char *vlan_id = 0;
+	json_object *vlan_json;
+	json_object *flags_json;
+
+	exists = json_object_object_get_ex(vlans_json, "vlan", &vlan_json);
+	if (!exists) {
+		LOGI("%s: ifname doesnt exist", __func__);
+		json_object_put(vlan_json);
+		return;
+	}
+
+	vlan_id = json_object_get_string(vlan_json);
+	for (i=0; i < eth_index; i++) {
+		if(!is_dup_vlan(ethport[i], atoi(vlan_id)))
+			ethport[i]->vlans.allowed_vlans[ethport[i]->vlans.vindex] = atoi(vlan_id);
+	}
+
+
+	exists = json_object_object_get_ex(vlans_json, "flags", &flags_json);
+	if (!exists) {
+		LOGD("%s:flags doesnt exist", __func__);
+		for (i=0; i < eth_index; i++)
+			ethport[i]->vlans.vindex++;
+		json_object_put(flags_json);
+		return;
+	}
+
+	parse_each_array_element(flags_json, flags_parse_element);
+
+	for (i=0; i < eth_index; i++)
+		ethport[i]->vlans.vindex++;
+
+	json_object_put(vlan_json);
+	json_object_put(flags_json);
+}
+
+void bridge_vlan_parse_element(json_object *if_obj) 
+{
+	const char *ifname;
+	struct json_object *ifname_json;
+	struct json_object *vlans_json;
+	bool exists;
+
+	exists = json_object_object_get_ex(if_obj, "ifname", &ifname_json);
+	if (!exists) {
+		LOGI("%s:ifname doesnt exist", __func__);
+		json_object_put(ifname_json);
+		return;
+	}
+
+	ifname = json_object_get_string(ifname_json);
+
+	ethport[eth_index] = get_eth_port(ifname);
+	if (!ethport[eth_index]) {
+		LOGI("%s:ifname=%s not there", __func__, ifname);
+		return;
+	}
+
+	eth_index++;
+	exists = json_object_object_get_ex(if_obj, "vlans", &vlans_json);
+	if (!exists) {
+		LOGD("%s: vlans doesnt exist", __func__);
+		json_object_put(vlans_json);
+		return;
+	}
+
+	if (parse_each_array_element(vlans_json, vlans_parse_element) < 0) {
+		LOGD("%s: vlans len doesnt exist", __func__);
+		json_object_put(vlans_json);
+		return;
+	}
+
+	eth_index = 0;
+
+	json_object_put(vlans_json);
+	json_object_put(ifname_json);
+}
+
+int vlan_state_json_parse(void)
+{
+	int i = 0;
+	struct json_object *vlan_json;
+
+	system("bridge -j vlan > /tmp/vlans.json");
+	vlan_json = json_object_from_file(TMP_VLAN_JSON);
+
+	memset(&wanport.vlans, 0, sizeof(struct eth_port_vlans));
+
+	for (i = 0; i < MAX_ETH_PORTS; i++) {
+		memset(&lanport[i].vlans, 0x0, sizeof(struct eth_port_vlans));
+	}
+
+	parse_each_array_element(vlan_json, bridge_vlan_parse_element);
+
+	json_object_put(vlan_json);
+	return 0;
+}

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/unit.mk
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/unit.mk
@@ -13,12 +13,13 @@ UNIT_SRC    += src/dhcp_lease.c
 UNIT_SRC    += src/inet_iface.c
 UNIT_SRC    += src/inet_conf.c
 UNIT_SRC    += src/dhcp_fingerprint.c
+UNIT_SRC    += src/bridge_vlan_parse.c
 
 UNIT_CFLAGS := -I$(UNIT_PATH)/inc
 UNIT_CFLAGS += -Isrc/lib/common/inc/
 UNIT_CFLAGS += -Isrc/lib/version/inc/
 
-UNIT_LDFLAGS += -lev -lubus -lubox -luci -lblobmsg_json -lnl-tiny
+UNIT_LDFLAGS += -lev -lubus -lubox -luci -lblobmsg_json -lnl-tiny -ljson-c
 UNIT_LDFLAGS += -lrt
 
 UNIT_EXPORT_CFLAGS := $(UNIT_CFLAGS)

--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
@@ -16,25 +16,61 @@ json_select ..
 }
 
 if [ "$ACTION" = ifup -o "$ACTION" = ifupdate ]; then
-	vid=$(uci get network.${INTERFACE}.vid)
-	net=$(uci get network.${INTERFACE}.ifname)
+	trunk=$(uci get network.${INTERFACE}.vlan_trunk)
+	if [ "$trunk" = 1 ]; then
+		net=$(uci get network.${INTERFACE}.ifname)
+		allowed_vlans=$(uci get network.${INTERFACE}.allowed_vlans)
+		pvid=$(uci get network.${INTERFACE}.pvid)
 
-	[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
+		[ -z "$allowed_vlans" ] || {
+			echo $pvid $allowed_vlans > /etc/allowed_vlans_$INTERFACE
+			for vid in $allowed_vlans
+			do
+				bridge vlan add vid $vid dev br-lan self
+				bridge vlan add vid $vid dev br-wan self
+				bridge vlan add vid $vid dev $ifname
+				bridge vlan add vid $vid dev $net
+			done
+		}
+		[ -z "$pvid" ] || {
+                        bridge vlan add vid $pvid dev br-lan self
+                        bridge vlan add vid $pvid dev br-wan self
+                        bridge vlan add vid $pvid dev $ifname
+                        bridge vlan add pvid $pvid vid $pvid dev $net untagged
+		}
+	else
+		vid=$(uci get network.${INTERFACE}.vid)
+		net=$(uci get network.${INTERFACE}.ifname)
 
-	bridge vlan add vid $vid dev br-lan self
-	bridge vlan add vid $vid dev br-wan self
-	bridge vlan add vid $vid dev $ifname
-	bridge vlan add pvid $vid vid $vid dev $net untagged
-	exit 0
+		[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
+
+		bridge vlan add vid $vid dev br-lan self
+		bridge vlan add vid $vid dev br-wan self
+		bridge vlan add vid $vid dev $ifname
+		bridge vlan add pvid $vid vid $vid dev $net untagged
+		exit 0
+	fi
 else
 	if [ "$ACTION" = ifdown ]; then
 		vid=`echo $INTERFACE | awk -F "_" '{ print $2 }'`
 		net=`echo $INTERFACE | awk -F "_" '{ print $1 }'`
 		[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
 
-		bridge vlan del vid $vid dev $ifname
-		bridge vlan del pvid $vid vid $vid dev $net untagged
-		bridge vlan add pvid 1 vid 1 dev $net untagged
+		if [ $vid  = "trunk" ]; then
+			allowed_vlans=`cat /etc/allowed_vlans_$INTERFACE`
+			for vid in $allowed_vlans
+			do
+				bridge vlan del vid $vid dev $net
+				bridge vlan del pvid $vid vid $vid dev $net untagged
+			done
+
+			bridge vlan add pvid 1 vid 1 dev $net untagged
+			rm /etc/allowed_vlans_$INTERFACE
+		else
+			bridge vlan del pvid $vid vid $vid dev $net untagged
+
+			bridge vlan add pvid 1 vid 1 dev $net untagged
+		fi
 		exit 0
 	fi
 fi


### PR DESCRIPTION
Add provision to set an ethernet lan port as a vlan
trunk port which will allow the specified vlan tagged
packets to pass through it. Also, add pvid to the trunk
port for ingress tagging. Config is added in Wifi_Inet_Config
table 'vlan_trunk'.
command:
ADD: /usr/opensync/bin/ovsh i Wifi_Inet_Config NAT:=true enable
d:=true if_name:=eth0_trunk if_type:=vlan_trunk ip_assign_scheme:=none network:=
true parent_ifname:=eth0 dhcp_sniff:=false eth_ports:="eth0" vlan_trunk:='["map"
,[["allowed_vlans","100 200 300"],["pvid","10"]]]'

DEL: /usr/opensync/bin/ovsh d Wifi_Inet_Config -w if_name==eth0_trunk

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>