### PR TITLE
Fix typo qos.json

### DIFF
--- a/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/qos.json
+++ b/feeds/ucentral/ucentral-schema/files/etc/ucentral/examples/qos.json
@@ -101,8 +101,8 @@
 		},
 		"quality-of-service": {
 			"select-ports": [ "WAN" ],
-			"bandwidth_up": 1000,
-			"bandwidth_down": 1000,
+			"bandwidth-up": 1000,
+			"bandwidth-down": 1000,
 			"bulk-detection": {
 				"dscp": "CS1",
 				"packets-per-second": 500


### PR DESCRIPTION
"bandwidth_up", and "bandwidth_down" had typos. The correct attributes are "bandwidth-up", and "bandwidth-down"