### PR TITLE
cybertan_eww631-b1: Fix LAN port mappings

### DIFF
--- a/feeds/ipq807x/ipq807x/base-files/etc/board.d/02_network
+++ b/feeds/ipq807x/ipq807x/base-files/etc/board.d/02_network
@@ -133,7 +133,7 @@ qcom_setup_interfaces()
 		ucidef_set_interface_lan ""
 		;;
 	cybertan,eww631-b1)
-		ucidef_add_switch "switch1" "5:wan" "2:lan" "3:lan" "4:lan" "6@eth0"
+		ucidef_add_switch "switch1" "5:wan" "4:lan" "3:lan" "2:lan" "6@eth0"
 		;;
 	wallys,dr5018)
                 ucidef_set_interface_lan "eth0 eth1"


### PR DESCRIPTION
The LAN port mappings were reversed, causing the port with LAN1 label to be reported as LAN3 in uCentral