### PR TITLE
Wifi-4930. Fix for DFS radar event not seen on UI

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/f00-022-CAC-chan-change-after-radar-send-DFS-evt.patch
+++ b/feeds/wifi-ax/hostapd/patches/f00-022-CAC-chan-change-after-radar-send-DFS-evt.patch
@@ -1,0 +1,16 @@
+Index: hostapd-2020-07-02-58b384f4/src/ap/dfs.c
+===================================================================
+--- hostapd-2020-07-02-58b384f4.orig/src/ap/dfs.c
++++ hostapd-2020-07-02-58b384f4/src/ap/dfs.c
+@@ -1014,6 +1014,11 @@ static int hostapd_dfs_start_channel_swi
+ 	err = 0;
+ 
+ 	hostapd_setup_interface_complete(iface, err);
++	if (!err) {
++		wpa_printf(MSG_DEBUG, "Reporting DFS event to ubus");
++		hostapd_ubus_handle_channel_switch_event(iface, HOSTAPD_UBUS_DFS_SWITCH,  channel->freq);
++	}
++
+ 	return err;
+ }
+ 

--- a/feeds/wifi-trunk/hostapd/patches/911-hapd-CAC-chan-change-after-radar-send-DFS-evt.patch
+++ b/feeds/wifi-trunk/hostapd/patches/911-hapd-CAC-chan-change-after-radar-send-DFS-evt.patch
@@ -1,0 +1,16 @@
+Index: hostapd-2020-06-08-5a8b3662/src/ap/dfs.c
+===================================================================
+--- hostapd-2020-06-08-5a8b3662.orig/src/ap/dfs.c
++++ hostapd-2020-06-08-5a8b3662/src/ap/dfs.c
+@@ -1032,6 +1032,11 @@ static int hostapd_dfs_start_channel_swi
+ 	err = 0;
+ 
+ 	hostapd_setup_interface_complete(iface, err);
++	if (!err) {
++		wpa_printf(MSG_DEBUG, "Reporting DFS event to ubus");
++		hostapd_ubus_handle_channel_switch_event(iface, HOSTAPD_UBUS_DFS_SWITCH,  channel->freq);
++	}
++
+ 	return err;
+ }
+ 


### PR DESCRIPTION
When a DFS radar is generated, Hostapd code takes a different path
to switch channels if CAC is still in progress. And this other path
did not generate the DFS radar detected event. Adding the same event.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>