### PR TITLE
ucentral-event: dhcp relay option 82 parameters

### DIFF
--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -231,14 +231,27 @@ function dhcp_subscriber_remove_cb(remove) {
 	printf('dhcp remove: %.J\n', remove);
 }
 
+function match_dhcp_relay_option82(format, hapd) {
+	switch(format) {
+		case 'ap-mac':
+			uci.load('ucentral');
+			let ucentral = uci.get_all('ucentral', 'config');
+			return ucentral.serial;
+		case 'ssid':
+			return hapd.config.ssid;
+		case 'vlan-id':
+			return hapd.config.vlan_id;
+	}
+}
+
 function dhcp_relay_subscriber_notify_cb(notify) {
 	let ifname = split(notify.data.info.device, '-v');
 	let hapd = hostapd[ifname[0]];
 	let vlan = ifname[1];
 	if (hapd) {
 		vlan ??= hapd.config.vlan_id;
-		let circuit_id = `${vlan}`;
-		let remote_id = hapd.bssid;
+		let circuit_id = match_dhcp_relay_option82(relay['vlan' + vlan]?.circuit_id, hapd);
+		let remote_id = match_dhcp_relay_option82(relay['vlan' + vlan]?.remote_id, hapd);
 		return {
 			address: relay['vlan' + vlan]?.server,
 			options: [


### PR DESCRIPTION
Add the ability to configure circuit-id and remote-id sub-options.