### PR TITLE
WIFI-14500: Fixes for Edgecore OAP103

### DIFF
--- a/feeds/bluetooth/nrf52840/files/etc/init.d/nrf52840
+++ b/feeds/bluetooth/nrf52840/files/etc/init.d/nrf52840
@@ -6,7 +6,8 @@ boot() {
 	. /lib/functions/system.sh
 	case $(board_name) in
 	edgecore,eap102|\
-	edgecore,oap102)
+	edgecore,oap102|\
+	edgecore,oap103)
 		echo 54 > /sys/class/gpio/export
 		echo out > /sys/class/gpio/gpio54/direction
 		echo 0 > /sys/class/gpio/gpio54/value

--- a/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
+++ b/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
@@ -9,7 +9,8 @@ case "$board" in
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;
-    "edgecore,eap102")
+    "edgecore,eap102"|\
+    "edgecore,oap103")
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;

--- a/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
+++ b/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
@@ -9,7 +9,8 @@ case "$board" in
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;
-    "edgecore,eap102")
+    "edgecore,eap102"|\
+    "edgecore,oap103")
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;

--- a/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
@@ -7,10 +7,11 @@ boot() {
 	hfcl,ion4xe|\
 	hfcl,ion4xi)
 		fw_setenv boot_count 0
-		;;		
+		;;
 	edgecore,eap101|\
 	edgecore,eap102|\
 	edgecore,oap102|\
+	edgecore,oap103|\
 	edgecore,eap104)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/board.d/01_leds
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/board.d/01_leds
@@ -13,8 +13,8 @@ cig,wf194c4)
         ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tpt"
 	;;
 edgecore,eap102|\
-edgecore,oap103|\
-edgecore,oap102)
+edgecore,oap102|\
+edgecore,oap103)
 	ucidef_set_led_netdev "poe" "poe" "green:wan" "eth0"
         ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy0tpt"
         ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy1tpt"

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-pdev-stats
@@ -9,7 +9,8 @@ case "$board" in
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq6018\ hw1.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;
-    "edgecore,eap102")
+    "edgecore,eap102"|\
+    "edgecore,oap103")
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac0/fw_stats/pdev_stats /tmp/pdev_stats_phy0
         ln -s /sys/kernel/debug/ath11k/ipq8074\ hw2.0/mac1/fw_stats/pdev_stats /tmp/pdev_stats_phy1
         ;;

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/etc/init.d/bootcount
@@ -11,6 +11,7 @@ boot() {
 	edgecore,eap101|\
 	edgecore,eap102|\
 	edgecore,oap102|\
+	edgecore,oap103|\
 	edgecore,eap104)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1

--- a/feeds/ipq807x_v5.4/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/feeds/ipq807x_v5.4/ipq807x/base-files/lib/upgrade/platform.sh
@@ -64,8 +64,8 @@ platform_do_upgrade() {
 		nand_upgrade_tar "$1"
 		;;
 	edgecore,eap102|\
-	edgecore,oap103|\
-	edgecore,oap102)
+	edgecore,oap102|\
+	edgecore,oap103)
 		if [ "$(find_mtd_chardev rootfs)" ]; then
 			CI_UBIPART="rootfs"
 		else

--- a/feeds/ipq807x_v5.4/ipq807x/image/ipq807x.mk
+++ b/feeds/ipq807x_v5.4/ipq807x/image/ipq807x.mk
@@ -43,7 +43,7 @@ define Device/edgecore_oap103
   DEVICE_TITLE := Edgecore OAP103
   DEVICE_DTS := qcom-ipq807x-oap103
   DEVICE_DTS_CONFIG=config@ac02
-  SUPPORTED_DEVICES := edgecore,oap103 edgecore,eap102
+  SUPPORTED_DEVICES := edgecore,oap103
   DEVICE_PACKAGES := ath11k-wifi-edgecore-oap103 kmod-usb2 kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += edgecore_oap103

--- a/feeds/mcu/mcu/files/uci-defaults/ipq807x
+++ b/feeds/mcu/mcu/files/uci-defaults/ipq807x
@@ -14,7 +14,8 @@ cig,wf196)
 			   "mcu-enable" "/dev/ttyMSM1" "115200"
 	;;
 edgecore,eap102|\
-edgecore,oap102)
+edgecore,oap102|\
+edgecore,oap103)
 	mcu_add_uci_config "nrf52840_usb" "usb" "mcuboot" \
 			   "zephyr-v3.3.x__hci_usb" \
 			   "mcu-enable"

--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -55,7 +55,8 @@ edgecore,eap112|\
 edgecore,oap101|\
 edgecore,oap101e|\
 edgecore,oap101-6e|\
-edgecore,oap101e-6e)
+edgecore,oap101e-6e|\
+edgecore,oap103)
 	if grep -q rootfs1 /proc/cmdline; then
 		PART_NAME=rootfs2
 	else


### PR DESCRIPTION
    - Support bluetooth
    - Allow certificate loading on dual boot
    - Support RRM with Channel Utilization
    - Remove EAP102 from supported devices