### PR TITLE
WIFI-14904 Enhance PKI enrollment on squashfs (SonicFi RAP6* series)

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -58,6 +58,42 @@ udaya,a5-id2)
 		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
 	fi
 	;;
+sonicfi,rap6*)
+	bootconfig=$(bootconfig_lookup)
+
+	if [ -n "$bootconfig" ]; then
+		mtd_dev=$(find_mtd_index $bootconfig)
+		block_size=$(cat /sys/class/mtd/mtd$mtd_dev/size)
+		mkdir -p /certificates
+		dd if=/dev/mtdblock$mtd_dev of=/tmp/certs.tar bs=$block_size count=1
+		if tar tf /tmp/certs.tar > /dev/null 2>&1; then
+			tar xf /tmp/certs.tar -C /certificates
+		fi
+		rm -f /tmp/certs.tar
+	fi
+
+	if [ ! -f /certificates/cert.pem ] || [ ! -f /certificates/key.pem ]; then
+		mtd=$(find_mtd_index certificates)
+
+		if [ "$(head -c 4 /dev/mtd$mtd)" == "hsqs" ]; then
+			mount -t squashfs /dev/mtdblock$mtd /certificates
+		else
+			[ -n "$mtd" -a -f /sys/class/mtd/mtd$mtd/oobsize ] && ubiattach -p /dev/mtd$mtd
+			if [ -n "$(ubinfo -a | grep certificates)" ]; then
+				[ -e /dev/ubi0 ] && mount -t ubifs ubi0:certificates /certificates
+				[ -e /dev/ubi1 ] && mount -t ubifs ubi1:certificates /certificates
+			fi
+		fi
+
+		if mount | grep "/certificates" | grep -qE "squashfs|ubifs"; then
+			mkdir -p /tmp/certs_backup
+			cp -a /certificates/* /tmp/certs_backup/
+			umount /certificates
+			mkdir -p /certificates
+			cp -a /tmp/certs_backup/* /certificates
+		fi
+	fi
+	;;
 *)
 	mtd=$(find_mtd_index certificates)
 

--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -59,40 +59,16 @@ udaya,a5-id2)
 	fi
 	;;
 sonicfi,rap6*)
-	bootconfig=$(bootconfig_lookup)
-
-	if [ -n "$bootconfig" ]; then
-		mtd_dev=$(find_mtd_index $bootconfig)
-		block_size=$(cat /sys/class/mtd/mtd$mtd_dev/size)
-		mkdir -p /certificates
-		if tar tf /dev/mtdblock$mtd_dev > /dev/null 2>&1; then
-			tar xf /dev/mtdblock$mtd_dev -C /certificates
-		fi
+	mtd=$(find_mtd_index certificates)
+	if [ "$(head -c 4 /dev/mtd$mtd)" == "hsqs" ]; then
+		mount -t squashfs /dev/mtdblock$mtd /mnt
+		cp /mnt/* /certificates
+		umount /mnt
 	fi
-
-	if [ ! -f /certificates/cert.pem ] || [ ! -f /certificates/key.pem ]; then
-		mtd=$(find_mtd_index certificates)
-
-		if [ "$(head -c 4 /dev/mtd$mtd)" == "hsqs" ]; then
-			mount -t squashfs /dev/mtdblock$mtd /certificates
-		else
-			[ -n "$mtd" -a -f /sys/class/mtd/mtd$mtd/oobsize ] && ubiattach -p /dev/mtd$mtd
-			if [ -n "$(ubinfo -a | grep certificates)" ]; then
-				[ -e /dev/ubi0 ] && mount -t ubifs ubi0:certificates /certificates
-				[ -e /dev/ubi1 ] && mount -t ubifs ubi1:certificates /certificates
-			fi
-		fi
-
-		overlay_name="certs_overlay"
-
-		if mount | grep "/certificates" | grep -qE "squashfs|ubifs" && \
-			! mount | grep "/certificates" | grep -q "$overlay_name"; then
-			mkdir -p /tmp/certs_upper /tmp/certs_work /tmp/certs_merged
-			mount -t overlay "$overlay_name" \
-				-o lowerdir=/certificates,upperdir=/tmp/certs_upper,workdir=/tmp/certs_work \
-				/tmp/certs_merged
-			mount --bind /tmp/certs_merged /certificates
-		fi
+	part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
+	if [ -n "$part" ]; then
+		mtd=$(find_mtd_index $part)
+		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
 	fi
 	;;
 *)

--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -65,11 +65,9 @@ sonicfi,rap6*)
 		mtd_dev=$(find_mtd_index $bootconfig)
 		block_size=$(cat /sys/class/mtd/mtd$mtd_dev/size)
 		mkdir -p /certificates
-		dd if=/dev/mtdblock$mtd_dev of=/tmp/certs.tar bs=$block_size count=1
-		if tar tf /tmp/certs.tar > /dev/null 2>&1; then
-			tar xf /tmp/certs.tar -C /certificates
+		if tar tf /dev/mtdblock$mtd_dev > /dev/null 2>&1; then
+			tar xf /dev/mtdblock$mtd_dev -C /certificates
 		fi
-		rm -f /tmp/certs.tar
 	fi
 
 	if [ ! -f /certificates/cert.pem ] || [ ! -f /certificates/key.pem ]; then
@@ -85,12 +83,15 @@ sonicfi,rap6*)
 			fi
 		fi
 
-		if mount | grep "/certificates" | grep -qE "squashfs|ubifs"; then
-			mkdir -p /tmp/certs_backup
-			cp -a /certificates/* /tmp/certs_backup/
-			umount /certificates
-			mkdir -p /certificates
-			cp -a /tmp/certs_backup/* /certificates
+		overlay_name="certs_overlay"
+
+		if mount | grep "/certificates" | grep -qE "squashfs|ubifs" && \
+			! mount | grep "/certificates" | grep -q "$overlay_name"; then
+			mkdir -p /tmp/certs_upper /tmp/certs_work /tmp/certs_merged
+			mount -t overlay "$overlay_name" \
+				-o lowerdir=/certificates,upperdir=/tmp/certs_upper,workdir=/tmp/certs_work \
+				/tmp/certs_merged
+			mount --bind /tmp/certs_merged /certificates
 		fi
 	fi
 	;;

--- a/feeds/tip/certificates/files/usr/bin/store_certs
+++ b/feeds/tip/certificates/files/usr/bin/store_certs
@@ -30,12 +30,13 @@ udaya,a5-id2)
 	;;
 sonicfi,rap6*)
 	if [ "$(fw_printenv -n store_certs_disabled)" != "1" ]; then
-		tar cf /tmp/certs.tar -C /certificates .
-		bootconfig=$(bootconfig_lookup)
-		mtd_dev=$(find_mtd_index $bootconfig)
-		block_size=$(cat /sys/class/mtd/mtd$mtd_dev/size)
+		cd /certificates
+		tar cf /tmp/certs.tar .
+		part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
+		mtd=$(find_mtd_index $part)
+		block_size=$(cat /sys/class/mtd/mtd$mtd/size)
 		dd if=/tmp/certs.tar of=/tmp/certs_pad.tar bs=$block_size conv=sync
-		mtd write /tmp/certs_pad.tar /dev/mtd$mtd_dev
+		mtd write /tmp/certs_pad.tar /dev/mtd$mtd
 		rm -f /tmp/certs.tar /tmp/certs_pad.tar
 	fi
 	;;

--- a/feeds/tip/certificates/files/usr/bin/store_certs
+++ b/feeds/tip/certificates/files/usr/bin/store_certs
@@ -28,4 +28,15 @@ udaya,a5-id2)
 	mtd=$(find_mtd_index $part)
 	dd if=/tmp/certs.tar of=/dev/mtdblock$mtd
 	;;
+sonicfi,rap6*)
+	if [ "$(fw_printenv -n store_certs_disabled)" != "1" ]; then
+		tar cf /tmp/certs.tar -C /certificates .
+		bootconfig=$(bootconfig_lookup)
+		mtd_dev=$(find_mtd_index $bootconfig)
+		block_size=$(cat /sys/class/mtd/mtd$mtd_dev/size)
+		dd if=/tmp/certs.tar of=/tmp/certs_pad.tar bs=$block_size conv=sync
+		mtd write /tmp/certs_pad.tar /dev/mtd$mtd_dev
+		rm -f /tmp/certs.tar /tmp/certs_pad.tar
+	fi
+	;;
 esac


### PR DESCRIPTION
Ensure PKI2.0 certificates are properly backed up when /certificates is mounted as squashfs (read-only). Enhance the persistent storage mechanism to retain PKI2.0 certificates across factory resets.

Following the current enrollment behavior, `operational.ca` and `operational.pem` - though restored to `/certificates` after a factory reset - are not directly used during enrollment. The `est_client` will still download both certificates again as part of the enrollment process. This patch does not modify that behavior, but simply ensures the certificates are persistently stored across resets.

Impacted models: SonicFi RAP6* series.