### PR TITLE
WIFI-14567-WF189-10G-PHY-code-optimization

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189.dts
@@ -44,6 +44,7 @@
 			uniphyaddr_fixup = <0xC90F014>;
 			mdio_clk_fixup; /* MDIO clock sequence fix up flag */
 			tip,clk_div = <0xff>; /* MDIO Frequency reduction*/
+			limit_rtlphy_10g_ablity;
 
 			phy0: ethernet-phy@0 {
 				reg = <8>;

--- a/feeds/qca-wifi-7/ipq53xx/files-6.1/drivers/net/phy/rtk/rtk_phy.c
+++ b/feeds/qca-wifi-7/ipq53xx/files-6.1/drivers/net/phy/rtk/rtk_phy.c
@@ -7,6 +7,7 @@
 #include <linux/module.h>
 #include <linux/phy.h>
 #include <linux/delay.h>
+#include <linux/of.h>
 
 #include "phy_rtl826xb_patch.h"
 #include "phy_rtl8251b_patch.h"
@@ -30,6 +31,7 @@ static int rtl8251_match_phy_device(struct phy_device *phydev)
 static int rtl826xb_get_features(struct phy_device *phydev)
 {
     int ret;
+    struct device_node *np;
     ret = genphy_c45_pma_read_abilities(phydev);
     if (ret)
         return ret;
@@ -48,8 +50,13 @@ static int rtl826xb_get_features(struct phy_device *phydev)
     linkmode_clear_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT,
                        phydev->supported);
 
-    linkmode_clear_bit(ETHTOOL_LINK_MODE_10000baseT_Full_BIT,
-                       phydev->supported);
+    np = of_find_node_by_name(NULL, "mdio");
+    if (np)
+	if (of_property_read_bool(np, "limit_rtlphy_10g_ablity"))
+	{
+		linkmode_clear_bit(ETHTOOL_LINK_MODE_10000baseT_Full_BIT, phydev->supported);
+	}
+
 
     return 0;
 }

--- a/feeds/qca-wifi-7/qca-ssdk-qca/patches/0006-qca-ssdk-Fix-10G-rtl-phy-driver-for-c45-mdio-read-wr.patch
+++ b/feeds/qca-wifi-7/qca-ssdk-qca/patches/0006-qca-ssdk-Fix-10G-rtl-phy-driver-for-c45-mdio-read-wr.patch
@@ -1,145 +1,78 @@
-From 9181fe30babf33002126dd4367fb314077827609 Mon Sep 17 00:00:00 2001
+From 85a7c62d4e3385de1a379959dd45148cfdc95b3b Mon Sep 17 00:00:00 2001
 From: huangyunxiang <huangyunxiang@cigtech.com>
-Date: Mon, 28 Apr 2025 09:51:00 +0800
-Subject: [PATCH] qca-ssdk Fix 10G rtl phy driver for c45 mdio read/write and
- set fix ablity set
+Date: Tue, 29 Apr 2025 09:56:28 +0800
+Subject: [PATCH] qca-ssdk modify rtl826x phy mdio read/write as c45 mode and
+ clear 10G ablity
 
 ---
- include/hsl/hsl.h                         |  4 +-
- include/init/ssdk_plat.h                  |  7 ++
- src/hsl/phy/rtl826xb_phy.c                | 73 +++++++++++--------
- src/init/ssdk_init.c                      |  2 +
- src/init/ssdk_plat.c                      | 54 ++++++++++++++
- 5 files changed, 106 insertions(+), 34 deletions(-)
+ src/hsl/phy/rtl826xb_phy.c                | 55 ++++++-------------
+ 1 file changed, 17 insertions(+), 38 deletions(-)
 
