### PR TITLE
hostapd: Added control for co-location enable and disable in config.

### DIFF
--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -114,6 +114,7 @@ hostapd_common_add_device_config() {
 
 	config_add_int airtime_mode
 
+	config_add_boolean rnr_beacon he_co_locate
 	hostapd_add_log_config
 }
 
@@ -125,7 +126,8 @@ hostapd_prepare_device_config() {
 
 	json_get_vars country country3 country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
 		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode cell_density \
-		rts_threshold beacon_rate rssi_reject_assoc_rssi rssi_ignore_probe_request maxassoc
+		rts_threshold beacon_rate rssi_reject_assoc_rssi rssi_ignore_probe_request maxassoc \
+		he_co_locate rnr_beacon
 
 	hostapd_set_log_options base_cfg
 
@@ -135,6 +137,8 @@ hostapd_prepare_device_config() {
 	set_default legacy_rates 0
 	set_default airtime_mode 0
 	set_default cell_density 0
+	set_default he_co_locate 0
+	set_default rnr_beacon 0
 
 	[ -n "$country" ] && {
 		append base_cfg "country_code=$country" "$N"
@@ -227,6 +231,8 @@ hostapd_prepare_device_config() {
 	append base_cfg "dtim_period=$dtim_period" "$N"
 	[ "$airtime_mode" -gt 0 ] && append base_cfg "airtime_mode=$airtime_mode" "$N"
 	[ -n "$maxassoc" ] && append base_cfg "iface_max_num_sta=$maxassoc" "$N"
+	[ "$rnr_beacon" -gt 0 ] && append base_cfg "rnr_beacon=$rnr_beacon" "$N"
+	[ "$he_co_locate" -gt 0 ] && append base_cfg "he_co_locate=$he_co_locate" "$N"
 
 	json_get_values opts hostapd_options
 	for val in $opts; do


### PR DESCRIPTION
Re-enabling support for enabling configuring rnr_beacon and he_co_locate flag in hostapd config files.

Signed-off-by: Sharadanand Karanjkar <sk@simonwunderlich.de>