### PR TITLE
wifi-6169 Fix survey stats inconsistencies

### DIFF
--- a/feeds/wifi-cs1/mac80211/patches/qca/321-ath11k-suppress-chan-info-event.patch
+++ b/feeds/wifi-cs1/mac80211/patches/qca/321-ath11k-suppress-chan-info-event.patch
@@ -1,0 +1,83 @@
+--- a/drivers/net/wireless/ath/ath11k/wmi.c	2021-12-31 12:50:46.647341108 -0800
++++ b/drivers/net/wireless/ath/ath11k/wmi.c	2021-12-31 13:16:53.627380659 -0800
+@@ -8069,78 +8069,9 @@
+ 
+ static void ath11k_chan_info_event(struct ath11k_base *ab, struct sk_buff *skb)
+ {
+-	struct wmi_chan_info_event ch_info_ev = {0};
+-	struct ath11k *ar;
+-	struct survey_info *survey;
+-	int idx;
+-	/* HW channel counters frequency value in hertz */
+-	u32 cc_freq_hz = ab->cc_freq_hz;
+-
+-	if (ath11k_pull_chan_info_ev(ab, skb->data, skb->len, &ch_info_ev) != 0) {
+-		ath11k_warn(ab, "failed to extract chan info event");
+-		return;
+-	}
+-
+-	ath11k_dbg(ab, ATH11K_DBG_WMI,
+-		   "chan info vdev_id %d err_code %d freq %d cmd_flags %d noise_floor %d rx_clear_count %d cycle_count %d mac_clk_mhz %d\n",
+-		   ch_info_ev.vdev_id, ch_info_ev.err_code, ch_info_ev.freq,
+-		   ch_info_ev.cmd_flags, ch_info_ev.noise_floor,
+-		   ch_info_ev.rx_clear_count, ch_info_ev.cycle_count,
+-		   ch_info_ev.mac_clk_mhz);
+-
+-	if (ch_info_ev.cmd_flags == WMI_CHAN_INFO_END_RESP) {
+-		ath11k_dbg(ab, ATH11K_DBG_WMI, "chan info report completed\n");
+-		return;
+-	}
+-
+-	rcu_read_lock();
+-	ar = ath11k_mac_get_ar_by_vdev_id(ab, ch_info_ev.vdev_id);
+-	if (!ar) {
+-		ath11k_warn(ab, "invalid vdev id in chan info ev %d",
+-			    ch_info_ev.vdev_id);
+-		rcu_read_unlock();
+-		return;
+-	}
+-	spin_lock_bh(&ar->data_lock);
+-
+-	switch (ar->scan.state) {
+-	case ATH11K_SCAN_IDLE:
+-	case ATH11K_SCAN_STARTING:
+-		ath11k_warn(ab, "received chan info event without a scan request, ignoring\n");
+-		goto exit;
+-	case ATH11K_SCAN_RUNNING:
+-	case ATH11K_SCAN_ABORTING:
+-		break;
+-	}
+-
+-	idx = freq_to_idx(ar, ch_info_ev.freq);
+-	if (idx >= ARRAY_SIZE(ar->survey)) {
+-		ath11k_warn(ab, "chan info: invalid frequency %d (idx %d out of bounds)\n",
+-			    ch_info_ev.freq, idx);
+-		goto exit;
+-	}
+-
+-	/* If FW provides MAC clock frequency in Mhz, overriding the initialized
+-	 * HW channel counters frequency value
++	/* Ignore this event. It was clear on read and overriding chan info
++	 * coming from bss_chan_info_event.
+ 	 */
+-	if (ch_info_ev.mac_clk_mhz)
+-		cc_freq_hz = (ch_info_ev.mac_clk_mhz * 1000);
+-
+-	if (ch_info_ev.cmd_flags == WMI_CHAN_INFO_START_RESP) {
+-		survey = &ar->survey[idx];
+-		memset(survey, 0, sizeof(*survey));
+-		survey->noise = ch_info_ev.noise_floor;
+-		survey->filled = SURVEY_INFO_NOISE_DBM | SURVEY_INFO_TIME |
+-				 SURVEY_INFO_TIME_BUSY;
+-		survey->time = div_u64(ch_info_ev.cycle_count, cc_freq_hz);
+-		survey->time_busy = div_u64(ch_info_ev.rx_clear_count, cc_freq_hz);
+-		if (survey->time)
+-			ar->hw->medium_busy = div_u64((survey->time_busy * 100),
+-						      survey->time);
+-	}
+-exit:
+-	spin_unlock_bh(&ar->data_lock);
+-	rcu_read_unlock();
+ }
+ 
+ static void

