### PR TITLE
WIFI-14840 6G-CBP-Test-Will-fail-Sometimes

### DIFF
--- a/feeds/qca-wifi-7/hostapd/patches/r45-Fix-6G-CBP-Test-Fail.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/r45-Fix-6G-CBP-Test-Fail.patch
@@ -1,0 +1,13 @@
+--- a/src/drivers/driver_nl80211_event.c	2025-07-11 09:37:29.772326959 +0800
++++ b/src/drivers/driver_nl80211_event.c	2025-07-14 15:27:22.079961399 +0800
+@@ -4904,6 +4904,10 @@
+ 	dl_list_for_each_safe(drv, tmp, &global->interfaces,
+ 			      struct wpa_driver_nl80211_data, list) {
+ 		for (bss = drv->first_bss; bss; bss = bss->next) {
++			if (gnlh->cmd == NL80211_CMD_AWGN_DETECT && 
++					(nla_get_u32(tb[NL80211_ATTR_WIPHY_FREQ])) != bss->flink->freq)
++				continue;
++
+ 			if (wiphy_idx_set)
+ 				wiphy_idx = nl80211_get_wiphy_index(bss);
+ 			if ((ifidx == -1 && !wiphy_idx_set && !wdev_id_set) ||

--- a/feeds/qca-wifi-7/hostapd/patches/r45-Fix-6G-CBP-Test-Fail.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/r45-Fix-6G-CBP-Test-Fail.patch
@@ -1,9 +1,10 @@
 --- a/src/drivers/driver_nl80211_event.c	2025-07-11 09:37:29.772326959 +0800
 +++ b/src/drivers/driver_nl80211_event.c	2025-07-14 15:27:22.079961399 +0800
-@@ -4904,6 +4904,10 @@
+@@ -4904,6 +4904,11 @@
  	dl_list_for_each_safe(drv, tmp, &global->interfaces,
  			      struct wpa_driver_nl80211_data, list) {
  		for (bss = drv->first_bss; bss; bss = bss->next) {
++           /* AWGN event should be delivered to 6G interface only. */
 +			if (gnlh->cmd == NL80211_CMD_AWGN_DETECT && 
 +					(nla_get_u32(tb[NL80211_ATTR_WIPHY_FREQ])) != bss->flink->freq)
 +				continue;


### PR DESCRIPTION
Root Cause: AWGN events sent by driver doesn't contain ifindex and sent phy idx only. So hostapd will pick the last interface to handle this event even if the interface is for 2G or 5G.
Solution: fix hostapd deliver AWGN event to 6G interface only