### PR TITLE
firewall4: Enable the HW offloading for Firewall4

### DIFF
--- a/patches/0049-firewall4-enable-hw-offload.patch
+++ b/patches/0049-firewall4-enable-hw-offload.patch
@@ -1,0 +1,20 @@
+diff --git a/package/network/config/firewall4/patches/100-allow-input-wan.patch b/package/network/config/firewall4/patches/100-allow-input-wan.patch
+index f44a2987cf..234da290f6 100644
+--- a/package/network/config/firewall4/patches/100-allow-input-wan.patch
++++ b/package/network/config/firewall4/patches/100-allow-input-wan.patch
+@@ -11,3 +11,15 @@ Index: firewall4-2023-03-23-04a06bd7/root/etc/config/firewall
+  	option output		ACCEPT
+  	option forward		REJECT
+  	option masq		1
++Index: firewall4-2023-03-23-04a06bd7/root/etc/config/firewall
++===================================================================
++--- firewall4-2023-03-23-04a06bd7.orig/root/etc/config/firewall
+++++ firewall4-2023-03-23-04a06bd7/root/etc/config/firewall
++@@ -3,6 +3,8 @@
++	option input		REJECT
++	option output		ACCEPT
++	option forward		REJECT
+++	option flow_offloading_hw	'1'
+++	option flow_offloading	'1'
++ # Uncomment this line to disable ipv6 rules
++ #	option disable_ipv6	1


### PR DESCRIPTION
Fixes the throughput issue while traffic run from LAN to WAN ports on AP yuncore ax820 model using wired clients.

Test scenario:
WiredClient[192.168.1.67] <======> (LAN)APX820(WAN) <=====> WiredClient[192.168.100.103]