### PR TITLE
ipq807x: add initial support for GL.iNet AXT1800

### DIFF
--- a/feeds/ipq807x/ipq807x/base-files/etc/board.d/01_leds
+++ b/feeds/ipq807x/ipq807x/base-files/etc/board.d/01_leds
@@ -39,7 +39,8 @@ hfcl,ion4xe)
         ucidef_set_led_wlan "wlan5g" "WLAN5G" "blue:wifi5" "phy0tpt"
         ucidef_set_led_wlan "wlan2g" "WLAN2G" "blue:wifi2" "phy1tpt"
 	;;
-glinet,ax1800)
+glinet,ax1800|\
+glinet,axt1800)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0" "tx rx link"
 	;;
 esac

--- a/feeds/ipq807x/ipq807x/base-files/etc/board.d/02_network
+++ b/feeds/ipq807x/ipq807x/base-files/etc/board.d/02_network
@@ -37,7 +37,8 @@ qcom_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		ucidef_set_interface_wan "eth1"
 		;;
-	edgecore,eap101)
+	edgecore,eap101|\
+	glinet,axt1800)
 		ucidef_set_interface_lan "eth1 eth2"
 		ucidef_set_interface_wan "eth0"
 		;;

--- a/feeds/ipq807x/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/feeds/ipq807x/ipq807x/base-files/lib/upgrade/platform.sh
@@ -27,6 +27,7 @@ platform_check_image() {
 	cig,wf196|\
 	cybertan,eww622-a1|\
 	glinet,ax1800|\
+	glinet,axt1800|\
 	wallys,dr6018|\
 	wallys,dr6018-v4|\
 	edgecore,eap101|\
@@ -65,6 +66,7 @@ platform_do_upgrade() {
 	cybertan,eww622-a1|\
 	edgecore,eap104|\
 	glinet,ax1800|\
+	glinet,axt1800|\
 	hfcl,ion4xi|\
 	hfcl,ion4xe|\
 	qcom,ipq6018-cp01|\

--- a/feeds/ipq807x/ipq807x/files/arch/arm/boot/dts/qcom-ipq6018-gl-axt1800.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm/boot/dts/qcom-ipq6018-gl-axt1800.dts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "../../../arm64/boot/dts/qcom/qcom-ipq6018-gl-axt1800.dts"
+#include "qcom-ipq6018.dtsi"

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq6018-gl-axt1800.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq6018-gl-axt1800.dts
@@ -1,0 +1,94 @@
+/dts-v1/;
+/*
+ * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "qcom-ipq6018-gl-ax1800.dtsi"
+
+/ {
+	model = "GL Technologies, Inc. AXT1800";
+	compatible = "glinet,axt1800", "qcom,ipq6018-cp03", "qcom,ipq6018";
+
+	aliases {
+		sdhc0 = &sdhc_2;
+	};
+};
+
+&tlmm {
+	sd_pins: sd_pins {
+		sd {
+			pins = "gpio62";
+			function = "sd_card";
+			bias-pull-up;
+		};
+		ldo {
+			pins = "gpio66";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	pwm_pins: pwm_pinmux {
+		pwm {
+			pins = "gpio30";
+			function = "pwm13";
+			drive-strength = <8>;
+		};
+	};
+
+	fan_pins: fan_pins {
+		pwr {
+			pins = "gpio29";
+			function = "gpio";
+			bias-pull-up;
+			output-high;
+		};
+		speed {
+			pins = "gpio31";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+};
+
+&soc {
+	pwm:pwm {
+		#pwm-cells = <2>;
+		pinctrl-0 = <&pwm_pins>;
+		pinctrl-names = "default";
+		used-pwm-indices = <0>, <1>, <0>, <0>;
+		status = "ok";
+	};
+
+	pwm-fan {
+		compatible = "pwm-fan";
+		pinctrl-0 = <&fan_pins>;
+		pinctrl-names = "default";
+		cooling-min-state = <0>;
+		cooling-max-state = <3>;
+		#cooling-cells = <2>;
+		pwms = <&pwm 1 255>;
+		cooling-levels = <0 150 200 255>;
+	};
+};
+
+&sdhc_2 {
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+	cd-gpios = <&tlmm 62 1>;
+	sd-ldo-gpios = <&tlmm 66 1>;
+	status = "ok";
+};

--- a/feeds/ipq807x/ipq807x/image/ipq60xx.mk
+++ b/feeds/ipq807x/ipq807x/image/ipq60xx.mk
@@ -82,6 +82,15 @@ define Device/glinet_ax1800
 endef
 TARGET_DEVICES += glinet_ax1800
 
+define Device/glinet_axt1800
+  DEVICE_TITLE := GL-iNet AXT1800
+  DEVICE_DTS := qcom-ipq6018-gl-axt1800
+  SUPPORTED_DEVICES := glinet,axt1800
+  DEVICE_DTS_CONFIG := config@cp03-c1
+  DEVICE_PACKAGES := ath11k-wifi-gl-ax1800 -kmod-usb-dwc3-of-simple kmod-usb-dwc3-qcom kmod-usb3
+endef
+TARGET_DEVICES += glinet_axt1800
+
 define Device/yuncore_ax840
   DEVICE_TITLE := YunCore AX840
   DEVICE_DTS := qcom-ipq6018-yuncore-ax840

--- a/profiles/glinet_axt1800.yml
+++ b/profiles/glinet_axt1800.yml
@@ -1,0 +1,13 @@
+profile: glinet_axt1800
+target: ipq807x
+subtarget: ipq60xx
+description: Build image for the GL.iNET AXT1800
+image: bin/targets/ipq807x/ipq60xx/openwrt-ipq807x-glinet_axt1800-squashfs-sysupgrade.tar
+feeds:
+  - name: ipq807x
+    path: ../../feeds/ipq807x
+include:
+  - wifi-ax
+  - ucentral-ap
+diffconfig: |
+  CONFIG_KERNEL_IPQ_MEM_PROFILE=0


### PR DESCRIPTION
Hardware:
* SoC: Qcom IPQ6000
* RAM: DDR3L 512MB
* Flash: 128MB Nand
* Ethernet: 3x GbE
* WLAN: 2x2 2.4GHz 600Mbps + 2x2 5GHz 1200Mbps (builtin + builtin)
* LEDS: 1x white, 1x blue
* Buttons: 1x switch, 1x reset
* USB: 1x 3.0(Type-A)
* SD: 1x microSD
* PWM Fan
* Power: 12VDC, 2A
* UART (4-pin, 2.54 mm pitch) pad on PCB
* JTAG (8-pin, 2.54 mm pitch) pad on PCB

Installation: upgrade "openwrt-ipq807x-glinet_ax1800-squashfs-sysupgrade.tar" directly.

Signed-off-by: Jianhui Zhao <jianhui.zhao@gl-inet.com>