### PR TITLE
WIFI-14623-WF188n-WF196-lost-the-certificates-files-after-upgrade

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -82,6 +82,8 @@ cig,wf189|\
 cig,wf189w|\
 cig,wf189h|\
 cig,wf186h|\
+cig,wf196|\
+cig,wf188n|\
 yuncore,ax840|\
 yuncore,fap655)
 	PART_NAME=rootfs_1


### PR DESCRIPTION
add 188n and 196 to mount_cert script.