### PR TITLE
EAP111: Disable surge protection mode for AN8801SB PHY driver

### DIFF
--- a/feeds/mediatek-sdk/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-edgecore-eap111.dts
+++ b/feeds/mediatek-sdk/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-edgecore-eap111.dts
@@ -200,7 +200,7 @@
 			phy-mode = "sgmii";
 			full-duplex;
 			pause;
-			airoha,surge = <1>;
+			airoha,surge = <0>;
 			airoha,polarity = <2>;
 		};
 


### PR DESCRIPTION
For AN8801SB PHY driver, disabling surge protection mode to prevent TX voltage going too high.