### PR TITLE
mediatek-sdk: Support AN8801SB PHY for Edgecore EAP112

### DIFF
--- a/feeds/mediatek-sdk/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-edgecore-eap112.dts
+++ b/feeds/mediatek-sdk/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981-edgecore-eap112.dts
@@ -169,7 +169,8 @@
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
 		phy-mode = "sgmii";
-		phy-handle = <&phy1>;      // add phy handler
+		phy-handle = <&phy30>;
+		phy-handle2 = <&phy1>;
 		mtd-mac-address = <&factory 0x24>;
 	};
 
@@ -193,6 +194,16 @@
 			nvmem-cell-names = "phy-cal-data";
 		};
 
+		phy30: ethernet-phy@30 { // AN8801SB
+			compatible = "ethernet-phy-idc0ff.0421";
+			reg = <30>; //0x1e
+			phy-mode = "sgmii";
+			full-duplex;
+			pause;
+			airoha,surge = <0>;
+			airoha,polarity = <2>;
+		};
+
 		phy1: ethernet-phy@1 {
 			compatible = "ethernet-phy-id03a2.9471";
 			reg = <24>;            // set phy address to 0x18
@@ -200,9 +211,8 @@
 			reset-assert-us = <600>;
 			reset-deassert-us = <20000>;
 			phy-mode = "sgmii";
-    };
-
-        };
+		};
+	};
 };
 
 &hnat {


### PR DESCRIPTION
Update Edgecore EAP112 device tree to support AN8801SB PHY.