### PR TITLE
Remove roaming configs from rate-limiting example

### DIFF
--- a/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/rate-limit.json
+++ b/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/rate-limit.json
@@ -3,21 +3,21 @@
 	"radios": [
 		{
 			"band": "6G",
-			"country": "CA",
+			"country": "US",
 			"channel-mode": "HE",
 			"channel-width": 80
 		},
 		{
 			"band": "5G",
-			"country": "CA",
+			"country": "US",
 			"channel-mode": "HE",
 			"channel-width": 80
 		},
 		{
 			"band": "2G",
-			"country": "CA",
+			"country": "US",
 			"channel-mode": "HE",
-			"channel-width": 80
+			"channel-width": 20
 		}
 	],
 
@@ -68,10 +68,6 @@
 						"proto": "psk2",
 						"key": "OpenWifi",
 						"ieee80211w": "optional"
-					},
-					"roaming": {
-						"message-exchange": "ds",
-						"generate-psk": true
 					},
 					"rate-limit": {
 						"ingress-rate": 10,


### PR DESCRIPTION
Redundant roaming configs left inside the rate limiting example.