### PR TITLE
Radius NAS IP improvements WIFI-11935

### DIFF
--- a/feeds/wifi-ax/hostapd/Makefile
+++ b/feeds/wifi-ax/hostapd/Makefile
@@ -595,12 +595,13 @@ define Install/supplicant
 endef
 
 define Package/hostapd-common/install
-	$(INSTALL_DIR) $(1)/etc/capabilities $(1)/etc/rc.button $(1)/etc/hotplug.d/ieee80211 $(1)/etc/init.d $(1)/lib/netifd  $(1)/usr/share/acl.d
+	$(INSTALL_DIR) $(1)/etc/capabilities $(1)/etc/rc.button $(1)/etc/hotplug.d/ieee80211 $(1)/etc/hotplug.d/iface $(1)/etc/init.d $(1)/lib/netifd  $(1)/usr/share/acl.d
 	$(INSTALL_DATA) ./files/hostapd.sh $(1)/lib/netifd/hostapd.sh
 	$(INSTALL_BIN) ./files/wpad.init $(1)/etc/init.d/wpad
 	$(INSTALL_BIN) ./files/wps-hotplug.sh $(1)/etc/rc.button/wps
 	$(INSTALL_DATA) ./files/wpad_acl.json $(1)/usr/share/acl.d
 	$(INSTALL_DATA) ./files/wpad.json $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/91-hostapd $(1)/etc/hotplug.d/iface/91-hostapd
 endef
 
 define Package/hostapd/install

--- a/feeds/wifi-ax/hostapd/files/91-hostapd
+++ b/feeds/wifi-ax/hostapd/files/91-hostapd
@@ -1,0 +1,27 @@
+[ "$ACTION" == "ifup" ] || return
+index=0
+match=0
+# Iterate through all wifi-ifaces and check if this interface is of ours
+while true
+do
+	network=`/sbin/uci get wireless.@wifi-iface[$index].network`
+	if [ "$network" == "" ]; then
+		# End of interafce sections
+		break
+	fi
+	if [ "$network" == "$INTERFACE" ]; then
+		# Found the interface
+		encr=`/sbin/uci get wireless.@wifi-iface[$index].encryption`
+		if [ "$encr" == "psk2-radius" ]; then
+			# Radius based authentication
+			match=1
+			break
+		fi
+	fi
+	index=`expr $index + 1`
+done
+if [ $match -eq 0 ]; then
+	# This event / interface combo is not of interest to us
+	return
+fi
+/sbin/wifi reconf

