### PR TITLE
leds: Add controllable power LED option for multiple platforms

### DIFF
--- a/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/board.d/01_leds
+++ b/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/board.d/01_leds
@@ -14,6 +14,15 @@ edgecore,eap104)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy1tpt"
 	ucidef_set_led_netdev "wan" "wan" "yellow:uplink" "eth0"
+        ucidef_set_led_default "power" "POWER" "green:power" "on"
+	;;
+cig,wf186h|\
+cig,wf186w)
+        ucidef_set_led_default "power" "POWER" "green:status" "on"
+	;;
+cybertan,eww631-a1|\
+cybertan,eww631-b1)
+        ucidef_set_led_default "power" "POWER" "sys:blue" "on"
 	;;
 edgecore,oap101|\
 edgecore,oap101-6e|\

--- a/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/board.d/01_leds
+++ b/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/board.d/01_leds
@@ -13,6 +13,7 @@ cig,wf188n)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0" "tx rx link"
         ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tpt"
         ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tpt"
+        ucidef_set_led_default "power" "POWER" "green:power" "on"
 	;;
 edgecore,eap101)
         ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tpt"
@@ -20,6 +21,7 @@ edgecore,eap101)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "eth1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "eth2"
 	ucidef_set_led_netdev "poe" "poe" "green:wan" "eth0"
+        ucidef_set_led_default "power" "POWER" "green:led_pwr" "on"
 	;;
 hfcl,ion4xi|\
 hfcl,ion4x|\

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/board.d/01_leds
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/board.d/01_leds
@@ -17,10 +17,14 @@ edgecore,oap102)
 	ucidef_set_led_netdev "poe" "poe" "green:wan" "eth0"
         ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tpt"
         ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tpt"
+        ucidef_set_led_wlan "power" "POWER" "green:power" "default-on"
 	;;
 sonicfi,rap630w-311g|\
 cybertan,eww631-b1)
 	ucidef_set_led_default "power" "POWER" "sys:blue" "on"
+	;;
+cig,wf196)
+        ucidef_set_led_default "power" "POWER" "green:status" "on"
 	;;
 esac
 


### PR DESCRIPTION
Add controllable power LED support for -

CIG WF186W, CIG WF186H, CIG WF188N, CIG WF196, Edgecore EAP101 and Edgecore EAP102 and Edgecore EAP104