### PR TITLE
eap104: Update the environment variable bootcount properly for EAP104

### DIFF
--- a/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/init.d/bootcount
@@ -7,5 +7,10 @@ boot() {
 	hfcl,ion4xi_w)
 		fw_setenv boot_count 0
 		;;		
+	edgecore,eap104)
+		avail=$(fw_printenv -n upgrade_available)
+		[ "${avail}" -eq 0 ] && fw_setenv upgrade_available 1
+		fw_setenv bootcount 0
+		;;
 	esac
 }


### PR DESCRIPTION
In the bootcount script there was no entry for Edgecore EAP104 to set the bootcount. This commit adds support for Edgecore EAP104 in bootcount script to set the environment variable correctly