### PR TITLE
wifi_max_user: read data from correct phy index for EAP112

### DIFF
--- a/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/wifi_max_user.uc
+++ b/feeds/ucentral/ucentral-schema/files/usr/share/ucentral/wifi_max_user.uc
@@ -1,7 +1,10 @@
 #!/usr/bin/ucode 
+import { readfile } from "fs";
 
 let nl = require("nl80211");
 let def = nl.const;
+let board_name = rtrim(readfile('/tmp/sysinfo/board_name'), '\n');
+let phy_index = 0;
 
 function phy_get() {
 	let res = nl.request(def.NL80211_CMD_GET_WIPHY, def.NLM_F_DUMP, { split_wiphy_dump: true });
@@ -12,5 +15,11 @@ function phy_get() {
 	return res;
 }
 
+switch(board_name) {
+case 'edgecore,eap112':
+        phy_index = 1;
+        break;
+}
+
 let phys = phy_get();
-printf("%d\n", phys[0].max_ap_assoc || 32);
+printf("%d\n", phys[phy_index].max_ap_assoc || 32);


### PR DESCRIPTION
- Set max_ap_assoc at wiphy init instead of vif init for mt7915.
- Hard code max_ap_assoc to 128 for EAP112 in wifi_max_user.uc

Fixes WIFI-15027