### PR TITLE
[for next] ipq807x: eap102/wf-196: prepare I/O for generic MCU support

### DIFF
--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
@@ -61,10 +61,22 @@
 			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 		};
 
-		usb-enable {
-			gpio-export,name = "usb-enable";
+		usb-hub-enable {
+			gpio-export,name = "usb-hub-enable";
 			gpio-export,output = <1>;
 			gpios = <&tlmm 55 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb-rear-power {
+			gpio-export,name = "usb-rear-power";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb-side-power {
+			gpio-export,name = "usb-side-power";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
@@ -57,7 +57,7 @@
 
 		mcu-enable {
 			gpio-export,name = "mcu-enable";
-			gpio-export,output = <1>;
+			gpio-export,output = <0>;
 			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 		};
 
@@ -90,7 +90,7 @@
 		function = "gpio";
 		drive-strength = <8>;
 		bias-disable;
-		output-high;
+		output-low;
 	};
 
 	mcu_rsv: mcu_rsv_pins {

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-eap102.dts
@@ -70,10 +70,10 @@
 };
 
 &tlmm {
-	pinctrl-0 = <&nrf52840_reset &usb_reset>;
+	pinctrl-0 = <&mcu_rst &mcu_rsv &usb_rear_pwr &usb_side_pwr &usb_hub_rst>;
 	pinctrl-names = "default";
 
-	nrf52840_reset: nrf52840_reset_pins {
+	mcu_rst: mcu_rst_pins {
 		pins = "gpio54";
 		function = "gpio";
 		drive-strength = <8>;
@@ -81,7 +81,30 @@
 		output-high;
 	};
 
-	usb_reset: usb_reset_pins {
+	mcu_rsv: mcu_rsv_pins {
+		pins = "gpio56";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	usb_rear_pwr: usb_rear_pwr_pins {
+		pins = "gpio29";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+		output-high;
+	};
+
+	usb_side_pwr: usb_side_pwr_pins {
+		pins = "gpio30";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+		output-high;
+	};
+
+	usb_hub_rst: usb_hub_rst_pins {
 		pins = "gpio55";
 		function = "gpio";
 		drive-strength = <8>;

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
@@ -55,6 +55,17 @@
 		#endif
 	};
 
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		mcu-enable {
+			gpio-export,name = "mcu-enable";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
 	reserved-memory {
 /* No Pine attach in 256M profile */
 #if !defined(__IPQ_MEM_PROFILE_256_MB__)

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
@@ -155,6 +155,17 @@
 };
 
 &tlmm {
+	pinctrl-0 = <&mcu_rst>;
+	pinctrl-names = "default";
+
+	mcu_rst: mcu_rst_pins {
+		pins = "gpio34";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+		output-high;
+	};
+
 	mdio_pins: mdio_pinmux {
 		mux_0 {
 			pins = "gpio68";

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
@@ -61,7 +61,7 @@
 
 		mcu-enable {
 			gpio-export,name = "mcu-enable";
-			gpio-export,output = <1>;
+			gpio-export,output = <0>;
 			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
 		};
 	};
@@ -174,7 +174,7 @@
 		function = "gpio";
 		drive-strength = <8>;
 		bias-disable;
-		output-high;
+		output-low;
 	};
 
 	mdio_pins: mdio_pinmux {

--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq807x-wf196.dts
@@ -155,30 +155,6 @@
 };
 
 &tlmm {
-	pinctrl-0 = <&btcoex_pins>;
-	pinctrl-names = "default";
-
-	btcoex_pins: btcoex_pins {
-		mux_0 {
-			pins = "gpio64";
-			function = "pta1_1";
-			drive-strength = <6>;
-			bias-pull-down;
-		};
-		mux_1 {
-			pins = "gpio65";
-			function = "pta1_2";
-			drive-strength = <6>;
-			bias-pull-down;
-		};
-		mux_2 {
-			pins = "gpio66";
-			function = "pta1_0";
-			drive-strength = <6>;
-			bias-pull-down;
-		};
-	};
-
 	mdio_pins: mdio_pinmux {
 		mux_0 {
 			pins = "gpio68";
@@ -207,47 +183,21 @@
 			bias-disable;
 		};
 	};
+
 	i2c_5_pins: i2c_5_pinmux {
-                mux {
-                        pins = "gpio0", "gpio2";
-                        function = "blsp5_i2c";
-                        drive-strength = <8>;
-                        bias-disable;
-                };
-        };
+		mux {
+			pins = "gpio0", "gpio2";
+			function = "blsp5_i2c";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
 
 	spi_0_pins: spi_0_pins {
 		mux {
 			pins = "gpio38", "gpio39", "gpio40", "gpio41";
 			function = "blsp0_spi";
 			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	spi_3_pins: spi_3_pins {
-		mux {
-			pins = "gpio50", "gpio52", "gpio53";
-			function = "blsp3_spi";
-			drive-strength = <8>;
-			bias-disable;
-		};
-		spi_cs {
-			pins = "gpio22";
-			function = "blsp3_spi2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-		quartz_interrupt {
-			pins = "gpio47";
-			function = "gpio";
-			input;
-			bias-disable;
-		};
-		quartz_reset {
-			pins = "gpio21";
-			function = "gpio";
-			output-low;
 			bias-disable;
 		};
 	};
@@ -312,7 +262,7 @@
 
 	hsuart_pins: hsuart_pins {
 		mux {
-			pins = "gpio46", "gpio47", "gpio48", "gpio49";
+			pins = "gpio48", "gpio49";
 			function = "blsp2_uart";
 			drive-strength = <8>;
 			bias-disable;
@@ -320,7 +270,6 @@
 	};
 
 	button_pins: button_pins {
-
 		wps_button {
 			pins = "gpio67";
 			function = "gpio";
@@ -366,24 +315,24 @@
 			bias-pull-down;
 		};
 	};
-	pwm_pins: pwm_pinmux {
-                mux_1 {
-                        pins = "gpio25";
-                        function = "pwm02";
-                        drive-strength = <8>;
-                };
-		mux_2 {
-                        pins = "gpio26";
-                        function = "pwm12";
-                        drive-strength = <8>;
-                };
-		mux_3 {
-                        pins = "gpio27";
-                        function = "pwm22";
-                        drive-strength = <8>;
-                };
-	};
 
+	pwm_pins: pwm_pinmux {
+		mux_1 {
+			pins = "gpio25";
+			function = "pwm02";
+			drive-strength = <8>;
+		};
+		mux_2 {
+			pins = "gpio26";
+			function = "pwm12";
+			drive-strength = <8>;
+		};
+		mux_3 {
+			pins = "gpio27";
+			function = "pwm22";
+			drive-strength = <8>;
+		};
+	};
 };
 
 &soc {


### PR DESCRIPTION
This is for **next** branch.

This series is a first step in adding generic support for on-board (and external) MCU management to OpenWiFi. Changes introduced in this series are focused only on the I/O configuration for two IPQ807x based boards:

- EdgeCore EAP102 with nRF52840 MCU on USB bus
- CIG WF-196 with nRF52833 MCU on UART (with h/w flow control)

These two devices are currently considered as "golden samples" for testing and development, support for more devices (IPQ60xx, with TI and QCA MCUs) will come later.

If you have access to early revision (engineering run, not in mass production) of the EdgeCore EAP101 with nRF52810 MCU, you can find patches with support for it (won't be included in upstream OpenWiFi project) in my custom branch: https://github.com/pepe2k/telecominfraproject-wlan-ap/tree/next__io-prepare-for-mcu-support__eap101-with-nrf52810

Cheers,
Piotr