### PR TITLE
usteer: fix init script

### DIFF
--- a/feeds/ucentral/usteer/files/etc/init.d/usteer
+++ b/feeds/ucentral/usteer/files/etc/init.d/usteer
@@ -143,5 +143,5 @@ start_service()
 	procd_open_instance
 	procd_set_param command "/usr/libexec/uchannel.uc"
 	procd_set_param respawn 1 300 0
-	procd_close_instancea
+	procd_close_instance
 }


### PR DESCRIPTION
The uchannel instance of the usteer init script contains a typo, causing
the following error when autochannel is enabled:

/etc/rc.common: line 147: procd_close_instancea: not found

Fixes: WIFI-7577
Fixes: c467a62af36f ("usteer: update to latest HEAD")
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>