### PR TITLE
Allow explicit warnings for missing host dependencies. 

### DIFF
--- a/patches/0048-scripts-gen_config-allow-explicit-warning-message.patch
+++ b/patches/0048-scripts-gen_config-allow-explicit-warning-message.patch
@@ -1,0 +1,54 @@
+From bcb6e18b492d4fa055c136729ad85c53c725f241 Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Fri, 5 Nov 2021 12:12:25 -1000
+Subject: [PATCH] scripts: gen_config allow explicit warning message
+
+Instead of generically mentioning a missing dependency the host
+dependency can also be explained by defining a `warning`.
+
+Warning messages are collected and printed at the end.
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ scripts/gen_config.py | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/gen_config.py b/scripts/gen_config.py
+index 5572de80c7..071e00bb4d 100755
+--- a/scripts/gen_config.py
++++ b/scripts/gen_config.py
+@@ -8,6 +8,7 @@ import sys
+ import yaml
+ 
+ profile_folder = Path(getenv("PROFILES", "./profiles")).absolute()
++warnings = []
+ 
+ 
+ def die(msg: str):
+@@ -48,8 +49,13 @@ def process_host_dependency(dependecy: dict, profile: dict):
+     if found:
+         profile["diffconfig"] += dependecy.get("success_diffconfig", "")
+     else:
+-        print(f"-> Could not find host dependecy {dependecy['name']}.")
+-        print(f"  -> Please make sure one of {dependecy['which']} is available")
++        if "warning" in dependecy:
++            warnings.append(f"Dependecy {dependecy['name']}: {dependecy['warning']}")
++        else:
++            warnings.append(
++                f"Dependecy {dependecy['name']}: Please install {dependecy['which']}"
++            )
++
+         if "fallback_diffconfig" in dependecy:
+             profile["diffconfig"] += dependecy["fallback_diffconfig"]
+         else:
+@@ -220,3 +226,7 @@ if __name__ == "__main__":
+     print("Running make defconfig")
+     if run(["make", "defconfig"]).returncode:
+         die(f"Error running make defconfig")
++
++    print("#########################\n" * 3)
++    print("\n".join(warnings))
++    print("#########################\n" * 3)
+-- 
+2.30.2
+

--- a/profiles/qosify.yml
+++ b/profiles/qosify.yml
@@ -6,6 +6,10 @@ packages:
 host_dependecies:
   - name: llvm/clang-12
 
+    warning: >
+      Building llvm/clang, this will take 1hr+, please install clang/llvm-12+
+      on your system
+
     which:
       - clang-13
       - clang-12


### PR DESCRIPTION
The generic warning list could also be used for other warnings later on.