### PR TITLE
mediatek: Enable dualboot for EAP111 and EAP112 by default

### DIFF
--- a/feeds/mediatek-sdk/mediatek/mt7981/base-files/etc/init.d/bootcount
+++ b/feeds/mediatek-sdk/mediatek/mt7981/base-files/etc/init.d/bootcount
@@ -8,6 +8,9 @@ boot() {
 	edgecore,eap112)
 		bootcount=$(fw_printenv -n bootcount)
 		[ "$bootcount" != 0 ] && fw_setenv bootcount 0
+		# enable dualboot
+		avail=$(fw_printenv -n upgrade_available)
+		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1
 		;;
 	esac
 }


### PR DESCRIPTION
Fixes: WIFI-14579