--- a/feeds/wlan-ap/opensync/patches/47-fix-sm-crash-on-stats-update.patch
+++ b/feeds/wlan-ap/opensync/patches/47-fix-sm-crash-on-stats-update.patch
@@ -1,0 +1,97 @@
+--- a/src/sm/src/sm_scan_schedule.c
++++ b/src/sm/src/sm_scan_schedule.c
+@@ -130,6 +130,9 @@ bool sm_scan_schedule_cb (
+ {
+     bool                            rc;
+     sm_scan_ctx_t                  *scan_ctx = NULL;
++    sm_scan_ctx_t                  *scan_ctx_queue = NULL;
++    ds_dlist_iter_t                 queue_iter;
++    bool scan_ctx_exists = false;
+ 
+     scan_schedule_timeout_timer_set(&g_scan_schedule_timer, false);
+ 
+@@ -142,41 +145,59 @@ bool sm_scan_schedule_cb (
+     scan_ctx = (sm_scan_ctx_t *) ctx;
+ 
+ clean:
+-    /* Notify upper layer about scan status */
+-    if (scan_ctx->scan_request.scan_cb)
+-    {
+-        scan_ctx->scan_request.scan_cb(scan_ctx->scan_request.scan_ctx, scan_status);
+-    }
+-
+-    // Something went wrong, clean pending requests and exit
+-    if (!scan_status) {
+-        return sm_scan_schedule_queue_flush();
++    /* Process only if scan queue exists, thereby avoiding double free in case
++     * the queue is just flushed by any of the other callbacks.
++     */
++    if (!ds_dlist_is_empty(&g_scan_ctx_list)) {
++        for (scan_ctx_queue = ds_dlist_ifirst(&queue_iter, &g_scan_ctx_list);
++             scan_ctx_queue != NULL;
++             scan_ctx_queue = ds_dlist_inext(&queue_iter)) {
++            if (scan_ctx == scan_ctx_queue) {
++	            scan_ctx_exists = true;
++	            break;
++            }
++        }
+     }
+ 
+-    /* Remove processed context */
+-    ds_dlist_remove_head(&g_scan_ctx_list);
+-    if (scan_ctx) {
+-	LOG(DEBUG, "sm_scan_schedule_cb. Scan done. Deleting scan_ctx. %p. %s %s %d\n",
+-		scan_ctx,
+-		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
+-		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
+-		scan_ctx->scan_request.chan_list[0]);
++    if (scan_ctx_exists) {
++        /* Notify upper layer about scan status */
++        if (scan_ctx->scan_request.scan_cb) {
++            LOG(DEBUG, "Calling scan_cb %s scan status %d\n", __func__, scan_status);
++            scan_ctx->scan_request.scan_cb(scan_ctx->scan_request.scan_ctx, scan_status);
++        }
++
++        /* Something went wrong, clean pending requests and exit */
++        if (!scan_status) {
++            LOG(DEBUG, "Scan trigger failed. Flushing the scan request queue. scan_ctx. %p. %s %s %d\n",
++                scan_ctx,
++                radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++                radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++                scan_ctx->scan_request.chan_list[0]);
++            return sm_scan_schedule_queue_flush();
++        }
++
++        /* Remove processed context */
++        LOG(DEBUG, "sm_scan_schedule_cb. Scan done. Deleting scan_ctx. %p. %s %s %d\n",
++            scan_ctx,
++            radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++            radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++            scan_ctx->scan_request.chan_list[0]);
++        ds_dlist_iremove(&queue_iter);
++        sm_scan_ctx_free(scan_ctx);
++        scan_ctx = NULL;
+     }
+ 
+-    sm_scan_ctx_free(scan_ctx);
+-    scan_ctx = NULL;
+-
+     /* Check for waiting scan requests an schedule next in line */
+     scan_ctx = ds_dlist_head(&g_scan_ctx_list);
+     if (scan_ctx)
+     {
+         scan_status = true;
+ 
+-	LOG(DEBUG, "sm_scan_schedule_cb. Schedule next scan request. %p. %s %s %d\n",
+-		scan_ctx,
+-		radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
+-		radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
+-		scan_ctx->scan_request.chan_list[0]);
++    LOG(DEBUG, "sm_scan_schedule_cb. Schedule next scan request. %p. %s %s %d\n",
++        scan_ctx,
++        radio_get_name_from_type(scan_ctx->scan_request.radio_cfg->type),
++        radio_get_scan_name_from_type(scan_ctx->scan_request.scan_type),
++        scan_ctx->scan_request.chan_list[0]);
+ 
+         rc =
+             sm_scan_schedule_process (

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/inc/nl80211.h
@@ -74,8 +74,8 @@ typedef struct ssid_list {
 } ssid_list_t;
 
 typedef struct channel_info {
-	int channel;
-	int bandwidth;
+	uint32_t channel;
+	uint32_t bandwidth;
 } channel_info_t;
 
 extern int stats_nl80211_init(void);

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats.c
@@ -258,18 +258,7 @@ bool target_stats_survey_convert(radio_entry_t *radio_cfg, radio_scan_type_t sca
 	if (data_new->info.chan != data_old->info.chan) {
 		/* Do not consider the old channel's data */
 		memset(data_old, 0, sizeof(*data_old));
-	} else if ((data_new->duration_ms <= data_old->duration_ms) &&
-			(data_new->chan_busy <= data_old->chan_busy)) {
-		/*
-		 * Take care of survey data from CHAN_INFO events which are Read-On-Clear
-		 * in nature, whereas survey data from BSS_CHAN_INFO events are Read only.
-		 * Chan_info event down in the driver updates only the duration, noise floor
-		 * and the chan_busy data.
-		 */
-		data_new->duration_ms += data_old->duration_ms;
-		data_new->chan_busy += data_old->chan_busy;
 	}
-
 
 	LOGD("Survey convert scan_type %d chan %d duration_new:%llu duration_old:%llu "
 	     "busy_new %llu busy_old:%llu tx_new %llu tx_old:%llu rx_new %llu rx_old:%llu "

--- a/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
+++ b/feeds/wlan-ap/opensync/src/platform/openwrt/src/lib/target/src/stats_nl80211.c
@@ -612,7 +612,11 @@ int nl80211_scan_trigger(struct nl_call_param *nl_call_param, uint32_t *chan_lis
 	if ((scan_type == RADIO_SCAN_TYPE_OFFCHAN) && dwell_time)
 		nla_put_u16(msg, NL80211_ATTR_MEASUREMENT_DURATION, dwell_time);
 
-	nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, requested_freq);
+	if ((scan_type == RADIO_SCAN_TYPE_OFFCHAN) && (chan_list[0] != oper_chan.channel)) {
+		nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, requested_freq);
+	} else if ((scan_type == RADIO_SCAN_TYPE_ONCHAN) && (chan_list[0] == oper_chan.channel)) {
+		nla_put_u32(msg, NL80211_ATTR_WIPHY_FREQ, requested_freq);
+	}
 
 	if (requested_freq > 5000) {
 		switch(oper_chan.bandwidth)


### PR DESCRIPTION
 - Simplify logic to store onchan/offchan survey entries. This helps
   avoid duplicate and invalid survey records.
 - Round off survey percentages to the nearest integer instead of chopping them.

Signed-off-by: Yashvardhan <yashvardhan@netexperience.com>