### PR TITLE
ipq50xx: Adjust ubootenv_size for ipq50xx

### DIFF
--- a/patches/0074-ipq50xx-Adjust-ubootenv_size-for-ipq50xx.patch
+++ b/patches/0074-ipq50xx-Adjust-ubootenv_size-for-ipq50xx.patch
@@ -1,0 +1,54 @@
+From ad05e4778d7a01e2005150d1dad44380dc4022f4 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Wed, 10 Jul 2024 15:32:24 +0530
+Subject: [PATCH] ipq50xx: Adjust ubootenv_size for ipq50xx
+
+ubootenv_size is computed dynamically similar to ipq807x.
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ package/boot/uboot-envtools/files/ipq50xx | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/package/boot/uboot-envtools/files/ipq50xx b/package/boot/uboot-envtools/files/ipq50xx
+index 84ed73f288..3163ae84d2 100644
+--- a/package/boot/uboot-envtools/files/ipq50xx
++++ b/package/boot/uboot-envtools/files/ipq50xx
+@@ -14,15 +14,30 @@ ubootenv_mtdinfo () {
+ 	mtd_erase=$(echo $UBOOTENV_PART | awk '{print "0x"$3}')
+ 	nor_flash=$(find /sys/bus/spi/devices/*/mtd -name ${mtd_dev})
+ 
+-	if [ -n "$nor_flash" ]; then
++	found_emmc=0
++
++	if [ -z "$UBOOTENV_PART" ]; then
++		mtd_dev=$(echo $(find_mmc_part "0:APPSBLENV") | sed 's/^.\{5\}//')
++		if [ -n "$mtd_dev" ]; then
++			EMMC_UBOOTENV_PART=$(cat /proc/partitions | grep $mtd_dev)
++			#convert block to bytes
++			emmc_ubootenv_size=`expr $(echo $EMMC_UBOOTENV_PART | awk '{print $3}') \* 1024`
++			ubootenv_size=0x`printf "%x" $emmc_ubootenv_size`
++			found_emmc=1
++		fi
++		mtd_erase=""
++	elif [ -n "$nor_flash" ]; then
+ 		ubootenv_size=$mtd_size
+ 	else
+ 		# size is fixed to 0x40000 in u-boot
+ 		ubootenv_size=0x40000
+ 	fi
+-
+-	sectors=$(( $ubootenv_size / $mtd_erase ))
+-	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
++	if [ $found_emmc -eq 0 ]; then
++		sectors=$(printf '0x%x' $(( $ubootenv_size / $mtd_erase )))
++		echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
++	else
++		echo /dev/$mtd_dev 0x0 $ubootenv_size
++	fi
+ }
+ 
+ case "$board" in
+-- 
+2.34.1
+


### PR DESCRIPTION
ubootenv_size is computed dynamically similar to ipq807x. This resolves the issue where fw_setenv fails with the following error.

MTD erase error on /dev/mtd13: Invalid argument
Error: can't write fw_env to flash