### PR TITLE
eap-104: fix dualboot: reset bootcount

### DIFF
--- a/feeds/ipq807x/ipq807x/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x/ipq807x/base-files/etc/init.d/bootcount
@@ -16,7 +16,8 @@ boot() {
 		;;		
 	edgecore,eap101|\
 	edgecore,eap102|\
-	edgecore,oap102)
+	edgecore,oap102|\
+	edgecore.eap104)
 		avail=$(fw_printenv -n upgrade_available)
 		[ "${avail}" -eq 1 ] || fw_setenv upgrade_available 1
 		fw_setenv bootcount 0

--- a/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
@@ -10,7 +10,8 @@ boot() {
 		;;		
 	edgecore,eap101|\
 	edgecore,eap102|\
-	edgecore,oap102)
+	edgecore,oap102|\
+	edgecore.eap104)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1
 		fw_setenv bootcount 0

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/init.d/bootcount
@@ -10,7 +10,8 @@ boot() {
 		;;		
 	edgecore,eap101|\
 	edgecore,eap102|\
-	edgecore,oap102)
+	edgecore,oap102|\
+	edgecore.eap104)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1
 		fw_setenv bootcount 0


### PR DESCRIPTION
The bootcount wasn't getting reset to 0 upon a successful boot,
resulting in falling back to the previous firmware version after three
reboots of the AP.
