### PR TITLE
WIFI-14092 Higher WAP2 SHA256 breaks MPSK deployments

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/files/hostapd.sh
+++ b/feeds/ipq807x_v5.4/hostapd/files/hostapd.sh
@@ -74,7 +74,7 @@ hostapd_append_wpa_key_mgmt() {
 			append wpa_key_mgmt "OWE"
 		;;
 		psk2-radius)
-			append wpa_key_mgmt "WPA-PSK-SHA256"
+			append wpa_key_mgmt "WPA-PSK"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-PSK"
 		;;
 	esac


### PR DESCRIPTION
https://telecominfraproject.atlassian.net/browse/WIFI-14092

### Description of Changes
- Changed the AKM encryption type from KDF to PRK to avoid breaking MPSK deployments with the 3.2 release.

### Author
- **Name**: Firas Shaari
- **Email**: firas.shaari@shaariconsultancy.com