### PR TITLE
WIFI-14970 fix qca83xx switch race condition

### DIFF
--- a/feeds/ipq807x_v5.4/qca-ssdk/patches/500-define-mib-loop-cnt-to-gobal.patch
+++ b/feeds/ipq807x_v5.4/qca-ssdk/patches/500-define-mib-loop-cnt-to-gobal.patch
@@ -1,0 +1,61 @@
+--- a/include/init/ssdk_plat.h
++++ b/include/init/ssdk_plat.h
+@@ -330,6 +330,7 @@ struct qca_phy_priv {
+ 	struct mii_bus *miibus;
+ /*qca808x_end*/
+ 	u64 *mib_counters;
++	a_uint32_t mib_loop_cnt;
+ 	/* dump buf */
+ 	a_uint8_t  buf[2048];
+ 	a_uint32_t link_polling_required;
+--- a/src/ref/ref_mib.c
++++ b/src/ref/ref_mib.c
+@@ -479,39 +479,37 @@ qca_ar8327_sw_get_port_mib(struct switch
+ #endif
+ 
+ int
+-_qca_ar8327_sw_capture_port_tx_counter(struct qca_phy_priv *priv, int port)
++_qca_ar8327_sw_capture_port_tx_counter(a_uint32_t dev_id, int port)
+ {
+     fal_mib_info_t  mib_Info;
+ 
+     memset(&mib_Info, 0, sizeof(fal_mib_info_t));
+-    fal_get_tx_mib_info(priv->device_id, port, &mib_Info);
++    fal_get_tx_mib_info(dev_id, port, &mib_Info);
+ 
+     return 0;
+ }
+ 
+ int
+-_qca_ar8327_sw_capture_port_rx_counter(struct qca_phy_priv *priv, int port)
++_qca_ar8327_sw_capture_port_rx_counter(a_uint32_t dev_id, int port)
+ {
+     fal_mib_info_t  mib_Info;
+ 
+     memset(&mib_Info, 0, sizeof(fal_mib_info_t));
+-    fal_get_rx_mib_info(priv->device_id, port, &mib_Info);
++    fal_get_rx_mib_info(dev_id, port, &mib_Info);
+     return 0;
+ }
+ 
+ void
+ qca_ar8327_sw_mib_task(struct qca_phy_priv *priv)
+ {
+-	static int loop = 0;
+-
+ 	mutex_lock(&priv->reg_mutex);
+-	if ((loop % 2) == 0)
+-		_qca_ar8327_sw_capture_port_rx_counter(priv, loop/2);
++	if ((priv->mib_loop_cnt % 2) == 0)
++		_qca_ar8327_sw_capture_port_rx_counter(priv->device_id, priv->mib_loop_cnt/2);
+ 	else
+-		_qca_ar8327_sw_capture_port_tx_counter(priv, loop/2);
++		_qca_ar8327_sw_capture_port_tx_counter(priv->device_id, priv->mib_loop_cnt/2);
+ 
+-	if(++loop == (2 * (priv->ports))) {
+-		loop = 0;
++	if(++priv->mib_loop_cnt == (2 * (priv->ports))) {
++		priv->mib_loop_cnt = 0;
+ 	}
+ 
+ 	mutex_unlock(&priv->reg_mutex);


### PR DESCRIPTION
<img width="338" height="248" alt="ar8327" src="https://github.com/user-attachments/assets/56ea82be-9309-4c22-b49b-3e1877d992ca" />
Each switch has its own task. If we have multiple switches on the AP, there may be a loop variable contention problem in qca_ar8327_sw_mib_task.
In qca-ssdk 12.x version. mutex is not enough to prevent this race condition because each switch has its own mutex.
If our EAP is set for a long enough time, there may be multiple switches ++loop at the same time,
causing the loop variable to increase by 2 at a time. This will skip the == (2 * (priv->ports) check,
and the loop variable will then increase infinitely, causing an out-of-bound write + crash.
 
In RAP630W-311G has two switches, so this race condition may occur:
> swconfig list
Found: switch0 - QCA MP
Found: switch1 - QCA AR8337
 
If change the mib work time from 120 seconds to 1 second, then found the race condition happen

the patch is from qca-ssdk 13.0 version, in 13.0 already fix it.