### PR TITLE
ipq807x: ipq6018 based boards caldata size fix

### DIFF
--- a/feeds/ipq807x/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
+++ b/feeds/ipq807x/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
@@ -93,7 +93,6 @@ case "$FIRMWARE" in
 	qcom,ipq807x-hk14|\
 	tplink,ex227|\
 	tplink,ex447|\
-	yuncore,ax840|\
 	sercomm,wallaby)
                 caldata_extract "0:ART" 0x1000 0x20000
 		;;
@@ -115,8 +114,9 @@ case "$FIRMWARE" in
 	xiaomi,ax1800|\
 	glinet,ax1800|\
 	plasmacloud,pax1800-v1|\
-	plasmacloud,pax1800-v2)
-                caldata_extract "0:ART" 0x1000 0x20000  
+	plasmacloud,pax1800-v2|\
+	yuncore,ax840)
+                caldata_extract "0:ART" 0x1000 0x10000  
 		;;
 	esac
 	;;


### PR DESCRIPTION
This fixes size of the caldata for ipq60xx based boards and moves the YunCore AX840 to correct case block (the board is IPQ60xx based, so the driver looks for ath11k/IPQ6018/hw1.0/caldata.bin, not ath11k/IPQ8074/hw2.0/caldata.bin). Without this fix, the driver isn't able to fetch caldata:
[ 16.792551] ath11k c000000.wifi: qmi failed to load CAL data file:caldata.bin

Signed-off-by: Isaev Ruslan <legale.legale@gmail.com>