### PR TITLE
WIFI-7614: usteer: more uchannel.uc fixes

### DIFF
--- a/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
+++ b/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
@@ -125,11 +125,11 @@ function channel_overlap() {
 
 	for (let id, i in info) {
 		peers.local[i.freq] = true;
-		block_list[freq2band(freq)][i.freq] = 0;
+		block_list[freq2band(i.freq)][i.freq] = 0;
 	}
 	for (let node, r in remote) {
 		peers[split(node, "#")][r.freq] = true;
-		block_list[freq2band(freq)][r.freq] = 0;
+		block_list[freq2band(r.freq)][r.freq] = 0;
 	}
 
 	for (let id, peer in peers)

--- a/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
+++ b/feeds/ucentral/usteer/files/usr/libexec/uchannel.uc
@@ -259,8 +259,8 @@ function channel_balance(band, mask) {
 
 function youngest() {
 	for (let ip, host in hosts) {
-		if (host.host_info.status == "overlap" &&
-		    host.host_info.uptime < uptime) {
+		if (host.host_info?.status == "overlap" &&
+		    host.host_info?.uptime < uptime) {
 			print("Found a younger host\n");
 			return 1;
 		}


### PR DESCRIPTION
This change corrects the uchannel.uc output which displayed 5G channels as both 2G and 5G.
Before:

```
root@903cb39d69ac:~# /usr/libexec/uchannel.uc 
discovered devices: [ { "path": "platform/soc/c000000.wifi1", "htmode": "he", "bandwidth": "80", "iface": [ "wlan0" ], "sta": false }, { "path": "platform/soc/c000000.wifi1+1", "htmode": "he", "bandwidth": "40", "iface": [ "wlan1" ], "sta": false } ]
list of blocked channels: { "2G": { "5660": 0, "2412": 1, "5580": 0, "5180": 0, "2437": 1 }, "5G": { "5660": 1, "5580": 2, "5180": 1 } }
list of overlapping channels: { }
entering happy state
```

After:

```
root@903cb39d69ac:~# /usr/libexec/uchannel.uc 
discovered devices: [ { "path": "platform/soc/c000000.wifi1", "htmode": "he", "bandwidth": "80", "iface": [ "wlan0" ], "sta": false }, { "path": "platform/soc/c000000.wifi1+1", "htmode": "he", "bandwidth": "40", "iface": [ "wlan1" ], "sta": false } ]
list of blocked channels: { "2G": { "2412": 1, "2437": 1 }, "5G": { "5660": 1, "5580": 2, "5180": 1 } }
list of overlapping channels: { }
entering happy state
```


Add further fix for situation where host_info is null for a particular host, ie where `autochannel` is disabled.

Signed-off-by: Matthew Hagan <mathagan@fb.com>