### PR TITLE
netifd: add GCMP-256 support for WPA3 on 6 GHz bands

### DIFF
--- a/patches/0090-netifd-add-gcmp-256-on-6GHz.patch
+++ b/patches/0090-netifd-add-gcmp-256-on-6GHz.patch
@@ -1,0 +1,68 @@
+From a2a7cdf9e292bac5b146738276a593d8e119fe8f Mon Sep 17 00:00:00 2001
+From: Marek Kwaczynski <marek@shasta.cloud>
+Date: Thu, 3 Jul 2025 15:55:43 +0000
+Subject: [PATCH] netifd: add gcmp-256 as a cipher suite when SAE is enabled on
+ HE/EHT
+
+Enabling gcmp-256 only on 6GHz radio.
+
+Fixes: WIFI-14594
+
+Signed-off-by: Marek Kwaczynski <marek@shasta.cloud>
+---
+ .../config/netifd/patches/200-gcmp-256.patch  | 43 +++++++++++++++++++
+ 1 file changed, 43 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/200-gcmp-256.patch
+
+diff --git a/package/network/config/netifd/patches/200-gcmp-256.patch b/package/network/config/netifd/patches/200-gcmp-256.patch
+new file mode 100644
+index 0000000000..7ac6262e7f
+--- /dev/null
++++ b/package/network/config/netifd/patches/200-gcmp-256.patch
+@@ -0,0 +1,43 @@
++Index: netifd-2023-09-19-8587c074/scripts/netifd-wireless.sh
++===================================================================
++--- netifd-2023-09-19-8587c074.orig/scripts/netifd-wireless.sh
+++++ netifd-2023-09-19-8587c074/scripts/netifd-wireless.sh
++@@ -39,11 +39,10 @@ prepare_key_wep() {
++ }
++ 
++ _wdev_prepare_channel() {
++-	json_get_vars channel band hwmode
+++	json_get_vars channel band hwmode htmode
++ 
++ 	auto_channel=0
++ 	enable_ht=0
++-	htmode=
++ 	hwmode="${hwmode##11}"
++ 
++ 	case "$channel" in
++@@ -70,7 +69,14 @@ _wdev_prepare_channel() {
++ 
++ 	case "$band" in
++ 		2g) hwmode=g;;
++-		5g|6g) hwmode=a;;
+++		5g) hwmode=a;;
+++		6g)
+++			hwmode=a;
+++			case "$htmode" in
+++				HE*|EHT*) wpa3_cipher="GCMP-256 ";;
+++				*) wpa3_cipher="";;
+++			esac
+++		;;
++ 		60g) hwmode=ad;;
++ 		*)
++ 			case "$hwmode" in
++@@ -216,6 +222,9 @@ wireless_vif_parse_encryption() {
++ 		wpa_cipher="GCMP"
++ 	else
++ 		wpa_cipher="CCMP"
+++		case "$encryption" in
+++			sae*|wpa3*|psk3*|owe) wpa_cipher="${wpa3_cipher}$wpa_cipher";;
+++		esac
++ 	fi
++ 
++ 	case "$encryption" in
+-- 
+2.43.0
+


### PR DESCRIPTION
This patch enhances WPA3 encryption support in netifd by introducing GCMP-256 cipher handling for wireless interfaces operating on the 6 GHz band with HE/EHT modes.

Fixes: WIFI-14594