### PR TITLE
WIFI-14951 Store-PKI2.0-key-for-RAP6x-production

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -65,7 +65,7 @@ sonicfi,rap6*)
 		cp /mnt/* /certificates
 		umount /mnt
 	fi
-	part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
+	part=$(tar_part_lookup "devinfo" "certificates")
 	if [ -n "$part" ]; then
 		mtd=$(find_mtd_index $part)
 		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates

--- a/feeds/tip/certificates/files/usr/bin/store_certs
+++ b/feeds/tip/certificates/files/usr/bin/store_certs
@@ -32,7 +32,7 @@ sonicfi,rap6*)
 	if [ "$(fw_printenv -n store_certs_disabled)" != "1" ]; then
 		cd /certificates
 		tar cf /tmp/certs.tar .
-		part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
+		part=$(tar_part_lookup "devinfo" "certificates")
 		mtd=$(find_mtd_index $part)
 		block_size=$(cat /sys/class/mtd/mtd$mtd/size)
 		dd if=/tmp/certs.tar of=/tmp/certs_pad.tar bs=$block_size conv=sync


### PR DESCRIPTION
This patch is for RAP6x productions.
Using devinfo & certificates mtdblock to store PKI2.0 key.