### PR TITLE
WIFI-13385: Fix DFS usage during csa

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/patches/s00-005-ubus-csa-add-dfs-support.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/s00-005-ubus-csa-add-dfs-support.patch
@@ -1,0 +1,50 @@
+Index: hostapd-2021-02-20-59e9794c/src/ap/ubus.c
+===================================================================
+--- hostapd-2021-02-20-59e9794c.orig/src/ap/ubus.c
++++ hostapd-2021-02-20-59e9794c/src/ap/ubus.c
+@@ -25,2 +25,3 @@
+ #include "airtime_policy.h"
++#include "dfs.h"
+ #include "hw_features.h"
+@@ -857,6 +858,7 @@ hostapd_switch_chan(struct ubus_context
+ 	u8 seg0 = 0, seg1 = 0;
+ 	int ret = UBUS_STATUS_OK;
+ 	int i;
++	int dfs_range = 0;
+ 
+ 	blobmsg_parse(csa_policy, __CSA_MAX, tb, blob_data(msg), blob_len(msg));
+ 
+@@ -912,6 +914,17 @@ hostapd_switch_chan(struct ubus_context
+ 		break;
+ 	}
+ 
++	if (css.freq_params.center_freq1)
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.center_freq1);
++	else
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.freq);
++
++	if (css.freq_params.center_freq2)
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.center_freq2);
++
+ 	hostapd_set_freq_params(&css.freq_params, iconf->hw_mode,
+ 				css.freq_params.freq,
+ 				css.freq_params.channel, iconf->enable_edmg,
+@@ -925,6 +938,15 @@ hostapd_switch_chan(struct ubus_context
+ 				mode ? &mode->he_capab[IEEE80211_MODE_AP] :
+ 				NULL);
+ 
++	if (dfs_range) {
++		/* Perform CAC and switch channel */
++		freq_params = malloc(sizeof(*freq_params));
++		memcpy(freq_params, &css.freq_params, sizeof(*freq_params));
++		eloop_register_timeout(0, 1, switch_chan_fallback_cb,
++				       hapd->iface, freq_params);
++		return 0;
++	}
++
+ 	for (i = 0; i < hapd->iface->num_bss; i++) {
+ 		struct hostapd_data *bss = hapd->iface->bss[i];
+ 

--- a/feeds/ipq807x_v5.4/hostapd/patches/s00-006-fix-dfs-csa-invalid-opclass.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/s00-006-fix-dfs-csa-invalid-opclass.patch
@@ -1,0 +1,25 @@
+Index: hostapd-2021-02-20-59e9794c/src/ap/hostapd.c
+===================================================================
+--- hostapd-2021-02-20-59e9794c.orig/src/ap/hostapd.c
++++ hostapd-2021-02-20-59e9794c/src/ap/hostapd.c
+@@ -3814,6 +3814,8 @@ hostapd_switch_channel_fallback(struct h
+ 				const struct hostapd_freq_params *freq_params)
+ {
+ 	int seg0_idx = 0, seg1_idx = 0, bw = CHANWIDTH_USE_HT;
++	u8 op_class;
++	u8 chan;
+ 
+ 	wpa_printf(MSG_DEBUG, "Restarting all CSA-related BSSes");
+ 
+@@ -3846,6 +3848,11 @@ hostapd_switch_channel_fallback(struct h
+ 	iface->freq = freq_params->freq;
+ 	iface->conf->channel = freq_params->channel;
+ 	iface->conf->secondary_channel = freq_params->sec_channel_offset;
++	ieee80211_freq_to_channel_ext(freq_params->freq, freq_params->sec_channel_offset, bw, &op_class, &chan);
++	if (chan != freq_params->channel)
++		wpa_printf(MSG_ERROR, "Channel mismatch: %d -> %d", freq_params->channel, chan);
++
++	iface->conf->op_class = op_class;
+ 	hostapd_set_oper_centr_freq_seg0_idx(iface->conf, seg0_idx);
+ 	hostapd_set_oper_centr_freq_seg1_idx(iface->conf, seg1_idx);
+ 	hostapd_set_oper_chwidth(iface->conf, bw);

--- a/feeds/wifi-ax/hostapd/patches/x-0006-ubus-csa-add-dfs-support.patch
+++ b/feeds/wifi-ax/hostapd/patches/x-0006-ubus-csa-add-dfs-support.patch
@@ -1,0 +1,50 @@
+Index: hostapd-2021-02-20-59e9794c/src/ap/ubus.c
+===================================================================
+--- hostapd-2021-02-20-59e9794c.orig/src/ap/ubus.c
++++ hostapd-2021-02-20-59e9794c/src/ap/ubus.c
+@@ -25,2 +25,3 @@
+ #include "airtime_policy.h"
++#include "dfs.h"
+ #include "hw_features.h"
+@@ -857,6 +858,7 @@ hostapd_switch_chan(struct ubus_context
+ 	u8 seg0 = 0, seg1 = 0;
+ 	int ret = UBUS_STATUS_OK;
+ 	int i;
++	int dfs_range = 0;
+ 
+ 	blobmsg_parse(csa_policy, __CSA_MAX, tb, blob_data(msg), blob_len(msg));
+ 
+@@ -912,6 +914,17 @@ hostapd_switch_chan(struct ubus_context
+ 		break;
+ 	}
+ 
++	if (css.freq_params.center_freq1)
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.center_freq1);
++	else
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.freq);
++
++	if (css.freq_params.center_freq2)
++		dfs_range += hostapd_is_dfs_overlap(
++			hapd->iface, chwidth, css.freq_params.center_freq2);
++
+ 	hostapd_set_freq_params(&css.freq_params, iconf->hw_mode,
+ 				css.freq_params.freq,
+ 				css.freq_params.channel, iconf->enable_edmg,
+@@ -925,6 +938,15 @@ hostapd_switch_chan(struct ubus_context
+ 				mode ? &mode->he_capab[IEEE80211_MODE_AP] :
+ 				NULL);
+ 
++	if (dfs_range) {
++		/* Perform CAC and switch channel */
++		freq_params = malloc(sizeof(*freq_params));
++		memcpy(freq_params, &css.freq_params, sizeof(*freq_params));
++		eloop_register_timeout(0, 1, switch_chan_fallback_cb,
++				       hapd->iface, freq_params);
++		return 0;
++	}
++
+ 	for (i = 0; i < hapd->iface->num_bss; i++) {
+ 		struct hostapd_data *bss = hapd->iface->bss[i];
+ 

--- a/feeds/wifi-ax/hostapd/patches/x-0007-fix-dfs-csa-invalid-opclass.patch
+++ b/feeds/wifi-ax/hostapd/patches/x-0007-fix-dfs-csa-invalid-opclass.patch
@@ -1,0 +1,25 @@
+Index: hostapd-2021-02-20-59e9794c/src/ap/hostapd.c
+===================================================================
+--- hostapd-2021-02-20-59e9794c.orig/src/ap/hostapd.c
++++ hostapd-2021-02-20-59e9794c/src/ap/hostapd.c
+@@ -3814,6 +3814,8 @@ hostapd_switch_channel_fallback(struct h
+ 				const struct hostapd_freq_params *freq_params)
+ {
+ 	int seg0_idx = 0, seg1_idx = 0, bw = CHANWIDTH_USE_HT;
++	u8 op_class;
++	u8 chan;
+ 
+ 	wpa_printf(MSG_DEBUG, "Restarting all CSA-related BSSes");
+ 
+@@ -3846,6 +3848,11 @@ hostapd_switch_channel_fallback(struct h
+ 	iface->freq = freq_params->freq;
+ 	iface->conf->channel = freq_params->channel;
+ 	iface->conf->secondary_channel = freq_params->sec_channel_offset;
++	ieee80211_freq_to_channel_ext(freq_params->freq, freq_params->sec_channel_offset, bw, &op_class, &chan);
++	if (chan != freq_params->channel)
++		wpa_printf(MSG_ERROR, "Channel mismatch: %d -> %d", freq_params->channel, chan);
++
++	iface->conf->op_class = op_class;
+ 	hostapd_set_oper_centr_freq_seg0_idx(iface->conf, seg0_idx);
+ 	hostapd_set_oper_centr_freq_seg1_idx(iface->conf, seg1_idx);
+ 	hostapd_set_oper_chwidth(iface->conf, bw);


### PR DESCRIPTION
We noticed two issues with DFS usage:

- can not use DFS channels with ubus channel switch command:

ubus call hostapd.wlan0 switch_chan '{"freq":5260,"bcn_count":10}'
Command failed: Operation not supported

- invalid opclass during channel switch with DFS channels (the same issue with hostap upstream):

"Could not convert op_class 124 channel 108 to operating frequency"