### PR TITLE
WIFI-15120 sonicfi squashfs certifiacte storage improve

### DIFF
--- a/feeds/tip/certificates/files/etc/init.d/early_boot
+++ b/feeds/tip/certificates/files/etc/init.d/early_boot
@@ -25,6 +25,11 @@ copy_certificates() {
 }
 
 boot() {
+	case "$(board_name)" in
+	sonicfi,rap6*)
+		touch /tmp/squashfs
+	;;
+	esac
 	[ -f /etc/ucentral/key.pem ] && return
 	/usr/bin/mount_certs
 	copy_certificates

--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -37,13 +37,16 @@ sonicfi,rap7*)
 		mtd=$(find_mtd_index certificates)
 		[ -n "$mtd" ] && mount -t ext4 /dev/mtdblock$mtd /certificates
 	fi
-	if [ ! -f /certificates/cert.pem ] || [ ! -f /certificates/key.pem ]; then
-		part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
-		if [ -n "part" ]; then
-			mmc_dev=$(echo $(find_mmc_part "$part") | sed 's/^.\{5\}//')
-			[ -n "$mmc_dev" ] && tar xf /dev/$mmc_dev -C /certificates
-		fi
+	;;
+sonicfi,rap6*)
+	mtd=$(find_mtd_index certificates)
+	if [ "$(head -c 4 /dev/mtd$mtd)" == "hsqs" ]; then
+		mount -t squashfs /dev/mtdblock$mtd /mnt
+		cp /mnt/* /certificates
+		umount /mnt
 	fi
+		mtd=$(find_mtd_index devinfo)
+		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
 	;;
 udaya,a5-id2|\
 yuncore,ax820)
@@ -55,19 +58,6 @@ yuncore,ax820)
 	fi
 	part=$(tar_part_lookup "insta1" "insta2")
 	if [ -n "insta" ]; then
-		mtd=$(find_mtd_index $part)
-		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
-	fi
-	;;
-sonicfi,rap6*)
-	mtd=$(find_mtd_index certificates)
-	if [ "$(head -c 4 /dev/mtd$mtd)" == "hsqs" ]; then
-		mount -t squashfs /dev/mtdblock$mtd /mnt
-		cp /mnt/* /certificates
-		umount /mnt
-	fi
-	part=$(tar_part_lookup "devinfo" "certificates")
-	if [ -n "$part" ]; then
 		mtd=$(find_mtd_index $part)
 		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
 	fi

--- a/feeds/tip/certificates/files/usr/bin/store_certs
+++ b/feeds/tip/certificates/files/usr/bin/store_certs
@@ -14,13 +14,6 @@ tar_part_lookup() {
 
 . /lib/functions.sh
 case "$(board_name)" in
-sonicfi,rap7110c-341x)
-	cd /certificates
-	tar cf /tmp/certs.tar .
-	part=$(tar_part_lookup "0:BOOTCONFIG" "0:BOOTCONFIG1")
-	mmc_dev=$(echo $(find_mmc_part $part) | sed 's/^.\{5\}//')
-	dd if=/tmp/certs.tar of=/dev/$mmc_dev
-	;;
 udaya,a5-id2|\
 yuncore,ax820)
 	cd /certificates
@@ -33,8 +26,7 @@ sonicfi,rap6*)
 	if [ "$(fw_printenv -n store_certs_disabled)" != "1" ]; then
 		cd /certificates
 		tar cf /tmp/certs.tar .
-		part=$(tar_part_lookup "devinfo" "certificates")
-		mtd=$(find_mtd_index $part)
+		mtd=$(find_mtd_index devinfo)
 		block_size=$(cat /sys/class/mtd/mtd$mtd/size)
 		dd if=/tmp/certs.tar of=/tmp/certs_pad.tar bs=$block_size conv=sync
 		mtd write /tmp/certs_pad.tar /dev/mtd$mtd


### PR DESCRIPTION
1. touch /tmp/squashfs in early_boot
2. [mount_certs] remove recover backup certification for RAP7 series (already change certification partition type to EXT4, no backup needed)
3. [mount_certs] for RAP6 series only backup and restore in "devinfo" partition
4. [store_certs] remove tar_part_lookup select, only backup in "devinfo" partition