### PR TITLE
WIFI-4924-Report-Channel-Bandwidth

### DIFF
--- a/feeds/wlan-ap/opensync/patches/46-add-channel-bandwidth-to-survey-sample.patch
+++ b/feeds/wlan-ap/opensync/patches/46-add-channel-bandwidth-to-survey-sample.patch
@@ -1,0 +1,66 @@
+Index: opensync-2.0.5.0/src/lib/datapipeline/inc/dpp_survey.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/datapipeline/inc/dpp_survey.h
++++ opensync-2.0.5.0/src/lib/datapipeline/inc/dpp_survey.h
+@@ -70,6 +70,7 @@ typedef struct
+     uint32_t                        chan_tx;
+     uint32_t                        chan_noise;
+     uint32_t                        duration_ms;
++    uint32_t                        chan_width;
+ 
+     /* Linked list survey data */
+     ds_dlist_node_t                 node;
+Index: opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/sm/src/sm_survey_report.c
++++ opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+@@ -526,7 +526,7 @@ bool sm_survey_report_calculate_raw (
+         memcpy(report_entry, record_entry, sizeof(*report_entry));
+ 
+         LOGD("Sending %s %s %u survey report "
+-             "{busy=%u tx=%u self=%u rx=%u ext=%u noise=%u duration=%u}",
++             "{busy=%u tx=%u self=%u rx=%u ext=%u noise=%u duration=%u chan_width=%u}",
+              radio_get_name_from_cfg(radio_cfg_ctx),
+              radio_get_scan_name_from_type(scan_type),
+              report_entry->info.chan,
+@@ -536,7 +536,8 @@ bool sm_survey_report_calculate_raw (
+              report_entry->chan_rx,
+              report_entry->chan_busy_ext,
+              report_entry->chan_noise,
+-             report_entry->duration_ms);
++             report_entry->duration_ms,
++	     report_entry->chan_width);
+ 
+         ds_dlist_insert_tail(report_list, report_entry);
+     }
+@@ -732,7 +733,7 @@ bool sm_survey_update_list_cb (
+                 result_entry);
+ 
+         LOGD("Processed %s %s %u survey percent "
+-             "{busy=%u tx=%u self=%u rx=%u ext=%u noise=%u duration=%u}",
++             "{busy=%u tx=%u self=%u rx=%u ext=%u noise=%u duration=%u channel_bandwidth:%u}",
+              radio_get_name_from_cfg(radio_cfg_ctx),
+              radio_get_scan_name_from_type(scan_type),
+              result_entry->info.chan,
+@@ -742,7 +743,8 @@ bool sm_survey_update_list_cb (
+              result_entry->chan_rx,
+              result_entry->chan_busy_ext,
+              result_entry->chan_noise,
+-             result_entry->duration_ms);
++             result_entry->duration_ms,
++	     result_entry->chan_width);
+ 
+         result_entry->info.timestamp_ms =
+             request_ctx->reporting_timestamp - survey_ctx->report_ts +
+Index: opensync-2.0.5.0/interfaces/opensync_stats.proto
+===================================================================
+--- opensync-2.0.5.0.orig/interfaces/opensync_stats.proto
++++ opensync-2.0.5.0/interfaces/opensync_stats.proto
+@@ -308,6 +308,7 @@ message Survey {
+         optional uint32     offset_ms       = 9;
+         optional uint32     busy_ext        = 10;   /* 40MHz extention channel busy */
+         optional uint32     noise           = 11;
++        optional uint32     chan_width      = 12;
+     }
+     message SurveyAvg {
+         required uint32     channel         = 1;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/target_OPENWRT.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/target_OPENWRT.h
@@ -53,6 +53,7 @@ typedef struct
 	uint64_t chan_tx;
 	uint32_t chan_noise;
 	uint64_t duration_ms;
+	uint64_t chan_width;
 } target_survey_record_t;
 
 typedef void target_capacity_data_t;

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/utils.h
@@ -42,6 +42,7 @@ extern int net_get_mtu(char *iface);
 extern int net_get_mac(char *iface, char *mac);
 extern int net_is_bridge(char *iface);
 extern char* get_max_channel_bw_channel(int channel_freq, const char* htmode);
+extern void get_on_channel_bandwidth(radio_entry_t *radio_cfg, int *channel_bandwidth);
 int phy_find_hwmon_helper(char *dir, char *file, char *hwmon);
 extern double dBm_to_mwatts(double dBm);
 extern double mWatts_to_dBm(double mW);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/utils.c
@@ -97,6 +97,23 @@ char * get_max_channel_bw_channel(int channel_freq, const char* htmode)
 	}
 	return "HT20";
 }
+
+void get_on_channel_bandwidth(radio_entry_t *radio_cfg, int *channel_bandwidth)
+{
+	if (radio_cfg->chanwidth == 1) {
+		*channel_bandwidth = 20;
+		return;
+	} else if (radio_cfg->chanwidth == 2) {
+		*channel_bandwidth = 40;
+		return;
+	} else if (radio_cfg->chanwidth == 5) {
+		*channel_bandwidth = 80;
+		return;
+	} else
+		*channel_bandwidth = 0;
+	return;
+}
+
 struct mode_map *mode_map_get_uci(const char *band, const char *htmode, const char *hwmode)
 {
 	unsigned int i;

--- a/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
+++ b/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
@@ -53,6 +53,7 @@ typedef struct
 	uint32_t chan_noise;
 	uint64_t duration_ms;
 	uint32_t chan_in_use;
+	uint64_t chan_width;
 } target_survey_record_t;
 
 typedef void target_capacity_data_t;


### PR DESCRIPTION
Current survey sample report doesn't include channel bandwidth parameter, hence cloud won't be having channel bandwidth information.
This patch will add support to add channel bandwidth attribute to survey sample report and will report available channel
bandwidth on respective channel to the cloud.

Signed-off-by: Nagendrababu <nagendrababu.bonkuri@connectus.ai>