### PR TITLE
wifi-5624: Fix eth port VLAN Access in wifi6

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/radio.c
@@ -1191,7 +1191,6 @@ void apc_init()
 	cloud_disconn_mon();
 
 }
-
 static void apply_config_handler(struct timeout *timeout)
 {
 	radius_proxy_fixup();

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/netifd/src/wifi_inet_state.c
@@ -304,15 +304,14 @@ static void update_eth_ports_states(struct schema_Wifi_Inet_State *state)
 	}
 	for (i = 0; i < MAX_ETH_PORTS && lanport[i].ifname != NULL; i++) {
 		if (strcmp(lanport[i].bridge, brname) == 0) {
-			STRSCPY(state->eth_ports_keys[cnt+i], lanport[i].ifname);
+			STRSCPY(state->eth_ports_keys[state->eth_ports_len], lanport[i].ifname);
 			memset(port_status, '\0', sizeof(port_status));
 			snprintf(port_status, sizeof(port_status), "%s lan %sMbps %s", 
 				 lanport[i].state, lanport[i].speed, lanport[i].duplex);
 
-			STRSCPY(state->eth_ports[cnt+i], port_status);
+			STRSCPY(state->eth_ports[state->eth_ports_len], port_status);
 			state->eth_ports_len++;
 		}
-
 	}
 
 	if (!strncmp(state->if_name, "eth", 3)) {

--- a/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
+++ b/feeds/wlan-ap/wlan-ap-config/files/etc/hotplug.d/iface/30-eth-vlan
@@ -14,19 +14,41 @@ json_select ..
 	ifname=$(uci get network.wan.ifname)
 	ifname=${ifname%% *}
 }
-
 if [ "$ACTION" = ifup -o "$ACTION" = ifupdate ]; then
 	trunk=$(uci get network.${INTERFACE}.vlan_trunk)
 	if [ "$trunk" = 1 ]; then
 		net=$(uci get network.${INTERFACE}.ifname)
 		allowed_vlans=$(uci get network.${INTERFACE}.allowed_vlans)
 		pvid=$(uci get network.${INTERFACE}.pvid)
+		brctl addif br-wan $net
 
 		[ -z "$allowed_vlans" ] || {
+			stale_allowed_vlans=`cat /etc/allowed_vlans_$INTERFACE`
+			for vid in $stale_allowed_vlans
+			do
+				echo "stale: $vid" >> /root/hello
+				brctl delif vlan-$vid $net.$vid
+				ip link set dev $net.$vid down
+		                ip link del link $net name $net.$vid
+				bridge vlan del vid $vid dev $net
+				bridge vlan del vid $vid dev br-lan self
+				bridge vlan del vid $vid dev br-wan self
+			done
+
 			echo $allowed_vlans > /etc/allowed_vlans_$INTERFACE
-			echo $pvid > /etc/pvid_$INTERFACE
 			for vid in $allowed_vlans
 			do
+		                ip link add link $ifname name $ifname.$vid type vlan id $vid
+		                ip link set dev $ifname.$vid up
+
+		                ip link add link $net name $net.$vid type vlan id $vid
+		                ip link set dev $net.$vid up
+
+				brctl addbr vlan-$vid
+				brctl addif vlan-$vid $ifname.$vid
+				brctl addif vlan-$vid $net.$vid
+				ifconfig vlan-$vid up
+
 				bridge vlan add vid $vid dev br-lan self
 				bridge vlan add vid $vid dev br-wan self
 				bridge vlan add vid $vid dev $ifname
@@ -34,16 +56,25 @@ if [ "$ACTION" = ifup -o "$ACTION" = ifupdate ]; then
 			done
 		}
 		[ -z "$pvid" ] || {
-                        bridge vlan add vid $pvid dev br-lan self
-                        bridge vlan add vid $pvid dev br-wan self
-                        bridge vlan add vid $pvid dev $ifname
-                        bridge vlan add pvid $pvid vid $pvid dev $net untagged
+			echo $pvid > /etc/pvid_$INTERFACE
 		}
 	else
 		vid=$(uci get network.${INTERFACE}.vid)
 		net=$(uci get network.${INTERFACE}.ifname)
 
 		[ -z "$net" -o -z "$vid" -o "$vid" = 0 ] && exit 0
+		$oldvid=`cat /etc/vid_$INTERFACE`
+		echo $vid > /etc/vid_$INTERFACE
+
+		ip link add link $ifname name $ifname.$vid type vlan id $vid
+		ip link set dev $ifname.$vid up
+		brctl addbr vlan-$vid
+		brctl addif vlan-$vid $ifname.$vid
+		brctl delif br-wan $net
+		brctl delif br-lan $net
+		brctl delif vlan-$oldvid $net
+		brctl addif vlan-$vid $net
+		ifconfig vlan-$vid up
 
 		bridge vlan add vid $vid dev br-lan self
 		bridge vlan add vid $vid dev br-wan self
@@ -62,6 +93,9 @@ else
 			for vid in $allowed_vlans
 			do
 				bridge vlan del vid $vid dev $net
+				brctl delif vlan-$vid $net.$vid
+				ip link set dev $net.$vid down
+				ip link del link $net name $net.$vid
 			done
 
 			pvid=`cat /etc/pvid_$INTERFACE`
@@ -73,6 +107,7 @@ else
 			bridge vlan del pvid $vid vid $vid dev $net untagged
 
 			bridge vlan add pvid 1 vid 1 dev $net untagged
+			brctl delif vlan-$vid $net
 		fi
 		exit 0
 	fi


### PR DESCRIPTION
Fix ethernet port vlan access mode in wifi6
Create a vlan bridge and attach wan vlan interface
and eth port in the vlan bridge.

Signed-off-by: Chaitanya Godavarthi <chaitanya.kiran@netexperience.com>