### PR TITLE
WIFI-14650-CIG-WF-189-CIG-WF-189H-LAN-and-WAN-Ports-Swapped-After-Upgrading-to-TIP-devel-14a0c2d-Image

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/etc/board.d/02_network
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/etc/board.d/02_network
@@ -20,7 +20,7 @@ ipq53xx_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	sonicfi,rap7110c-341x|\
-	sonicfi,rap750e-h|\)
+	sonicfi,rap750e-h|\
 	sonicfi,rap750e-s)
 		ucidef_set_interfaces_lan_wan "" "eth0"
 		;;


### PR DESCRIPTION
it seems there’s a script syntax error which cause the 02_network can NOT be executed successfully when you add it for “Support for CyberTAN RAP750E-S AP”, please take a look.