### PR TITLE
WIFI-14560: Update file names from /tmp dir in rrmd init script that need to be removed when rrmd (re)starts

### DIFF
--- a/feeds/ucentral/rrmd/files/etc/init.d/rrmd
+++ b/feeds/ucentral/rrmd/files/etc/init.d/rrmd
@@ -6,8 +6,8 @@ STOP=01
 USE_PROCD=1
 
 start_service() {
-	rm -rf /tmp/threshold_breach_count_phy*
-	rm -rf /tmp/fixed_channel_phy*
+	rm -rf /tmp/threshold_breach_count*
+	rm -rf /tmp/fixed_channel*
 
 	procd_open_instance
 	procd_set_param command /usr/bin/rrmd.uc

--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
@@ -265,7 +265,7 @@ function dfs_chan_check(iface_num, rcs_channel) {
 }
 
 function fixed_channel_config(iface, iface_num, fixed_channel_f, auto_channel_f, fixed_chan_bkp, channel_config) {
-    // if fixed channel config is stored in the /tmp/fixed_channel_phyX file
+    // if fixed channel config is stored in the /tmp/fixed_channel_<radio_iface> file
     if (fixed_channel_f == 1) {
         if (auto_channel_f == 1) {
             // if current channel is auto => change to fixed
@@ -675,7 +675,7 @@ function channel_optimize() {
                 ulog_info(`[%s] Allowed consecutive Channel Utilization threshold breach count = %d \n`, radio_iface[j], config.consecutive_threshold_breach);
 
                 if (!current_threshold_breach_count || current_threshold_breach_count == null || current_threshold_breach_count == 'NaN') {
-                    // /tmp/phyX_breachcount file doesn't exist yet or has invalid value
+                    // /tmp/threshold_breach_count_<radio_iface> file doesn't exist yet or has invalid value
                     current_threshold_breach_count = 0;
                 }
                 ulog_info(`[%s] Previous consecutive Channel Utilization threshold breach count = %d \n`, radio_iface[j], current_threshold_breach_count);


### PR DESCRIPTION
There was typo in the file names that had to be removed