### PR TITLE
hostapd: proxy arp: fail gracefully

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/patches/t00-013-proxy-arp-fail-gracefully.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/t00-013-proxy-arp-fail-gracefully.patch
@@ -1,0 +1,27 @@
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -1527,19 +1527,15 @@ int hostapd_setup_bss(struct hostapd_dat
+ 		if (x_snoop_init(hapd)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Generic snooping infrastructure initialization failed");
+-			return -1;
+-		}
+-
+-		if (dhcp_snoop_init(hapd)) {
++			conf->proxy_arp = 0;
++		} else if (dhcp_snoop_init(hapd)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "DHCP snooping initialization failed");
+-			return -1;
+-		}
+-
+-		if (ndisc_snoop_init(hapd)) {
++			conf->proxy_arp = 0;
++		} else if (ndisc_snoop_init(hapd)) {
+ 			wpa_printf(MSG_ERROR,
+ 				   "Neighbor Discovery snooping initialization failed");
+-			return -1;
++			conf->proxy_arp = 0;
+ 		}
+ 	}
+ 


### PR DESCRIPTION
Disable proxy arp and continue if snoop interface setup fail.

Fixes WIFI-14507