### PR TITLE
[cosmetic] base-files: fix foreign sysupgrade detection

### DIFF
--- a/patches/base/0013-base-files-ignore-sysupgrade-that-was-not-ours.patch
+++ b/patches/base/0013-base-files-ignore-sysupgrade-that-was-not-ours.patch
@@ -17,7 +17,7 @@ index 3f75411a43..7cf16e68e0 100644
  	mount_root
  	boot_run_hook preinit_mount_root
 -	[ -f /sysupgrade.tgz ] && {
-+	(tar tf /sysupgrade.tgz | grep ucentral) 2> /dev/null
++	(tar tzf /sysupgrade.tgz | grep -q ucentral) 2> /dev/null
 +	[ $? -eq 0 ] && {
  		echo "- config restore -"
  		cp /etc/passwd /etc/group /etc/shadow /tmp


### PR DESCRIPTION
Backups are gzipped, include the missing `z` parameter in `tar` call. While at it, make `grep` call quiet (add `q` parameter).
This is more a cosmetic change, relevant only to locally/manually made sysupgrade.

Should cleanly apply to `main` and `next`.