### PR TITLE
WIFI-14631 CIG WiFi 7 Product Save crash log into pstore

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189h.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189h.dts
@@ -85,6 +85,15 @@
 		/delete-node/ wcnss@4a900000;
 		/delete-node/ q6_caldb_region@4ce00000;
 
+        ramoops@49c00000 {
+            compatible = "ramoops";
+            no-map;
+            reg = <0x0 0x49c00000 0x0 0x50000>;
+            record-size = <0x20000>;
+            console-size = <0x8000>;
+            pmsg-size = <0x8000>;
+        };
+
 		q6_mem_regions: q6_mem_regions@4A900000  {
 			reg = <0x0 0x4a900000 0x0 0x6D00000>;
 			no-map;

--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189w.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189w.dts
@@ -85,6 +85,15 @@
 		/delete-node/ wcnss@4a900000;
 		/delete-node/ q6_caldb_region@4ce00000;
 
+        ramoops@49c00000 {
+            compatible = "ramoops";
+            no-map;
+            reg = <0x0 0x49c00000 0x0 0x50000>;
+            record-size = <0x20000>;
+            console-size = <0x8000>;
+            pmsg-size = <0x8000>;
+        };
+
 		q6_mem_regions: q6_mem_regions@4A900000  {
 			reg = <0x0 0x4a900000 0x0 0x6D00000>;
 			no-map;

--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf672.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf672.dts
@@ -18,6 +18,21 @@
 	model = "CIG WF672";
 	compatible = "cig,wf672", "qcom,ipq5332-rdp468", "qcom,ipq5332";
 
+    reserved-memory {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+
+       ramoops@49c00000 {
+           compatible = "ramoops";
+           no-map;
+           reg = <0x0 0x49c00000 0x0 0x50000>;
+           record-size = <0x20000>;
+           console-size = <0x8000>;
+           pmsg-size = <0x8000>;
+       };
+    };
+
 	aliases {
 		serial0 = &blsp1_uart0;
 		serial1 = &blsp1_uart1;


### PR DESCRIPTION
Enable the feature to  Save crash log into pstore on CIG WiFi 7 products: CIG WF189H, CIG WF89W, CIG WF672