### PR TITLE
WIFI-13428 : Fix traffic disruption for MPSK clients for yuncore_fap655,cigwf186w,eap104

### DIFF
--- a/patches/0072-WIFI-13428-Fix-Traffic-Disruption-for-MPSK-clients-f.patch
+++ b/patches/0072-WIFI-13428-Fix-Traffic-Disruption-for-MPSK-clients-f.patch
@@ -1,0 +1,111 @@
+From da1d005199f6485c37aed3ae15faf1b9ab79d88d Mon Sep 17 00:00:00 2001
+From: joydeepbenison <joydeep.ghosh@benisontech.com>
+Date: Mon, 27 May 2024 13:34:25 +0530
+Subject: [PATCH] WIFI-13428 Fix:Traffic Disruption for MPSK clients for
+ yuncore_fap655
+
+Fix Traffic Disruption for MPSK clients for yuncore_fap655 when
+vlan-id of the lan port is modified.Any change in swconfig resets the
+internal switch of FAP655 due to which all the dynamically added vlans
+for MPSK clients are lost. Configure the Dynamic Vlans for MPSK Clients
+again after switch reset.
+
+Signed-off-by: joydeepbenison <joydeep.ghosh@benisontech.com>
+---
+ .../files/etc/hotplug.d/net/50-switch-dvlan   | 43 +++++++++++++++++++
+ .../files/lib/functions/dyn_vlan_switch.sh    | 33 ++++++++++++++
+ 2 files changed, 76 insertions(+)
+ create mode 100644 package/base-files/files/etc/hotplug.d/net/50-switch-dvlan
+ create mode 100644 package/base-files/files/lib/functions/dyn_vlan_switch.sh
+
+diff --git a/package/base-files/files/etc/hotplug.d/net/50-switch-dvlan b/package/base-files/files/etc/hotplug.d/net/50-switch-dvlan
+new file mode 100644
+index 0000000000..f24329cfe6
+--- /dev/null
++++ b/package/base-files/files/etc/hotplug.d/net/50-switch-dvlan
+@@ -0,0 +1,43 @@
++#!/bin/sh
++
++. /lib/functions.sh
++. /lib/functions/dyn_vlan_switch.sh
++
++debug() {
++	logger -t HOTPLUG-DVLAN "$*"
++}
++
++if [ "${INTERFACE:0:2}" != "up" ]; then
++	exit 0
++fi
++
++case "$(board_name)" in
++	"yuncore,fap655")
++		switch_dev="switch1"
++		switch_wan_port=5t
++		switch_cpu_port=6t
++		;;
++	"cig,wf186w")
++		switch_dev="switch0"
++		switch_wan_port=4t
++		switch_cpu_port=6t
++		;;
++	"edgecore,eap104")
++		switch_dev="switch1"
++                switch_wan_port=
++                switch_cpu_port=6t
++                ;;
++	*)
++		exit 0
++esac
++
++VSTR="$(echo $INTERFACE | egrep -o 'v([0-9]+)$')"
++[ -z "$VSTR" ] && exit 0
++VID="${VSTR:1}"
++[ $VID -lt 1 -o $VID -gt 4096 ] && exit 0
++
++if [ "$ACTION" = "add" ]; then
++	debug "$INTERFACE added on bridge ${INTERFACE:0:2}, configuring $switch_dev for dynamic vlans"
++        configure_bridge_dyn_vlans ${INTERFACE:0:2} $switch_dev $switch_wan_port $switch_cpu_port
++fi
++
+diff --git a/package/base-files/files/lib/functions/dyn_vlan_switch.sh b/package/base-files/files/lib/functions/dyn_vlan_switch.sh
+new file mode 100644
+index 0000000000..5901a1537d
+--- /dev/null
++++ b/package/base-files/files/lib/functions/dyn_vlan_switch.sh
+@@ -0,0 +1,33 @@
++
++configure_switch_dynamic_vlan(){
++vid=$1
++switch_dev=$2
++switch_wan_port=$3
++switch_cpu_port=$4
++debug "configured switch $switch_dev ports $switch_wan_port $switch_cpu_port for dynamic vlans $vid"
++swconfig dev ${switch_dev} vlan $vid set ports "${switch_wan_port} ${switch_cpu_port}"
++
++}
++
++
++configure_bridge_dyn_vlans () {
++interfaces=$(ls /sys/class/net/$1/brif)
++
++switch_dev=$2
++switch_wan_port=$3
++switch_cpu_port=$4
++
++# Convert the string into an array
++IFS=' ' set -- $interfaces
++
++# Loop through the array and print each element
++for interface in "$@"; do
++   case "$interface" in
++        wlan*-v*)
++            # Use parameter expansion to extract the part after "wlan*-v"
++            dyn_vlan_id="${interface#*wlan*-v}"
++	    configure_switch_dynamic_vlan $dyn_vlan_id $switch_dev $switch_wan_port $switch_cpu_port ;;
++    esac
++done
++}
++
+-- 
+2.34.1
+


### PR DESCRIPTION

Fixes WIFI-13428 : traffic disruption for FAP655,CIG_WF186w,EAP-104 for MPSK Clients when VLAN id of the Lan port is modified . This Commit configures the dynamic VLANs on the switch of fap655,eap104,cig_wf186w again after reset.