### PR TITLE
ipq807x: wifi-ax/ath11-firmware/Makefile yuncore ax840 fix

### DIFF
--- a/feeds/wifi-ax/ath11k-firmware/Makefile
+++ b/feeds/wifi-ax/ath11k-firmware/Makefile
@@ -115,6 +115,11 @@ define Package/ath11k-firmware-qcn9000/install
 		$(1)/lib/firmware/ath11k/QCN9074/hw1.0/
 endef
 
+define Package/ath11k-wifi-yuncore-ax840/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ6018/hw1.0/
+	$(INSTALL_DATA) ./board-2.bin.IPQ6018 $(1)/lib/firmware/ath11k/IPQ6018/hw1.0/board-2.bin
+endef
+
 $(eval $(call BuildPackage,ath11k-firmware-ipq50xx))
 $(eval $(call BuildPackage,ath11k-firmware-ipq50xx-spruce))
 $(eval $(call BuildPackage,ath11k-firmware-ipq60xx))


### PR DESCRIPTION
This fix add recipe to feeds/wifi-ax/ath11k-firmware/Makefile for yuncore ax840 device to copy IPQ6018 firmware to the correct location.