### PR TITLE
mediatek: disable ubi auto attach to retain dualboot behavior for EAP111

### DIFF
--- a/feeds/mediatek/mediatek/dts/mt7981a-edgecore-eap111.dts
+++ b/feeds/mediatek/mediatek/dts/mt7981a-edgecore-eap111.dts
@@ -151,13 +151,11 @@
 			partition@580000 {
 				label = "rootfs1";
 				reg = <0x580000 0x4000000>;
-				compatible = "linux,ubi";
 			};
 
 			partition@4580000 {
 				label = "rootfs2";
 				reg = <0x4580000 0x4000000>;
-				compatible = "linux,ubi";
 			};
 		};
 	};


### PR DESCRIPTION
Issue: 
If both bootbanks are attached automatically, the first bootbank is always attached as ubi0 and the second bootbank is always ubi1. The rootfs and rootfs_data of the first bootbank is always mounted no matter active is 1 or 2.

Solution:
Remove "compatible" line in the dts to disable ubi auto attach when loading fixed MTD partition. The correct bootbank will be attached afterward.