### PR TITLE
ipq807x: fix silent reboot caused by broken printk

### DIFF
--- a/feeds/ipq807x_v5.4/mac80211/patches/pending/999-remove-kernel-warn-msg-abnormal-he-nss-value.patch
+++ b/feeds/ipq807x_v5.4/mac80211/patches/pending/999-remove-kernel-warn-msg-abnormal-he-nss-value.patch
@@ -6,7 +6,7 @@
  		return 0;
 -	if (WARN_ON_ONCE(rate->nss < 1 || rate->nss > 8))
 +	if (rate->nss < 1 || rate->nss > 8) {
-+		printk_once(1, "invalid rate->nss: %d\n", rate->nss);
++		printk_once(KERN_WARNING "cfg80211_calculate_bitrate_he: invalid rate->nss: %d\n", rate->nss);
  		return 0;
 -
 +	}


### PR DESCRIPTION
A printk() was previously introduced that is passing the log level as the first argument instead of prefixing the format with the level.  Given this code path, this is causing a kernel fault and CPU reboot without any kernel panic/stack trace, since it's crashing inside of printk().

CPU:0 ts:206871944795 ffffffc008dcf828  ffffffc008dfe914  cleanup_module [batman_adv] <- cfg80211_vendor_cmd_reply+0x7ff4/0xa064 [cfg80211]
CPU:0 ts:206871944800 ffffffc0108e69d0  ffffffc008dcf80c  printk <- cleanup_module+0xb22c/0xa20 [batman_adv]
CPU:0 ts:206871944802 ffffffc0101173c0  ffffffc0108e6a08  vprintk_func <- printk+0x60/0x6c
CPU:0 ts:206871944806 ffffffc010115e44  ffffffc0101160ec  vprintk_emit <- vprintk_default+0x4c/0x60
CPU:0 ts:206871944809 ffffffc0101172d0  ffffffc010115e88  __printk_safe_enter <- vprintk_emit+0x84/0x29c
CPU:0 ts:206871944812 ffffffc010115c20  ffffffc010115ec4  vprintk_store <- vprintk_emit+0xc0/0x29c
CPU:0 ts:206871944816 ffffffc0100a53a4  ffffffc010080fb4  do_translation_fault <- do_mem_abort+0x54/0xb0
CPU:0 ts:206871944819 ffffffc0100a4eb4  ffffffc0100a5448  do_page_fault <- do_translation_fault+0xc8/0xe0
CPU:0 ts:206871944821 ffffffc0100a4d08  ffffffc0100a5038  __do_kernel_fault <- do_page_fault+0x1a8/0x4f0
CPU:0 ts:206871944837 ffffffc0100a4c88  ffffffc0100a4df0  die_kernel_fault <- __do_kernel_fault+0x110/0x1b0

After applying the fix, we can see this code path is being hit:
    [26799.175166] cfg80211_calculate_bitrate_he: invalid rate->nss: 0

This still doesn't fix the original issue triggering this code path, which is why a nss value of 0 is being reported.

Fxies: eb9cbaec7 ("ipq807x: Shorten the kernel backtrace warning msg for ieee80211_bss_get_elem")