### PR TITLE
WIFI-14529: "udhcpinject" missing from the package list in ucentral-ap.yml

### DIFF
--- a/profiles/ucentral-ap.yml
+++ b/profiles/ucentral-ap.yml
@@ -45,6 +45,7 @@ packages:
   - ucentral-schema
   - ucentral-state
   - ucentral-tools
+  - udhcpinject
   - udhcprelay
   - ufp
   - ugps


### PR DESCRIPTION

  Add package udhcpinject into profiles/ucentral-ap.yml