-diff --git a/include/hsl/hsl.h b/include/hsl/hsl.h
-index e6b49d6b55..6e82450991 100644
---- a/include/hsl/hsl.h
-+++ b/include/hsl/hsl.h
-@@ -193,7 +193,7 @@ do { \
-         rv = SW_NOT_INITIALIZED; \
-     } \
- } while (0);
--
-+#endif
- #define HSL_PHY_GET(rv, dev, phy_addr, reg, value) \
- do { \
-     hsl_api_t *p_api = hsl_api_ptr_get(dev); \
-@@ -213,7 +213,7 @@ do { \
-         rv = SW_NOT_INITIALIZED; \
-     } \
- } while (0);
--#endif
-+//#endif
- /*qca808x_start*/
- #if (defined(API_LOCK) \
- && (defined(HSL_STANDALONG) || (defined(KERNEL_MODULE) && defined(USER_MODE))))
-diff --git a/include/init/ssdk_plat.h b/include/init/ssdk_plat.h
-index 92596477af..9fe5bb824a 100644
---- a/include/init/ssdk_plat.h
-+++ b/include/init/ssdk_plat.h
-@@ -471,6 +471,13 @@ a_uint32_t qca_mii_read(a_uint32_t dev_id, a_uint32_t reg);
- void qca_mii_write(a_uint32_t dev_id, a_uint32_t reg, a_uint32_t val);
- int qca_mii_update(a_uint32_t dev_id, a_uint32_t reg, a_uint32_t mask, a_uint32_t val);
- 
-+sw_error_t
-+qca_ar8327_phy_read(a_uint32_t dev_id, a_uint32_t phy_addr,
-+			a_uint32_t reg, a_uint16_t* data);
-+sw_error_t
-+qca_ar8327_phy_write(a_uint32_t dev_id, a_uint32_t phy_addr,
-+			a_uint32_t reg, a_uint16_t data);
-+
- a_uint32_t __qca_mii_read(a_uint32_t dev_id, a_uint32_t reg);
- void __qca_mii_write(a_uint32_t dev_id, a_uint32_t reg, a_uint32_t val);
- int __qca_mii_update(a_uint32_t dev_id, a_uint32_t reg, a_uint32_t mask, a_uint32_t val);
 diff --git a/src/hsl/phy/rtl826xb_phy.c b/src/hsl/phy/rtl826xb_phy.c
-index a336348aa9..4eaa1ea4f1 100644
+index a336348aa9..9a67b45948 100644
 --- a/src/hsl/phy/rtl826xb_phy.c
 +++ b/src/hsl/phy/rtl826xb_phy.c
-@@ -48,46 +48,66 @@ void rtl826xb_phy_lock_init(void)
+@@ -48,46 +48,39 @@ void rtl826xb_phy_lock_init(void)
  
  static a_uint16_t rtl826x_phy_mmd_read(a_uint32_t dev_id, a_uint32_t phy_id, a_uint16_t reg_mmd, a_uint16_t reg_id)
  {
-+	a_uint16_t phy_data;
-+	sw_error_t rv;
- 	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(reg_mmd, reg_id);
+-	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(reg_mmd, reg_id);
 -
 -	return __hsl_phy_mii_reg_read(dev_id, phy_id, reg_id_c45);
-+	HSL_PHY_GET(rv, dev_id, phy_id, reg_id_c45, &phy_data);
-+	return phy_data;
++	return hsl_phy_mmd_reg_read(dev_id, phy_id, A_TRUE, reg_mmd, reg_id);
  }
  
  
  static sw_error_t rtl826x_phy_mmd_write(a_uint32_t dev_id, a_uint32_t phy_id, a_uint16_t reg_mmd, a_uint16_t reg_id, a_uint16_t reg_val)
  {
-+	sw_error_t rv;
- 	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(reg_mmd, reg_id);
+-	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(reg_mmd, reg_id);
 -
 -	return __hsl_phy_mii_reg_write(dev_id, phy_id, reg_id_c45, reg_val);
-+	HSL_PHY_SET(rv, dev_id,  phy_id, reg_id_c45, reg_val);
-+	return rv;
++	return hsl_phy_mmd_reg_write(dev_id, phy_id, A_TRUE, reg_mmd, reg_id, reg_val);
  }
  
  
  static a_uint16_t rtl826x_phy_reg_read(a_uint32_t dev_id, a_uint32_t phy_id, a_uint32_t reg)
  {
 -	return __hsl_phy_mii_reg_read(dev_id, phy_id, reg);
-+	a_uint16_t phy_data;
-+	sw_error_t rv;
-+	HSL_PHY_GET(rv, dev_id, phy_id, reg, &phy_data);
-+	return phy_data;
++	return hsl_phy_mii_reg_read(dev_id, phy_id, reg);
  }
  
  
  static sw_error_t rtl826x_phy_reg_write(a_uint32_t dev_id, a_uint32_t phy_id, a_uint32_t reg, a_uint16_t reg_val)
  {
 -	return __hsl_phy_mii_reg_write(dev_id, phy_id, reg, reg_val);
-+	sw_error_t rv;
-+	
-+	HSL_PHY_SET(rv, dev_id,  phy_id, reg, reg_val);
 +
-+	return rv;
++	return hsl_phy_mii_reg_write(dev_id, phy_id, reg, reg_val);
  }
  
  
  static a_int16_t hal_miim_mmd_read(a_uint32_t dev_id, a_uint32_t phy_id, a_uint16_t mmdAddr, a_uint16_t mmdReg)
  {
-+	a_uint16_t phy_data;
-+	sw_error_t rv;
-+
- 	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(mmdAddr, mmdReg);
- 
+-	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(mmdAddr, mmdReg);
+-
 -	return __hsl_phy_mii_reg_read(dev_id, phy_id, reg_id_c45);
-+	HSL_PHY_GET(rv, dev_id, phy_id, reg_id_c45, &phy_data);
-+
-+	return phy_data;
++	return hsl_phy_mmd_reg_read(dev_id, phy_id, A_TRUE, mmdAddr, mmdReg);
  }
  
  
  
  static a_int32_t hal_miim_mmd_write(a_uint32_t dev_id, a_uint32_t phy_id, a_uint16_t mmdAddr, a_uint16_t mmdReg, a_uint16_t phy_data)
  {
-+	sw_error_t rv;
-+
- 	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(mmdAddr, mmdReg);
- 
+-	a_uint32_t reg_id_c45 = RTL826XB_REG_ADDRESS(mmdAddr, mmdReg);
+-
 -	return __hsl_phy_mii_reg_write(dev_id, phy_id, reg_id_c45, phy_data);
-+	HSL_PHY_SET(rv, dev_id, phy_id, reg_id_c45, phy_data);
-+
-+
-+	return rv;
++	return hsl_phy_mmd_reg_write(dev_id, phy_id, A_TRUE, mmdAddr, mmdReg, phy_data);
  }
  
  
