### PR TITLE
openssl is needed to verify the command signatures

### DIFF
--- a/feeds/tip/certificates/files/etc/init.d/certificates
+++ b/feeds/tip/certificates/files/etc/init.d/certificates
@@ -11,6 +11,7 @@ copy_certificates() {
 	chmod 0440 root.network /etc/ucentral/*.pem
 	chmod 0400 /etc/ucentral/dev-id
 	[ -f /certificates/restrictions.json ] && cp /certificates/restrictions.json /etc/ucentral/
+	[ -f /certificates/sign_pubkey.pem ] && cp /certificates/sign_pubkey.pem /etc/ucentral/
 	exit 0
 }
 

--- a/profiles/ucentral-ap.yml
+++ b/profiles/ucentral-ap.yml
@@ -53,6 +53,7 @@ packages:
   - usteer2
   - ustp
   - libustream-openssl
+  - openssl-util
   - udevmand
   - umdns
   - oping


### PR DESCRIPTION
1. Enable openssl in AP firmware
2. Copy /certificates/sign_pubkey.pem into /etc/ucentral at boot time

Signed-off-by: Venkat Chimata <venkata@shasta.cloud>