### PR TITLE
ucentral-schema: Use default google DNS for on-boarding

### DIFF
--- a/feeds/ucentral/ucentral-schema/files/etc/ucentral/ucentral.cfg.0000000001
+++ b/feeds/ucentral/ucentral-schema/files/etc/ucentral/ucentral.cfg.0000000001
@@ -34,7 +34,8 @@
 			"name": "WAN-wifi",
 			"role": "upstream",
 			"ipv4": {
-				"addressing": "dynamic"
+				"addressing": "dynamic",
+				"use-dns": [ "8.8.8.8" ]
 			},
 			"metric": 6,
 			"ssids": [


### PR DESCRIPTION
In case DHCP server is not serving DNS, then the node is left without any internet, and cannot onboard, so, use a default google DNS for on-boarding.

Signed-off-by: Alex Ballmer <alexb@meshplusplus.com>
Signed-off-by: Krishna <krishna@meshplusplus.com>