### PR TITLE
ucentral-client: health: remove redundant check for zero value

### DIFF
--- a/feeds/ucentral/ucentral-client/files/etc/init.d/uhealth
+++ b/feeds/ucentral/ucentral-client/files/etc/init.d/uhealth
@@ -20,10 +20,8 @@ start_service() {
 	config_load 'ustats'
 	config_get interval 'health' 'interval' 120
 
-	[ "$interval" -eq 0 ] || {
-		procd_open_instance
-		procd_set_param command "$PROG"
-		procd_set_param respawn 1 $interval 0
-		procd_close_instance
-	}
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_set_param respawn 1 $interval 0
+	procd_close_instance
 }


### PR DESCRIPTION
config_get is issued with a default (120) parameter, which makes a check for 0 a redundant.
It can be safely removed, as the check for "[ "$interval" -eq 0 ]" is always non-zero.

Fixes 396e2bd06cbe ("ucentral-client: cleanup health parameter")

Tested on virtual Wlan-AP img (OpenWRT): no syntax error occured / executed OK.

Signed-off-by: Oleksandr Mazur <cahbua@gmail.com>