### PR TITLE
WIFI-10739 OpenWiFi periodically (typically 120 seconds) issues nl80211

### DIFF
--- a/feeds/wifi-ax/mac80211/patches/pending/221-Sleep-issue-with-locks.patch
+++ b/feeds/wifi-ax/mac80211/patches/pending/221-Sleep-issue-with-locks.patch
@@ -1,8 +1,20 @@
-From 3cf580b4b222e0e19a0aa8d87bf207969e447b3e Mon Sep 17 00:00:00 2001
+From 5ec79fa4fdf7715c916c85eb2dd4e6f24d4e6263 Mon Sep 17 00:00:00 2001
 From: Venkat Chimata <venkata@shasta.cloud>
-Date: Mon, 12 Sep 2022 10:41:10 +0530
-Subject: [PATCH] Sleep issue with locks
+Date: Tue, 13 Sep 2022 22:26:34 +0530
+Subject: [PATCH] OpenWiFi periodically (typically 120 seconds) issues nl80211
+ call to get associated client list from the AP. The associated client list
+ was protected by a mutex lock. Somehow it was causing tx/rx issues sometimes,
+ speciically there was jitter in the video calls. Changing the lock to
+ rcu_read lock from mutex. This resolved the issue and now there is no jitter
+ in the calls.
 
+Tested thoroughly with the following procedure.
+
+1. Connect 3 clients
+2. A script running dumping clients in an infinite loop
+3. Continuously disconnect/connect one client and check if there is any crash.
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
 ---
  net/mac80211/cfg.c      | 6 ++----
  net/mac80211/sta_info.c | 3 +--

--- a/feeds/wifi-ax/mac80211/patches/pending/221-Sleep-issue-with-locks.patch
+++ b/feeds/wifi-ax/mac80211/patches/pending/221-Sleep-issue-with-locks.patch
@@ -1,0 +1,50 @@
+From 3cf580b4b222e0e19a0aa8d87bf207969e447b3e Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Mon, 12 Sep 2022 10:41:10 +0530
+Subject: [PATCH] Sleep issue with locks
+
+---
+ net/mac80211/cfg.c      | 6 ++----
+ net/mac80211/sta_info.c | 3 +--
+ 2 files changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/net/mac80211/cfg.c b/net/mac80211/cfg.c
+index 6a8350d..0b526b5 100644
+--- a/net/mac80211/cfg.c
++++ b/net/mac80211/cfg.c
+@@ -794,16 +794,14 @@ static int ieee80211_dump_station(struct wiphy *wiphy, struct net_device *dev,
+ 	struct sta_info *sta;
+ 	int ret = -ENOENT;
+ 
+-	mutex_lock(&local->sta_mtx);
+-
++	rcu_read_lock();
+ 	sta = sta_info_get_by_idx(sdata, idx);
+ 	if (sta) {
+ 		ret = 0;
+ 		memcpy(mac, sta->sta.addr, ETH_ALEN);
+ 		sta_set_sinfo(sta, sinfo, true);
+ 	}
+-
+-	mutex_unlock(&local->sta_mtx);
++	rcu_read_unlock();
+ 
+ 	return ret;
+ }
+diff --git a/net/mac80211/sta_info.c b/net/mac80211/sta_info.c
+index 550a610..af6fa75 100644
+--- a/net/mac80211/sta_info.c
++++ b/net/mac80211/sta_info.c
+@@ -231,8 +231,7 @@ struct sta_info *sta_info_get_by_idx(struct ieee80211_sub_if_data *sdata,
+ 	struct sta_info *sta;
+ 	int i = 0;
+ 
+-	list_for_each_entry_rcu(sta, &local->sta_list, list,
+-				lockdep_is_held(&local->sta_mtx)) {
++	list_for_each_entry_rcu(sta, &local->sta_list, list) {
+ 		if (sdata != sta->sdata)
+ 			continue;
+ 		if (i < idx) {
+-- 
+2.34.1
+


### PR DESCRIPTION
call to get associated client list from the AP. The associated client list was protected by a mutex lock. Somehow it was causing tx/rx issues sometimes, speciically there was jitter in the video calls. Changing the lock to rcu_read lock from mutex. This resolved the issue and now there is no jitter in the calls.