### PR TITLE
hostapd: CONFIG_TLS=internal fix

### DIFF
--- a/feeds/wifi-ax/hostapd/patches/y-0001-CONFIG_TLS-internal-fix.patch
+++ b/feeds/wifi-ax/hostapd/patches/y-0001-CONFIG_TLS-internal-fix.patch
@@ -1,0 +1,15 @@
+diff -aur a/src/tls/asn1.h b/src/tls/asn1.h
+--- a/src/tls/asn1.h	2021-02-23 01:46:37.000000000 +0300
++++ b/src/tls/asn1.h	2022-11-04 19:39:12.085912578 +0300
+@@ -104,4 +104,11 @@
+ extern const struct asn1_oid asn1_dpp_config_params_oid;
+ extern const struct asn1_oid asn1_dpp_asymmetric_key_package_oid;
+ 
++static inline bool asn1_is_null(const struct asn1_hdr *hdr)
++{
++      return hdr->class == ASN1_CLASS_UNIVERSAL &&
++              hdr->tag == ASN1_TAG_NULL;
++}
++
++
+ #endif /* ASN1_H */


### PR DESCRIPTION
Compilation fails with CONFIG_TLS=internal.
This patch adds necessary function to compile hostapd with CONFIG_TLS=internal

Signed-off-by: Isaev Ruslan <legale.legale@gmail.com>