### PR TITLE
Wifi-6165. Handling durationMs from Chan_info events

### DIFF
--- a/feeds/wifi-cs1/mac80211/patches/pending/217-ath11k-debug.patch
+++ b/feeds/wifi-cs1/mac80211/patches/pending/217-ath11k-debug.patch
@@ -1,0 +1,33 @@
+diff -Naur a/drivers/net/wireless/ath/ath11k/wmi.c b/drivers/net/wireless/ath/ath11k/wmi.c
+--- a/drivers/net/wireless/ath/ath11k/wmi.c	2021-12-15 19:14:36.363332750 -0500
++++ b/drivers/net/wireless/ath/ath11k/wmi.c	2021-12-22 13:09:19.899202295 -0500
+@@ -8127,6 +8127,7 @@
+ 		cc_freq_hz = (ch_info_ev.mac_clk_mhz * 1000);
+ 
+ 	if (ch_info_ev.cmd_flags == WMI_CHAN_INFO_START_RESP) {
++	#if 0
+ 		survey = &ar->survey[idx];
+ 		memset(survey, 0, sizeof(*survey));
+ 		survey->noise = ch_info_ev.noise_floor;
+@@ -8137,6 +8138,9 @@
+ 		if (survey->time)
+ 			ar->hw->medium_busy = div_u64((survey->time_busy * 100),
+ 						      survey->time);
++		printk("DBGL: CHAN_info: freq:%d, nf:%d, time:%llu, time_busy:%llu\n",
++			ch_info_ev.freq, survey->noise, survey->time, survey->time_busy);
++	#endif
+ 	}
+ exit:
+ 	spin_unlock_bh(&ar->data_lock);
+@@ -8211,6 +8215,11 @@
+ 			       SURVEY_INFO_TIME_RX |
+ 			       SURVEY_INFO_TIME_TX |
+ 			       SURVEY_INFO_TIME_BSS_RX);
++	printk("DBGL: BSS_CHAN: freq:%d, nf:%d, time:%llu, time_busy:%llu, time_rx:%llu,"
++		" time_bss_rx:%llu, time_tx:%llu\n",
++		bss_ch_info_ev.freq, survey->noise, survey->time, survey->time_busy,
++		survey->time_rx, survey->time_bss_rx, survey->time_tx);
++
+ exit:
+ 	spin_unlock_bh(&ar->data_lock);
+ 	complete(&ar->bss_survey_done);

--- a/feeds/wlan-ap/opensync/patches/47-cap_survey_sample_interval.patch
+++ b/feeds/wlan-ap/opensync/patches/47-cap_survey_sample_interval.patch
@@ -1,0 +1,44 @@
+Index: opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+===================================================================
+--- opensync-2.0.5.0.orig/src/sm/src/sm_survey_report.c
++++ opensync-2.0.5.0/src/sm/src/sm_survey_report.c
+@@ -714,7 +714,10 @@ bool sm_survey_update_list_cb (
+                     scan_type,
+                     survey_entry,
+                     record_entry,
+-                    result_entry);
++                    result_entry,
++		    request_ctx->sampling_interval,
++		    request_ctx->scan_interval,
++		    true);
+         if (true != rc) {
+             LOGN("Processing %s %s %u survey record %u "
+                  "(Failed to convert stats)",
+@@ -960,7 +963,10 @@ bool sm_survey_threshold_util_cb (
+                 RADIO_SCAN_TYPE_ONCHAN,
+                 survey_entry,
+                 &survey_ctx->threshold_record,
+-                &result_entry);
++                &result_entry,
++		request_ctx->sampling_interval,
++		request_ctx->scan_interval,
++		false);
+     if (true != rc) {
+         LOGE("Processing %s %s %u survey "
+              "(failed to convert threshold stats)",
+Index: opensync-2.0.5.0/src/lib/target/inc/target_common.h
+===================================================================
+--- opensync-2.0.5.0.orig/src/lib/target/inc/target_common.h
++++ opensync-2.0.5.0/src/lib/target/inc/target_common.h
+@@ -486,7 +486,10 @@ bool target_stats_survey_convert (
+         radio_scan_type_t           scan_type,
+         target_survey_record_t     *data_new,
+         target_survey_record_t     *data_old,
+-        dpp_survey_record_t        *survey_record);
++        dpp_survey_record_t        *survey_record,
++	int                        sampling_interval,
++	int                        scan_interval,
++	bool                       for_report);
+ 
+ /// @} LIB_TARGET_SURVEY
+ 

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/rootfs/common/etc/init.d/opensync
@@ -56,6 +56,13 @@ start_service() {
     fi
     echo "Starting OpenSync"
     procd_set_param command ${PROG}
+
+    [ -e /proc/sys/kernel/core_pattern ] && {
+         procd_set_param limits core="unlimited"
+         #echo '/tmp/%e.%p.%s.%t.core' > /proc/sys/kernel/core_pattern
+         echo '/tmp/%e.core' > /proc/sys/kernel/core_pattern
+    }
+
     procd_close_instance
 }
 


### PR DESCRIPTION
Chan_info events use the same container as BSS_info events,
hence the durationMs from Chan_info events need special handling.
Adding a separate counter to track the old and new durationMs
from Chan_info events and adding the differential duration to the
old Bss_info duration.

Signed-off-by: ravi vaishnav <ravi.vaishnav@netexperience.com>