### PR TITLE
mac80211: scan: Decrease passive scan channel time in sw_scan

### DIFF
--- a/feeds/mediatek-sdk/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
+++ b/feeds/mediatek-sdk/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
@@ -1,0 +1,34 @@
+Index: backports-5.15.81-1/net/mac80211/scan.c
+===================================================================
+--- backports-5.15.81-1.orig/net/mac80211/scan.c
++++ backports-5.15.81-1/net/mac80211/scan.c
+@@ -29,6 +29,9 @@
+ #define IEEE80211_CHANNEL_TIME (HZ / 33)
+ #define IEEE80211_PASSIVE_CHANNEL_TIME (HZ / 9)
+ 
++/* Additional time used for passive SW scaning */
++#define IEEE80211_PASSIVE_MIN_CHANNEL_TIME (HZ / 13)
++
+ void ieee80211_rx_bss_put(struct ieee80211_local *local,
+ 			  struct ieee80211_bss *bss)
+ {
+@@ -1014,10 +1017,15 @@ set_channel:
+ 	 */
+ 	if ((chan->flags & (IEEE80211_CHAN_NO_IR | IEEE80211_CHAN_RADAR)) ||
+ 	    !scan_req->n_ssids) {
+-		*next_delay = msecs_to_jiffies(scan_req->duration) >
+-			      IEEE80211_PASSIVE_CHANNEL_TIME ?
+-			      msecs_to_jiffies(scan_req->duration) :
+-			      IEEE80211_PASSIVE_CHANNEL_TIME;
++		if (msecs_to_jiffies(scan_req->duration) > IEEE80211_PASSIVE_CHANNEL_TIME) {
++			*next_delay = msecs_to_jiffies(scan_req->duration);
++		} else if (scan_req->duration > 0) {
++			*next_delay = scan_req->duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME ?
++				msecs_to_jiffies(scan_req->duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME) :
++				0;
++		} else {
++			*next_delay = IEEE80211_PASSIVE_CHANNEL_TIME;
++		}
+ 		local->next_scan_state = SCAN_DECISION;
+ 		if (scan_req->n_ssids)
+ 			set_bit(SCAN_BEACON_WAIT, &local->scanning);


### PR DESCRIPTION
Allow configuring small values of duration time for passive scanning in software scan.

Fixes: WIFI-14822