--- a/feeds/wifi-ax/hostapd/files/hostapd.sh
+++ b/feeds/wifi-ax/hostapd/files/hostapd.sh
@@ -301,6 +301,7 @@ hostapd_common_add_bss_config() {
 
 	config_add_string nasid
 	config_add_string ownip
+	config_add_string detect_local_ip
 	config_add_string radius_client_addr
 	config_add_string iapp_interface
 	config_add_string eap_type ca_cert client_cert identity anonymous_identity auth priv_key priv_key_pwd
@@ -555,7 +556,8 @@ append_radius_server() {
 		ownip radius_client_addr \
 		eap_reauth_period request_cui \
 		erp_domain mobility_domain \
-		fils_realm fils_dhcp
+		fils_realm fils_dhcp \
+		detect_local_ip
 
 	# legacy compatibility
 	[ -n "$auth_server" ] || json_get_var auth_server server
@@ -605,6 +607,9 @@ append_radius_server() {
 	}
 	json_for_each_item append_radius_auth_req_attr radius_auth_req_attr
 
+	if [ 0$detect_local_ip -eq 1 ]; then
+		ownip=`/sbin/ip -o -4 addr list $network_ifname | awk '{print $4}' | cut -d/ -f1`
+	fi
 	[ -n "$ownip" ] && append bss_conf "own_ip_addr=$ownip" "$N"
 	[ -n "$radius_client_addr" ] && append bss_conf "radius_client_addr=$radius_client_addr" "$N"
 	[ "$macfilter" = radius ] && append bss_conf "macaddr_acl=2" "$N"

--- a/feeds/wifi-ax/hostapd/patches/x-0005-Support-multiple-Hostapd_data-interfaces-for-radius-.patch
+++ b/feeds/wifi-ax/hostapd/patches/x-0005-Support-multiple-Hostapd_data-interfaces-for-radius-.patch
@@ -1,0 +1,114 @@
+From bdfa30d3292a2d17ef80de2d3e419dc8aeedecbe Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Wed, 14 Dec 2022 18:22:09 +0530
+Subject: [PATCH] Support multiple Hostapd_data interfaces for radius das
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ src/radius/radius_das.c | 43 ++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 42 insertions(+), 1 deletion(-)
+
+diff --git a/src/radius/radius_das.c b/src/radius/radius_das.c
+index 17dc3d2..9c25cfa 100644
+--- a/src/radius/radius_das.c
++++ b/src/radius/radius_das.c
+@@ -8,6 +8,7 @@
+ 
+ #include "includes.h"
+ #include <net/if.h>
++#include <pthread.h>
+ 
+ #include "utils/common.h"
+ #include "utils/eloop.h"
+@@ -30,6 +31,9 @@ struct radius_das_data {
+ 	enum radius_das_res (*coa)(void *ctx, struct radius_das_attrs *attr);
+ };
+ 
++#define MAX_HAPDS 16
++static void* hapd_data_ctx[MAX_HAPDS];
++pthread_mutex_t das_sock_lock = PTHREAD_MUTEX_INITIALIZER;
+ 
+ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ 						 struct radius_msg *msg,
+@@ -38,6 +42,8 @@ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ {
+ 	struct radius_hdr *hdr;
+ 	struct radius_msg *reply;
++	int i;
++
+ 	u8 allowed[] = {
+ 		RADIUS_ATTR_USER_NAME,
+ 		RADIUS_ATTR_NAS_IP_ADDRESS,
+@@ -146,7 +152,14 @@ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ 		attrs.cui_len = len;
+ 	}
+ 
+-	res = das->disconnect(das->ctx, &attrs);
++	for(i = 0; i < MAX_HAPDS; i++) {
++		if (hapd_data_ctx[i] != NULL) {
++			res = das->disconnect(hapd_data_ctx[i], &attrs);
++			if (res == RADIUS_DAS_SUCCESS) {
++				break;
++			}
++		}
++	}
+ 	switch (res) {
+ 	case RADIUS_DAS_NAS_MISMATCH:
+ 		wpa_printf(MSG_INFO, "DAS: NAS mismatch from %s:%d",
+@@ -538,11 +551,29 @@ struct radius_das_data *
+ radius_das_init(struct radius_das_conf *conf)
+ {
+ 	struct radius_das_data *das;
++	int i;
++	int exists = 0;
+ 
+ 	if (conf->port == 0 || conf->shared_secret == NULL ||
+ 	    conf->client_addr == NULL)
+ 		return NULL;
+ 
++	pthread_mutex_lock(&das_sock_lock);
++	for(i = 0; i < MAX_HAPDS; i++) {
++		if(conf->ctx == hapd_data_ctx[i]) {
++			break;
++		}
++	}
++	if (!exists) {
++		for(i = 0; i < MAX_HAPDS; i++) {
++			if (hapd_data_ctx[i] == NULL) {
++				hapd_data_ctx[i] = conf->ctx;
++				break;
++			}	
++		}
++	}
++	pthread_mutex_unlock(&das_sock_lock);
++
+ 	das = os_zalloc(sizeof(*das));
+ 	if (das == NULL)
+ 		return NULL;
+@@ -585,6 +616,8 @@ radius_das_init(struct radius_das_conf *conf)
+ 
+ void radius_das_deinit(struct radius_das_data *das)
+ {
++	int i;
++
+ 	if (das == NULL)
+ 		return;
+ 
+@@ -592,6 +625,14 @@ void radius_das_deinit(struct radius_das_data *das)
+ 		eloop_unregister_read_sock(das->sock);
+ 		close(das->sock);
+ 	}
++	pthread_mutex_lock(&das_sock_lock);
++	for(i = 0; i < MAX_HAPDS; i++) {
++		if(das->ctx == hapd_data_ctx[i]) {
++			hapd_data_ctx[i] = NULL;
++			break;
++		}
++	}
++	pthread_mutex_unlock(&das_sock_lock);
+ 
+ 	os_free(das->shared_secret);
+ 	os_free(das);
+-- 
+2.34.1
+


### PR DESCRIPTION
1. Add NAS IP Address support to hostapd configuration
2. Check for stations in all interfaces across radios while handling client disconnect request from Radius

Signed-off-by: Venkat Chimata <venkata@shasta.cloud>