### PR TITLE
ratelimit: fix rate limiting on WiFi-7 devices

### DIFF
--- a/feeds/ucentral/ratelimit/files/usr/bin/ratelimit
+++ b/feeds/ucentral/ratelimit/files/usr/bin/ratelimit
@@ -350,7 +350,7 @@ function run_service() {
 				printf('-> reload\n');
 				let list = uctx.list();
 				for (let obj in list) {
-					if (!wildcard(obj, 'hostapd.wlan*'))
+					if (!wildcard(obj, 'hostapd.wlan*') && !wildcard(obj, 'hostapd.phy*'))
 						continue;
 					let iface = split(obj, '.')[1];
 					let device = get_device(devices, req.args.device);


### PR DESCRIPTION
Rate limiting was not applied on WiFi-7 devices because their hostapd interface names use the phy* prefix instead of wlan*. This patch extends the match pattern to include both wlan* and phy*.

Fixes: WIFI-14884