### PR TITLE
wifi-4936: Fix NM crash in single eth ports APs

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_config.c
@@ -202,8 +202,7 @@ static void wifi_inet_conf_load(struct uci_section *s)
 		SCHEMA_SET_STR(conf.parent_ifname, info.name);
 		if (info.vid)
 			SCHEMA_SET_INT(conf.vlan_id, info.vid);
-	} else {
-
+	} else if (ifname) {
 		SCHEMA_SET_STR(conf.eth_ports, ifname);
 		if (!strncmp(conf.if_name, "wan", 3) &&
 				strncmp(conf.if_name, "wan6", 4) != 0) {


### PR DESCRIPTION
This fixes the Null pointer crash in single eth port
APs as a consequence to the eth ports setting in the
Wifi_Inet_Config.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>