### PR TITLE
Wifi-6129. Fix for client connectivity with EAP102 VLAN

### DIFF
--- a/patches/0068-Importing-missing-fixes-for-EAP102.patch
+++ b/patches/0068-Importing-missing-fixes-for-EAP102.patch
@@ -1,0 +1,70 @@
+From 94ff87833a58ec44d79bd9c2e30f2058fb692e66 Mon Sep 17 00:00:00 2001
+From: ravi vaishnav <ravi.vaishnav@netexperience.com>
+Date: Wed, 8 Dec 2021 12:23:08 -0500
+Subject: [PATCH] Importing missing fixes for EAP102
+
+Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>
+---
+ target/linux/ipq807x/base-files/etc/board.d/02_network | 2 +-
+ target/linux/ipq807x/image/ipq60xx.mk                  | 4 ++--
+ target/linux/ipq807x/image/ipq807x.mk                  | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/target/linux/ipq807x/base-files/etc/board.d/02_network b/target/linux/ipq807x/base-files/etc/board.d/02_network
+index d53f743d27..9151f84a1f 100755
+--- a/target/linux/ipq807x/base-files/etc/board.d/02_network
++++ b/target/linux/ipq807x/base-files/etc/board.d/02_network
+@@ -24,6 +24,7 @@ qcom_setup_interfaces()
+ 		ucidef_set_interface_wan "eth5"
+ 		;;
+ 	cig,wf194c|\
++	edgecore,eap102|\
+ 	sercomm,wallaby)
+ 		ucidef_set_interface_lan "eth0"
+ 		ucidef_set_interface_wan "eth1"
+@@ -32,7 +33,6 @@ qcom_setup_interfaces()
+ 		ucidef_set_interface_lan "eth1 eth2"
+ 		ucidef_set_interface_wan "eth0"
+ 		;;
+-	edgecore,eap102|\
+ 	edgecore,eap106|\
+ 	cig,wf188n)
+ 		ucidef_set_interface_lan "eth1"
+diff --git a/target/linux/ipq807x/image/ipq60xx.mk b/target/linux/ipq807x/image/ipq60xx.mk
+index 2751391ac7..201885a760 100644
+--- a/target/linux/ipq807x/image/ipq60xx.mk
++++ b/target/linux/ipq807x/image/ipq60xx.mk
+@@ -7,7 +7,7 @@ define Device/cig_wf188
+   SUPPORTED_DEVICES := cig,wf188
+   IMAGES := sysupgrade.tar
+   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+-  DEVICE_PACKAGES := ath11k-wifi-cig-wf188 uboot-env
++  DEVICE_PACKAGES := ath11k-wifi-cig-wf188 uboot-envtools
+ endef
+ TARGET_DEVICES += cig_wf188
+ 
+@@ -16,7 +16,7 @@ define Device/cig_wf188n
+   DEVICE_DTS := qcom-ipq6018-cig-wf188n
+   DEVICE_DTS_CONFIG := config@cp03-c1
+   SUPPORTED_DEVICES := cig,wf188n
+-  DEVICE_PACKAGES := ath11k-wifi-cig-wf188n uboot-env
++  DEVICE_PACKAGES := ath11k-wifi-cig-wf188n uboot-envtools
+ endef
+ TARGET_DEVICES += cig_wf188n
+ 
+diff --git a/target/linux/ipq807x/image/ipq807x.mk b/target/linux/ipq807x/image/ipq807x.mk
+index 92b301bcfb..a25267aeb9 100644
+--- a/target/linux/ipq807x/image/ipq807x.mk
++++ b/target/linux/ipq807x/image/ipq807x.mk
+@@ -41,7 +41,7 @@ define Device/edgecore_eap102
+   DEVICE_DTS := qcom-ipq807x-eap102
+   DEVICE_DTS_CONFIG=config@ac02
+   SUPPORTED_DEVICES := edgecore,eap102
+-  DEVICE_PACKAGES := ath11k-wifi-edgecore-eap102 kmod-usb3 uboot-envtools
++  DEVICE_PACKAGES := ath11k-wifi-edgecore-eap102 kmod-usb2 uboot-envtools
+ endef
+ TARGET_DEVICES += edgecore_eap102
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Bringing in the missing changes from a patch which was earlier
committed on Pennding and which got over-written with CS merge.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>