### PR TITLE
ipq807x: fix qca-nss-clients feed

### DIFF
--- a/feeds/ipq807x/qca-nss-clients/Makefile
+++ b/feeds/ipq807x/qca-nss-clients/Makefile
@@ -5,7 +5,7 @@ PKG_NAME:=qca-nss-clients
 PKG_SOURCE_PROTO:=git
 PKG_BRANCH:=master
 PKG_RELEASE:=2
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-clients/
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-clients
 PKG_MIRROR_HASH:=802bf8b2dac8da0549e108b873afd982d127370c07d6574ece71f902eafe7698
 PKG_VERSION:=153998d70fdba508a59a28c13a606032cbf32686
 


### PR DESCRIPTION
Update qca-nss-clients feed source url to fix build failure.