### PR TITLE
iwinfo.uc: Fix access to undefined htmode object

### DIFF
--- a/feeds/qca-wifi-7/iwinfo/files-iwinfo/usr/share/ucode/iwinfo.uc
+++ b/feeds/qca-wifi-7/iwinfo/files-iwinfo/usr/share/ucode/iwinfo.uc
@@ -397,7 +397,7 @@ export function info(name) {
 			mode: data.mode,
 			channel: format_channel(data.wiphy_freq),
 			freq: format_frequency(data.wiphy_freq),
-			htmode: data.radio.htmode,
+			htmode: data?.radio?.htmode,
 			center_freq1: format_channel(data.center_freq1) || 'unknown',
 			center_freq2: format_channel(data.center_freq2) || 'unknown',
 			txpower: data.wiphy_tx_power_level / 100,


### PR DESCRIPTION
iwinfo command failed due to undefined htmode object

Fixes: WIFI-14666


(cherry picked from commit 7ee4a766e73676ce14c6013e032c55566b42196c)