### PR TITLE
ieee8021x / hostapd: Fix 802.1x + DVLAN issues

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/patches/t00-012-hostapd-Fix-DVLAN-802.1x-issue.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/t00-012-hostapd-Fix-DVLAN-802.1x-issue.patch
@@ -1,0 +1,53 @@
+From 98b6503b87bb36bf2f5ae16e52e230e8870c867f Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Fri, 28 Jun 2024 14:39:31 +0530
+Subject: [PATCH] hostapd: Fix DVLAN + 802.1x issue
+
+In case of swconfig switches, the basename of the interface should be based on the last dot.
+Earlier it was done based on the first dot, which would result in incorrect basename.
+For example if the interface name is eth0.4087 then the vlan->ifname would be eth0.4087.  (A dot at the end) .
+Before this patch, the basename was returned as eth0. It should be eth0.4087
+
+Also fixed the return code by adding a default value of 0 and removed an unncessary check
+for if_add before ubus add call.
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ src/ap/vlan_init.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/ap/vlan_init.c b/src/ap/vlan_init.c
+index 3e27671..cfeb1e5 100644
+--- a/src/ap/vlan_init.c
++++ b/src/ap/vlan_init.c
+@@ -23,7 +23,8 @@ static int vlan_if_add(struct hostapd_data *hapd, struct hostapd_vlan *vlan,
+ 		       int existsok)
+ {
+ 	bool vlan_exists = iface_exists(vlan->ifname);
+-	int ret;
++	int ret = 0;
++
+ #ifdef CONFIG_WEP
+ 	int i;
+ 
+@@ -38,7 +39,7 @@ static int vlan_if_add(struct hostapd_data *hapd, struct hostapd_vlan *vlan,
+ #endif /* CONFIG_WEP */
+ 
+ 	if (!hapd->driver || !hapd->driver->if_add) {
+-		char *dot = strstr(vlan->ifname, ".");
++		char *dot = strrchr(vlan->ifname, '.');
+ 		if (dot)
+ 			*dot = '\0';
+ 		ret = 0;
+@@ -59,7 +60,7 @@ static int vlan_if_add(struct hostapd_data *hapd, struct hostapd_vlan *vlan,
+ 	if (hapd->wpa_auth)
+ 		ret = wpa_auth_ensure_group(hapd->wpa_auth, vlan->vlan_id);
+ 
+-	if (!ret && !vlan_exists && hapd->driver->if_add)
++	if (!ret && !vlan_exists)
+ 		hostapd_ubus_add_vlan(hapd, vlan);
+ 
+ 	if (ret == 0)
+-- 
+2.34.1
+


### PR DESCRIPTION
ieee8021x
---------
1. Handle link_up events and update hostapd config
2. For certains scenarios, we need to remove and add instead of reload (reload did not work). Consider the following scenario - Say on CIG 186w as an example eth0.4086 interface exists with some non-ieee8021x config. Push ieee8021x config. In general the flow is that reload_config is called followed by invocation of services (from ucentral-schema) Services inovation does n't wait until the configi reloaded ie in this context ieee8021x service is invoked much before the network interfaces are recreated. That is not correct. To handle this, we capture link-up events and remove the existing interface (in hostapd as shown below) and add again
3. For swconfig platforms, the names contain a dot. Handle that gracefully in ubus_unsub_object while adding hostapd interface
4. Add better logging using log.syslog

hostapd
---------
In case of swconfig switches, the basename of the interface should be based on the last dot. Earlier it was done based on the first dot, which would result in incorrect basename. For example if the interface name is eth0.4087 then the vlan->ifname would be eth0.4087.  (A dot at the end) . Before this patch, the basename was returned as eth0. It should be eth0.4087

Also fixed the return code by adding a default value of 0 and removed an unncessary check for if_add before ubus add call.