### PR TITLE
hapd, ucentral-event: fix 802.1x with dynamic VLAN

### DIFF
--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -34,6 +34,7 @@ let boot_file = "/tmp/booted";
 let ucentral_running = false;
 let pending_events = [];
 let relay = {};
+let net_config = {};
 
 
 function config_load() {
@@ -46,12 +47,39 @@ function config_load() {
 
 	if (config.dhcp?.filter == '*')
 		config.dhcp.filter = [ 'ack', 'discover', 'offer', 'request', 'solicit', 'reply', 'renew' ];
+
+	net_config = {};
 }
 
 function match(object, type, list) {
 	if (object in list || type in list)
 		return true;
 	return false;
+}
+
+function eth_find_bridge_vlan_id(ifname) {
+	for (let k, v in net_config) {
+		if (v['.type'] != "bridge-vlan")
+			continue;
+		if (ifname in v.ports)
+			return v.vlan;
+	}
+
+	return 0;
+}
+
+function eth_get_bridge_vlan_id(ifname) {
+	if (!ifname || length(ifname) == 0)
+		return 0;
+
+	let vlan_id = eth_find_bridge_vlan_id(ifname);
+	if (!vlan_id) {
+		uci.load('network');
+		net_config = uci.get_all('network');
+		vlan_id = eth_find_bridge_vlan_id(ifname);
+	}
+
+	return vlan_id;
 }
 
 function event(object, verb, payload) {
@@ -81,6 +109,33 @@ function event(object, verb, payload) {
 let handlers;
 handlers = {
 	'sta-authorized': function(notify, hapd) {
+		if (!hapd || wildcard(hapd['ifname'], 'eth*')) {
+			if (!('vlan_id' in notify.data) || notify.data['vlan_id'] == 0)
+				return;
+
+			if (!wildcard(notify.data.ifname, 'eth*'))
+				return;
+
+			/*
+			 * This must be a wired 802.1x client with a dynamic VLAN assigned, let's check
+			 * if we need to workaround the bridge VLAN config
+			 */
+
+			let br_vid = eth_get_bridge_vlan_id(notify.data.ifname);
+			if (!br_vid || br_vid == notify.data['vlan_id'])
+				return;
+
+			/*
+			 * netifd will make the bridge VLAN the untagged PVID for the port
+			 * and will add the assigned DVLAN also as an untagged (non-PVID) to the port.
+			 * The result of this is that the client will have access on the bridge VLAN,
+			 * not the correct assigned VLAN.  The proper fix should be in netifd, but
+			 * that is complex and will take time, so this workaround seems to work for now
+			 */
+			system("bridge vlan del dev " + notify.data.ifname + " vid " + br_vid);
+			system("bridge vlan add dev " + notify.data.ifname + " vid " + notify.data.vlan_id + " pvid untagged");
+			return;
+		}
 		/* force FDB flush on QCA Wifi-6 silicon */
 		system(`echo ${notify.data.address} > /sys/kernel/debug/ssdk_flush_mac`);
 		event('client', 'join', {
@@ -186,6 +241,8 @@ function hapd_subscriber_notify_cb(notify) {
 
 function hostapd_event(ifname, type) {
 	let payload = {};
+	if (!(ifname in hostapd) || wildcard(ifname, 'eth*'))
+		return;
 	for (let p in [ 'ssid', 'bssid', 'channel', 'band' ])
 		payload[p] = hostapd[ifname][p];
 

--- a/feeds/wifi-ax/hostapd/patches/x-0005-add-vlan_id-to-sta-authorized-event.patch
+++ b/feeds/wifi-ax/hostapd/patches/x-0005-add-vlan_id-to-sta-authorized-event.patch
@@ -1,0 +1,11 @@
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -1914,6 +1914,8 @@ void hostapd_ubus_notify_authorized(stru
+ 	blob_buf_init(&b, 0);
+ 	blobmsg_add_macaddr(&b, "address", sta->addr);
+ 	blobmsg_add_string(&b, "ifname", hapd->conf->iface);
++	if (sta->vlan_id)
++		blobmsg_add_u32(&b, "vlan_id", sta->vlan_id);
+ 	if (sta->bandwidth[0] || sta->bandwidth[1]) {
+ 		void *r = blobmsg_open_array(&b, "rate-limit");
+ 


### PR DESCRIPTION
This adds a workaround to fix an issue with 802.1x + DVLANs on platforms
where LAN ports are through an integrated switch (swconfig).

Netifd is tracking the wired ports as part of a bridge-vlan: either a
static one, or 4090 for the default untagged bridge.  When hostapd
authorizes the wired port, netifd is automatically adding this bridge
vlan as PVID untagged to the port.  The vlan_add event then adds the
dynamic VLAN as untagged to the same port.  The result is that the
port is operating on the PVID bridge vlan, and not the dynamic VLAN.
Fixing this in netifd is going to be complex and take time, so this
change includes a workaround.   When a wired client is authorized
using a dynamic VLAN, ucentral-event takes the following actions:
   - Remove the bridge VLAN from the port
       bridge vlan del dev <port> vid <bridge-vlan>
   - Modify the dynamic VLAN to PVID
       bridge vlan add dev <port> vid <dynamic-vlan> pvid untagged
