### PR TITLE
ucentral-state: Respect LED config before enabling

### DIFF
--- a/feeds/ucentral/ucentral-state/files/ucentral-state
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state
@@ -20,6 +20,7 @@ let config;
 let offline_timer;
 let current_state;
 let online = false;
+let leds_off = false;
 
 function self_healing() {
 	let heal_wifi = false;
@@ -148,6 +149,13 @@ function online_handler() {
 
 function config_load() {
 	ulog(LOG_INFO, 'loading config\n');
+
+	uci.load('system');
+	let led_off_cfg = uci.get("system", "@system[0]", "leds_off");
+	if (led_off_cfg == 1) {
+		leds_off = true;
+	}
+
 	uci.load('state');
 	config = uci.get_all('state');
 
@@ -191,7 +199,7 @@ function led_find(alias) {
 function factory_reset_timeout() {
 	let led = led_find('led-running');
 	if (led)
-		led_write(led, 'trigger', 'default-on');
+		led_write(led, 'trigger', leds-off ? 'none' : 'default-on');
 }
 
 let blink_timer;
@@ -210,7 +218,7 @@ let state_handler = {
 	offline: function() {
 		online = false;
 		let led = led_find('led-running');
-		if (led)
+		if (!leds_off && led)
 			led_write(led, 'trigger', 'heartbeat');
 		if (config.ui.offline_trigger) {
 			if (offline_timer)
@@ -223,7 +231,7 @@ let state_handler = {
 	online: function() {
 		online = true;
 		let led = led_find('led-running');
-		if (led)
+		if (!leds_off && led)
 			led_write(led, 'trigger', 'default-on');
 		online_handler();
 		return 0;


### PR DESCRIPTION
Ensure that LEDs are configured to be ON before attempting to change their state.

Previously, if the LED was configured to be OFF, it would still enter a double-blink state when the cloud connection was lost, and then switch to solid ON upon reconnection—ignoring the configured OFF state.

This update changes that behavior:
    - If LEDs are configured OFF, they will remain OFF even during cloud disconnection (no double-blink).
    - After temporary state changes (e.g., during factory reset), the LED will return to its configured state (either OFF or ON).