### PR TITLE
WIFI-14825 Enable mpstats and iperf3 On CIG WiFi 7 Products

### DIFF
--- a/profiles/cig_wf189.yml
+++ b/profiles/cig_wf189.yml
@@ -13,4 +13,6 @@ packages:
   - ipq53xx
   - ftm
   - qca-ssdk-shell
+  - iperf3
+  - sysstat
   - kmod-cig-poe-judgment 

--- a/profiles/cig_wf189h.yml
+++ b/profiles/cig_wf189h.yml
@@ -12,4 +12,6 @@ include:
 packages:
   - ipq53xx
   - qca-ssdk-shell
+  - iperf3
+  - sysstat
   - kmod-cig-poe-judgment 

--- a/profiles/cig_wf189w.yml
+++ b/profiles/cig_wf189w.yml
@@ -12,4 +12,6 @@ include:
 packages:
   - ipq53xx
   - qca-ssdk-shell
+  - iperf3
+  - sysstat
   - kmod-cig-poe-judgment 


### PR DESCRIPTION
Enable mpstats and iperf3 On CIG WiFi 7 Products: cig wf189, cig wf189h, cig wf189w