### PR TITLE
sk_buff's cb should be cleared in the entry point for both incoming and outgoing  packets at each layer.

### DIFF
--- a/feeds/ipq807x/ipq807x/patches/224-clear-skbuffs-cb-for-incoming-packets.patch
+++ b/feeds/ipq807x/ipq807x/patches/224-clear-skbuffs-cb-for-incoming-packets.patch
@@ -1,0 +1,30 @@
+From a0d398a7373b395a2cbdc865815560671d1e8a08 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Fri, 12 Aug 2022 15:42:40 +0530
+Subject: [PATCH] sk_buff's cb should be cleared in the entry point for both
+ incoming and outgoing packets at each layer. At bridge, it is already handled
+ in the outgoing path, but not in the incoming path. We have seen cases where
+ proxyarp_replied was 1 on sk_buffs coming from the WLAN driver and they were
+ getting dropped in forwarding path.
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ net/bridge/br_input.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/net/bridge/br_input.c b/net/bridge/br_input.c
+index e6b745b7..09cd5b72 100644
+--- a/net/bridge/br_input.c
++++ b/net/bridge/br_input.c
+@@ -282,6 +282,8 @@ rx_handler_result_t br_handle_frame(struct sk_buff **pskb)
+ 	if (!skb)
+ 		return RX_HANDLER_CONSUMED;
+ 
++	memset(skb->cb, 0, sizeof(struct br_input_skb_cb));
++
+ 	p = br_port_get_rcu(skb->dev);
+ 
+ 	if (unlikely(is_link_local_ether_addr(dest))) {
+-- 
+2.34.1
+


### PR DESCRIPTION
At bridge, it is already handled in the outgoing path,
but not in the incoming path. We have seen cases where proxyarp_replied was 1
on sk_buffs coming from the WLAN driver and they were getting dropped in forwarding path.

Signed-off-by: Venkat Chimata <venkata@shasta.cloud>