### PR TITLE
wifi-5041: Disable Network probe stats - Disable Synthetic client

### DIFF
--- a/feeds/wlan-ap/opensync/patches/46-ignore_nw_probe_stats_timer_synthetic_client_disable.patch
+++ b/feeds/wlan-ap/opensync/patches/46-ignore_nw_probe_stats_timer_synthetic_client_disable.patch
@@ -1,0 +1,15 @@
+Index: opensync-2.0.5.0/src/sm/src/sm_network_probe_report.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/sm/src/sm_network_probe_report.c
++++ opensync-2.0.5.0/src/sm/src/sm_network_probe_report.c
+@@ -254,6 +254,10 @@ bool sm_network_probe_report_request(
+     /* Restart timers with new parameters */
+     dpp_network_probe_report_timer_set(report_timer, false);
+ 
++    /* NOTE: Disable synthertic client, ignore the timer value set by the
++     * cloud and disable network probe stats */
++    request_ctx->reporting_interval = 0;
++
+     if (request_ctx->reporting_interval) {
+         network_probe_ctx->report_ts = get_timestamp();
+         report_timer->repeat = request_ctx->reporting_interval;


### PR DESCRIPTION
Disable Network probe stats and hence the Synthetic client

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>