### PR TITLE
qosify: speedup builds by using host clang/llvm

### DIFF
--- a/patches/0047-scripts-gen_config.py-add-host_dependencies-option.patch
+++ b/patches/0047-scripts-gen_config.py-add-host_dependencies-option.patch
@@ -1,0 +1,78 @@
+From b144b80999d1e1facf299b57c5fa3305cdfd9ee8 Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Thu, 4 Nov 2021 12:48:04 -1000
+Subject: [PATCH] scripts: gen_config.py add host_dependencies option
+
+In case a package/image requres specific host dependencies it is
+possible to define entries in the `host_dependencies` array. Each entry
+is an object containing at least `name` and `which`. The `which` array
+contains tools to be checked in the current `PATH`.
+
+Optionally the two options `success_diffconfig` and
+`fallback_diffconfig` can be set. The former is optionally added in case
+the tool is found. The latter is added if the dependency is not
+available.
+
+If the dependecy is not available and no `fallback_diffconfig` is set,
+the config generation is considered impossible and stopped.
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ scripts/gen_config.py | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/gen_config.py b/scripts/gen_config.py
+index a348386124..5572de80c7 100755
+--- a/scripts/gen_config.py
++++ b/scripts/gen_config.py
+@@ -2,7 +2,7 @@
+ 
+ from os import getenv
+ from pathlib import Path
+-from shutil import rmtree
++from shutil import rmtree, which
+ from subprocess import run
+ import sys
+ import yaml
+@@ -36,7 +36,27 @@ def usage(code: int = 0):
+     sys.exit(code)
+ 
+ 
+-def load_yaml(fname: str, profile: dict, include = True):
++def process_host_dependency(dependecy: dict, profile: dict):
++    print(f"Checking host dependecy {dependecy['name']}")
++    found = False
++    for w in dependecy["which"]:
++        if which(w):
++            print(f"-> Found {w}")
++            found = True
++            break
++
++    if found:
++        profile["diffconfig"] += dependecy.get("success_diffconfig", "")
++    else:
++        print(f"-> Could not find host dependecy {dependecy['name']}.")
++        print(f"  -> Please make sure one of {dependecy['which']} is available")
++        if "fallback_diffconfig" in dependecy:
++            profile["diffconfig"] += dependecy["fallback_diffconfig"]
++        else:
++            die("Can't continue without dependency and no `fallback_diffconfig` set")
++
++
++def load_yaml(fname: str, profile: dict, include=True):
+     profile_file = (profile_folder / fname).with_suffix(".yml")
+ 
+     if not profile_file.is_file():
+@@ -59,6 +79,9 @@ def load_yaml(fname: str, profile: dict, include = True):
+                 if f.get("name", "") == "" or (f.get("uri", "") == "" and f.get("path", "") == ""):
+                     die(f"Found bad feed {f}")
+                 profile["feeds"][f.get("name")] = f
++        elif n in {"host_dependecies"}:
++            for d in new.get(n):
++                process_host_dependency(d, profile)
+ 
+     if "include" in new and include:
+         for i in range(len(new["include"])):
+-- 
+2.30.2
+

--- a/profiles/qosify.yml
+++ b/profiles/qosify.yml
@@ -1,0 +1,19 @@
+---
+description: Add qosify package
+packages:
+  - qosify
+
+host_dependecies:
+  - name: llvm/clang-12
+
+    which:
+      - clang
+      - clang-13
+      - clang-12
+
+    success_diffconfig: |
+      CONFIG_BPF_TOOLCHAIN_HOST=y
+
+    fallback_diffconfig: |
+      CONFIG_DEVEL=y
+      CONFIG_BPF_TOOLCHAIN_BUILD_LLVM=y

--- a/profiles/ucentral-ap-light.yml
+++ b/profiles/ucentral-ap-light.yml
@@ -8,6 +8,7 @@ feeds:
 
 include:
   - webui
+  - qosify
 
 packages:
   - kmod-batman-adv
@@ -16,7 +17,6 @@ packages:
   - ip-bridge
   - maverick
   - ratelimit
-  - qosify
   - tip-defaults
   - ucentral-client
   - ucentral-event

--- a/profiles/ucentral-ap-mikrotik.yml
+++ b/profiles/ucentral-ap-mikrotik.yml
@@ -8,6 +8,7 @@ feeds:
 
 include:
   - webui
+  - qosify
 
 packages:
   - firstcontact
@@ -16,7 +17,6 @@ packages:
   - maverick
   - ratelimit
   - rtty-openssl
-  - qosify
   - tip-defaults
   - ucentral-client
   - ucentral-event

--- a/profiles/ucentral-ap.yml
+++ b/profiles/ucentral-ap.yml
@@ -11,6 +11,7 @@ include:
   - openflow
   - fbwifi
   - chilli-redirect
+  - qosify
 
 packages:
   - kmod-batman-adv
@@ -28,7 +29,6 @@ packages:
   - lldpd
   - maverick
   - opennds
-  - qosify
   - radsecproxy
   - ratelimit
   - rtty-openssl


### PR DESCRIPTION
* Add `host_dependencies` config option to `gen_config.py` script to handle potential host dependencies.
* If available use clang/llvm from host instead of building it which speeds up image generation by some 30 minutes
* Add qosify profile
* Switch to use qosify profile instead of installing package directly

