### PR TITLE
[for main/next]: feeds: ucentral: include BlueZ 5.66

### DIFF
--- a/feeds/ucentral/bluez/Makefile
+++ b/feeds/ucentral/bluez/Makefile
@@ -1,0 +1,169 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bluez
+PKG_VERSION:=5.66
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/
+PKG_HASH:=39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=
+PKG_CPE_ID:=cpe:/a:bluez:bluez
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/bluez/Default
+  TITLE:=Bluetooth
+  URL:=http://www.bluez.org/
+endef
+
+define Package/bluez-libs
+$(call Package/bluez/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= library
+  DEPENDS:=+libpthread +USB_SUPPORT:kmod-bluetooth
+endef
+
+define Package/bluez-utils
+$(call Package/bluez/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= utilities
+  DEPENDS:=+bluez-libs
+endef
+
+define Package/bluez-utils-btmon
+$(call Package/bluez/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= utilities
+  DEPENDS:=+bluez-libs +glib2
+endef
+
+define Package/bluez-utils-extra
+$(call Package/bluez/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= additional utilities
+  DEPENDS:=+bluez-libs +libpthread +librt +glib2 +libncurses +libreadline $(INTL_DEPENDS) $(ICONV_DEPENDS) +dbus
+endef
+
+define Package/bluez-daemon
+$(call Package/bluez/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= daemon
+  DEPENDS:=+bluez-libs +bluez-utils +bluez-utils-extra +glib2 +libncurses +libreadline +dbus +libical $(INTL_DEPENDS) $(ICONV_DEPENDS)
+endef
+
+define Package/bluez-daemon/conffiles
+/etc/bluetooth/main.conf
+/etc/bluetooth/network.conf
+/etc/bluetooth/input.conf
+/etc/bluetooth/keys
+/etc/config/bluetooth
+endef
+
+TARGET_CFLAGS += -D_GNU_SOURCE -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+CONFIGURE_ARGS += \
+	--enable-static \
+	--enable-shared \
+	--enable-client \
+	--enable-datafiles \
+	--enable-experimental \
+	--enable-library \
+	--enable-monitor \
+	--enable-obex \
+	--enable-threads \
+	--enable-tools \
+	--disable-android \
+	--disable-cups \
+	--disable-manpages \
+	--disable-sixaxis \
+	--disable-systemd \
+	--disable-test \
+	--disable-udev \
+	--enable-deprecated
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/bluetooth $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbluetooth.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/bluez.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/bluez-libs/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbluetooth.so.* $(1)/usr/lib/
+endef
+
+define Package/bluez-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/bdaddr $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bluemoon $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/btattach $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ciptool $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hciattach $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hciconfig $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcidump $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hcitool $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hex2hcd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/l2ping $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/l2test $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rctest $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rfcomm $(1)/usr/bin/
+endef
+
+define Package/bluez-utils-btmon/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/btmon $(1)/usr/bin/
+endef
+
+define Package/bluez-utils-extra/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/btmgmt $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mpris-proxy $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sdptool $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/attrib/gatttool $(1)/usr/bin/
+endef
+
+define Package/bluez-daemon/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/bluetooth/bluetoothd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/bluetoothctl $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/bluetooth/obexd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/bluetooth.conf $(1)/etc/dbus-1/system.d/bluetooth.conf
+	$(INSTALL_DIR) $(1)/etc/bluetooth
+	$(INSTALL_DIR) $(1)/etc/bluetooth/keys
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/main.conf $(1)/etc/bluetooth/main.conf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/profiles/network/network.conf $(1)/etc/bluetooth/network.conf
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/profiles/input/input.conf $(1)/etc/bluetooth/input.conf
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/bluetoothd.init $(1)/etc/init.d/bluetoothd
+endef
+
+$(eval $(call BuildPackage,bluez-libs))
+$(eval $(call BuildPackage,bluez-utils))
+$(eval $(call BuildPackage,bluez-utils-btmon))
+$(eval $(call BuildPackage,bluez-utils-extra))
+$(eval $(call BuildPackage,bluez-daemon))

--- a/feeds/ucentral/bluez/files/bluetoothd.init
+++ b/feeds/ucentral/bluez/files/bluetoothd.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2007 OpenWrt.org
+
+#start after dbus (60)
+START=62
+USE_PROCD=1
+PROG=/usr/bin/bluetoothd
+
+start_service() {
+	ln -snf /etc/bluetooth/keys/ /var/lib/bluetooth
+	procd_open_instance
+	procd_set_param command "$PROG" -n
+	procd_close_instance
+}

--- a/feeds/ucentral/bluez/files/givepin
+++ b/feeds/ucentral/bluez/files/givepin
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Write bluetooth PIN number here:
+pin=
+
+if [ -z "$pin" ]; then
+	msg="Set bluetooth PIN in file $0"
+	logger -p user.err "$msg"
+	for i in /dev/pts/* ; do
+		[ -w $i ] && echo "$msg" > $i
+	done
+else
+	echo "PIN:$pin"
+fi

--- a/feeds/ucentral/bluez/patches/001-bcm43xx-Add-bcm43xx-3wire-variant.patch
+++ b/feeds/ucentral/bluez/patches/001-bcm43xx-Add-bcm43xx-3wire-variant.patch
@@ -1,0 +1,21 @@
+From b4f2b77472aeb967d3a7595e8a965785c7a37c87 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 16 Feb 2016 16:40:46 +0000
+Subject: [PATCH 1/4] bcm43xx: Add bcm43xx-3wire variant
+
+---
+ tools/hciattach.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/tools/hciattach.c
++++ b/tools/hciattach.c
+@@ -1078,6 +1078,9 @@ struct uart_t uart[] = {
+ 	{ "bcm43xx",    0x0000, 0x0000, HCI_UART_H4,   115200, 3000000,
+ 				FLOW_CTL, DISABLE_PM, NULL, bcm43xx, NULL  },
+ 
++	{ "bcm43xx-3wire",    0x0000, 0x0000, HCI_UART_3WIRE, 115200, 3000000,
++				0, DISABLE_PM, NULL, bcm43xx, NULL  },
++
+ 	{ "ath3k",    0x0000, 0x0000, HCI_UART_ATH3K, 115200, 115200,
+ 			FLOW_CTL, DISABLE_PM, NULL, ath3k_ps, ath3k_pm  },
+ 

--- a/feeds/ucentral/bluez/patches/002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch
+++ b/feeds/ucentral/bluez/patches/002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch
@@ -1,0 +1,33 @@
+From e145c9621f976063e5c573db1f2053d906f63427 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 16 Feb 2016 16:39:09 +0000
+Subject: [PATCH 2/4] bcm43xx: The UART speed must be reset after the firmware
+ download
+
+---
+ tools/hciattach_bcm43xx.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/tools/hciattach_bcm43xx.c
++++ b/tools/hciattach_bcm43xx.c
+@@ -350,11 +350,8 @@ int bcm43xx_init(int fd, int def_speed,
+ 		return -1;
+ 
+ 	if (bcm43xx_locate_patch(FIRMWARE_DIR, chip_name, fw_path)) {
+-		fprintf(stderr, "Patch not found, continue anyway\n");
++		fprintf(stderr, "Patch not found for %s, continue anyway\n", chip_name);
+ 	} else {
+-		if (bcm43xx_set_speed(fd, ti, speed))
+-			return -1;
+-
+ 		if (bcm43xx_load_firmware(fd, fw_path))
+ 			return -1;
+ 
+@@ -364,6 +361,7 @@ int bcm43xx_init(int fd, int def_speed,
+ 			return -1;
+ 		}
+ 
++		sleep(1);
+ 		if (bcm43xx_reset(fd))
+ 			return -1;
+ 	}

--- a/feeds/ucentral/bluez/patches/003-Increase-firmware-load-timeout-to-30s.patch
+++ b/feeds/ucentral/bluez/patches/003-Increase-firmware-load-timeout-to-30s.patch
@@ -1,0 +1,20 @@
+From d41dc2046dd08d8c95197f677e224506f5b39bdd Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Wed, 20 Jan 2016 16:00:37 +0000
+Subject: [PATCH 3/4] Increase firmware load timeout to 30s
+
+---
+ tools/hciattach.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/hciattach.c
++++ b/tools/hciattach.c
+@@ -1227,7 +1227,7 @@ int main(int argc, char *argv[])
+ {
+ 	struct uart_t *u = NULL;
+ 	int detach, printpid, raw, opt, i, n, ld, err;
+-	int to = 10;
++	int to = 30;
+ 	int init_speed = 0;
+ 	int send_break = 0;
+ 	pid_t pid;

--- a/feeds/ucentral/bluez/patches/004-Move-the-43xx-firmware-into-lib-firmware.patch
+++ b/feeds/ucentral/bluez/patches/004-Move-the-43xx-firmware-into-lib-firmware.patch
@@ -1,0 +1,20 @@
+From 76681284b0ea49852041fdb97a35175089a08781 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 23 Feb 2016 17:52:29 +0000
+Subject: [PATCH 4/4] Move the 43xx firmware into /lib/firmware
+
+---
+ tools/hciattach_bcm43xx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/hciattach.h
++++ b/tools/hciattach.h
+@@ -41,7 +41,7 @@
+ #define HCI_UART_VND_DETECT	5
+ 
+ #ifndef FIRMWARE_DIR
+-#define FIRMWARE_DIR "/etc/firmware"
++#define FIRMWARE_DIR "/lib/firmware/brcm"
+ #endif
+ 
+ int read_hci_event(int fd, unsigned char *buf, int size);

--- a/feeds/ucentral/bluez/patches/201-readline.patch
+++ b/feeds/ucentral/bluez/patches/201-readline.patch
@@ -1,0 +1,75 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -3598,7 +3598,7 @@ unit_tests = $(am__append_62) unit/test-
+ @CLIENT_TRUE@					client/player.h client/player.c
+ 
+ @CLIENT_TRUE@client_bluetoothctl_LDADD = gdbus/libgdbus-internal.la src/libshared-glib.la \
+-@CLIENT_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++@CLIENT_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -lreadline -lncurses
+ 
+ @ZSH_COMPLETIONS_TRUE@zshcompletiondir = $(ZSH_COMPLETIONDIR)
+ @ZSH_COMPLETIONS_TRUE@dist_zshcompletion_DATA = completion/zsh/_bluetoothctl
+@@ -3877,7 +3877,7 @@ unit_tests = $(am__append_62) unit/test-
+ 
+ @DEPRECATED_TRUE@@MESH_TRUE@@TOOLS_TRUE@tools_meshctl_LDADD = gdbus/libgdbus-internal.la src/libshared-glib.la \
+ @DEPRECATED_TRUE@@MESH_TRUE@@TOOLS_TRUE@				lib/libbluetooth-internal.la \
+-@DEPRECATED_TRUE@@MESH_TRUE@@TOOLS_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -ljson-c -lreadline
++@DEPRECATED_TRUE@@MESH_TRUE@@TOOLS_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -ljson-c -lreadline -lncurses
+ 
+ @MESH_TRUE@@TOOLS_TRUE@tools_mesh_cfgclient_SOURCES = tools/mesh-cfgclient.c \
+ @MESH_TRUE@@TOOLS_TRUE@				tools/mesh/model.h tools/mesh/config-model.h \
+@@ -3891,7 +3891,7 @@ unit_tests = $(am__append_62) unit/test-
+ @MESH_TRUE@@TOOLS_TRUE@				mesh/crypto.h mesh/crypto.c
+ 
+ @MESH_TRUE@@TOOLS_TRUE@tools_mesh_cfgclient_LDADD = lib/libbluetooth-internal.la src/libshared-ell.la \
+-@MESH_TRUE@@TOOLS_TRUE@						$(ell_ldadd) -ljson-c -lreadline
++@MESH_TRUE@@TOOLS_TRUE@						$(ell_ldadd) -ljson-c -lreadline -lncurses
+ 
+ @MESH_TRUE@@TOOLS_TRUE@tools_mesh_cfgtest_SOURCES = tools/mesh-cfgtest.c
+ @MESH_TRUE@@TOOLS_TRUE@tools_mesh_cfgtest_LDADD = lib/libbluetooth-internal.la src/libshared-ell.la \
+@@ -3948,7 +3948,7 @@ unit_tests = $(am__append_62) unit/test-
+ @READLINE_TRUE@						tools/obex-client-tool.c
+ 
+ @READLINE_TRUE@tools_obex_client_tool_LDADD = lib/libbluetooth-internal.la \
+-@READLINE_TRUE@			       src/libshared-glib.la $(GLIB_LIBS) -lreadline
++@READLINE_TRUE@			       src/libshared-glib.la $(GLIB_LIBS) -lreadline -lncurses
+ 
+ @READLINE_TRUE@tools_obex_server_tool_SOURCES = $(gobex_sources) $(btio_sources) \
+ @READLINE_TRUE@						tools/obex-server-tool.c
+@@ -3959,15 +3959,15 @@ unit_tests = $(am__append_62) unit/test-
+ @READLINE_TRUE@tools_bluetooth_player_SOURCES = tools/bluetooth-player.c client/player.c
+ @READLINE_TRUE@tools_bluetooth_player_LDADD = gdbus/libgdbus-internal.la \
+ @READLINE_TRUE@				src/libshared-glib.la \
+-@READLINE_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++@READLINE_TRUE@				$(GLIB_LIBS) $(DBUS_LIBS) -lreadline -lncurses
+ 
+ @READLINE_TRUE@tools_obexctl_SOURCES = tools/obexctl.c
+ @READLINE_TRUE@tools_obexctl_LDADD = gdbus/libgdbus-internal.la src/libshared-glib.la \
+-@READLINE_TRUE@			$(GLIB_LIBS) $(DBUS_LIBS) -lreadline
++@READLINE_TRUE@			$(GLIB_LIBS) $(DBUS_LIBS) -lreadline -lncurses
+ 
+ @READLINE_TRUE@tools_btmgmt_SOURCES = tools/btmgmt.c src/uuid-helper.c client/display.c
+ @READLINE_TRUE@tools_btmgmt_LDADD = lib/libbluetooth-internal.la src/libshared-mainloop.la \
+-@READLINE_TRUE@				-lreadline
++@READLINE_TRUE@				-lreadline -lncurses
+ 
+ @DEPRECATED_TRUE@@READLINE_TRUE@attrib_gatttool_SOURCES = attrib/gatttool.c attrib/att.c attrib/gatt.c \
+ @DEPRECATED_TRUE@@READLINE_TRUE@				attrib/gattrib.c btio/btio.c \
+@@ -3976,7 +3976,7 @@ unit_tests = $(am__append_62) unit/test-
+ @DEPRECATED_TRUE@@READLINE_TRUE@				client/display.h
+ 
+ @DEPRECATED_TRUE@@READLINE_TRUE@attrib_gatttool_LDADD = lib/libbluetooth-internal.la \
+-@DEPRECATED_TRUE@@READLINE_TRUE@			src/libshared-glib.la $(GLIB_LIBS) -lreadline
++@DEPRECATED_TRUE@@READLINE_TRUE@			src/libshared-glib.la $(GLIB_LIBS) -lreadline -lncurses
+ 
+ @CUPS_TRUE@cupsdir = $(libdir)/cups/backend
+ @CUPS_TRUE@profiles_cups_bluetooth_SOURCES = profiles/cups/main.c \
+@@ -3996,7 +3996,7 @@ unit_tests = $(am__append_62) unit/test-
+ @BTPCLIENT_TRUE@tools_btpclient_DEPENDENCIES = lib/libbluetooth-internal.la $(ell_dependencies)
+ @BTPCLIENT_TRUE@tools_btpclientctl_SOURCES = tools/btpclientctl.c client/display.c
+ @BTPCLIENT_TRUE@tools_btpclientctl_LDADD = src/libshared-mainloop.la src/libshared-glib.la \
+-@BTPCLIENT_TRUE@				lib/libbluetooth-internal.la -lreadline
++@BTPCLIENT_TRUE@				lib/libbluetooth-internal.la -lreadline -lncurses
+ 
+ 
+ # SPDX-License-Identifier: GPL-2.0

--- a/feeds/ucentral/bluez/patches/202-fix-endianness.patch
+++ b/feeds/ucentral/bluez/patches/202-fix-endianness.patch
@@ -1,0 +1,10 @@
+--- a/src/shared/util.h
++++ b/src/shared/util.h
+@@ -15,6 +15,7 @@
+ #include <byteswap.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <endian.h>
+ 
+ #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+ #define BIT(n)  (1 << (n))

--- a/feeds/ucentral/bluez/patches/203-obexd_without_systemd.patch
+++ b/feeds/ucentral/bluez/patches/203-obexd_without_systemd.patch
@@ -1,0 +1,49 @@
+Submitted By:            Armin K. <krejzi at email dot com>
+Date:                    2013-04-29
+Initial Package Version: 5.17
+Upstream Status:         unknown
+Origin:                  Arch Linux (Giovanni Campagna)
+Description:             Allow using obexd without systemd in the user session
+
+Not all sessions run systemd --user (actually, the majority
+doesn't), so the dbus daemon must be able to spawn obexd
+directly, and to do so it needs the full path of the daemon.
+---
+ Makefile.obexd                      | 4 ++--
+ obexd/src/org.bluez.obex.service    | 4 ----
+ obexd/src/org.bluez.obex.service.in | 4 ++++
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+ delete mode 100644 obexd/src/org.bluez.obex.service
+ create mode 100644 obexd/src/org.bluez.obex.service.in
+
+--- a/Makefile.obexd
++++ b/Makefile.obexd
+@@ -2,12 +2,12 @@
+ if SYSTEMD
+ systemduserunitdir = $(SYSTEMD_USERUNITDIR)
+ systemduserunit_DATA = obexd/src/obex.service
++endif
+ 
+ dbussessionbusdir = $(DBUS_SESSIONBUSDIR)
+ dbussessionbus_DATA = obexd/src/org.bluez.obex.service
+-endif
+ 
+-EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service
++EXTRA_DIST += obexd/src/obex.service.in obexd/src/org.bluez.obex.service.in
+ 
+ if OBEX
+ 
+--- a/obexd/src/org.bluez.obex.service
++++ /dev/null
+@@ -1,4 +0,0 @@
+-[D-BUS Service]
+-Name=org.bluez.obex
+-Exec=/bin/false
+-SystemdService=dbus-org.bluez.obex.service
+--- /dev/null
++++ b/obexd/src/org.bluez.obex.service.in
+@@ -0,0 +1,4 @@
++[D-BUS Service]
++Name=org.bluez.obex
++Exec=@libexecdir@/obexd
++SystemdService=dbus-org.bluez.obex.service

--- a/feeds/ucentral/bluez/patches/205-refresh_adv_manager_for_non-LE_devices.patch
+++ b/feeds/ucentral/bluez/patches/205-refresh_adv_manager_for_non-LE_devices.patch
@@ -1,0 +1,47 @@
+From 2c3bba7b38be03834162e34069156f1fd49f0528 Mon Sep 17 00:00:00 2001
+From: "antoine.belvire@laposte.net" <antoine.belvire@laposte.net>
+Date: Tue, 27 Mar 2018 20:30:26 +0200
+Subject: adapter: Don't refresh adv_manager for non-LE devices
+
+btd_adv_manager_refresh is called upon MGMT_SETTING_DISCOVERABLE setting change
+but as only LE adapters have an adv_manager, this leads to segmentation fault
+for non-LE devices:
+
+0  btd_adv_manager_refresh (manager=0x0) at src/advertising.c:1176
+1  0x0000556fe45fcb02 in settings_changed (settings=<optimized out>,
+    adapter=0x556fe53f7c70) at src/adapter.c:543
+2  new_settings_callback (index=<optimized out>, length=<optimized out>,
+    param=<optimized out>, user_data=0x556fe53f7c70) at src/adapter.c:573
+3  0x0000556fe462c278 in request_complete (mgmt=mgmt@entry=0x556fe53f20c0,
+    status=<optimized out>, opcode=opcode@entry=7, index=index@entry=0,
+    length=length@entry=4, param=0x556fe53eb5f9) at src/shared/mgmt.c:261
+4  0x0000556fe462cd9d in can_read_data (io=<optimized out>,
+    user_data=0x556fe53f20c0) at src/shared/mgmt.c:353
+5  0x0000556fe46396e3 in watch_callback (channel=<optimized out>,
+    cond=<optimized out>, user_data=<optimized out>)
+    at src/shared/io-glib.c:170
+6  0x00007fe351c980e5 in g_main_context_dispatch ()
+   from /usr/lib64/libglib-2.0.so.0
+7  0x00007fe351c984b0 in ?? () from /usr/lib64/libglib-2.0.so.0
+8  0x00007fe351c987c2 in g_main_loop_run () from /usr/lib64/libglib-2.0.so.0
+9  0x0000556fe45abc75 in main (argc=<optimized out>, argv=<optimized out>)
+    at src/main.c:770
+
+This commit prevents the call to btd_adv_manager_refresh for non-LE devices.
+---
+ src/adapter.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/src/adapter.c
++++ b/src/adapter.c
+@@ -634,7 +634,9 @@ static void settings_changed(struct btd_
+ 		 */
+ 		if (!adapter->discovery_discoverable)
+ 			store_adapter_info(adapter);
+-		btd_adv_manager_refresh(adapter->adv_manager);
++
++		if (adapter->supported_settings & MGMT_SETTING_LE)
++			btd_adv_manager_refresh(adapter->adv_manager);
+ 	}
+ 
+ 	if (changed_mask & MGMT_SETTING_BONDABLE) {

--- a/feeds/ucentral/bluez/patches/206-sync.patch
+++ b/feeds/ucentral/bluez/patches/206-sync.patch
@@ -1,0 +1,27 @@
+--- a/obexd/client/sync.c
++++ b/obexd/client/sync.c
+@@ -209,7 +209,7 @@ static void sync_remove(struct obc_sessi
+ 	g_dbus_unregister_interface(conn, path, SYNC_INTERFACE);
+ }
+ 
+-static struct obc_driver sync = {
++static struct obc_driver sync2 = {
+ 	.service = "SYNC",
+ 	.uuid = SYNC_UUID,
+ 	.target = OBEX_SYNC_UUID,
+@@ -228,7 +228,7 @@ int sync_init(void)
+ 	if (!conn)
+ 		return -EIO;
+ 
+-	err = obc_driver_register(&sync);
++	err = obc_driver_register(&sync2);
+ 	if (err < 0) {
+ 		dbus_connection_unref(conn);
+ 		conn = NULL;
+@@ -245,5 +245,5 @@ void sync_exit(void)
+ 	dbus_connection_unref(conn);
+ 	conn = NULL;
+ 
+-	obc_driver_unregister(&sync);
++	obc_driver_unregister(&sync2);
+ }

--- a/feeds/ucentral/bluez/patches/210-util-define-MAX_INPUT.patch
+++ b/feeds/ucentral/bluez/patches/210-util-define-MAX_INPUT.patch
@@ -1,0 +1,12 @@
+--- a/src/shared/util.c
++++ b/src/shared/util.c
+@@ -23,6 +23,9 @@
+ #include <dirent.h>
+ #include <limits.h>
+ #include <string.h>
++#ifndef MAX_INPUT
++#define MAX_INPUT _POSIX_MAX_INPUT
++#endif
+ 
+ #ifdef HAVE_SYS_RANDOM_H
+ #include <sys/random.h>


### PR DESCRIPTION
This is for **next** and **main** (+ **release/v2.9.0**) branches.

Copy `bluez` package from OpenWrt's packages master branch to `ucentral` feed so that we can use latest version and add custom, local changes.

Keep this within `ucentral` feeds directory to override version provided by community based `packages` feed from OpenWrt 21.02.