### PR TITLE
[next] ipq807x: ipq5018: fix EdgeCore EAP104 pinctrl configuration

### DIFF
--- a/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
+++ b/feeds/ipq807x/ipq807x/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
@@ -541,8 +541,7 @@
 };
 
 &tlmm {
-	/* pinctrl-0 = <&blsp0_uart_pins &phy_led_pins>; */
-	pinctrl-0 = <&blsp0_uart_pins &phy_led_pins &ble_pins>;
+	pinctrl-0 = <&blsp0_uart_pins &ble_pins>;
 	pinctrl-names = "default";
 
 	leds_pins: leds_pins {
@@ -660,16 +659,6 @@
 			function = "mdio";
 			drive-strength = <8>;
 			bias-pull-up;
-		};
-	};
-
-	phy_led_pins: phy_led_pins {
-		gephy_led_pin {
-			pins = "gpio46";
-			/* function = "led0"; */
-			function = "gpio";
-			drive-strength = <8>;
-			bias-pull-down;
 		};
 	};
 	

--- a/feeds/ipq807x_v5.4/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
+++ b/feeds/ipq807x_v5.4/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
@@ -479,7 +479,7 @@
 };
 
 &tlmm {
-	pinctrl-0 = <&blsp0_uart_pins &phy_led_pins>;
+	pinctrl-0 = <&blsp0_uart_pins>;
 	pinctrl-names = "default";
 
 	blsp0_uart_pins: uart_pins {
@@ -543,15 +543,6 @@
 			function = "mdio";
 			drive-strength = <8>;
 			bias-pull-up;
-		};
-	};
-
-	phy_led_pins: phy_led_pins {
-		gephy_led_pin {
-			pins = "gpio46";
-			function = "led0";
-			drive-strength = <8>;
-			bias-pull-down;
 		};
 	};
 


### PR DESCRIPTION
Drop `phy_led_pins` node which duplicates configuration for `gpio46`, used in different place (`led_cloud` node). This solves below error:

```
pin GPIO_46 already requested by 1000000.pinctrl; cannot claim for leds
```