### PR TITLE
[for main/next]: mcu: select host dependencies based on MCU firmware type

### DIFF
--- a/feeds/mcu/mcu-firmware/Makefile
+++ b/feeds/mcu/mcu-firmware/Makefile
@@ -65,7 +65,7 @@ $(foreach FW,$(ZEPHYR_VERSIONS),$(eval $(call Download,zephyr-fw,$(FW))))
 define zephyr-fw
   define Package/$(1)-$(2)-$(3)
     $(call Package/mcu-fw-default)
-    DEPENDS:=+mcu
+    DEPENDS:=+mcu $(call zephyr-fw-deps,$(2))
     TITLE:=Zephyr '$(2)'
   endef
 
@@ -78,6 +78,10 @@ define zephyr-fw
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(1)/$(3)/$(1)__$(2)/*.bin \
 		$$(1)/lib/firmware/mcu/$(3)/$(1)__$(2)/
   endef
+endef
+
+define zephyr-fw-deps
+	$(if $(findstring hci_u,$1),+bluez-daemon +kmod-bluetooth +kmod-crypto-user)
 endef
 
 define zephyr-fw-unzip


### PR DESCRIPTION
This is for **next** and **main** (+ **release/v2.9.0**) branches.
Depends/requires: https://github.com/Telecominfraproject/wlan-ap/pull/528

In case of some types of MCU firmware, additional tools, daemons, kernel drivers, etc. are required on the host side. For example, for Bluetooth HCI controller, at least kernel module and BlueZ should be included.

This adds a simple recipe which generates dependencies list per firmware type/name and for existing `hci_usb` and `hci_uart`, selects 3 packages: `bluez-daemon`, `kmod-bluetooth` and `kmod-crypto-user`.

Kernel crypto interface in user space has to be also included because the BlueZ isn't able to create static address for LE-only controller without it, which results in no registration of new BT interface:

```
  bluetoothd[668]: src/adapter.c:get_static_addr() Failed to open crypto
  bluetoothd[668]: No Bluetooth address for index 0
```