### PR TITLE
wifi-ax: batman-adv: Add fixes from openwrt-routing 21.02 branch

### DIFF
--- a/feeds/wifi-ax/batman-adv/Makefile
+++ b/feeds/wifi-ax/batman-adv/Makefile
@@ -61,6 +61,7 @@ PKG_EXTRA_CFLAGS:= \
 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
 
 NOSTDINC_FLAGS = \
+	$(KERNEL_NOSTDINC_FLAGS) \
 	-I$(PKG_BUILD_DIR)/net/batman-adv \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \

--- a/feeds/wifi-ax/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
@@ -12,11 +12,9 @@ or newer - otherwise it will not work as expected.
 
 This reverts commit 725b4ef5be840cfcd0ca33b9393c14dee40c10f7.
 
-diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
-index 56a9ab22c062b1d0d01ef9d09ce796075d3d6df7..8f542bef10dc0f2682ab2d428c90df9ab97977ce 100644
 --- a/compat-include/net/genetlink.h
 +++ b/compat-include/net/genetlink.h
-@@ -31,17 +31,15 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
+@@ -31,17 +31,15 @@ void batadv_genl_dump_check_consistent(s
  #endif /* LINUX_VERSION_IS_LESS(4, 15, 0) */
  
  
@@ -48,7 +46,7 @@ index 56a9ab22c062b1d0d01ef9d09ce796075d3d6df7..8f542bef10dc0f2682ab2d428c90df9a
  	unsigned int n_mcgrps;
  	struct module *module;
  
-@@ -96,32 +94,24 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+@@ -96,32 +94,24 @@ static inline int batadv_genl_register_f
  	family->family.pre_doit = family->pre_doit;
  	family->family.post_doit = family->post_doit;
  	family->family.mcgrps = family->mcgrps;
@@ -89,7 +87,7 @@ index 56a9ab22c062b1d0d01ef9d09ce796075d3d6df7..8f542bef10dc0f2682ab2d428c90df9a
  	family->family.ops = ops;
  	family->copy_ops = ops;
  
-@@ -136,7 +126,7 @@ typedef struct genl_ops batadv_genl_ops_old;
+@@ -136,7 +126,7 @@ typedef struct genl_ops batadv_genl_ops_
  #define batadv_post_doit(__x, __y, __z) \
  	batadv_post_doit(const batadv_genl_ops_old *ops, __y, __z)
  
@@ -98,7 +96,7 @@ index 56a9ab22c062b1d0d01ef9d09ce796075d3d6df7..8f542bef10dc0f2682ab2d428c90df9a
  #define genl_family batadv_genl_family
  
  #define genl_register_family(family) \
-@@ -160,6 +150,6 @@ batadv_genl_unregister_family(struct batadv_genl_family *family)
+@@ -160,6 +150,6 @@ batadv_genl_unregister_family(struct bat
  	genlmsg_multicast_netns(&(_family)->family, _net, _skb, _portid, \
  				_group, _flags)
  
@@ -106,11 +104,9 @@ index 56a9ab22c062b1d0d01ef9d09ce796075d3d6df7..8f542bef10dc0f2682ab2d428c90df9a
 +#endif /* LINUX_VERSION_IS_LESS(5, 2, 0) */
  
  #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
-diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
-index f317d206b411d87b4da2f57e35c3fb78cedfb160..bdac5dbd899a9540d58052fd32c8c89520927390 100644
 --- a/net/batman-adv/netlink.c
 +++ b/net/batman-adv/netlink.c
-@@ -1351,7 +1351,7 @@ static void batadv_post_doit(const struct genl_ops *ops, struct sk_buff *skb,
+@@ -1351,7 +1351,7 @@ static void batadv_post_doit(const struc
  	}
  }
  
@@ -119,7 +115,7 @@ index f317d206b411d87b4da2f57e35c3fb78cedfb160..bdac5dbd899a9540d58052fd32c8c895
  	{
  		.cmd = BATADV_CMD_GET_MESH,
  		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
-@@ -1485,8 +1485,8 @@ struct genl_family batadv_netlink_family __ro_after_init = {
+@@ -1485,8 +1485,8 @@ struct genl_family batadv_netlink_family
  	.pre_doit = batadv_pre_doit,
  	.post_doit = batadv_post_doit,
  	.module = THIS_MODULE,

--- a/feeds/wifi-ax/batman-adv/patches/0002-Revert-batman-adv-Add-new-include-for-min-max-helper.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0002-Revert-batman-adv-Add-new-include-for-min-max-helper.patch
@@ -9,9 +9,6 @@ This reverts commit 1810de05310d5c5e9140f870ac21052f38bc06b8.
 
 Signed-off-by: Sven Eckelmann <sven@narfation.org>
 
-diff --git a/compat-include/linux/minmax.h b/compat-include/linux/minmax.h
-deleted file mode 100644
-index 9b7269e8a760361c1650b947c77702f0bdcd73d9..0000000000000000000000000000000000000000
 --- a/compat-include/linux/minmax.h
 +++ /dev/null
 @@ -1,20 +0,0 @@
@@ -35,8 +32,6 @@ index 9b7269e8a760361c1650b947c77702f0bdcd73d9..00000000000000000000000000000000
 -#endif
 -
 -#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_MINMAX_H_ */
-diff --git a/net/batman-adv/bat_v.c b/net/batman-adv/bat_v.c
-index e1ca2b8c315235f234c9061fc73cde2c1b76aa46..eeb3f6d00d8541b377c9703837ef76b05e8d061e 100644
 --- a/net/batman-adv/bat_v.c
 +++ b/net/batman-adv/bat_v.c
 @@ -15,7 +15,6 @@
@@ -47,8 +42,6 @@ index e1ca2b8c315235f234c9061fc73cde2c1b76aa46..eeb3f6d00d8541b377c9703837ef76b0
  #include <linux/netdevice.h>
  #include <linux/netlink.h>
  #include <linux/rculist.h>
-diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
-index 423c2d17170387bfe89b83c4e20f06d525a36b30..4d8e3fdb4427a431cab903bc8a20edb816079fd7 100644
 --- a/net/batman-adv/bat_v_elp.c
 +++ b/net/batman-adv/bat_v_elp.c
 @@ -18,7 +18,6 @@
@@ -59,8 +52,6 @@ index 423c2d17170387bfe89b83c4e20f06d525a36b30..4d8e3fdb4427a431cab903bc8a20edb8
  #include <linux/netdevice.h>
  #include <linux/nl80211.h>
  #include <linux/prandom.h>
-diff --git a/net/batman-adv/bat_v_ogm.c b/net/batman-adv/bat_v_ogm.c
-index a0a9636d17406362f879f342300a18e75424efa5..89ba88322c9c11acc49a9dcd9877ad8767fe713b 100644
 --- a/net/batman-adv/bat_v_ogm.c
 +++ b/net/batman-adv/bat_v_ogm.c
 @@ -18,7 +18,6 @@
@@ -71,8 +62,6 @@ index a0a9636d17406362f879f342300a18e75424efa5..89ba88322c9c11acc49a9dcd9877ad87
  #include <linux/mutex.h>
  #include <linux/netdevice.h>
  #include <linux/prandom.h>
-diff --git a/net/batman-adv/fragmentation.c b/net/batman-adv/fragmentation.c
-index a5d9d800082bade3a1d52cc040557e41f963fac3..96873d47fac5cb9b4fbfa217eedf1f92818b0e98 100644
 --- a/net/batman-adv/fragmentation.c
 +++ b/net/batman-adv/fragmentation.c
 @@ -14,8 +14,8 @@
@@ -85,8 +74,6 @@ index a5d9d800082bade3a1d52cc040557e41f963fac3..96873d47fac5cb9b4fbfa217eedf1f92
  #include <linux/netdevice.h>
  #include <linux/skbuff.h>
  #include <linux/slab.h>
-diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
-index 4a6a25d551a83b1723e80a349e1a655a2152b0ac..eabde547d308438257622879e77d84c24daa2199 100644
 --- a/net/batman-adv/hard-interface.c
 +++ b/net/batman-adv/hard-interface.c
 @@ -18,7 +18,6 @@
@@ -97,8 +84,6 @@ index 4a6a25d551a83b1723e80a349e1a655a2152b0ac..eabde547d308438257622879e77d84c2
  #include <linux/mutex.h>
  #include <linux/netdevice.h>
  #include <linux/printk.h>
-diff --git a/net/batman-adv/main.c b/net/batman-adv/main.c
-index 3ddd66e4c29ef532de33c7182cc0cc470b33fd4f..c552bc4168d0abd7bf6d23e570d583806fb162b1 100644
 --- a/net/batman-adv/main.c
 +++ b/net/batman-adv/main.c
 @@ -23,7 +23,6 @@
@@ -109,8 +94,6 @@ index 3ddd66e4c29ef532de33c7182cc0cc470b33fd4f..c552bc4168d0abd7bf6d23e570d58380
  #include <linux/module.h>
  #include <linux/netdevice.h>
  #include <linux/printk.h>
-diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
-index bdac5dbd899a9540d58052fd32c8c89520927390..b6a703ddd8e97e6a02e8d73c5728802f090ab419 100644
 --- a/net/batman-adv/netlink.c
 +++ b/net/batman-adv/netlink.c
 @@ -23,7 +23,6 @@
@@ -121,8 +104,6 @@ index bdac5dbd899a9540d58052fd32c8c89520927390..b6a703ddd8e97e6a02e8d73c5728802f
  #include <linux/netdevice.h>
  #include <linux/netlink.h>
  #include <linux/printk.h>
-diff --git a/net/batman-adv/tp_meter.c b/net/batman-adv/tp_meter.c
-index 789c851732b78ad9d1515f7b171219cc770c7045..46b774c08c947def8f72f260224254b01c3a387d 100644
 --- a/net/batman-adv/tp_meter.c
 +++ b/net/batman-adv/tp_meter.c
 @@ -23,7 +23,6 @@

--- a/feeds/wifi-ax/batman-adv/patches/0003-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0003-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
@@ -5,11 +5,9 @@ Subject: batman-adv: Fix build of multicast code against Linux < 5.13
 Fixes: 007b4c4b031f ("batman-adv: convert ifmcaddr6 to RCU")
 Signed-off-by: Sven Eckelmann <sven@narfation.org>
 
-diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
-index 1d63c8cbbfe7b16e360e91bcf3bb77ec7b12893b..ece9fb5dd81bfadbdbe15363dfd8fd257dbe942f 100644
 --- a/net/batman-adv/multicast.c
 +++ b/net/batman-adv/multicast.c
-@@ -454,9 +454,14 @@ batadv_mcast_mla_softif_get_ipv6(struct net_device *dev,
+@@ -454,9 +454,14 @@ batadv_mcast_mla_softif_get_ipv6(struct
  		return 0;
  	}
  
@@ -24,7 +22,7 @@ index 1d63c8cbbfe7b16e360e91bcf3bb77ec7b12893b..ece9fb5dd81bfadbdbe15363dfd8fd25
  		if (IPV6_ADDR_MC_SCOPE(&pmc6->mca_addr) <
  		    IPV6_ADDR_SCOPE_LINKLOCAL)
  			continue;
-@@ -485,6 +490,9 @@ batadv_mcast_mla_softif_get_ipv6(struct net_device *dev,
+@@ -485,6 +490,9 @@ batadv_mcast_mla_softif_get_ipv6(struct
  		hlist_add_head(&new->list, mcast_list);
  		ret++;
  	}

--- a/feeds/wifi-ax/batman-adv/patches/0004-batman-adv-Always-send-iface-index-name-in-genlmsg.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0004-batman-adv-Always-send-iface-index-name-in-genlmsg.patch
@@ -23,11 +23,9 @@ adding a lot of extra overhead in the kernel portion.
 Signed-off-by: Sven Eckelmann <sven@narfation.org>
 Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/77c7d62618259f22f36427eaa62668e6e1c43090
 
-diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
-index 789f257be24f36ace3e63628a3381a6d46dcccd9..680def809838097a9949de1dc9861923911f3d04 100644
 --- a/net/batman-adv/bat_iv_ogm.c
 +++ b/net/batman-adv/bat_iv_ogm.c
-@@ -1849,6 +1849,8 @@ batadv_iv_ogm_orig_dump_subentry(struct sk_buff *msg, u32 portid, u32 seq,
+@@ -1849,6 +1849,8 @@ batadv_iv_ogm_orig_dump_subentry(struct
  		    orig_node->orig) ||
  	    nla_put(msg, BATADV_ATTR_NEIGH_ADDRESS, ETH_ALEN,
  		    neigh_node->addr) ||
@@ -36,7 +34,7 @@ index 789f257be24f36ace3e63628a3381a6d46dcccd9..680def809838097a9949de1dc9861923
  	    nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
  			neigh_node->if_incoming->net_dev->ifindex) ||
  	    nla_put_u8(msg, BATADV_ATTR_TQ, tq_avg) ||
-@@ -2078,6 +2080,8 @@ batadv_iv_ogm_neigh_dump_neigh(struct sk_buff *msg, u32 portid, u32 seq,
+@@ -2078,6 +2080,8 @@ batadv_iv_ogm_neigh_dump_neigh(struct sk
  
  	if (nla_put(msg, BATADV_ATTR_NEIGH_ADDRESS, ETH_ALEN,
  		    hardif_neigh->addr) ||
@@ -45,7 +43,7 @@ index 789f257be24f36ace3e63628a3381a6d46dcccd9..680def809838097a9949de1dc9861923
  	    nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
  			hardif_neigh->if_incoming->net_dev->ifindex) ||
  	    nla_put_u32(msg, BATADV_ATTR_LAST_SEEN_MSECS,
-@@ -2459,6 +2463,8 @@ static int batadv_iv_gw_dump_entry(struct sk_buff *msg, u32 portid,
+@@ -2459,6 +2463,8 @@ static int batadv_iv_gw_dump_entry(struc
  		    router->addr) ||
  	    nla_put_string(msg, BATADV_ATTR_HARD_IFNAME,
  			   router->if_incoming->net_dev->name) ||
@@ -54,11 +52,9 @@ index 789f257be24f36ace3e63628a3381a6d46dcccd9..680def809838097a9949de1dc9861923
  	    nla_put_u32(msg, BATADV_ATTR_BANDWIDTH_DOWN,
  			gw_node->bandwidth_down) ||
  	    nla_put_u32(msg, BATADV_ATTR_BANDWIDTH_UP,
-diff --git a/net/batman-adv/bat_v.c b/net/batman-adv/bat_v.c
-index eeb3f6d00d8541b377c9703837ef76b05e8d061e..fd7f30f5f3033fd1a9e21518a71e66b557212374 100644
 --- a/net/batman-adv/bat_v.c
 +++ b/net/batman-adv/bat_v.c
-@@ -145,6 +145,8 @@ batadv_v_neigh_dump_neigh(struct sk_buff *msg, u32 portid, u32 seq,
+@@ -145,6 +145,8 @@ batadv_v_neigh_dump_neigh(struct sk_buff
  
  	if (nla_put(msg, BATADV_ATTR_NEIGH_ADDRESS, ETH_ALEN,
  		    hardif_neigh->addr) ||
@@ -67,7 +63,7 @@ index eeb3f6d00d8541b377c9703837ef76b05e8d061e..fd7f30f5f3033fd1a9e21518a71e66b5
  	    nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
  			hardif_neigh->if_incoming->net_dev->ifindex) ||
  	    nla_put_u32(msg, BATADV_ATTR_LAST_SEEN_MSECS,
-@@ -297,6 +299,8 @@ batadv_v_orig_dump_subentry(struct sk_buff *msg, u32 portid, u32 seq,
+@@ -297,6 +299,8 @@ batadv_v_orig_dump_subentry(struct sk_bu
  	if (nla_put(msg, BATADV_ATTR_ORIG_ADDRESS, ETH_ALEN, orig_node->orig) ||
  	    nla_put(msg, BATADV_ATTR_NEIGH_ADDRESS, ETH_ALEN,
  		    neigh_node->addr) ||
@@ -76,24 +72,22 @@ index eeb3f6d00d8541b377c9703837ef76b05e8d061e..fd7f30f5f3033fd1a9e21518a71e66b5
  	    nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
  			neigh_node->if_incoming->net_dev->ifindex) ||
  	    nla_put_u32(msg, BATADV_ATTR_THROUGHPUT, throughput) ||
-@@ -738,6 +742,12 @@ static int batadv_v_gw_dump_entry(struct sk_buff *msg, u32 portid,
+@@ -737,6 +741,12 @@ static int batadv_v_gw_dump_entry(struct
+ 		genlmsg_cancel(msg, hdr);
  		goto out;
  	}
- 
++
 +	if (nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
 +			router->if_incoming->net_dev->ifindex)) {
 +		genlmsg_cancel(msg, hdr);
 +		goto out;
 +	}
-+
+ 
  	if (nla_put_u32(msg, BATADV_ATTR_BANDWIDTH_DOWN,
  			gw_node->bandwidth_down)) {
- 		genlmsg_cancel(msg, hdr);
-diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
-index b6a703ddd8e97e6a02e8d73c5728802f090ab419..27f78f0c4aea025b964301e20f972031ab8ad478 100644
 --- a/net/batman-adv/netlink.c
 +++ b/net/batman-adv/netlink.c
-@@ -813,6 +813,10 @@ static int batadv_netlink_hardif_fill(struct sk_buff *msg,
+@@ -813,6 +813,10 @@ static int batadv_netlink_hardif_fill(st
  			bat_priv->soft_iface->ifindex))
  		goto nla_put_failure;
  
@@ -104,7 +98,7 @@ index b6a703ddd8e97e6a02e8d73c5728802f090ab419..27f78f0c4aea025b964301e20f972031
  	if (nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX,
  			net_dev->ifindex) ||
  	    nla_put_string(msg, BATADV_ATTR_HARD_IFNAME,
-@@ -1044,6 +1048,10 @@ static int batadv_netlink_vlan_fill(struct sk_buff *msg,
+@@ -1044,6 +1048,10 @@ static int batadv_netlink_vlan_fill(stru
  			bat_priv->soft_iface->ifindex))
  		goto nla_put_failure;
  

--- a/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
@@ -15,11 +15,9 @@ Fixes: 29b9256e6631 ("batman-adv: consider outgoing interface in OGM sending")
 Signed-off-by: Sven Eckelmann <sven@narfation.org>
 Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/5061f9c502d7101912089d8f4a7866e0a926a49a
 
-diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
-index 680def809838097a9949de1dc9861923911f3d04..12022378f892b34d3d619ad01a4678571ab0cc77 100644
 --- a/net/batman-adv/bat_iv_ogm.c
 +++ b/net/batman-adv/bat_iv_ogm.c
-@@ -409,8 +409,10 @@ static void batadv_iv_ogm_emit(struct batadv_forw_packet *forw_packet)
+@@ -409,8 +409,10 @@ static void batadv_iv_ogm_emit(struct ba
  	if (WARN_ON(!forw_packet->if_outgoing))
  		return;
  

--- a/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0005-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
@@ -1,0 +1,33 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 18 May 2021 21:00:27 +0200
+Subject: batman-adv: Avoid WARN_ON timing related checks
+
+The soft/batadv interface for a queued OGM can be changed during the time
+the OGM was queued for transmission and when the OGM is actually
+transmitted by the worker.
+
+But WARN_ON must be used to denote kernel bugs and not to print simple
+warnings. A warning can simply be printed using pr_warn.
+
+Reported-by: Tetsuo Handa <penguin-kernel@i-love.sakura.ne.jp>
+Reported-by: syzbot+c0b807de416427ff3dd1@syzkaller.appspotmail.com
+Fixes: 29b9256e6631 ("batman-adv: consider outgoing interface in OGM sending")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/5061f9c502d7101912089d8f4a7866e0a926a49a
+
+diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+index 680def809838097a9949de1dc9861923911f3d04..12022378f892b34d3d619ad01a4678571ab0cc77 100644
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -409,8 +409,10 @@ static void batadv_iv_ogm_emit(struct batadv_forw_packet *forw_packet)
+ 	if (WARN_ON(!forw_packet->if_outgoing))
+ 		return;
+ 
+-	if (WARN_ON(forw_packet->if_outgoing->soft_iface != soft_iface))
++	if (forw_packet->if_outgoing->soft_iface != soft_iface) {
++		pr_warn("%s: soft interface switch for queued OGM\n", __func__);
+ 		return;
++	}
+ 
+ 	if (forw_packet->if_incoming->if_status != BATADV_IF_ACTIVE)
+ 		return;

--- a/feeds/wifi-ax/batman-adv/patches/0006-batman-adv-fix-error-handling.patch
+++ b/feeds/wifi-ax/batman-adv/patches/0006-batman-adv-fix-error-handling.patch
@@ -1,0 +1,162 @@
+From: Pavel Skripkin <paskripkin@gmail.com>
+Date: Sun, 24 Oct 2021 16:13:56 +0300
+Subject: batman-adv: fix error handling
+
+Syzbot reported ODEBUG warning in batadv_nc_mesh_free(). The problem was
+in wrong error handling in batadv_mesh_init().
+
+Before this patch batadv_mesh_init() was calling batadv_mesh_free() in case
+of any batadv_*_init() calls failure. This approach may work well, when
+there is some kind of indicator, which can tell which parts of batadv are
+initialized; but there isn't any.
+
+All written above lead to cleaning up uninitialized fields. Even if we hide
+ODEBUG warning by initializing bat_priv->nc.work, syzbot was able to hit
+GPF in batadv_nc_purge_paths(), because hash pointer in still NULL. [1]
+
+To fix these bugs we can unwind batadv_*_init() calls one by one.
+It is good approach for 2 reasons: 1) It fixes bugs on error handling
+path 2) It improves the performance, since we won't call unneeded
+batadv_*_free() functions.
+
+So, this patch makes all batadv_*_init() clean up all allocated memory
+before returning with an error to no call correspoing batadv_*_free()
+and open-codes batadv_mesh_free() with proper order to avoid touching
+uninitialized fields.
+
+Link: https://lore.kernel.org/netdev/000000000000c87fbd05cef6bcb0@google.com/ [1]
+Reported-and-tested-by: syzbot+28b0702ada0bf7381f58@syzkaller.appspotmail.com
+Fixes: 21e838760727 ("[batman-adv] fix various race conditions during startup & shutdown")
+Signed-off-by: Pavel Skripkin <paskripkin@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/0631e0825c8129cd3896926da62a09ac00bf13a0
+
+--- a/net/batman-adv/bridge_loop_avoidance.c
++++ b/net/batman-adv/bridge_loop_avoidance.c
+@@ -1556,10 +1556,14 @@ int batadv_bla_init(struct batadv_priv *
+ 		return 0;
+ 
+ 	bat_priv->bla.claim_hash = batadv_hash_new(128);
+-	bat_priv->bla.backbone_hash = batadv_hash_new(32);
++	if (!bat_priv->bla.claim_hash)
++		return -ENOMEM;
+ 
+-	if (!bat_priv->bla.claim_hash || !bat_priv->bla.backbone_hash)
++	bat_priv->bla.backbone_hash = batadv_hash_new(32);
++	if (!bat_priv->bla.backbone_hash) {
++		batadv_hash_destroy(bat_priv->bla.claim_hash);
+ 		return -ENOMEM;
++	}
+ 
+ 	batadv_hash_set_lock_class(bat_priv->bla.claim_hash,
+ 				   &batadv_claim_hash_lock_class_key);
+--- a/net/batman-adv/main.c
++++ b/net/batman-adv/main.c
+@@ -189,29 +189,41 @@ int batadv_mesh_init(struct net_device *
+ 
+ 	bat_priv->gw.generation = 0;
+ 
+-	ret = batadv_v_mesh_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
+-
+ 	ret = batadv_originator_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_orig;
++	}
+ 
+ 	ret = batadv_tt_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_tt;
++	}
++
++	ret = batadv_v_mesh_init(bat_priv);
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_v;
++	}
+ 
+ 	ret = batadv_bla_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_bla;
++	}
+ 
+ 	ret = batadv_dat_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_dat;
++	}
+ 
+ 	ret = batadv_nc_mesh_init(bat_priv);
+-	if (ret < 0)
+-		goto err;
++	if (ret < 0) {
++		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
++		goto err_nc;
++	}
+ 
+ 	batadv_gw_init(bat_priv);
+ 	batadv_mcast_init(bat_priv);
+@@ -221,8 +233,20 @@ int batadv_mesh_init(struct net_device *
+ 
+ 	return 0;
+ 
+-err:
+-	batadv_mesh_free(soft_iface);
++err_nc:
++	batadv_dat_free(bat_priv);
++err_dat:
++	batadv_bla_free(bat_priv);
++err_bla:
++	batadv_v_mesh_free(bat_priv);
++err_v:
++	batadv_tt_free(bat_priv);
++err_tt:
++	batadv_originator_free(bat_priv);
++err_orig:
++	batadv_purge_outstanding_packets(bat_priv, NULL);
++	atomic_set(&bat_priv->mesh_state, BATADV_MESH_INACTIVE);
++
+ 	return ret;
+ }
+ 
+--- a/net/batman-adv/network-coding.c
++++ b/net/batman-adv/network-coding.c
+@@ -152,8 +152,10 @@ int batadv_nc_mesh_init(struct batadv_pr
+ 				   &batadv_nc_coding_hash_lock_class_key);
+ 
+ 	bat_priv->nc.decoding_hash = batadv_hash_new(128);
+-	if (!bat_priv->nc.decoding_hash)
++	if (!bat_priv->nc.decoding_hash) {
++		batadv_hash_destroy(bat_priv->nc.coding_hash);
+ 		goto err;
++	}
+ 
+ 	batadv_hash_set_lock_class(bat_priv->nc.decoding_hash,
+ 				   &batadv_nc_decoding_hash_lock_class_key);
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -4193,8 +4193,10 @@ int batadv_tt_init(struct batadv_priv *b
+ 		return ret;
+ 
+ 	ret = batadv_tt_global_init(bat_priv);
+-	if (ret < 0)
++	if (ret < 0) {
++		batadv_tt_local_table_free(bat_priv);
+ 		return ret;
++	}
+ 
+ 	batadv_tvlv_handler_register(bat_priv, batadv_tt_tvlv_ogm_handler_v1,
+ 				     batadv_tt_tvlv_unicast_handler_v1,


### PR DESCRIPTION
The batman-adv for non-802.11ax devices is a fork from the openwrt-routing 21.02 branch. The private copy is used because the QCA kernel is extremely old and doesn't match the kernel from OpenWrt 21.02. And the mac80211 version (and its backports/compat code) is not fully compatible with the official one.

The batman-adv updates from the official openwrt-routing 21.02 branch must be regularly, manually cherry picked.