### PR TITLE
WIFI-15124 Add KERNEL_IPQ_MEM_PROFILE for IPQ53XX

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/patches-6.1/0660-add-IPQ_MEM_PROFILE-in-arm64-kconfig.patch
+++ b/feeds/qca-wifi-7/ipq53xx/patches-6.1/0660-add-IPQ_MEM_PROFILE-in-arm64-kconfig.patch
@@ -1,0 +1,33 @@
+From f7b27331b915477cd289c37b56efb0d28b2d6f38 Mon Sep 17 00:00:00 2001
+From: Antonio Wu <antonio.wu@cybertan.com.tw>
+Date: Tue, 5 Aug 2025 10:39:58 +0000
+Subject: [PATCH] Add IPQ_MEM_PROFILE in arm64 kconfig
+
+---
+ arch/arm64/Kconfig | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 702a289..7864e79 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -2143,6 +2143,16 @@ config STACKPROTECTOR_PER_TASK
+ 	def_bool y
+ 	depends on STACKPROTECTOR && CC_HAVE_STACKPROTECTOR_SYSREG
+ 
++config IPQ_MEM_PROFILE
++	int "Select Memory Profile"
++	range 0 1024
++	default 0
++	help
++	  This option select memory profile to be used, which defines
++	  the reserved memory configuration used in device tree.
++
++	  If unsure, say 0
++
+ # The GPIO number here must be sorted by descending number. In case of
+ # a multiplatform kernel, we just want the highest value required by the
+ # selected platforms.
+-- 
+2.17.1
+

--- a/patches/0101-ipq53xx-add-KERNEL_IPQ_MEM_PROFILE.patch
+++ b/patches/0101-ipq53xx-add-KERNEL_IPQ_MEM_PROFILE.patch
@@ -1,0 +1,25 @@
+From 40894005e2c114664a44abb0ffadb1cb945a88e2 Mon Sep 17 00:00:00 2001
+From: Antonio Wu <antonio.wu@cybertan.com.tw>
+Date: Mon, 4 Aug 2025 05:10:41 +0000
+Subject: [PATCH] add KERNEL_IPQ_MEM_PROFILE for IPQ53XX 
+
+---
+ config/Config-kernel.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/Config-kernel.in b/config/Config-kernel.in
+index 3529696559..b7f13eccbe 100644
+--- a/config/Config-kernel.in
++++ b/config/Config-kernel.in
+@@ -6,7 +6,7 @@ config KERNEL_IPQ_MEM_PROFILE
+ 	int "Different memory profile "
+ 	range 0 1024
+ 	default 512
+-	depends on TARGET_ipq807x || TARGET_ipq60xx || TARGET_ipq50xx || TARGET_ipq95xx
++	depends on TARGET_ipq807x || TARGET_ipq60xx || TARGET_ipq50xx || TARGET_ipq95xx || TARGET_ipq53xx
+ 	help
+ 	  This option select memory profile to be used,which defines
+ 	  the reserved memory configuration used in device tree.
+-- 
+2.17.1
+


### PR DESCRIPTION
Add KERNEL_IPQ_MEM_PROFILE for IPQ53XX
It can be used for configure  “CONFIG_KERNEL_IPQ_MEM_PROFILE=512” in profile 