### PR TITLE
mediatek/hostap: fix roaming ASSOC REJECT

### DIFF
--- a/feeds/hostapd/hostapd/patches/zzzz-001-fix-assoc-reject-during-roaming.patch
+++ b/feeds/hostapd/hostapd/patches/zzzz-001-fix-assoc-reject-during-roaming.patch
@@ -1,0 +1,46 @@
+Index: hostapd-2023-09-08-e5ccbfc6/src/ap/wpa_auth_ft.c
+===================================================================
+--- hostapd-2023-09-08-e5ccbfc6.orig/src/ap/wpa_auth_ft.c
++++ hostapd-2023-09-08-e5ccbfc6/src/ap/wpa_auth_ft.c
+@@ -3293,6 +3297,8 @@ static int wpa_ft_process_auth_req(struc
+ 	size_t identity_len = 0, radius_cui_len = 0;
+ 	size_t pmk_r1_len, kdk_len, len;
+ 	int retval = WLAN_STATUS_UNSPECIFIED_FAILURE;
++	struct os_reltime now;
++	struct rsn_ftie *ftie;
+ 
+ 	*resp_ies = NULL;
+ 	*resp_ies_len = 0;
+@@ -3324,6 +3330,9 @@ static int wpa_ft_process_auth_req(struc
+ 		goto out;
+ 	}
+ 
++	ftie = (struct rsn_ftie *) parse.ftie;
++	os_memcpy(sm->SNonce, ftie->snonce, WPA_NONCE_LEN);
++
+ 	if (parse.r0kh_id == NULL) {
+ 		wpa_printf(MSG_DEBUG, "FT: Invalid FTIE - no R0KH-ID");
+ 		retval = WLAN_STATUS_INVALID_FTIE;
+@@ -3424,10 +3433,18 @@ pmk_r1_derived:
+ 	os_memcpy(sm->pmk_r1, pmk_r1, pmk_r1_len);
+ 	sm->pmk_r1_len = pmk_r1_len;
+ 
+-	if (random_get_bytes(sm->ANonce, WPA_NONCE_LEN)) {
+-		wpa_printf(MSG_DEBUG, "FT: Failed to get random data for "
+-			   "ANonce");
+-		goto out;
++	if (os_get_reltime(&now) < 0 ||
++	    os_reltime_expired(&now, &sm->ANonce_time, 1)) {
++		if (random_get_bytes(sm->ANonce, WPA_NONCE_LEN)) {
++			wpa_printf(MSG_DEBUG, "FT: Failed to get random data for "
++				   "ANonce");
++			return WLAN_STATUS_UNSPECIFIED_FAILURE;
++		}
++		sm->ANonce_time.sec = now.sec;
++		sm->ANonce_time.usec = now.usec;
++		wpa_printf(MSG_INFO, "FT: ANonce was randomized");
++	} else {
++		wpa_printf(MSG_INFO, "FT: ANonce has not expired");
+ 	}
+ 
+ 	/* Now that we know the correct PMK-R1 length and as such, the length


### PR DESCRIPTION
During roaming validation, an issue was detected with the ASSOC-REJECT event, which had a status code of 55.

To resolve this, the SNonce from the Auth Request Frame was copied, and the random ANonce is now used
only when expired.

Fixes: WIFI-14326