-@@ -1281,34 +1301,23 @@ phy_826xb_autoNegoAbility_set(a_uint32_t dev_id, a_uint32_t phy_id, a_uint32_t a
+@@ -1281,34 +1274,20 @@ phy_826xb_autoNegoAbility_set(a_uint32_t dev_id, a_uint32_t phy_id, a_uint32_t a
  	hsl_phy_phydev_autoneg_update(dev_id, phy_id, A_TRUE, autoneg);
  	
  	phyData = phy_common_general_reg_mmd_get(dev_id, phy_id, PHY_MMD_AN, 16);
 +	phyData &= (~(0x0020 | 0x0040 | FAL_PHY_ADV_100TX_HD | FAL_PHY_ADV_100TX_FD | FAL_PHY_ADV_PAUSE | FAL_PHY_ADV_ASY_PAUSE));
 +	phyData |= (autoneg & FAL_PHY_ADV_100TX_HD) ? (FAL_PHY_ADV_100TX_HD) : (0);
 +	phyData |= ((autoneg & FAL_PHY_ADV_100TX_FD)) ? (FAL_PHY_ADV_100TX_FD) : (0);
-+//	phyData |= (autoneg & FAL_PHY_ADV_PAUSE) ? (FAL_PHY_ADV_PAUSE) : (0);
-+//	phyData |= (autoneg & FAL_PHY_ADV_ASY_PAUSE) ? (FAL_PHY_ADV_ASY_PAUSE) : (0);
  
 -    phyData &= (~(0x0020 | 0x0040 | 0x0080 | 0x0100 | 0x0400 | 0x0800));
 -	phyData |= ((autoneg & 1 << 1)) ? (0x0040) : (0);
@@ -157,7 +90,6 @@ index a336348aa9..4eaa1ea4f1 100644
 +	phyData &= (~(FAL_PHY_ADV_2500T_FD | FAL_PHY_ADV_5000T_FD | FAL_PHY_ADV_10000T_FD));
 +	phyData |= (autoneg & FAL_PHY_ADV_2500T_FD) ? (FAL_PHY_ADV_2500T_FD) : (0);
 +	phyData |= (autoneg & FAL_PHY_ADV_5000T_FD) ? (FAL_PHY_ADV_5000T_FD) : (0);
-+//	phyData |= (autoneg & FAL_PHY_ADV_10000T_FD) ? (FAL_PHY_ADV_10000T_FD) : (0);
  
 -    phyData &= (~(0x4000 | 0x2000 | 0x1000));
 -    phyData |= (autoneg & 1 << 12) ? (0x0080) : (0);
@@ -179,84 +111,6 @@ index a336348aa9..4eaa1ea4f1 100644
  
      phy_common_general_reg_mmd_set(dev_id, phy_id, PHY_MMD_VEND2, 0xA412, phyData);
          
-diff --git a/src/init/ssdk_init.c b/src/init/ssdk_init.c
-index 59f5fc43c0..fb6288db73 100644
---- a/src/init/ssdk_init.c
-+++ b/src/init/ssdk_init.c
-@@ -2210,6 +2210,8 @@ static void ssdk_cfg_default_init(ssdk_init_cfg *cfg)
- 	memset(cfg, 0, sizeof(ssdk_init_cfg));
- 	cfg->cpu_mode = HSL_CPU_1;
- 	cfg->nl_prot = 30;
-+	cfg->reg_func.mdio_set = qca_ar8327_phy_write;
-+	cfg->reg_func.mdio_get = qca_ar8327_phy_read;
- /*qca808x_end*/
- 
- 	cfg->reg_func.header_reg_set = qca_switch_reg_write;
-diff --git a/src/init/ssdk_plat.c b/src/init/ssdk_plat.c
-index 87bd0dbaf1..24285c8de7 100644
---- a/src/init/ssdk_plat.c
-+++ b/src/init/ssdk_plat.c
-@@ -458,6 +458,60 @@ int __qca_mii_update(a_uint32_t dev_id, a_uint32_t reg, a_uint32_t mask, a_uint3
- 	return 0;
- }
- 
-+a_bool_t
-+phy_addr_validation_check(a_uint32_t phy_addr)
-+{
-+
-+        if ((phy_addr > SSDK_PHY_BCAST_ID) || (phy_addr < SSDK_PHY_MIN_ID))
-+                return A_FALSE;
-+        else
-+                return A_TRUE;
-+}
-+
-+sw_error_t
-+qca_ar8327_phy_read(a_uint32_t dev_id, a_uint32_t phy_addr,
-+                           a_uint32_t reg, a_uint16_t* data)
-+{
-+        struct mii_bus *bus = NULL;
-+
-+        if (A_TRUE != phy_addr_validation_check (phy_addr))
-+        {
-+                return SW_BAD_PARAM;
-+        }
-+
-+        bus = ssdk_phy_miibus_get(dev_id, phy_addr);
-+        if (!bus)
-+                return SW_NOT_SUPPORTED;
-+
-+        mutex_lock(&bus->mdio_lock);
-+        *data = __mdiobus_read(bus, phy_addr, reg);
-+        mutex_unlock(&bus->mdio_lock);
-+
-+        return 0;
-+}
-+
-+sw_error_t
-+qca_ar8327_phy_write(a_uint32_t dev_id, a_uint32_t phy_addr,
-+                            a_uint32_t reg, a_uint16_t data)
-+{
-+        struct mii_bus *bus = NULL;
-+
-+        if (A_TRUE != phy_addr_validation_check (phy_addr))
-+        {
-+                return SW_BAD_PARAM;
-+        }
-+
-+        bus = ssdk_phy_miibus_get(dev_id, phy_addr);
-+        if (!bus)
-+                return SW_NOT_SUPPORTED;
-+
-+        mutex_lock(&bus->mdio_lock);
-+        __mdiobus_write(bus, phy_addr, reg, data);
-+        mutex_unlock(&bus->mdio_lock);
-+
-+        return 0;
-+}
-+
- a_uint32_t qca_mii_read(a_uint32_t dev_id, a_uint32_t reg)
- {
- 	a_uint32_t val = 0xffffffff;
 -- 
 2.34.1
 


### PR DESCRIPTION
1. feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189.dts --- add "limit_rtlphy_10g_ablity"  in DTS  , no side effect on other product.
2. feeds/qca-wifi-7/ipq53xx/files-6.1/drivers/net/phy/rtk/rtk_phy.c  --  disable 10G capability if DTS defined limit_rtlphy_10g_ablity , no side effect on other product.
3. feeds/qca-wifi-7/qca-ssdk-qca/patches/0006-qca-ssdk-Fix-10G-rtl-phy-driver-for-c45-mdio-read-wr.patch ---  revert the last 0006-qca-ssdk-Fix-10G-rtl-phy-driver-for-c45-mdio-read-wr.patch and based on 0005 patch, only touch rtl826xb_phy.c for CIG 189 only. -- no side effect on other product.