### PR TITLE
dvlan: dhcpsnoop fix

### DIFF
--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -131,8 +131,11 @@ handlers = {
 			name: 'eth0.' + notify.data.vlan_id,
 			vlan: [ `${notify.data.vlan_id}:u` ]
 		};
-
 		ubus.call('network.interface.up_none', 'add_device', msg);
+
+		msg = { 'devices': { } };
+		msg['devices']['eth0.' + notify.data.vlan_id] = { 'ingress': true, 'egress': true };
+		ubus.call('dhcpsnoop', 'add_devices', msg);
 
 		let cmd = 'swconfig dev ' + config.config.swconfig + ' vlan ' + notify.data.vlan_id + ' set ports \"' + join(' ', config.config.swconfig_ports) + '\"';
 		system(cmd);                                                                                                                                           

--- a/feeds/ucentral/udhcpsnoop/src/dev.c
+++ b/feeds/ucentral/udhcpsnoop/src/dev.c
@@ -449,15 +449,19 @@ free:
 	return;
 }
 
-void dhcpsnoop_dev_config_update(struct blob_attr *data)
+void dhcpsnoop_dev_config_update(struct blob_attr *data, bool add_only)
 {
 	struct blob_attr *cur;
 	int rem;
 
-	vlist_update(&devices);
+	if (!add_only)
+		vlist_update(&devices);
+
 	blobmsg_for_each_attr(cur, data, rem)
 		dhcpsnoop_dev_config_add(cur);
-	vlist_flush(&devices);
+
+	if (!add_only)
+		vlist_flush(&devices);
 }
 
 void dhcpsnoop_dev_check(void)

--- a/feeds/ucentral/udhcpsnoop/src/dhcpsnoop.h
+++ b/feeds/ucentral/udhcpsnoop/src/dhcpsnoop.h
@@ -16,7 +16,7 @@ int dhcpsnoop_run_cmd(char *cmd, bool ignore_error);
 
 int dhcpsnoop_dev_init(void);
 void dhcpsnoop_dev_done(void);
-void dhcpsnoop_dev_config_update(struct blob_attr *data);
+void dhcpsnoop_dev_config_update(struct blob_attr *data, bool add_only);
 void dhcpsnoop_dev_check(void);
 
 void dhcpsnoop_ubus_init(void);

--- a/feeds/ucentral/udhcpsnoop/src/ubus.c
+++ b/feeds/ucentral/udhcpsnoop/src/ubus.c
@@ -27,13 +27,30 @@ dhcpsnoop_ubus_config(struct ubus_context *ctx, struct ubus_object *obj,
 	blobmsg_parse(dhcpsnoop_config_policy, __DS_CONFIG_MAX, tb,
 		      blobmsg_data(msg), blobmsg_len(msg));
 
-	dhcpsnoop_dev_config_update(tb[DS_CONFIG_DEVICES]);
+	dhcpsnoop_dev_config_update(tb[DS_CONFIG_DEVICES], false);
 
 	dhcpsnoop_dev_check();
 
 	return 0;
 }
 
+
+static int
+dhcpsnoop_ubus_add_devices(struct ubus_context *ctx, struct ubus_object *obj,
+		           struct ubus_request_data *req, const char *method,
+		           struct blob_attr *msg)
+{
+	struct blob_attr *tb[__DS_CONFIG_MAX];
+
+	blobmsg_parse(dhcpsnoop_config_policy, __DS_CONFIG_MAX, tb,
+		      blobmsg_data(msg), blobmsg_len(msg));
+
+	dhcpsnoop_dev_config_update(tb[DS_CONFIG_DEVICES], true);
+
+	dhcpsnoop_dev_check();
+
+	return 0;
+}
 
 static int
 dhcpsnoop_ubus_check_devices(struct ubus_context *ctx, struct ubus_object *obj,
@@ -61,6 +78,7 @@ dhcpsnoop_ubus_dump(struct ubus_context *ctx, struct ubus_object *obj,
 
 static const struct ubus_method dhcpsnoop_methods[] = {
 	UBUS_METHOD("config", dhcpsnoop_ubus_config, dhcpsnoop_config_policy),
+	UBUS_METHOD("add_devices", dhcpsnoop_ubus_add_devices, dhcpsnoop_config_policy),
 	UBUS_METHOD_NOARG("check_devices", dhcpsnoop_ubus_check_devices),
 	UBUS_METHOD_NOARG("dump", dhcpsnoop_ubus_dump),
 };


### PR DESCRIPTION
When a DVLAN is initialized, it creates a new eth0.XXX interface. This interface didn't have DHCP snooping enabled on it, causing uCentral to not have the connecting clients IP address info