### PR TITLE
uboot-envtools: Fix syntax on number of sectors

### DIFF
--- a/patches/backports/0062-uboot-envtools-ipq40xx-ipq806x-fix-syntax.patch
+++ b/patches/backports/0062-uboot-envtools-ipq40xx-ipq806x-fix-syntax.patch
@@ -1,0 +1,40 @@
+From d0ccce13b5d72712ffb19af77fbab2b4926e8d28 Mon Sep 17 00:00:00 2001
+From: Ravi Vaishnav <ravi.vaishnav@netexperience.com>
+Date: Mon, 23 Jan 2023 13:46:32 -0500
+Subject: [PATCH] uboot-envtools. ipq40xx, ipq806x. Fix syntax
+
+Signed-off-by: Ravi Vaishnav <ravi.vaishnav@netexperience.com>
+---
+ package/boot/uboot-envtools/files/ipq40xx | 2 +-
+ package/boot/uboot-envtools/files/ipq806x | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/boot/uboot-envtools/files/ipq40xx b/package/boot/uboot-envtools/files/ipq40xx
+index c51b40ab12..d112d9eb40 100644
+--- a/package/boot/uboot-envtools/files/ipq40xx
++++ b/package/boot/uboot-envtools/files/ipq40xx
+@@ -26,7 +26,7 @@ ubootenv_mtdinfo () {
+ 		ubootenv_size=0x40000
+ 	fi
+ 
+-	sectors=$(( $ubootenv_size / $mtd_erase ))
++	sectors=$(printf '0x%x' $(( $ubootenv_size / $mtd_erase )))
+ 	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+ }
+ 
+diff --git a/package/boot/uboot-envtools/files/ipq806x b/package/boot/uboot-envtools/files/ipq806x
+index 1b49fd51d4..06507f8087 100644
+--- a/package/boot/uboot-envtools/files/ipq806x
++++ b/package/boot/uboot-envtools/files/ipq806x
+@@ -26,7 +26,7 @@ ubootenv_mtdinfo () {
+ 		ubootenv_size=0x40000
+ 	fi
+ 
+-	sectors=$(( $ubootenv_size / $mtd_erase ))
++	sectors=$(printf '0x%x' $(( $ubootenv_size / $mtd_erase )))
+ 	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+ }
+ 
+-- 
+2.25.1
+

--- a/patches/ipq807x/0007-uboot-envtools-ipq807x-fix-syntax.patch
+++ b/patches/ipq807x/0007-uboot-envtools-ipq807x-fix-syntax.patch
@@ -1,0 +1,26 @@
+From 326075f4a7002886b2e3c0f19215f71e8e8d78dd Mon Sep 17 00:00:00 2001
+From: Ravi Vaishnav <ravi.vaishnav@netexperience.com>
+Date: Mon, 23 Jan 2023 13:49:57 -0500
+Subject: [PATCH] uboot-envtools. ipq807x. Fix syntax
+
+Signed-off-by: Ravi Vaishnav <ravi.vaishnav@netexperience.com>
+---
+ package/boot/uboot-envtools/files/ipq807x | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package/boot/uboot-envtools/files/ipq807x b/package/boot/uboot-envtools/files/ipq807x
+index 6c429f1852..37e06dca04 100644
+--- a/package/boot/uboot-envtools/files/ipq807x
++++ b/package/boot/uboot-envtools/files/ipq807x
+@@ -21,7 +21,7 @@ ubootenv_mtdinfo () {
+ 		ubootenv_size=0x40000
+ 	fi
+ 
+-	sectors=$(( $ubootenv_size / $mtd_erase ))
++	sectors=$(printf '0x%x' $(( $ubootenv_size / $mtd_erase )))
+ 	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
ProblemStatement: On EAP104, "fw_setenv" fails with the error "MTD erase error on /dev/mtd10: Invalid argument"
RootCause: uboot-envtools expects hex format for the number of sectors while the config file (/etc/fw_env.config) contains a decimal number format for the number of sectors. This leads to out-of-boundary size calculation within the function "environment_end()".
Solution: Update the scripts to write a hex value instead of a decimal value in the config file.

Reference for the expected format from the config file: Please check the function "get_config" in the file "fw_env.c", where the function uses sscanf to read the parameters from the config file.

Fixes: WIFI-12189
Signed-off-by: Ravi Vaishnav <ravi.vaishnav@netexperience.com>