### PR TITLE
wifi-4952: Fix eth port vlan Inet_State missing in eap101

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/bridge_vlan_parse.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/bridge_vlan_parse.c
@@ -3,8 +3,7 @@
 #include "schema_consts.h"
 #include "eth_vlan.h"
 
-static struct eth_port_state *ethport[MAX_ETH_PORTS+1];
-static int eth_index;
+static struct eth_port_state *ethport;
 
 bool is_dup_vlan(struct eth_port_state *eps, int vlan_id)
 {
@@ -43,7 +42,7 @@ int parse_each_array_element(json_object *arr_json,
 		if (tmp)
 			parse_func(tmp);
 		else {
-			LOGI("%s:Error: Failed to parse info",
+			LOGD("%s:Error: Failed to parse info",
 			     __func__);
 			continue;
 		}
@@ -58,15 +57,15 @@ void flags_parse_element(json_object *flag_json)
 
 	flags = json_object_get_string(flag_json);
 	if (!strncmp(flags, "PVID", 4)) {
-
-	ethport[eth_index-1]->vlans.pvid = ethport[eth_index-1]->vlans.allowed_vlans[ethport[eth_index-1]->vlans.vindex];
+		ethport->vlans.pvid = ethport->vlans.allowed_vlans[ethport->vlans.vindex];
+		ethport->vlans.allowed_vlans[ethport->vlans.vindex] = 0;
+		ethport->vlans.vindex--;
 	}
 }
 
 /*[{"vlan":1,"flags":["PVID","Egress Untagged"]}] */
 void vlans_parse_element(json_object *vlans_json) 
 {
-	int i = 0;
 	int exists = 0;
 	const char *vlan_id = 0;
 	json_object *vlan_json;
@@ -74,32 +73,26 @@ void vlans_parse_element(json_object *vlans_json)
 
 	exists = json_object_object_get_ex(vlans_json, "vlan", &vlan_json);
 	if (!exists) {
-		LOGI("%s: ifname doesnt exist", __func__);
+		LOGD("%s: vlan doesnt exist", __func__);
 		json_object_put(vlan_json);
 		return;
 	}
 
 	vlan_id = json_object_get_string(vlan_json);
-	for (i=0; i < eth_index; i++) {
-		if(!is_dup_vlan(ethport[i], atoi(vlan_id)))
-			ethport[i]->vlans.allowed_vlans[ethport[i]->vlans.vindex] = atoi(vlan_id);
-	}
 
+	ethport->vlans.allowed_vlans[ethport->vlans.vindex] = atoi(vlan_id);
 
 	exists = json_object_object_get_ex(vlans_json, "flags", &flags_json);
 	if (!exists) {
 		LOGD("%s:flags doesnt exist", __func__);
-		for (i=0; i < eth_index; i++)
-			ethport[i]->vlans.vindex++;
+		ethport->vlans.vindex++;
 		json_object_put(flags_json);
 		return;
 	}
 
 	parse_each_array_element(flags_json, flags_parse_element);
 
-	for (i=0; i < eth_index; i++)
-		ethport[i]->vlans.vindex++;
-
+	ethport->vlans.vindex++;
 	json_object_put(vlan_json);
 	json_object_put(flags_json);
 }
@@ -113,34 +106,31 @@ void bridge_vlan_parse_element(json_object *if_obj)
 
 	exists = json_object_object_get_ex(if_obj, "ifname", &ifname_json);
 	if (!exists) {
-		LOGI("%s:ifname doesnt exist", __func__);
-		json_object_put(ifname_json);
+		LOGD("%s:ifname doesnt exist", __func__);
 		return;
 	}
 
 	ifname = json_object_get_string(ifname_json);
 
-	ethport[eth_index] = get_eth_port(ifname);
-	if (!ethport[eth_index]) {
-		LOGI("%s:ifname=%s not there", __func__, ifname);
+	ethport = get_eth_port(ifname);
+	if (!ethport) {
+		LOGD("%s:ifname=%s not there", __func__, ifname);
 		return;
 	}
 
-	eth_index++;
 	exists = json_object_object_get_ex(if_obj, "vlans", &vlans_json);
 	if (!exists) {
 		LOGD("%s: vlans doesnt exist", __func__);
-		json_object_put(vlans_json);
+		json_object_put(ifname_json);
 		return;
 	}
 
 	if (parse_each_array_element(vlans_json, vlans_parse_element) < 0) {
 		LOGD("%s: vlans len doesnt exist", __func__);
 		json_object_put(vlans_json);
+		json_object_put(ifname_json);
 		return;
 	}
-
-	eth_index = 0;
 
 	json_object_put(vlans_json);
 	json_object_put(ifname_json);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
@@ -310,9 +310,9 @@ static void update_eth_ports_states(struct schema_Wifi_Inet_State *state)
 				 lanport[i].state, lanport[i].speed, lanport[i].duplex);
 
 			STRSCPY(state->eth_ports[cnt+i], port_status);
-			cnt++;
-			state->eth_ports_len = cnt;
+			state->eth_ports_len++;
 		}
+
 	}
 
 	if (!strncmp(state->if_name, "eth", 3)) {
@@ -469,7 +469,7 @@ void wifi_inet_state_set(struct blob_attr *msg)
 						vlan_state_json_parse();
 						eps = get_eth_port(info.name);
 						SCHEMA_SET_INT(state.vlan_id,
-							       eps->vlans.pvid);
+			       ((eps->vlans.pvid > 0 && eps->vlans.pvid < 4095)? eps->vlans.pvid:1));
 					}
 				}
 			}

--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
@@ -23,7 +23,8 @@ if [ "$ACTION" = ifup -o "$ACTION" = ifupdate ]; then
 		pvid=$(uci get network.${INTERFACE}.pvid)
 
 		[ -z "$allowed_vlans" ] || {
-			echo $pvid $allowed_vlans > /etc/allowed_vlans_$INTERFACE
+			echo $allowed_vlans > /etc/allowed_vlans_$INTERFACE
+			echo $pvid > /etc/pvid_$INTERFACE
 			for vid in $allowed_vlans
 			do
 				bridge vlan add vid $vid dev br-lan self
@@ -61,11 +62,13 @@ else
 			for vid in $allowed_vlans
 			do
 				bridge vlan del vid $vid dev $net
-				bridge vlan del pvid $vid vid $vid dev $net untagged
 			done
 
+			pvid=`cat /etc/pvid_$INTERFACE`
+			bridge vlan del pvid $pvid vid $pvid dev $net untagged
 			bridge vlan add pvid 1 vid 1 dev $net untagged
 			rm /etc/allowed_vlans_$INTERFACE
+			rm /etc/pvid_$INTERFACE
 		else
 			bridge vlan del pvid $vid vid $vid dev $net untagged
 


### PR DESCRIPTION
Fix Wifi_Inet_State missing issue in eap101 when both the
ethernet ports are configured as vlan trunk/access mode.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>