### PR TITLE
WIFI-14441/mac80211: workaround: Send multicast frames as multiple

### DIFF
--- a/feeds/ipq807x_v5.4/mac80211/patches/pending/a-002-mac80211-workaround-Send-multicast-frames-as-multipl.patch
+++ b/feeds/ipq807x_v5.4/mac80211/patches/pending/a-002-mac80211-workaround-Send-multicast-frames-as-multipl.patch
@@ -1,0 +1,36 @@
+From 93d02017c444d9bcb5e319ba6d9dac5794529cdd Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkata@shasta.cloud>
+Date: Fri, 19 Jul 2024 18:43:19 +0530
+Subject: [PATCH] mac80211: workaround: Send multicast frames as multiple
+ unicast frames in DVLAN mode
+
+Broadcast / Multciast transmission is not working in DVLAN mode in the driver.
+If we send the frames as unicast frames, it works. This is a workaround for now.
+Need to rollback once we add a clean fix.
+
+Signed-off-by: Venkat Chimata <venkata@shasta.cloud>
+---
+ net/mac80211/tx.c | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/net/mac80211/tx.c b/net/mac80211/tx.c
+index 9e978f9..6ebf9c2 100644
+--- a/net/mac80211/tx.c
++++ b/net/mac80211/tx.c
+@@ -4197,11 +4197,8 @@ static bool ieee80211_multicast_to_unicast(struct sk_buff *skb,
+ 
+ 	switch (sdata->vif.type) {
+ 	case NL80211_IFTYPE_AP_VLAN:
+-		if (sdata->u.vlan.sta)
+-			return false;
+-		if (sdata->wdev.use_4addr)
+-			return false;
+-		fallthrough;
++		// For now always enable multicast_to_unicast in DVLAN
++		return true;
+ 	case NL80211_IFTYPE_AP:
+ 		/* check runtime toggle for this bss */
+ 		if (!sdata->bss->multicast_to_unicast)
+-- 
+2.34.1
+


### PR DESCRIPTION
 unicast frames in DVLAN mode

Broadcast / Multciast transmission is not working in DVLAN mode in the driver. If we send the frames as unicast frames, it works. This is a workaround for now. Need to rollback once we add a clean fix.

Fixes WIFI-14441