### PR TITLE
[for main/next]: bluetooth backports for LE-only HCI controllers

### DIFF
--- a/feeds/ipq807x/ipq807x/patches/801-v4.9-Bluetooth-Fix-using-the-correct-source-address-type.patch
+++ b/feeds/ipq807x/ipq807x/patches/801-v4.9-Bluetooth-Fix-using-the-correct-source-address-type.patch
@@ -1,0 +1,131 @@
+From 39385cb5f3274735b03ed1f8e7ff517b02a0beed Mon Sep 17 00:00:00 2001
+From: Johan Hedberg <johan.hedberg@intel.com>
+Date: Sat, 12 Nov 2016 17:03:07 +0200
+Subject: [PATCH] Bluetooth: Fix using the correct source address type
+
+The hci_get_route() API is used to look up local HCI devices, however
+so far it has been incapable of dealing with anything else than the
+public address of HCI devices. This completely breaks with LE-only HCI
+devices that do not come with a public address, but use a static
+random address instead.
+
+This patch exteds the hci_get_route() API with a src_type parameter
+that's used for comparing with the right address of each HCI device.
+
+Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ include/net/bluetooth/hci_core.h |  2 +-
+ net/bluetooth/6lowpan.c          |  4 ++--
+ net/bluetooth/hci_conn.c         | 26 ++++++++++++++++++++++++--
+ net/bluetooth/l2cap_core.c       |  2 +-
+ net/bluetooth/rfcomm/tty.c       |  2 +-
+ net/bluetooth/sco.c              |  2 +-
+ 6 files changed, 30 insertions(+), 8 deletions(-)
+
+--- a/include/net/bluetooth/hci_core.h
++++ b/include/net/bluetooth/hci_core.h
+@@ -1003,7 +1003,7 @@ static inline void hci_set_drvdata(struc
+ }
+ 
+ struct hci_dev *hci_dev_get(int index);
+-struct hci_dev *hci_get_route(bdaddr_t *dst, bdaddr_t *src);
++struct hci_dev *hci_get_route(bdaddr_t *dst, bdaddr_t *src, u8 src_type);
+ 
+ struct hci_dev *hci_alloc_dev(void);
+ void hci_free_dev(struct hci_dev *hdev);
+--- a/net/bluetooth/6lowpan.c
++++ b/net/bluetooth/6lowpan.c
+@@ -1102,7 +1102,6 @@ static int get_l2cap_conn(char *buf, bda
+ {
+ 	struct hci_conn *hcon;
+ 	struct hci_dev *hdev;
+-	bdaddr_t *src = BDADDR_ANY;
+ 	int n;
+ 
+ 	n = sscanf(buf, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx %hhu",
+@@ -1113,7 +1112,8 @@ static int get_l2cap_conn(char *buf, bda
+ 	if (n < 7)
+ 		return -EINVAL;
+ 
+-	hdev = hci_get_route(addr, src);
++	/* The LE_PUBLIC address type is ignored because of BDADDR_ANY */
++	hdev = hci_get_route(addr, BDADDR_ANY, BDADDR_LE_PUBLIC);
+ 	if (!hdev)
+ 		return -ENOENT;
+ 
+--- a/net/bluetooth/hci_conn.c
++++ b/net/bluetooth/hci_conn.c
+@@ -609,7 +609,7 @@ int hci_conn_del(struct hci_conn *conn)
+ 	return 0;
+ }
+ 
+-struct hci_dev *hci_get_route(bdaddr_t *dst, bdaddr_t *src)
++struct hci_dev *hci_get_route(bdaddr_t *dst, bdaddr_t *src, uint8_t src_type)
+ {
+ 	int use_src = bacmp(src, BDADDR_ANY);
+ 	struct hci_dev *hdev = NULL, *d;
+@@ -630,7 +630,29 @@ struct hci_dev *hci_get_route(bdaddr_t *
+ 		 */
+ 
+ 		if (use_src) {
+-			if (!bacmp(&d->bdaddr, src)) {
++			bdaddr_t id_addr;
++			u8 id_addr_type;
++
++			if (src_type == BDADDR_BREDR) {
++				if (!lmp_bredr_capable(d))
++					continue;
++				bacpy(&id_addr, &d->bdaddr);
++				id_addr_type = BDADDR_BREDR;
++			} else {
++				if (!lmp_le_capable(d))
++					continue;
++
++				hci_copy_identity_address(d, &id_addr,
++							  &id_addr_type);
++
++				/* Convert from HCI to three-value type */
++				if (id_addr_type == ADDR_LE_DEV_PUBLIC)
++					id_addr_type = BDADDR_LE_PUBLIC;
++				else
++					id_addr_type = BDADDR_LE_RANDOM;
++			}
++
++			if (!bacmp(&id_addr, src) && id_addr_type == src_type) {
+ 				hdev = d; break;
+ 			}
+ 		} else {
+--- a/net/bluetooth/l2cap_core.c
++++ b/net/bluetooth/l2cap_core.c
+@@ -7044,7 +7044,7 @@ int l2cap_chan_connect(struct l2cap_chan
+ 	BT_DBG("%pMR -> %pMR (type %u) psm 0x%2.2x", &chan->src, dst,
+ 	       dst_type, __le16_to_cpu(psm));
+ 
+-	hdev = hci_get_route(dst, &chan->src);
++	hdev = hci_get_route(dst, &chan->src, chan->src_type);
+ 	if (!hdev)
+ 		return -EHOSTUNREACH;
+ 
+--- a/net/bluetooth/rfcomm/tty.c
++++ b/net/bluetooth/rfcomm/tty.c
+@@ -178,7 +178,7 @@ static void rfcomm_reparent_device(struc
+ 	struct hci_dev *hdev;
+ 	struct hci_conn *conn;
+ 
+-	hdev = hci_get_route(&dev->dst, &dev->src);
++	hdev = hci_get_route(&dev->dst, &dev->src, BDADDR_BREDR);
+ 	if (!hdev)
+ 		return;
+ 
+--- a/net/bluetooth/sco.c
++++ b/net/bluetooth/sco.c
+@@ -219,7 +219,7 @@ static int sco_connect(struct sock *sk)
+ 
+ 	BT_DBG("%pMR -> %pMR", &sco_pi(sk)->src, &sco_pi(sk)->dst);
+ 
+-	hdev = hci_get_route(&sco_pi(sk)->dst, &sco_pi(sk)->src);
++	hdev = hci_get_route(&sco_pi(sk)->dst, &sco_pi(sk)->src, BDADDR_BREDR);
+ 	if (!hdev)
+ 		return -EHOSTUNREACH;
+ 

--- a/feeds/ipq807x/ipq807x/patches/802-v4.9-Bluetooth-Fix-the-HCI-to-MGMT-status-conversion-tabl.patch
+++ b/feeds/ipq807x/ipq807x/patches/802-v4.9-Bluetooth-Fix-the-HCI-to-MGMT-status-conversion-tabl.patch
@@ -1,0 +1,37 @@
+From 345bafc04fa2dea44dbdc8bda5633de256a74262 Mon Sep 17 00:00:00 2001
+From: Yu Liu <yudiliu@google.com>
+Date: Mon, 19 Apr 2021 16:53:30 -0700
+Subject: [PATCH] Bluetooth: Fix the HCI to MGMT status conversion table
+
+[ Upstream commit 4ef36a52b0e47c80bbfd69c0cce61c7ae9f541ed ]
+
+0x2B, 0x31 and 0x33 are reserved for future use but were not present in
+the HCI to MGMT conversion table, this caused the conversion to be
+incorrect for the HCI status code greater than 0x2A.
+
+Reviewed-by: Miao-chen Chou <mcchou@chromium.org>
+Signed-off-by: Yu Liu <yudiliu@google.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ net/bluetooth/mgmt.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/net/bluetooth/mgmt.c
++++ b/net/bluetooth/mgmt.c
+@@ -212,12 +212,15 @@ static u8 mgmt_status_table[] = {
+ 	MGMT_STATUS_TIMEOUT,		/* Instant Passed */
+ 	MGMT_STATUS_NOT_SUPPORTED,	/* Pairing Not Supported */
+ 	MGMT_STATUS_FAILED,		/* Transaction Collision */
++	MGMT_STATUS_FAILED,		/* Reserved for future use */
+ 	MGMT_STATUS_INVALID_PARAMS,	/* Unacceptable Parameter */
+ 	MGMT_STATUS_REJECTED,		/* QoS Rejected */
+ 	MGMT_STATUS_NOT_SUPPORTED,	/* Classification Not Supported */
+ 	MGMT_STATUS_REJECTED,		/* Insufficient Security */
+ 	MGMT_STATUS_INVALID_PARAMS,	/* Parameter Out Of Range */
++	MGMT_STATUS_FAILED,		/* Reserved for future use */
+ 	MGMT_STATUS_BUSY,		/* Role Switch Pending */
++	MGMT_STATUS_FAILED,		/* Reserved for future use */
+ 	MGMT_STATUS_FAILED,		/* Slot Violation */
+ 	MGMT_STATUS_FAILED,		/* Role Switch Failed */
+ 	MGMT_STATUS_INVALID_PARAMS,	/* EIR Too Large */

--- a/feeds/ipq807x/ipq807x/patches/803-v4.9-Bluetooth-skip-invalid-hci_sync_conn_complete_evt.patch
+++ b/feeds/ipq807x/ipq807x/patches/803-v4.9-Bluetooth-skip-invalid-hci_sync_conn_complete_evt.patch
@@ -1,0 +1,52 @@
+From 433c3febcb837cf8f2758660c6a89e1d734c55dc Mon Sep 17 00:00:00 2001
+From: Desmond Cheong Zhi Xi <desmondcheongzx@gmail.com>
+Date: Wed, 28 Jul 2021 15:51:04 +0800
+Subject: [PATCH] Bluetooth: skip invalid hci_sync_conn_complete_evt
+
+[ Upstream commit 92fe24a7db751b80925214ede43f8d2be792ea7b ]
+
+Syzbot reported a corrupted list in kobject_add_internal [1]. This
+happens when multiple HCI_EV_SYNC_CONN_COMPLETE event packets with
+status 0 are sent for the same HCI connection. This causes us to
+register the device more than once which corrupts the kset list.
+
+As this is forbidden behavior, we add a check for whether we're
+trying to process the same HCI_EV_SYNC_CONN_COMPLETE event multiple
+times for one connection. If that's the case, the event is invalid, so
+we report an error that the device is misbehaving, and ignore the
+packet.
+
+Link: https://syzkaller.appspot.com/bug?extid=66264bf2fd0476be7e6c [1]
+Reported-by: syzbot+66264bf2fd0476be7e6c@syzkaller.appspotmail.com
+Tested-by: syzbot+66264bf2fd0476be7e6c@syzkaller.appspotmail.com
+Signed-off-by: Desmond Cheong Zhi Xi <desmondcheongzx@gmail.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ net/bluetooth/hci_event.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -3748,6 +3748,21 @@ static void hci_sync_conn_complete_evt(s
+ 
+ 	switch (ev->status) {
+ 	case 0x00:
++		/* The synchronous connection complete event should only be
++		 * sent once per new connection. Receiving a successful
++		 * complete event when the connection status is already
++		 * BT_CONNECTED means that the device is misbehaving and sent
++		 * multiple complete event packets for the same new connection.
++		 *
++		 * Registering the device more than once can corrupt kernel
++		 * memory, hence upon detecting this invalid event, we report
++		 * an error and ignore the packet.
++		 */
++		if (conn->state == BT_CONNECTED) {
++			bt_dev_err(hdev, "Ignoring connect complete event for existing connection");
++			goto unlock;
++		}
++
+ 		conn->handle = __le16_to_cpu(ev->handle);
+ 		conn->state  = BT_CONNECTED;
+ 		conn->type   = ev->link_type;

--- a/feeds/ipq807x/ipq807x/patches/804-v4.9-Bluetooth-Fix-debugfs-entry-leak-in-hci_register_dev.patch
+++ b/feeds/ipq807x/ipq807x/patches/804-v4.9-Bluetooth-Fix-debugfs-entry-leak-in-hci_register_dev.patch
@@ -1,0 +1,33 @@
+From 69f728dac41d13fc3e8d4514684e476ebd0d61f5 Mon Sep 17 00:00:00 2001
+From: Wei Yongjun <weiyongjun1@huawei.com>
+Date: Wed, 13 Oct 2021 16:55:46 +0800
+Subject: [PATCH] Bluetooth: Fix debugfs entry leak in hci_register_dev()
+
+[ Upstream commit 5a4bb6a8e981d3d0d492aa38412ee80b21033177 ]
+
+Fault injection test report debugfs entry leak as follows:
+
+debugfs: Directory 'hci0' with parent 'bluetooth' already present!
+
+When register_pm_notifier() failed in hci_register_dev(), the debugfs
+create by debugfs_create_dir() do not removed in the error handing path.
+
+Add the remove debugfs code to fix it.
+
+Signed-off-by: Wei Yongjun <weiyongjun1@huawei.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ net/bluetooth/hci_core.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/net/bluetooth/hci_core.c
++++ b/net/bluetooth/hci_core.c
+@@ -3420,6 +3420,7 @@ int hci_register_dev(struct hci_dev *hde
+ 	return id;
+ 
+ err_wqueue:
++	debugfs_remove_recursive(hdev->debugfs);
+ 	destroy_workqueue(hdev->workqueue);
+ 	destroy_workqueue(hdev->req_workqueue);
+ err:


### PR DESCRIPTION
This is for **main** (+ **release/v2.9.0**) and **next** branches.

The most important fix is a backport from 4.9 for LE-only HCI Bluetooth controllers: https://github.com/torvalds/linux/commit/39385cb5f3274735b03ed1f8e7ff517b02a0beed. The three additional backports from second commit were found missing during some initial testing.

Due to the fact that the kernel 4.4 used currently in OpenWiFi lacks many more Bluetooth subsystem related fixes, we should consider backporting the whole stack from more up to date version, with e.g. the backports project.