### PR TITLE
ipq50xx: Fix missing ';;' in 02_network script

### DIFF
--- a/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/board.d/02_network
+++ b/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/board.d/02_network
@@ -71,6 +71,7 @@ qcom_setup_interfaces()
 	sonicfi,rap630e)
 		ucidef_set_interface_wan "eth1"
 		ucidef_set_interface_lan "eth0"
+		;;
 	emplus,wap581)
 		ucidef_set_interface_wan "eth0 eth1"
 		;;


### PR DESCRIPTION
Description:
A missing ;; in the 02_network file for the ipq50xx target caused improper network configuration across all ipq50xx platforms (e.g., Edgecore EAP104, Cybertan RAP630C-311G).
This resulted in loss of Internet connectivity.

Fix:
Added the missing ;; in the appropriate case block.

Tests Performed:
Verified on Edgecore EAP104. Network configuration was applied correctly and Internet connectivity was restored.

Fixes: WIFI-14847