### PR TITLE
qca-wifi-7: hostapd.sh: add missed functionality from ipq807x_v5.4

### DIFF
--- a/feeds/qca-wifi-7/hostapd/files/hostapd.sh
+++ b/feeds/qca-wifi-7/hostapd/files/hostapd.sh
@@ -126,12 +126,15 @@ hostapd_common_add_device_config() {
 	config_add_int maxassoc
 	config_add_int reg_power_type
 	config_add_boolean stationary_ap
+	config_add_boolean maxassoc_ignore_probe
 
 	config_add_string acs_chan_bias
+	config_add_boolean acs_exclude_dfs
 	config_add_array hostapd_options
 
 	config_add_int airtime_mode
 	config_add_int mbssid
+	config_add_boolean rnr_beacon ema
 
 	hostapd_add_log_config
 }
@@ -142,10 +145,11 @@ hostapd_prepare_device_config() {
 
 	local base_cfg=
 
-	json_get_vars country country3 country_ie beacon_int:100 doth require_mode legacy_rates \
+	json_get_vars country country3 country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
 		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode cell_density \
 		rts_threshold beacon_rate rssi_reject_assoc_rssi rssi_ignore_probe_request maxassoc \
-		mbssid:0 band reg_power_type stationary_ap
+		rnr_beacon mbssid:0 band reg_power_type stationary_ap acs_exclude_dfs\
+		maxassoc_ignore_probe band
 
 	hostapd_set_log_options base_cfg
 
@@ -155,6 +159,9 @@ hostapd_prepare_device_config() {
 	set_default legacy_rates 0
 	set_default airtime_mode 0
 	set_default cell_density 0
+	set_default rnr_beacon 0
+	set_default ema 0
+	set_default acs_exclude_dfs 0
 
 	[ -n "$country" ] && {
 		append base_cfg "country_code=$country" "$N"
@@ -244,8 +251,14 @@ hostapd_prepare_device_config() {
 	[ -n "$brlist" ] && append base_cfg "basic_rates=$brlist" "$N"
 	append base_cfg "beacon_int=$beacon_int" "$N"
 	[ -n "$rts_threshold" ] && append base_cfg "rts_threshold=$rts_threshold" "$N"
+	append base_cfg "dtim_period=$dtim_period" "$N"
 	[ "$airtime_mode" -gt 0 ] && append base_cfg "airtime_mode=$airtime_mode" "$N"
 	[ -n "$maxassoc" ] && append base_cfg "iface_max_num_sta=$maxassoc" "$N"
+	[ "$maxassoc_ignore_probe" -gt 0 ] && append base_cfg "no_probe_resp_if_max_sta=1" "$N"
+	[ "$rnr_beacon" -gt 0 ] && append base_cfg "rnr_beacon=$rnr_beacon" "$N"
+	[ "$ema" -gt 0 ] && append base_cfg "ema=$ema" "$N"
+	[ "$acs_exclude_dfs" -gt 0 ] && append base_cfg "acs_exclude_dfs=$acs_exclude_dfs" "$N"
+
 	[ "$mbssid" -gt 0 ] && [ "$mbssid" -le 2 ] && append base_cfg "mbssid=$mbssid" "$N"
 
 	[ "$band" = "6g" ] && {
@@ -287,14 +300,23 @@ hostapd_common_add_bss_config() {
 	config_add_int ieee80211w
 	config_add_int eapol_version
 
-	config_add_array auth_server acct_server
-	config_add_string 'server:host'
+	config_add_string 'auth_server:host' 'server:host'
 	config_add_string auth_secret key
 	config_add_int 'auth_port:port' 'port:port'
 
+	config_add_string acct_server
 	config_add_string acct_secret
 	config_add_int acct_port
+
+	config_add_string acct_server_secondary
+	config_add_string acct_secret_secondary
+	config_add_int acct_port_secondary
+
 	config_add_int acct_interval
+
+	config_add_string auth_server_secondary
+	config_add_string auth_secret_secondary
+	config_add_int auth_port_secondary
 
 	config_add_int bss_load_update_period chan_util_avg_period
 
@@ -339,8 +361,8 @@ hostapd_common_add_bss_config() {
 	config_add_string lci civic
 
 	config_add_boolean ieee80211r pmk_r1_push ft_psk_generate_local ft_over_ds
-	config_add_int r0_key_lifetime reassociation_deadline
-	config_add_string mobility_domain r1_key_holder
+	config_add_int r0_key_lifetime reassociation_deadline ft_l2_refresh
+	config_add_string mobility_domain r1_key_holder ft_key
 	config_add_array r0kh r1kh
 
 	config_add_int ieee80211w_max_timeout ieee80211w_retry_timeout
@@ -391,13 +413,17 @@ hostapd_common_add_bss_config() {
 	config_add_array radius_auth_req_attr
 	config_add_array radius_acct_req_attr
 
-	config_add_int eap_server radius_server_auth_port
-	config_add_string eap_user_file ca_cert server_cert private_key private_key_passwd server_id radius_server_clients
+	config_add_int eap_server
+	config_add_string eap_user_file ca_cert server_cert private_key private_key_passwd server_id
 
 	config_add_boolean fils
 	config_add_string fils_dhcp
 
+	config_add_boolean ratelimit
 	config_add_int ocv
+
+	config_add_string uci_section
+	config_add_boolean dynamic_probe_resp
 
 	config_add_boolean apup
 	config_add_string apup_peer_ifname_prefix
@@ -433,6 +459,7 @@ hostapd_set_psk() {
 	local ifname="$1"
 
 	rm -f /var/run/hostapd-${ifname}.psk
+	touch /var/run/hostapd-${ifname}.psk
 	for_each_station hostapd_set_psk_file ${ifname}
 }
 
@@ -549,18 +576,83 @@ append_airtime_sta_weight() {
 	[ -n "$1" ] && append bss_conf "airtime_sta_weight=$1" "$N"
 }
 
-append_auth_server() {
-	[ -n "$1" ] || return
-	append bss_conf "auth_server_addr=$1" "$N"
-	append bss_conf "auth_server_port=$auth_port" "$N"
-	[ -n "$auth_secret" ] && append bss_conf "auth_server_shared_secret=$auth_secret" "$N"
-}
+append_radius_server() {
 
-append_acct_server() {
-	[ -n "$1" ] || return
-	append bss_conf "acct_server_addr=$1" "$N"
-	append bss_conf "acct_server_port=$acct_port" "$N"
-	[ -n "$acct_secret" ] && append bss_conf "acct_server_shared_secret=$acct_secret" "$N"
+	json_get_vars \
+		auth_server auth_secret auth_port \
+		auth_server_secondary auth_secret_secondary auth_port_secondary \
+		dae_client dae_secret dae_port \
+		dynamic_ownip ownip radius_client_addr \
+		eap_reauth_period request_cui \
+		erp_domain mobility_domain \
+		fils_realm fils_dhcp
+
+	set_default dynamic_ownip 1
+
+	# legacy compatibility
+	[ -n "$auth_server" ] || json_get_var auth_server server
+	[ -n "$auth_port" ] || json_get_var auth_port port
+	[ -n "$auth_secret" ] || json_get_var auth_secret key
+
+	[ "$fils" -gt 0 ] && {
+		set_default erp_domain "$mobility_domain"
+		set_default erp_domain "$(echo "$ssid" | md5sum | head -c 8)"
+		set_default fils_realm "$erp_domain"
+
+		append bss_conf "erp_send_reauth_start=1" "$N"
+		append bss_conf "erp_domain=$erp_domain" "$N"
+		append bss_conf "fils_realm=$fils_realm" "$N"
+		append bss_conf "fils_cache_id=$(echo "$fils_realm" | md5sum | head -c 4)" "$N"
+
+		[ "$fils_dhcp" = "*" ] && {
+			json_get_values network network
+			fils_dhcp=
+			for net in $network; do
+				fils_dhcp="$(ifstatus "$net" | jsonfilter -e '@.data.dhcpserver')"
+				[ -n "$fils_dhcp" ] && break
+			done
+
+			[ -z "$fils_dhcp" -a -n "$network_bridge" -a -n "$network_ifname" ] && \
+				fils_dhcp="$(udhcpc -B -n -q -s /lib/netifd/dhcp-get-server.sh -t 1 -i "$network_ifname" 2>/dev/null)"
+		}
+		[ -n "$fils_dhcp" ] && append bss_conf "dhcp_server=$fils_dhcp" "$N"
+	}
+
+	set_default auth_port 1812
+	set_default auth_port_secondary 1812
+	set_default dae_port 3799
+	set_default request_cui 0
+
+	[ "$eap_server" -eq 0  -a -n "$auth_server" ] && {
+		append bss_conf "auth_server_addr=$auth_server" "$N"
+		append bss_conf "auth_server_port=$auth_port" "$N"
+		append bss_conf "auth_server_shared_secret=$auth_secret" "$N"
+	}
+
+	[ -n "$auth_server_secondary" ] && {
+		append bss_conf "auth_server_addr=$auth_server_secondary" "$N"
+		append bss_conf "auth_server_port=$auth_port_secondary" "$N"
+		[ -n "$auth_secret_secondary" ] && \
+			append bss_conf "auth_server_shared_secret=$auth_secret_secondary" "$N"
+	}
+
+	[ "$request_cui" -gt 0 ] && append bss_conf "radius_request_cui=$request_cui" "$N"
+	[ -n "$eap_reauth_period" ] && append bss_conf "eap_reauth_period=$eap_reauth_period" "$N"
+
+	[ -n "$dae_client" -a -n "$dae_secret" ] && {
+		append bss_conf "radius_das_port=$dae_port" "$N"
+		append bss_conf "radius_das_client=$dae_client $dae_secret" "$N"
+	}
+	json_for_each_item append_radius_auth_req_attr radius_auth_req_attr
+
+	if [ -n "$ownip" ]; then
+		append bss_conf "own_ip_addr=$ownip" "$N"
+	elif [ "$dynamic_ownip" -gt 0 ]; then
+		append bss_conf "dynamic_own_ip_addr=$dynamic_ownip" "$N"
+	fi
+
+	[ -n "$radius_client_addr" ] && append bss_conf "radius_client_addr=$radius_client_addr" "$N"
+	[ "$macfilter" = radius ] && append bss_conf "macaddr_acl=2" "$N"
 }
 
 hostapd_set_bss_options() {
@@ -570,7 +662,7 @@ hostapd_set_bss_options() {
 
 	wireless_vif_parse_encryption
 
-	local bss_conf bss_md5sum ft_key
+	local bss_conf bss_md5sum
 	local wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_key_mgmt
 
 	json_get_vars \
@@ -581,13 +673,14 @@ hostapd_set_bss_options() {
 		wps_independent wps_device_type wps_device_name wps_manufacturer wps_pin \
 		macfilter ssid utf8_ssid wmm uapsd hidden short_preamble rsn_preauth \
 		iapp_interface eapol_version dynamic_vlan ieee80211w nasid \
-		acct_secret acct_port acct_interval \
+		acct_server acct_secret acct_port acct_interval \
+		acct_server_secondary acct_secret_secondary acct_port_secondary \
 		bss_load_update_period chan_util_avg_period sae_require_mfp sae_pwe \
 		multi_ap multi_ap_backhaul_ssid multi_ap_backhaul_key skip_inactivity_poll \
 		ppsk airtime_bss_weight airtime_bss_limit airtime_sta_weight \
 		multicast_to_unicast_all proxy_arp per_sta_vif \
 		eap_server eap_user_file ca_cert server_cert private_key private_key_passwd server_id radius_server_clients radius_server_auth_port \
-		vendor_elements fils ocv apup multi_psk
+		vendor_elements fils ocv apup uci_section dynamic_probe_resp multi_psk
 
 	set_default fils 0
 	set_default isolate 0
@@ -604,6 +697,7 @@ hostapd_set_bss_options() {
 	set_default tdls_prohibit 0
 	set_default eapol_version $((wpa & 1))
 	set_default acct_port 1813
+	set_default acct_port_secondary 1813
 	set_default bss_load_update_period 60
 	set_default chan_util_avg_period 600
 	set_default utf8_ssid 1
@@ -612,6 +706,7 @@ hostapd_set_bss_options() {
 	set_default airtime_bss_weight 0
 	set_default airtime_bss_limit 0
 	set_default eap_server 0
+	set_default dynamic_probe_resp 0
 	set_default apup 0
 
 	/usr/sbin/hostapd -vfils || fils=0
@@ -638,6 +733,7 @@ hostapd_set_bss_options() {
 	append bss_conf "preamble=$short_preamble" "$N"
 	append bss_conf "wmm_enabled=$wmm" "$N"
 	append bss_conf "ignore_broadcast_ssid=$hidden" "$N"
+	append bss_conf "dynamic_probe_resp=$dynamic_probe_resp" "$N"
 	append bss_conf "uapsd_advertisement_enabled=$uapsd" "$N"
 	append bss_conf "utf8_ssid=$utf8_ssid" "$N"
 	append bss_conf "multi_ap=$multi_ap" "$N"
@@ -654,10 +750,22 @@ hostapd_set_bss_options() {
 
 	[ -n "$nasid" ] && append bss_conf "nas_identifier=$nasid" "$N"
 
-	[ -n "$acct_interval" ] && \
-		append bss_conf "radius_acct_interim_interval=$acct_interval" "$N"
-	json_for_each_item append_acct_server acct_server
-	json_for_each_item append_radius_acct_req_attr radius_acct_req_attr
+	[ -n "$acct_server" ] && {
+		append bss_conf "acct_server_addr=$acct_server" "$N"
+		append bss_conf "acct_server_port=$acct_port" "$N"
+		[ -n "$acct_secret" ] && \
+			append bss_conf "acct_server_shared_secret=$acct_secret" "$N"
+		[ -n "$acct_interval" ] && \
+			append bss_conf "radius_acct_interim_interval=$acct_interval" "$N"
+		json_for_each_item append_radius_acct_req_attr radius_acct_req_attr
+	}
+
+	[ -n "$acct_server_secondary" ] && {
+		append bss_conf "acct_server_addr=$acct_server_secondary" "$N"
+		append bss_conf "acct_server_port=$acct_port_secondary" "$N"
+		[ -n "$acct_secret_secondary" ] && \
+			append bss_conf "acct_server_shared_secret=$acct_secret_secondary" "$N"
+	}
 
 	[ -n "$ocv" ] && append bss_conf "ocv=$ocv" "$N"
 
@@ -690,6 +798,8 @@ hostapd_set_bss_options() {
 			# Here we make the assumption that if we're in open mode
 			# with WPS enabled, we got to be in unconfigured state.
 			wps_not_configured=1
+			vlan_possible=1
+			append_radius_server
 		;;
 		psk|sae|psk-sae)
 			json_get_vars key wpa_psk_file
@@ -714,74 +824,15 @@ hostapd_set_bss_options() {
 			}
 			[ "$eapol_version" -ge "1" -a "$eapol_version" -le "2" ] && append bss_conf "eapol_version=$eapol_version" "$N"
 
+			append_radius_server
 			set_default dynamic_vlan 0
 			vlan_possible=1
 			wps_possible=1
 		;;
-		eap|eap2|eap-eap2|eap192)
-			json_get_vars \
-				auth_server auth_secret auth_port \
-				dae_client dae_secret dae_port \
-				dynamic_ownip ownip radius_client_addr \
-				eap_reauth_period request_cui \
-				erp_domain mobility_domain \
-				fils_realm fils_dhcp
-
+		eap|eap192|eap-eap2|eap2)
+			append_radius_server
 			# radius can provide VLAN ID for clients
 			vlan_possible=1
-
-			set_default dynamic_ownip 1
-
-			# legacy compatibility
-			[ -n "$auth_server" ] || json_get_var auth_server server
-			[ -n "$auth_port" ] || json_get_var auth_port port
-			[ -n "$auth_secret" ] || json_get_var auth_secret key
-
-			[ "$fils" -gt 0 ] && {
-				set_default erp_domain "$mobility_domain"
-				set_default erp_domain "$(echo "$ssid" | md5sum | head -c 8)"
-				set_default fils_realm "$erp_domain"
-
-				append bss_conf "erp_send_reauth_start=1" "$N"
-				append bss_conf "erp_domain=$erp_domain" "$N"
-				append bss_conf "fils_realm=$fils_realm" "$N"
-				append bss_conf "fils_cache_id=$(echo "$fils_realm" | md5sum | head -c 4)" "$N"
-
-				[ "$fils_dhcp" = "*" ] && {
-					json_get_values network network
-					fils_dhcp=
-					for net in $network; do
-						fils_dhcp="$(ifstatus "$net" | jsonfilter -e '@.data.dhcpserver')"
-						[ -n "$fils_dhcp" ] && break
-					done
-
-					[ -z "$fils_dhcp" -a -n "$network_bridge" -a -n "$network_ifname" ] && \
-						fils_dhcp="$(udhcpc -B -n -q -s /lib/netifd/dhcp-get-server.sh -t 1 -i "$network_ifname" 2>/dev/null)"
-				}
-				[ -n "$fils_dhcp" ] && append bss_conf "dhcp_server=$fils_dhcp" "$N"
-			}
-
-			set_default auth_port 1812
-			set_default dae_port 3799
-			set_default request_cui 0
-
-			[ "$eap_server" -eq 0 ] && json_for_each_item append_auth_server auth_server
-			[ "$request_cui" -gt 0 ] && append bss_conf "radius_request_cui=$request_cui" "$N"
-			[ -n "$eap_reauth_period" ] && append bss_conf "eap_reauth_period=$eap_reauth_period" "$N"
-
-			[ -n "$dae_client" -a -n "$dae_secret" ] && {
-				append bss_conf "radius_das_port=$dae_port" "$N"
-				append bss_conf "radius_das_client=$dae_client $dae_secret" "$N"
-			}
-			json_for_each_item append_radius_auth_req_attr radius_auth_req_attr
-
-			if [ -n "$ownip" ]; then
-				append bss_conf "own_ip_addr=$ownip" "$N"
-			elif [ "$dynamic_ownip" -gt 0 ]; then
-				append bss_conf "dynamic_own_ip_addr=$dynamic_ownip" "$N"
-			fi
-
-			[ -n "$radius_client_addr" ] && append bss_conf "radius_client_addr=$radius_client_addr" "$N"
 			append bss_conf "eapol_key_index_workaround=1" "$N"
 			append bss_conf "ieee8021x=1" "$N"
 
@@ -798,6 +849,7 @@ hostapd_set_bss_options() {
 			append bss_conf "wpa_psk_radius=3" "$N"
 			append_radius_server
 			vlan_possible=1
+		;;
 	esac
 
 	case "$auth_type" in
@@ -921,35 +973,31 @@ hostapd_set_bss_options() {
 		}
 	fi
 
-	json_get_vars ieee80211r
-	set_default ieee80211r 0
 	if [ "$wpa" -ge "1" ]; then
-		if [ "$fils" -gt 0 ]; then
-			json_get_vars fils_realm
-			set_default fils_realm "$(echo "$ssid" | md5sum | head -c 8)"
-		fi
+		json_get_vars ieee80211r
+		set_default ieee80211r 0
 
-		append bss_conf "wpa_disable_eapol_key_retries=$wpa_disable_eapol_key_retries" "$N"
-
-		hostapd_append_wpa_key_mgmt
-		[ -n "$wpa_key_mgmt" ] && append bss_conf "wpa_key_mgmt=$wpa_key_mgmt" "$N"
-	fi
-
-	if [ "$wpa" -ge "2" ]; then
 		if [ "$ieee80211r" -gt "0" ]; then
-			json_get_vars mobility_domain ft_psk_generate_local ft_over_ds reassociation_deadline
+			json_get_vars mobility_domain ft_psk_generate_local ft_over_ds reassociation_deadline ft_l2_refresh
 
 			set_default mobility_domain "$(echo "$ssid" | md5sum | head -c 4)"
-			set_default ft_over_ds 0
+			set_default ft_over_ds 1
+			set_default ft_l2_refresh 30
 			set_default reassociation_deadline 1000
+			skip_kh_setup=0
 
 			case "$auth_type" in
-				psk)
+				psk|psk-sae)
 					set_default ft_psk_generate_local 1
+					skip_kh_setup="$ft_psk_generate_local"
 				;;
 				*)
 					set_default ft_psk_generate_local 0
 				;;
+			esac
+
+			case "$auth_type" in
+				*sae*) skip_kh_setup=0;;
 			esac
 
 			[ -n "$network_ifname" ] && append bss_conf "ft_iface=$network_ifname" "$N"
@@ -957,9 +1005,10 @@ hostapd_set_bss_options() {
 			append bss_conf "ft_psk_generate_local=$ft_psk_generate_local" "$N"
 			append bss_conf "ft_over_ds=$ft_over_ds" "$N"
 			append bss_conf "reassociation_deadline=$reassociation_deadline" "$N"
+			[ -n "$ft_l2_refresh" ] && append bss_conf "ft_l2_refresh=$ft_l2_refresh" "$N"
 
-			if [ "$ft_psk_generate_local" -eq "0" ]; then
-				json_get_vars r0_key_lifetime r1_key_holder pmk_r1_push
+			if [ "$skip_kh_setup" -eq "0" ]; then
+				json_get_vars r0_key_lifetime r1_key_holder pmk_r1_push ft_key
 				json_get_values r0kh r0kh
 				json_get_values r1kh r1kh
 
@@ -971,12 +1020,15 @@ hostapd_set_bss_options() {
 						wireless_setup_vif_failed FT_KEY_CANT_BE_DERIVED
 						return 1
 					fi
-					ft_key=`echo -n "$mobility_domain/${auth_secret:-${key}}" | md5sum | awk '{print $1}'`
+					[ -z "$ft_key" ] && {
+						key=`echo -n "$mobility_domain/$auth_secret" | md5sum | awk '{print $1}'`
 
-					set_default r0kh "ff:ff:ff:ff:ff:ff,*,$ft_key"
-					set_default r1kh "00:00:00:00:00:00,00:00:00:00:00:00,$ft_key"
+						set_default r0kh "ff:ff:ff:ff:ff:ff,*,$key"
+						set_default r1kh "00:00:00:00:00:00,00:00:00:00:00:00,$key"
+					}
 				}
 
+				[ -n "$ft_key" ] && append bss_conf "ft_key=$ft_key" "$N"
 				[ -n "$r1_key_holder" ] && append bss_conf "r1_key_holder=$r1_key_holder" "$N"
 				append bss_conf "r0_key_lifetime=$r0_key_lifetime" "$N"
 				append bss_conf "pmk_r1_push=$pmk_r1_push" "$N"
@@ -989,7 +1041,18 @@ hostapd_set_bss_options() {
 				done
 			fi
 		fi
+		if [ "$fils" -gt 0 ]; then
+			json_get_vars fils_realm
+			set_default fils_realm "$(echo "$ssid" | md5sum | head -c 8)"
+		fi
 
+		append bss_conf "wpa_disable_eapol_key_retries=$wpa_disable_eapol_key_retries" "$N"
+
+		hostapd_append_wpa_key_mgmt
+		[ -n "$wpa_key_mgmt" ] && append bss_conf "wpa_key_mgmt=$wpa_key_mgmt" "$N"
+	fi
+
+	if [ "$wpa" -ge "2" ]; then
 		if [ -n "$network_bridge" -a "$rsn_preauth" = 1 ]; then
 			set_default auth_cache 1
 			append bss_conf "rsn_preauth=1" "$N"
@@ -1188,6 +1251,8 @@ hostapd_set_bss_options() {
 	if [ "$per_sta_vif" -gt 0 ]; then
 		append bss_conf "per_sta_vif=$per_sta_vif" "$N"
 	fi
+
+	[ -n "$uci_section" ] && append bss_conf "uci_section=$uci_section" "$N"
 
 	if [ "$apup" -gt 0 ]; then
 		append bss_conf "apup=$apup" "$N"


### PR DESCRIPTION
The main reason was adding missed functionality for Radius configuration which caused rejecting WiFi clients on authentication level.

Still some changes not included:
* AFC,
* hs20_release,
* multiple_bssid,
* he_co_locate

Fixes: WIFI-14459