### PR TITLE
hostapd: add WPA-PSK key mgmt for psk2-radius

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/files/hostapd.sh
+++ b/feeds/ipq807x_v5.4/hostapd/files/hostapd.sh
@@ -74,7 +74,7 @@ hostapd_append_wpa_key_mgmt() {
 			append wpa_key_mgmt "OWE"
 		;;
 		psk2-radius)
-			append wpa_key_mgmt "WPA-PSK-SHA256"
+			append wpa_key_mgmt "WPA-PSK"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-PSK"
 		;;
 	esac


### PR DESCRIPTION
Using WPA-PSK-SHA256 caused issue with WiFi clients connection which support only WPA-PSK.
Added WPA-PSK to avoid of regression and solving
isssue with clients connectivity.

Fixes: 0a21b9d2 ("hostapd: enable FT-PSK for psk2-radius")