### PR TITLE
ipq807x: Fix build of kmod-br-netfilter

### DIFF
--- a/feeds/ipq807x/ipq807x/patches/235-generic-Fix-per-interface-nf_call_iptables-setting.patch
+++ b/feeds/ipq807x/ipq807x/patches/235-generic-Fix-per-interface-nf_call_iptables-setting.patch
@@ -1,0 +1,234 @@
+From: Sven Eckelmann <sven@open-mesh.com>
+Date: Wed, 2 Sep 2015 19:47:43 +0200
+Subject: generic: Fix per interface nf_call_iptables setting
+
+commit r30917 ("kernel: bypass all netfilter hooks if the sysctls for that
+functionality have been disabled - eliminates the overhead of enabling
+CONFIG_BRIDGE_NETFILTER in the kernel config") introduced an optimization
+which should reduce/eliminate the overhead for traffic send over bridges on
+kernels compiled with CONFIG_BRIDGE_NETFILTER=y. But this optimization
+breaks the nf_call_iptables per bridge setting which is more fine grained
+than the global sysctl net.bridge.bridge-nf-call-iptables setting.
+
+A test reflecting a real world setup was created to identify if this really
+eliminates the overhead and if per-bridge nf_call_iptables could be used in
+some setups to increase the throughput. A Qualcomm Atheros QCA9558 based
+system with one ethernet and an ath9k wifi 3x3 in HT40 mode was used.
+Cables from the AP to the wifi station were used to reduce interference
+problems during the tests.
+
+The wlan interface was put in one bridge interface called br-wlan. This
+bridge usually contains some more wlan interfaces. The eth0 was put in a
+second bridge called br-lan. This usually contains some other privileged
+wlan or mesh interfaces. Routing was added between br-lan and br-wlan.
+
+Three kernels were tested:
+
+ * (default) OpenWrt kernel for this device
+ * (brfilter-global) OpenWrt kernel with CONFIG_BRIDGE_NETFILTER=y
+ * (brfilter-local)  OpenWrt kernel with CONFIG_BRIDGE_NETFILTER=y and
+    without 644-bridge_optimize_netfilter_hooks.patch
+
+The changes to the the netfilter settings of the bridge were done via:
+
+ * (brfilter-global) /sbin/sysctl -w net.bridge.bridge-nf-call-iptables=1
+ * (brfilter-lobal) echo 1 > /sys/class/net/br-lan/bridge/nf_call_iptables
+   and/or echo 1 > /sys/class/net/br-wan/bridge/nf_call_iptables
+
+A station connected to the wlan0 (AP) interface was used to send traffic to
+a PC connected via ethernet. iperf with 3 concurrent transmissions was used
+to generate the traffic.
+
+| kernel          | br-nf-* global | nf-call* iface | download | upload   |
+|-----------------|----------------|----------------|----------|----------|
+| default         | 0              | -              |      209 |      268 |
+| brfilter-global | 0              | -              |      185 |      243 |
+| brfilter-local  | 0              | -              |      187 |      243 |
+| brfilter-local  | 0              | br-lan         |      157 |      226 |
+| brfilter-local  | 0              | br-lan br-wlan |      139 |      161 |
+| brfilter-global | 1              | -              |      136 |      162 |
+
+Download/upload results in Mibit/s
+
+It can be seen that the patch doesn't eliminate the overhead. It can also
+be seen that the throughput of brfilter-global and brfilter-local with
+disabled filtering is the roughly the same. Also the throughput for
+brfilter-global and brfilter-local for enabled filtering on all bridges is
+roughly the same.
+
+But also the brfilter-local throughput is higher when only br-lan requires
+the filtering. This setting would not be possible with
+644-bridge_optimize_netfilter_hooks.patch applied and thus can only be
+compared with brfilter-global and filtering enabled for all interfaces.
+
+Signed-off-by: Sven Eckelmann <sven@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/513592/
+Applied-Upstream: https://dev.openwrt.org/changeset/46835
+
+--- a/net/bridge/br_forward.c
++++ b/net/bridge/br_forward.c
+@@ -69,7 +69,7 @@ EXPORT_SYMBOL_GPL(br_dev_queue_push_xmit
+ 
+ int br_forward_finish(struct net *net, struct sock *sk, struct sk_buff *skb)
+ {
+-	return BR_HOOK(NFPROTO_BRIDGE, NF_BR_POST_ROUTING,
++	return NF_HOOK(NFPROTO_BRIDGE, NF_BR_POST_ROUTING,
+ 		       net, sk, skb, NULL, skb->dev,
+ 		       br_dev_queue_push_xmit);
+ 
+@@ -97,7 +97,7 @@ static void __br_deliver(const struct ne
+ 		return;
+ 	}
+ 
+-	BR_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
++	NF_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
+ 		dev_net(skb->dev), NULL, skb,NULL, skb->dev,
+ 		br_forward_finish);
+ }
+@@ -121,7 +121,7 @@ static void __br_forward(const struct ne
+ 	skb->dev = to->dev;
+ 	skb_forward_csum(skb);
+ 
+-	BR_HOOK(NFPROTO_BRIDGE, NF_BR_FORWARD,
++	NF_HOOK(NFPROTO_BRIDGE, NF_BR_FORWARD,
+ 		dev_net(indev), NULL, skb, indev, skb->dev,
+ 		br_forward_finish);
+ }
+--- a/net/bridge/br_input.c
++++ b/net/bridge/br_input.c
+@@ -70,7 +70,7 @@ int br_pass_frame_up(struct sk_buff *skb
+ 	if (!skb)
+ 		return NET_RX_DROP;
+ 
+-	return BR_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_IN,
++	return NF_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_IN,
+ 		       dev_net(indev), NULL, skb, indev, NULL,
+ 		       br_netif_receive_skb);
+ }
+@@ -320,7 +320,7 @@ rx_handler_result_t br_handle_frame(stru
+ 		}
+ 
+ 		/* Deliver packet to local host only */
+-		if (BR_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_IN,
++		if (NF_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_IN,
+ 			    dev_net(skb->dev), NULL, skb, skb->dev, NULL,
+ 			    br_handle_local_finish)) {
+ 			return RX_HANDLER_CONSUMED; /* consumed by filter */
+@@ -337,7 +337,7 @@ forward:
+ 			if (ether_addr_equal(p->br->dev->dev_addr, dest))
+ 				skb->pkt_type = PACKET_HOST;
+ 
+-			if (BR_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING, dev_net(skb->dev), NULL,
++			if (NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING, dev_net(skb->dev), NULL,
+ 				skb, skb->dev, NULL, br_handle_local_finish))
+ 				break;
+ 
+@@ -361,7 +361,7 @@ forward:
+ 		if (ether_addr_equal(p->br->dev->dev_addr, dest))
+ 			skb->pkt_type = PACKET_HOST;
+ 
+-		BR_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
++		NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
+ 			dev_net(skb->dev), NULL, skb, skb->dev, NULL,
+ 			br_handle_frame_finish);
+ 		break;
+--- a/net/bridge/br_multicast.c
++++ b/net/bridge/br_multicast.c
+@@ -856,7 +856,7 @@ static void __br_multicast_send_query(st
+ 
+ 	if (port) {
+ 		skb->dev = port->dev;
+-		BR_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
++		NF_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
+ 			dev_net(port->dev), NULL, skb, NULL, skb->dev,
+ 			br_dev_queue_push_xmit);
+ 	} else {
+--- a/net/bridge/br_netfilter_hooks.c
++++ b/net/bridge/br_netfilter_hooks.c
+@@ -72,15 +72,6 @@ static int brnf_pass_vlan_indev __read_m
+ #define IS_ARP(skb) \
+ 	(!skb_vlan_tag_present(skb) && skb->protocol == htons(ETH_P_ARP))
+ 
+-int brnf_call_ebtables __read_mostly;
+-EXPORT_SYMBOL_GPL(brnf_call_ebtables);
+-
+-bool br_netfilter_run_hooks(void)
+-{
+-	return brnf_call_iptables | brnf_call_ip6tables | brnf_call_arptables |
+-		brnf_call_ebtables | brnf_call_custom;
+-}
+-
+ static inline __be16 vlan_proto(const struct sk_buff *skb)
+ {
+ 	if (skb_vlan_tag_present(skb))
+--- a/net/bridge/br_private.h
++++ b/net/bridge/br_private.h
+@@ -909,29 +909,15 @@ extern const struct nf_br_ops __rcu *nf_
+ 
+ /* br_netfilter.c */
+ #if IS_ENABLED(CONFIG_BRIDGE_NETFILTER)
+-extern int brnf_call_ebtables;
+ int br_nf_core_init(void);
+ void br_nf_core_fini(void);
+ void br_netfilter_rtable_init(struct net_bridge *);
+-bool br_netfilter_run_hooks(void);
+ #else
+ static inline int br_nf_core_init(void) { return 0; }
+ static inline void br_nf_core_fini(void) {}
+ #define br_netfilter_rtable_init(x)
+-#define br_netfilter_run_hooks()	false
+ #endif
+ 
+-static inline int
+-BR_HOOK(uint8_t pf, unsigned int hook, struct net *net, struct sock *sk,
+-	struct sk_buff *skb, struct net_device *in, struct net_device *out,
+-	int (*okfn)(struct net *, struct sock *, struct sk_buff *))
+-{
+-	if (!br_netfilter_run_hooks())
+-		return okfn(net, sk, skb);
+-
+-	return NF_HOOK(pf, hook, net, sk, skb, in, out, okfn);
+-}
+-
+ /* br_stp.c */
+ void br_log_state(const struct net_bridge_port *p);
+ void br_set_state(struct net_bridge_port *p, unsigned int state);
+--- a/net/bridge/br_stp_bpdu.c
++++ b/net/bridge/br_stp_bpdu.c
+@@ -60,7 +60,7 @@ static void br_send_bpdu(struct net_brid
+ 
+ 	skb_reset_mac_header(skb);
+ 
+-	BR_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
++	NF_HOOK(NFPROTO_BRIDGE, NF_BR_LOCAL_OUT,
+ 		dev_net(p->dev), NULL, skb, NULL, skb->dev,
+ 		br_send_bpdu_finish);
+ }
+--- a/net/bridge/netfilter/ebtables.c
++++ b/net/bridge/netfilter/ebtables.c
+@@ -2416,13 +2416,11 @@ static int __init ebtables_init(void)
+ 	}
+ 
+ 	printk(KERN_INFO "Ebtables v2.0 registered\n");
+-	brnf_call_ebtables = 1;
+ 	return 0;
+ }
+ 
+ static void __exit ebtables_fini(void)
+ {
+-	brnf_call_ebtables = 0;
+ 	nf_unregister_sockopt(&ebt_sockopts);
+ 	xt_unregister_target(&ebt_standard_target);
+ 	printk(KERN_INFO "Ebtables v2.0 unregistered\n");
+--- a/net/ipv4/netfilter/nf_nat_l3proto_ipv4.c
++++ b/net/ipv4/netfilter/nf_nat_l3proto_ipv4.c
+@@ -310,7 +310,7 @@ nf_nat_ipv4_fn(void *priv, struct sk_buf
+ 		 * nf_bridge will be set and nf_bridge->physoutdev is not null,
+ 		 * We can assume that it is not expecting NAT operation.
+ 		 *
+-		 * when BR_HOOK is enabled, multicast packets will reach
++		 * when NF_HOOK is enabled, multicast packets will reach
+ 		 * postrouting twice,the first time is when it is forwarded
+ 		 * between ports of a bridge, the second time is that it is
+ 		 * forwarded to upstream port.


### PR DESCRIPTION
QCA is still backporting the old OpenWrt hack for BR_HOOK to newer kernels. This change was identified as a source for bugs and also caused performance problems in certain scenarios.

And since OpenWrt is now building the bridge as part of the kernel and the br-netfilter code as module, the build of the QCA kernel fork will also fail because the kernel binary is depending on a module:

    net/built-in.o: in function `BR_HOOK':
    net/bridge/br_private.h:929: undefined reference to `br_netfilter_run_hooks'
    net/bridge/br_private.h:929: undefined reference to `br_netfilter_run_hooks'
    net/bridge/br_private.h:929: undefined reference to `br_netfilter_run_hooks'
    net/bridge/br_private.h:929: undefined reference to `br_netfilter_run_hooks'
    net/bridge/br_private.h:929: undefined reference to `br_netfilter_run_hooks'
    net/built-in.o:net/bridge/br_private.h:929: more undefined references to `br_netfilter_run_hooks' follow

Just getting rid of this patch (as OpenWrt did) is therefore the best option.