### PR TITLE
WIFI-3512: Fixed stats formula when client reconnects

### DIFF
--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
@@ -157,13 +157,26 @@ bool target_stats_clients_convert(radio_entry_t *radio_cfg, target_client_record
 	client_record->stats.rssi       = data_new->stats.rssi;
 	client_record->stats.rate_tx    = data_new->stats.rate_tx;
 	client_record->stats.rate_rx    = data_new->stats.rate_rx;
-	client_record->stats.bytes_tx   = data_new->stats.bytes_tx   - data_old->stats.bytes_tx;
-	client_record->stats.bytes_rx   = data_new->stats.bytes_rx   - data_old->stats.bytes_rx;
-	client_record->stats.frames_tx  = data_new->stats.frames_tx  - data_old->stats.frames_tx;
-	client_record->stats.frames_rx  = data_new->stats.frames_rx  - data_old->stats.frames_rx;
-	client_record->stats.retries_tx = data_new->stats.retries_tx - data_old->stats.retries_tx;
-	client_record->stats.errors_tx  = data_new->stats.errors_tx  - data_old->stats.errors_tx;
-	client_record->stats.errors_rx  = data_new->stats.errors_rx  - data_old->stats.errors_rx;
+	
+	// If the new data is less than the old that we know there was a reconnect since the last collection period
+	// If this is the case we should just use the new value only
+	if (data_new->connectedTime < data_old->connectedTime) {
+		client_record->stats.bytes_tx   = data_new->stats.bytes_tx;
+		client_record->stats.bytes_rx   = data_new->stats.bytes_rx;
+		client_record->stats.frames_tx  = data_new->stats.frames_tx;
+		client_record->stats.frames_rx  = data_new->stats.frames_rx;
+		client_record->stats.retries_tx = data_new->stats.retries_tx;
+		client_record->stats.errors_tx  = data_new->stats.errors_tx;
+		client_record->stats.errors_rx  = data_new->stats.errors_rx;
+	} else {
+		client_record->stats.bytes_tx   = data_new->stats.bytes_tx - data_old->stats.bytes_tx;
+		client_record->stats.bytes_rx   = data_new->stats.bytes_rx - data_old->stats.bytes_rx;
+		client_record->stats.frames_tx  = data_new->stats.frames_tx - data_old->stats.frames_tx;
+		client_record->stats.frames_rx  = data_new->stats.frames_rx - data_old->stats.frames_rx;
+		client_record->stats.retries_tx = data_new->stats.retries_tx - data_old->stats.retries_tx;
+		client_record->stats.errors_tx  = data_new->stats.errors_tx - data_old->stats.errors_tx;
+		client_record->stats.errors_rx  = data_new->stats.errors_rx - data_old->stats.errors_rx;
+	}
 
 	return true;
 }

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
@@ -111,18 +111,19 @@ static int nl80211_interface_recv(struct nl_msg *msg, void *arg)
 static int nl80211_assoclist_recv(struct nl_msg *msg, void *arg)
 {
 	static struct nla_policy stats_policy[NL80211_STA_INFO_MAX + 1] = {
-		[NL80211_STA_INFO_INACTIVE_TIME] = { .type = NLA_U32    },
-		[NL80211_STA_INFO_RX_PACKETS]    = { .type = NLA_U32    },
-		[NL80211_STA_INFO_TX_PACKETS]    = { .type = NLA_U32    },
-		[NL80211_STA_INFO_RX_BITRATE]    = { .type = NLA_NESTED },
-		[NL80211_STA_INFO_TX_BITRATE]    = { .type = NLA_NESTED },
-		[NL80211_STA_INFO_SIGNAL]        = { .type = NLA_U8     },
-		[NL80211_STA_INFO_RX_BYTES]      = { .type = NLA_U32    },
-		[NL80211_STA_INFO_TX_BYTES]      = { .type = NLA_U32    },
-		[NL80211_STA_INFO_TX_RETRIES]    = { .type = NLA_U32    },
-		[NL80211_STA_INFO_TX_FAILED]     = { .type = NLA_U32    },
-		[NL80211_STA_INFO_RX_DROP_MISC]  = { .type = NLA_U64    },
-		[NL80211_STA_INFO_T_OFFSET]      = { .type = NLA_U64    },
+		[NL80211_STA_INFO_INACTIVE_TIME]  = { .type = NLA_U32    },
+		[NL80211_STA_INFO_RX_PACKETS]     = { .type = NLA_U32    },
+		[NL80211_STA_INFO_TX_PACKETS]     = { .type = NLA_U32    },
+		[NL80211_STA_INFO_RX_BITRATE]     = { .type = NLA_NESTED },
+		[NL80211_STA_INFO_TX_BITRATE]     = { .type = NLA_NESTED },
+		[NL80211_STA_INFO_SIGNAL]         = { .type = NLA_U8     },
+		[NL80211_STA_INFO_RX_BYTES]       = { .type = NLA_U32    },
+		[NL80211_STA_INFO_TX_BYTES]       = { .type = NLA_U32    },
+		[NL80211_STA_INFO_TX_RETRIES]     = { .type = NLA_U32    },
+		[NL80211_STA_INFO_TX_FAILED]      = { .type = NLA_U32    },
+		[NL80211_STA_INFO_RX_DROP_MISC]   = { .type = NLA_U64    },
+		[NL80211_STA_INFO_T_OFFSET]       = { .type = NLA_U64    },
+		[NL80211_STA_INFO_CONNECTED_TIME] = { .type = NLA_U32    },
 		[NL80211_STA_INFO_STA_FLAGS] =
 			{ .minlen = sizeof(struct nl80211_sta_flag_update) },
 	};
@@ -190,6 +191,8 @@ static int nl80211_assoclist_recv(struct nl_msg *msg, void *arg)
 		client_entry->stats.errors_tx = nla_get_u32(sinfo[NL80211_STA_INFO_TX_FAILED]);
 	if (sinfo[NL80211_STA_INFO_RX_DROP_MISC])
 		client_entry->stats.errors_rx = nla_get_u64(sinfo[NL80211_STA_INFO_RX_DROP_MISC]);
+	if (sinfo[NL80211_STA_INFO_CONNECTED_TIME])
+		client_entry->connectedTime = nla_get_u32(sinfo[NL80211_STA_INFO_CONNECTED_TIME]);
 
 	ds_dlist_insert_tail(nl_call_param->list, client_entry);
 

--- a/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
+++ b/feeds/wlan-ap/opensync/src/vendor/tip/src/lib/target/inc/target_tip.h
@@ -39,6 +39,7 @@ typedef struct
 {
 	DPP_TARGET_CLIENT_RECORD_COMMON_STRUCT;
 	dpp_client_stats_t  stats;
+	uint32_t connectedTime;
 } target_client_record_t;
 
 typedef struct


### PR DESCRIPTION
Made it so that if the client reconnects (which resets the stats) it doesn't use the difference between the new and only value for the rate, it just uses the new value on its own.

Just went with the naive solution since I couldn't figure out how to access the data for "NL80211_STA_INFO_CONNECTED_TIME" in "nl_call_param" given the params that are passed into "target_stats_clients_convert". Knowing this info we could probably get a more accurate taking into account the shorter collection period for that client since it wasn't connected the entire period.