### PR TITLE
Removing 802.11w and SHA256 encryption from PSK-Radius

### DIFF
--- a/feeds/mediatek-sdk/hostapd/files/hostapd.sh
+++ b/feeds/mediatek-sdk/hostapd/files/hostapd.sh
@@ -76,7 +76,6 @@ hostapd_append_wpa_key_mgmt() {
 		psk2-radius)
 			append wpa_key_mgmt "WPA-PSK"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-PSK"
-			[ "${ieee80211w:-0}" -gt 0 ] && append wpa_key_mgmt "WPA-PSK-SHA256"
 		;;
 	esac
 


### PR DESCRIPTION
Removing 802.11w and SHA256 encryption feature from PSK-Radius for MediaTek based APs


