### PR TITLE
base-files/ipq807x: wf196: fix BSSIDs

### DIFF
--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/hotplug.d/firmware/10-ath11k-caldata
@@ -16,9 +16,9 @@ ath11k_generate_macs() {
 	echo -ne \\x${mac3//:/\\x} >> /lib/firmware/ath11k-macs
 }
 
-ath11k_generate_macs_wf194() {
+ath11k_generate_macs_wf196() {
 	touch /lib/firmware/ath11k-macs
-	mac=$(grep BaseMacAddress= /dev/mtd14 | cut -dx -f2)
+	mac=$(grep BaseMacAddress= /dev/mtd18 | cut -dx -f2)
 	eth=$(macaddr_canonicalize $mac)
 	mac1=$(macaddr_add $eth 2)
 	mac2=$(macaddr_add $eth 3)
@@ -92,8 +92,8 @@ ath11k-macs)
 	edgecore,eap106)
 		ath11k_generate_macs
 		;;
-	cig,wf194c)
-		ath11k_generate_macs_wf194
+	cig,wf196)
+		ath11k_generate_macs_wf196
 		;;
 	esac
 	;;


### PR DESCRIPTION
Use base MAC address to generate PHY BSSIDs.