### PR TITLE
ucentral-event: add unit boot-up event

### DIFF
--- a/feeds/ucentral/ucentral-event/files/events.json
+++ b/feeds/ucentral/ucentral-event/files/events.json
@@ -3,5 +3,6 @@
 	"health","health.dns", "health.dhcp", "health.radius", "health.memory",
 	"client", "client.join", "client.leave", "client.key-mismatch",
 	"wifi", "wifi.start", "wifi.stop",
-	"wired", "wired.carrier-up", "wired.carrier-down"
+	"wired", "wired.carrier-up", "wired.carrier-down",
+	"unit", "unit.boot-up"
 ]

--- a/feeds/ucentral/ucentral-event/files/events.json
+++ b/feeds/ucentral/ucentral-event/files/events.json
@@ -2,5 +2,6 @@
 	"ssh",
 	"health","health.dns", "health.dhcp", "health.radius", "health.memory",
 	"client", "client.join", "client.leave", "client.key-mismatch",
-	"wifi", "wifi.start", "wifi.stop"
+	"wifi", "wifi.start", "wifi.stop",
+	"wired", "wired.carrier-up", "wired.carrier-down"
 ]

--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -29,6 +29,7 @@ let ratelimit = false;
 let config;
 let wan_ports;
 let carrier = {};
+let boot_file = "/tmp/booted";
 
 function config_load() {
 	uci.load('event');
@@ -284,6 +285,17 @@ function rtnl_cb(msg) {
 	}
 }
 
+function is_reboot() {
+	if (!fs.access(boot_file, "f")){
+		let file = fs.open(boot_file, "w");
+		if(file)
+			file.close();
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
 let ubus_methods = {
 	event: {
 		call: function(req) {
@@ -327,6 +339,10 @@ ubus.publish("event", ubus_methods);
 
 nl80211.listener(nl_cb, [ nl80211.const.NL80211_CMD_DEL_STATION ]);
 rtnl.listener(rtnl_cb, null, [ rtnl.const.RTNLGRP_LINK ]);
+
+if(is_reboot()) {
+	event('unit', 'boot-up', { cause:"" });
+}
 
 uloop.run();
 uloop.done();

--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -7,6 +7,14 @@ import * as libuci from 'uci';
 import * as uloop from 'uloop';
 import * as nl80211 from 'nl80211';
 import * as rtnl from 'rtnl';
+import * as fs from 'fs';
+
+let capab = {};
+let capabfile = fs.open("/etc/ucentral/capabilities.json", "r");
+if (capabfile) {
+	capab = json(capabfile.read("all"));
+	capabfile.close();
+}
 
 uloop.init();
 
@@ -20,6 +28,7 @@ let log_subscriber;
 let ratelimit = false;
 let config;
 let wan_ports;
+let carrier = {};
 
 function config_load() {
 	uci.load('event');
@@ -255,8 +264,24 @@ function nl_cb(msg) {
 	event('client', 'leave',  payload);
 }
 
+function ifname_lookup(prefix, ifname, list) {
+	let idx = index(list, ifname);
+	if (idx < 0)
+		return;
+	return prefix + (idx + 1);
+}
+
 function rtnl_cb(msg) {
-	printf('%.J\n', msg);
+	let name = ifname_lookup('LAN', msg.msg?.ifname, capab.network?.lan);
+	if (!name)
+		name = ifname_lookup('WAN', msg.msg?.ifname, capab.network?.wan);
+	if (name) {
+		let verb = msg.msg.carrier ? 'carrier-up' : 'carrier-down';	
+		if (carrier[name] == verb)
+			return;
+		carrier[name] = verb;
+		event('wired', verb, { name });
+	}
 }
 
 let ubus_methods = {

--- a/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/telemetry.json
+++ b/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/telemetry.json
@@ -81,7 +81,7 @@
 			"types": [ "ssh", "health", "wifi" ]
 		},
 		"realtime": {
-			"types": [ "client.join", "client.leave", "client.key-mismatch" ]
+			"types": [ "client.join", "client.leave", "client.key-mismatch", "wired" ]
 		},
 		"health": {
 			"interval": 120

--- a/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/telemetry.json
+++ b/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/telemetry.json
@@ -81,7 +81,7 @@
 			"types": [ "ssh", "health", "wifi" ]
 		},
 		"realtime": {
-			"types": [ "client.join", "client.leave", "client.key-mismatch", "wired" ]
+			"types": [ "client.join", "client.leave", "client.key-mismatch", "wired", "unit.boot-up" ]
 		},
 		"health": {
 			"interval": 120


### PR DESCRIPTION
Added support of unit boot-up event in uncetral-event. 
Cheks weather /tmp/booted file exists or not. If not exists then crete that file and generate unit.boot-up event