### PR TITLE
mac80211: Update tx stats correctly in case of AP mode

### DIFF
--- a/feeds/ipq807x_v5.4/mac80211/patches/pending/331-mac80211-Update-tx-stats-correctly-in-case-of-AP-mod.patch
+++ b/feeds/ipq807x_v5.4/mac80211/patches/pending/331-mac80211-Update-tx-stats-correctly-in-case-of-AP-mod.patch
@@ -1,0 +1,30 @@
+From f3eaf64231edde8b6553f869cf33ff2b2897be38 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Mon, 8 Jul 2024 19:23:34 +0530
+Subject: [PATCH] mac80211: Update tx stats correctly in case of AP mode
+
+In the backports driver the tx stats are updated in ieee80211_8023_xmit.
+However in AP mode the packets are transmitted in ieee80211_8023_xmit_ap.
+ieee80211_8023_xmit is not hit in case of AP mode. Update the stats just
+before calling ieee80211_8023_xmit_ap
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ net/mac80211/tx.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/mac80211/tx.c b/net/mac80211/tx.c
+index d6181be..9e978f9 100644
+--- a/net/mac80211/tx.c
++++ b/net/mac80211/tx.c
+@@ -4526,6 +4526,7 @@ void ieee80211_8023_xmit_ap(struct ieee80211_sub_if_data *sdata,
+ 
+ 	control.sta = pubsta;
+ 
++	ieee80211_tx_stats(dev, skb->len);
+ 	drv_tx(local, &control, skb);
+ 
+ 	if (sta)
+-- 
+2.34.1
+


### PR DESCRIPTION
In the backports driver the tx stats are updated in ieee80211_8023_xmit. However in AP mode the packets are transmitted in ieee80211_8023_xmit_ap. ieee80211_8023_xmit is not hit in case of AP mode. Update the stats in ieee80211_8023_xmit_ap path too.