### PR TITLE
usteer: fix uchannel.uc script

### DIFF
--- a/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
+++ b/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
@@ -272,7 +272,7 @@ function youngest() {
 let state = state_get();
 
 if (state.status == "waiting" &&
-    (uptime - state.uptime < (12 * 60 * 60))) {
+    (uptime - state.changed < (12 * 60 * 60))) {
 	state_set(state);
 	return;
 }

--- a/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
+++ b/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
@@ -56,7 +56,7 @@ function state_get() {
 function state_set(state) {
 	let file = fs.open("/tmp/uchannel.json", "w");
 
-	state.uptime = uptime;
+	state.executed = uptime;
 	file.write(state);
 	file.close();
 
@@ -64,7 +64,7 @@ function state_set(state) {
 		node: "*",
 		data: {
 			status: state.status,
-			uptime: state.uptime,
+			uptime: state.executed,
 		}
 	});
 	printf("entering %s state\n", state.status);


### PR DESCRIPTION
Once the uchannel.uc script sets its status to waiting, it becomes
defunct. The next invocation of the script will compare uptime to
state.uptime, and if the difference is less than 12h, it will change
state.uptime to the current uptime and return. As the script runs every
5 minutes, the difference will always be less than 12h.

Fix this by comparing uptime against state.changed rather than
state.uptime.

While at it, rename state.uptime to state.executed, to be more
descriptive.