### PR TITLE
base-files: boot: add sync after uci-defaults

### DIFF
--- a/patches/0096-base-files-boot-add-sync-after-uci-defaults.patch
+++ b/patches/0096-base-files-boot-add-sync-after-uci-defaults.patch
@@ -1,0 +1,33 @@
+From 309a419087da906a2f3b0f39763f021e9729dd85 Mon Sep 17 00:00:00 2001
+From: Paul White <paul@shasta.cloud>
+Date: Mon, 4 Aug 2025 04:14:23 +0000
+Subject: [PATCH] base-files: boot: add sync after uci-defaults
+
+A scenario was seen where UCI config was not flushed to disk before
+an AP power-cycle after uci-defaults was completed.  Since these
+scripts are deleted after being ran once, there is no way to recover
+without a factory reset.
+
+Adding this sync operation proved to help avoid this situation from
+happening
+
+Signed-off-by: Paul White <paul@shasta.cloud>
+---
+ package/base-files/files/etc/init.d/boot | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/package/base-files/files/etc/init.d/boot b/package/base-files/files/etc/init.d/boot
+index 15756669a9..c8a803e32c 100755
+--- a/package/base-files/files/etc/init.d/boot
++++ b/package/base-files/files/etc/init.d/boot
+@@ -15,6 +15,7 @@ uci_apply_defaults() {
+ 		( . "./$(basename $file)" ) && rm -f "$file"
+ 	done
+ 	uci commit
++	sync
+ }
+ 
+ boot() {
+-- 
+2.43.0
+


### PR DESCRIPTION
A scenario was seen where UCI config was not flushed to disk before an AP power-cycle after uci-defaults was completed.  Since these scripts are deleted after being ran once, there is no way to recover without a factory reset.

Adding this sync operation proved to help avoid this situation from happening