### PR TITLE
WIFI-14564: Multiple ssids sometime didn't display dhcp option 82 rules

### DIFF
--- a/feeds/ucentral/udhcpinject/files/etc/config/dhcpinject
+++ b/feeds/ucentral/udhcpinject/files/etc/config/dhcpinject
@@ -5,3 +5,6 @@
 #   list ssid 'EAP101-ERICHI'
 #   list ssid 'EAP101-AKIHO'
 #   list ssid 'EAP101-DAMAYU'
+#
+# config dhcpinject 'dhcpinject'
+#   option iface_count '6'

--- a/feeds/ucentral/udhcpinject/files/etc/init.d/dhcpinject
+++ b/feeds/ucentral/udhcpinject/files/etc/init.d/dhcpinject
@@ -9,9 +9,9 @@ SERVICE_NAME="dhcpinject"
 PROG=/usr/bin/udhcpinject
 
 start_service() {
-    local ssid_list=""
     local ssids=""
     local ports=""
+    local ifaces=""
 
     # Function to process each ssid
     append_ssid() {
@@ -40,6 +40,9 @@ start_service() {
 
     # Get the list of ports
     config_list_foreach uplink port append_port
+
+    # Get the iface_count
+    config_get ifaces dhcpinject iface_count
     
     # Fallback to eth0 if no ports are specified
     if [ -z "$ports" ]; then
@@ -47,11 +50,11 @@ start_service() {
     fi
 
     # Optional: Log or echo for debugging
-    logger -t dhcp_inject "Generated SSIDs=$ssids, Uplink=$ports"
+    logger -t dhcp_inject "Generated SSIDs=$ssids, Uplink=$ports, IFACEs=$ifaces"
 
     procd_open_instance "$SERVICE_NAME"
     procd_set_param command $PROG
-    procd_set_param env SSIDs="$ssids" PORTs="$ports"
+    procd_set_param env SSIDs="$ssids" PORTs="$ports" IFACEs="$ifaces"
     procd_set_param respawn 3600 10 10
     procd_set_param file /etc/config/dhcpinject
     procd_set_param reload_signal SIGHUP


### PR DESCRIPTION
Added check when parsing ssid info retrieved from iwinfo. 
Program will exit if expected interface count and iwinfo entry count mismatch.