### PR TITLE
Fix 802.11k config issues

### DIFF
--- a/feeds/qca-wifi-6/hostapd/files/hostapd.sh
+++ b/feeds/qca-wifi-6/hostapd/files/hostapd.sh
@@ -972,8 +972,8 @@ hostapd_set_bss_options() {
 		set_default rrm_beacon_report 0
 	fi
 
-	[ "$rrm_neighbor_report" -eq "1" ] && append bss_conf "rrm_neighbor_report=1" "$N"
-	[ "$rrm_beacon_report" -eq "1" ] && append bss_conf "rrm_beacon_report=1" "$N"
+	append bss_conf "rrm_neighbor_report=$rrm_neighbor_report" "$N"
+	append bss_conf "rrm_beacon_report=$rrm_beacon_report" "$N"
 
 	json_get_vars ftm_responder stationary_ap lci civic
 	set_default ftm_responder 0

--- a/feeds/qca-wifi-6/hostapd/patches/zzz-acl-radius-cui.patch
+++ b/feeds/qca-wifi-6/hostapd/patches/zzz-acl-radius-cui.patch
@@ -1,0 +1,17 @@
+--- a/src/ap/ieee802_11_auth.c
++++ b/src/ap/ieee802_11_auth.c
+@@ -149,6 +149,14 @@
+ 	if (add_common_radius_attr(hapd, hapd->conf->radius_auth_req_attr,
+ 				   NULL, msg) < 0)
+ 		goto fail;
++
++	if (hapd->conf->radius_request_cui &&
++	    !radius_msg_add_attr(msg,
++				 RADIUS_ATTR_CHARGEABLE_USER_IDENTITY,
++				 (const u8 *) "\0", 1)) {
++		wpa_printf(MSG_DEBUG, "Could not add CUI");
++		goto fail;
++	}
+
+ 	os_snprintf(buf, sizeof(buf), RADIUS_802_1X_ADDR_FORMAT,
+ 		    MAC2STR(addr));

--- a/feeds/qca-wifi-6/hostapd/patches/zzzz-001-WiFi-6-hostapd-ubus-Clear-bss_mgmt_enable-params-whe.patch
+++ b/feeds/qca-wifi-6/hostapd/patches/zzzz-001-WiFi-6-hostapd-ubus-Clear-bss_mgmt_enable-params-whe.patch
@@ -1,0 +1,139 @@
+From bc7ad0243307f12fbcb29200e7798b5290175a5f Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkat@nearhop.com>
+Date: Fri, 6 Feb 2026 01:24:36 +0530
+Subject: [PATCH] WiFi-6 / hostapd/ubus: Clear bss_mgmt_enable params when they
+ are  disabled.
+
+bss_mgmt_enable params -neighbor_report, beacon_report and bss_transition -
+once enabled through the ubus, are not disabled.
+Disable them when they are not set.
+
+Signed-off-by: Venkat Chimata <venkat@nearhop.com>
+---
+ src/ap/ubus.c | 87 ++++++++++++++++++++---
+ 1 file changed, 79 insertions(+), 8 deletions(-)
+
+diff --git a/src/ap/ubus.c b/src/ap/ubus.c
+index 2f7fdc0..cd8ffc5 100644
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -1016,6 +1016,70 @@ __hostapd_bss_mgmt_enable_f(struct hostapd_data *hapd, int flag)
+ 	}
+ }
+ 
++static bool
++__hostapd_bss_mgmt_disable_f(struct hostapd_data *hapd, int flag)
++{
++	struct hostapd_bss_config *bss = hapd->conf;
++	uint32_t flags;
++
++	switch (flag) {
++	case BSS_MGMT_EN_NEIGHBOR:
++		if (bss->radio_measurements[0] &
++		    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
++			bss->radio_measurements[0] &=
++				~WLAN_RRM_CAPS_NEIGHBOR_REPORT;
++			return true;
++		}
++		return false;
++	case BSS_MGMT_EN_BEACON:
++		flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
++
++		if (bss->radio_measurements[0] & flags == flags) {
++			bss->radio_measurements[0] &= ~(u8) flags;
++			return true;
++		}
++		return false;
++#ifdef CONFIG_WNM_AP
++	case BSS_MGMT_EN_BSS_TRANSITION:
++		if (bss->bss_transition) {
++			bss->bss_transition = 0;
++			return true;
++		}
++
++		bss->bss_transition = 0;
++		return false;
++#endif
++	}
++}
++
++static int
++__hostapd_bss_mgmt_get_f(struct hostapd_data *hapd)
++{
++	struct hostapd_bss_config *bss = hapd->conf;
++	uint32_t beacon_flags;
++	int flags = 0;
++
++
++	if (bss->radio_measurements[0] &
++	    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
++		flags |= (1 << BSS_MGMT_EN_NEIGHBOR);
++	}
++	beacon_flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
++
++	if (bss->radio_measurements[0] & beacon_flags == beacon_flags) {
++		flags |= (1 << BSS_MGMT_EN_BEACON);
++	}
++#ifdef CONFIG_WNM_AP
++	if (bss->bss_transition) {
++		flags |= (1 << BSS_MGMT_EN_BSS_TRANSITION);
++	}
++#endif
++	return flags;
++}
+ static void
+ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
+ {
+@@ -1023,10 +1087,11 @@ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
+ 	int i;
+ 
+ 	for (i = 0; i < __BSS_MGMT_EN_MAX; i++) {
+-		if (!(flags & (1 << i)))
+-			continue;
+-
+-		update |= __hostapd_bss_mgmt_enable_f(hapd, i);
++		if (!(flags & (1 << i))) {
++			update |= __hostapd_bss_mgmt_disable_f(hapd, i);
++		} else {
++			update |= __hostapd_bss_mgmt_enable_f(hapd, i);
++		}
+ 	}
+ 
+ 	if (update)
+@@ -1057,11 +1122,16 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
+ 
+ 	blobmsg_parse(bss_mgmt_enable_policy, __BSS_MGMT_EN_MAX, tb, blob_data(msg), blob_len(msg));
+ 
++	flags = __hostapd_bss_mgmt_get_f(hapd);
+ 	for (i = 0; i < ARRAY_SIZE(tb); i++) {
+-		if (!tb[i] || !blobmsg_get_bool(tb[i]))
++		if (!tb[i]) {
+ 			continue;
+-
+-		flags |= (1 << i);
++		}
++		if (blobmsg_get_bool(tb[i])) {
++			flags |= (1 << i);
++		} else {
++			flags &= ~(1 << i);
++		}
+ 	}
+ 
+ 	__hostapd_bss_mgmt_enable(hapd, flags);
+@@ -1071,7 +1141,8 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
+ static void
+ hostapd_rrm_nr_enable(struct hostapd_data *hapd)
+ {
+-	__hostapd_bss_mgmt_enable(hapd, 1 << BSS_MGMT_EN_NEIGHBOR);
++	int flags = __hostapd_bss_mgmt_get_f(hapd);
++	__hostapd_bss_mgmt_enable(hapd, flags | (1 << BSS_MGMT_EN_NEIGHBOR));
+ }
+ 
+ static int
+-- 
+2.34.1
+

--- a/feeds/qca-wifi-7/hostapd/files/hostapd.sh
+++ b/feeds/qca-wifi-7/hostapd/files/hostapd.sh
@@ -964,8 +964,8 @@ hostapd_set_bss_options() {
 		set_default rrm_beacon_report 0
 	fi
 
-	[ "$rrm_neighbor_report" -eq "1" ] && append bss_conf "rrm_neighbor_report=1" "$N"
-	[ "$rrm_beacon_report" -eq "1" ] && append bss_conf "rrm_beacon_report=1" "$N"
+	append bss_conf "rrm_neighbor_report=$rrm_neighbor_report" "$N"
+	append bss_conf "rrm_beacon_report=$rrm_beacon_report" "$N"
 	[ "$rnr" -eq "1" ] && append bss_conf "rnr=1" "$N"
 
 	json_get_vars ftm_responder stationary_ap lci civic

--- a/feeds/qca-wifi-7/hostapd/patches/zzz-t00-014-hostapd-ubus-Clear-bss_mgmt_enable-params-when-they-.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzz-t00-014-hostapd-ubus-Clear-bss_mgmt_enable-params-when-they-.patch
@@ -1,0 +1,147 @@
+From 7d2f21d50e06755968953093a5d5badc811cbbc1 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkat@nearhop.com>
+Date: Thu, 5 Feb 2026 22:13:56 +0530
+Subject: [PATCH] hostapd/ubus: Clear bss_mgmt_enable params when they are
+ disabled.
+
+bss_mgmt_enable params -neighbor_report, beacon_report and bss_transition -
+once enabled through the ubus, are not disabled.
+Disable them when they are not set.
+
+Signed-off-by: Venkat Chimata <venkat@nearhop.com>
+---
+ src/ap/ubus.c | 88 +++++++++++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 79 insertions(+), 9 deletions(-)
+
+diff --git a/src/ap/ubus.c b/src/ap/ubus.c
+index 4eb5a11..30e8a21 100644
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -947,7 +947,6 @@ __hostapd_bss_mgmt_enable_f(struct hostapd_data *hapd, int flag)
+ 		if (bss->radio_measurements[0] &
+ 		    WLAN_RRM_CAPS_NEIGHBOR_REPORT)
+ 			return false;
+-
+ 		bss->radio_measurements[0] |=
+ 			WLAN_RRM_CAPS_NEIGHBOR_REPORT;
+ 		hostapd_neighbor_set_own_report(hapd);
+@@ -973,6 +972,70 @@ __hostapd_bss_mgmt_enable_f(struct hostapd_data *hapd, int flag)
+ 	}
+ }
+ 
++static bool
++__hostapd_bss_mgmt_disable_f(struct hostapd_data *hapd, int flag)
++{
++	struct hostapd_bss_config *bss = hapd->conf;
++	uint32_t flags;
++
++	switch (flag) {
++	case BSS_MGMT_EN_NEIGHBOR:
++		if (bss->radio_measurements[0] &
++		    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
++			bss->radio_measurements[0] &=
++				~WLAN_RRM_CAPS_NEIGHBOR_REPORT;
++			return true;
++		}
++		return false;
++	case BSS_MGMT_EN_BEACON:
++		flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
++
++		if (bss->radio_measurements[0] & flags == flags) {
++			bss->radio_measurements[0] &= ~(u8) flags;
++			return true;
++		}
++		return false;
++#ifdef CONFIG_WNM_AP
++	case BSS_MGMT_EN_BSS_TRANSITION:
++		if (bss->bss_transition) {
++			bss->bss_transition = 0;
++			return true;
++		}
++
++		bss->bss_transition = 0;
++		return false;
++#endif
++	}
++}
++
++static int
++__hostapd_bss_mgmt_get_f(struct hostapd_data *hapd)
++{
++	struct hostapd_bss_config *bss = hapd->conf;
++	uint32_t beacon_flags;
++	int flags = 0;
++
++
++	if (bss->radio_measurements[0] &
++	    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
++		flags |= (1 << BSS_MGMT_EN_NEIGHBOR);
++	}
++	beacon_flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
++
++	if (bss->radio_measurements[0] & beacon_flags == beacon_flags) {
++		flags |= (1 << BSS_MGMT_EN_BEACON);
++	}
++#ifdef CONFIG_WNM_AP
++	if (bss->bss_transition) {
++		flags |= (1 << BSS_MGMT_EN_BSS_TRANSITION);
++	}
++#endif
++	return flags;
++}
+ static void
+ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
+ {
+@@ -980,10 +1043,11 @@ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
+ 	int i;
+ 
+ 	for (i = 0; i < __BSS_MGMT_EN_MAX; i++) {
+-		if (!(flags & (1 << i)))
+-			continue;
+-
+-		update |= __hostapd_bss_mgmt_enable_f(hapd, i);
++		if (!(flags & (1 << i))) {
++			update |= __hostapd_bss_mgmt_disable_f(hapd, i);
++		} else {
++			update |= __hostapd_bss_mgmt_enable_f(hapd, i);
++		}
+ 	}
+ 
+ 	if (update)
+@@ -1014,11 +1078,16 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
+ 
+ 	blobmsg_parse(bss_mgmt_enable_policy, __BSS_MGMT_EN_MAX, tb, blob_data(msg), blob_len(msg));
+ 
++	flags = __hostapd_bss_mgmt_get_f(hapd);
+ 	for (i = 0; i < ARRAY_SIZE(tb); i++) {
+-		if (!tb[i] || !blobmsg_get_bool(tb[i]))
++		if (!tb[i]) {
+ 			continue;
+-
+-		flags |= (1 << i);
++		}
++		if (blobmsg_get_bool(tb[i])) {
++			flags |= (1 << i);
++		} else {
++			flags &= ~(1 << i);
++		}
+ 	}
+ 
+ 	__hostapd_bss_mgmt_enable(hapd, flags);
+@@ -1028,7 +1097,8 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
+ static void
+ hostapd_rrm_nr_enable(struct hostapd_data *hapd)
+ {
+-	__hostapd_bss_mgmt_enable(hapd, 1 << BSS_MGMT_EN_NEIGHBOR);
++	int flags = __hostapd_bss_mgmt_get_f(hapd);
++	__hostapd_bss_mgmt_enable(hapd, flags | (1 << BSS_MGMT_EN_NEIGHBOR));
+ }
+ 
+ static int
+-- 
+2.34.1
+

--- a/feeds/ucentral/libwebsockets/patches/200-openssl-x509-truncate-CN-in-presence-of-other-attr.patch
+++ b/feeds/ucentral/libwebsockets/patches/200-openssl-x509-truncate-CN-in-presence-of-other-attr.patch
@@ -1,0 +1,49 @@
+From 975ef85e3fc478dc96b19d9862a1ade383fe48f8 Mon Sep 17 00:00:00 2001
+From: Arif Alam <arif.alam@netexperience.com>
+Date: Thu, 12 Mar 2026 09:53:21 -0400
+Subject: [PATCH] openssl: x509: truncate CN in presence of other attr
+
+Backport of upstream commit 5124ffe9d431ca866ef90cb6f5167a837fdc4840.
+https://github.com/warmcat/libwebsockets/issues/2542
+
+Signed-off-by: Arif Alam <arif.alam@netexperience.com>
+---
+ lib/tls/openssl/openssl-x509.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/lib/tls/openssl/openssl-x509.c b/lib/tls/openssl/openssl-x509.c
+index 185a84a8..df324aa0 100644
+--- a/lib/tls/openssl/openssl-x509.c
++++ b/lib/tls/openssl/openssl-x509.c
+@@ -77,7 +77,8 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
+ {
+ 	X509_NAME *xn;
+ #if !defined(LWS_PLAT_OPTEE)
+-	char *p;
++	char *p, *p1;
++	size_t rl;
+ #endif
+ 
+ 	if (!x509)
+@@ -112,8 +113,16 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
+ 			return -1;
+ 		X509_NAME_oneline(xn, buf->ns.name, (int)len - 2);
+ 		p = strstr(buf->ns.name, "/CN=");
+-		if (p)
+-			memmove(buf->ns.name, p + 4, strlen(p + 4) + 1);
++		if (p) {
++			p += 4;
++			p1 = strchr(p, '/');
++			if (p1)
++				rl = (size_t)(p1 - p);
++			else
++				rl = strlen(p);
++			memmove(buf->ns.name, p, rl);
++			buf->ns.name[rl] = '\0';
++		}
+ 		buf->ns.len = (int)strlen(buf->ns.name);
+ 		return 0;
+ #endif
+-- 
+2.53.0
+

--- a/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
+++ b/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
@@ -63,6 +63,8 @@ start_service() {
 	[ "$debug" -eq 0 ] || procd_append_param command -d
 	[ "$insecure" -eq 0 ] || procd_append_param command -i
 	[ -n "$cert" -a -n "$ca" ] && procd_append_param command -c $cert -C $ca
+	hostname_validate=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["hostname_validate"]')
+	[ "$hostname_validate" = "0" ] || procd_append_param command -h
 	[ -z "$(mount | grep 'tmpfs on / type tmpfs')" ] || procd_append_param command -r
 	procd_append_param command -b "$boot_cause"
 	procd_append_param command -f "$(cat /tmp/ucentral.version)"

--- a/patches-25.12/0044-mediatek-edgecore-eap111-fixes.patch
+++ b/patches-25.12/0044-mediatek-edgecore-eap111-fixes.patch
@@ -1,4 +1,4 @@
-From 3e85d0984d2df4092e518685ae55f745a3eace5f Mon Sep 17 00:00:00 2001
+From a2edd27a8b077a51994f693eac50beafa6cc061f Mon Sep 17 00:00:00 2001
 From: John Crispin <john@phrozen.org>
 Date: Sat, 2 Aug 2025 06:47:35 +0200
 Subject: [PATCH] mediatek: edgecore eap111 fixes
@@ -19,12 +19,13 @@ Signed-off-by: John Crispin <john@phrozen.org>
  .../files-6.12/drivers/net/phy/an8801.c       | 1535 +++++++++++++++++
  .../files-6.12/drivers/net/phy/an8801.h       |  233 +++
  .../filogic/base-files/etc/board.d/01_leds    |    5 +
+ .../filogic/base-files/etc/board.d/02_network |    2 +-
  .../filogic/base-files/etc/init.d/bootcount   |    8 +
  .../base-files/lib/upgrade/platform.sh        |   32 +-
  target/linux/mediatek/filogic/config-6.12     |    1 +
  ...y-support-an8801-and-mdio-second-phy.patch |   94 +
  ...net-mtk_eth_soc-add-mdio-reset-delay.patch |   26 +
- 11 files changed, 1955 insertions(+), 5 deletions(-)
+ 12 files changed, 1956 insertions(+), 6 deletions(-)
  create mode 100644 package/kernel/mt76/edgecore_eap111_eeprom_dbdc.bin
  create mode 100644 target/linux/mediatek/files-6.12/drivers/net/phy/an8801.c
  create mode 100644 target/linux/mediatek/files-6.12/drivers/net/phy/an8801.h
@@ -1916,6 +1917,26 @@ index 133db38005..0787a12913 100644
  elecom,wrc-x3000gs3)
  	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
  	;;
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+index 9a41600c32..5b714f9d91 100644
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+@@ -121,7 +121,6 @@ mediatek_setup_interfaces()
+ 		;;
+ 	airpi,ap3000m|\
+ 	bananapi,bpi-r3-mini|\
+-	edgecore,eap111|\
+ 	huasifei,wh3000|\
+ 	huasifei,wh3000-pro)
+ 		ucidef_set_interfaces_lan_wan eth0 eth1
+@@ -131,6 +130,7 @@ mediatek_setup_interfaces()
+ 	cudy,tr3000-256mb-v1|\
+ 	cudy,tr3000-v1|\
+ 	cudy,tr3000-v1-ubootmod|\
++	edgecore,eap111|\
+ 	glinet,gl-mt2500|\
+ 	glinet,gl-mt2500-airoha|\
+ 	glinet,gl-mt3000|\
 diff --git a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
 index 415674322f..947e31c649 100755
 --- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount

--- a/patches-25.12/0095-mediatek-add-support-for-EMPLUS-WAP588M.patch
+++ b/patches-25.12/0095-mediatek-add-support-for-EMPLUS-WAP588M.patch
@@ -1,4 +1,4 @@
-From 3dd9325bbae88486e2870b23700b221e78901608 Mon Sep 17 00:00:00 2001
+From 9f1d7ff0ea913a68576eb9f1a69047db72fcc24b Mon Sep 17 00:00:00 2001
 From: John Crispin <john@phrozen.org>
 Date: Tue, 3 Mar 2026 07:50:14 +0100
 Subject: [PATCH] mediatek: add support for EMPLUS WAP588M
@@ -282,13 +282,13 @@ index cbbaa9dfd7..fef7297f19 100644
  	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
  	;;
 diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
-index 800c40f93d..86e15d92ab 100644
+index 45649285b4..09a4730d29 100644
 --- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
 +++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
 @@ -121,6 +121,7 @@ mediatek_setup_interfaces()
+ 		;;
  	airpi,ap3000m|\
  	bananapi,bpi-r3-mini|\
- 	edgecore,eap111|\
 +	emplus,wap588m|\
  	huasifei,wh3000|\
  	huasifei,wh3000-pro)
@@ -324,7 +324,7 @@ index 5603bb6249..e4449abdd0 100644
  		nand_do_upgrade "$1"
  		;;
 diff --git a/target/linux/mediatek/image/filogic.mk b/target/linux/mediatek/image/filogic.mk
-index 7807433e22..0b0d81b622 100644
+index b9ed67ff04..a46cff2201 100644
 --- a/target/linux/mediatek/image/filogic.mk
 +++ b/target/linux/mediatek/image/filogic.mk
 @@ -1426,6 +1426,25 @@ define Device/edgecore_eap115a

--- a/patches-25.12/0099-iwinfo-add-he-eht-scan-info-feature-define.patch
+++ b/patches-25.12/0099-iwinfo-add-he-eht-scan-info-feature-define.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 13 Mar 2026 09:00:00 +0100
+Subject: [PATCH] iwinfo: add HE/EHT scan info feature define
+
+Add IWINFO_HAS_EHT_CHAN_INFO to the standard iwinfo header so that
+consumers can detect at compile time whether HE/EHT channel info
+fields are available in struct iwinfo_scanlist_entry.
+
+This allows rpcd and other packages to conditionally compile HE/EHT
+scan result handling, avoiding build failures against older iwinfo
+versions (e.g. qca-wifi-7's iwinfo which lacks these fields).
+
+Signed-off-by: John Crispin <john@phrozen.org>
+---
+ .../utils/iwinfo/patches/200-add-he-eht-feature-define.patch | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+ create mode 100644 package/network/utils/iwinfo/patches/200-add-he-eht-feature-define.patch
+
+diff --git a/package/network/utils/iwinfo/patches/200-add-he-eht-feature-define.patch b/package/network/utils/iwinfo/patches/200-add-he-eht-feature-define.patch
+new file mode 100644
+--- /dev/null
++++ b/package/network/utils/iwinfo/patches/200-add-he-eht-feature-define.patch
+@@ -0,0 +1,11 @@
++--- a/include/iwinfo.h
+++++ b/include/iwinfo.h
++@@ -335,6 +335,8 @@
++    2 = 80 MHz
++    3 = 80+80 or 160 MHz
++    4 = 160+160 or 320 MHz */
+++
+++#define IWINFO_HAS_EHT_CHAN_INFO
++ extern const uint16_t eht_chan_width[5];
++
++ struct iwinfo_scanlist_entry {

--- a/patches-25.12/0100-rpcd-guard-he-eht-iwinfo-fields.patch
+++ b/patches-25.12/0100-rpcd-guard-he-eht-iwinfo-fields.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 13 Mar 2026 09:00:00 +0100
+Subject: [PATCH] rpcd: guard HE/EHT iwinfo scan fields
+
+Wrap the HE and EHT channel info scan result blocks in rpcd's iwinfo
+plugin with an IWINFO_HAS_EHT_CHAN_INFO ifdef guard. The qca-wifi-7
+iwinfo (v2024-10-20) does not provide he_chan_info, eht_chan_info or
+eht_chan_width, so building rpcd against it fails. With this guard,
+rpcd compiles against both the standard and qca-wifi-7 iwinfo.
+
+Signed-off-by: John Crispin <john@phrozen.org>
+---
+ .../system/rpcd/patches/100-guard-he-eht-fields.patch | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+ create mode 100644 package/system/rpcd/patches/100-guard-he-eht-fields.patch
+
+diff --git a/package/system/rpcd/patches/100-guard-he-eht-fields.patch b/package/system/rpcd/patches/100-guard-he-eht-fields.patch
+new file mode 100644
+--- /dev/null
++++ b/package/system/rpcd/patches/100-guard-he-eht-fields.patch
+@@ -0,0 +1,25 @@
++--- a/iwinfo.c
+++++ b/iwinfo.c
++@@ -437,20 +437,22 @@
++ 				blobmsg_close_table(&buf, t);
++ 			}
++
+++#ifdef IWINFO_HAS_EHT_CHAN_INFO
++ 			if (e->he_chan_info.center_chan_1) {
++ 				t = blobmsg_open_table(&buf, "he_operation");
++ 				blobmsg_add_u32(&buf, "channel_width", eht_chan_width[e->he_chan_info.chan_width]);
++ 				blobmsg_add_u32(&buf, "center_freq_1", e->he_chan_info.center_chan_1);
++ 				blobmsg_add_u32(&buf, "center_freq_2", e->he_chan_info.center_chan_2);
++ 				blobmsg_close_table(&buf, t);
++ 			}
++
++ 			if (e->eht_chan_info.center_chan_1) {
++ 				t = blobmsg_open_table(&buf, "eht_operation");
++ 				blobmsg_add_u32(&buf, "channel_width", eht_chan_width[e->eht_chan_info.chan_width]);
++ 				blobmsg_add_u32(&buf, "center_freq_1", e->eht_chan_info.center_chan_1);
++ 				blobmsg_add_u32(&buf, "center_freq_2", e->eht_chan_info.center_chan_2);
++ 				blobmsg_close_table(&buf, t);
++ 			}
+++#endif
++
++ 			rpc_iwinfo_add_encryption("encryption", &e->crypto);

--- a/patches-25.12/0101-hostapd-add-CUI-to-ACL-RADIUS-Access-Request.patch
+++ b/patches-25.12/0101-hostapd-add-CUI-to-ACL-RADIUS-Access-Request.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Fri, 14 Mar 2026 09:00:00 +0100
+Subject: [PATCH] hostapd: add CUI to ACL RADIUS Access-Request
+
+When radius_request_cui=1 is configured, hostapd includes the
+Chargeable-User-Identity attribute (RFC 4372) in EAP Access-Request
+messages but not in the ACL path used by psk2-radius / mpsk-radius.
+RADIUS servers expecting CUI for PSK-RADIUS therefore receive no CUI.
+
+Add a nul CUI to hostapd_radius_acl_query() so that the RADIUS server
+is solicited for a CUI in the Access-Accept, matching the initial-request
+behaviour of the EAP path when no prior CUI is known. The response side
+already extracts CUI from Access-Accept and stores it.
+
+Signed-off-by: John Crispin <john@phrozen.org>
+---
+ .../hostapd/patches/zzz-0018-acl-radius-cui.patch | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 package/network/services/hostapd/patches/zzz-0018-acl-radius-cui.patch
+
+diff --git a/package/network/services/hostapd/patches/zzz-0018-acl-radius-cui.patch b/package/network/services/hostapd/patches/zzz-0018-acl-radius-cui.patch
+new file mode 100644
+--- /dev/null
++++ b/package/network/services/hostapd/patches/zzz-0018-acl-radius-cui.patch
+@@ -0,0 +1,17 @@
++--- a/src/ap/ieee802_11_auth.c
+++++ b/src/ap/ieee802_11_auth.c
++@@ -149,6 +149,14 @@
++ 	if (add_common_radius_attr(hapd, hapd->conf->radius_auth_req_attr,
++ 				   NULL, msg) < 0)
++ 		goto fail;
+++
+++	if (hapd->conf->radius_request_cui &&
+++	    !radius_msg_add_attr(msg,
+++				 RADIUS_ATTR_CHARGEABLE_USER_IDENTITY,
+++				 (const u8 *) "\0", 1)) {
+++		wpa_printf(MSG_DEBUG, "Could not add CUI");
+++		goto fail;
+++	}
++
++ 	os_snprintf(buf, sizeof(buf), RADIUS_802_1X_ADDR_FORMAT,
++ 		    MAC2STR(addr));

--- a/patches-25.12/0103-hostapd-ubus-Clear-bss_mgmt_enable-params-when.patch
+++ b/patches-25.12/0103-hostapd-ubus-Clear-bss_mgmt_enable-params-when.patch
@@ -1,0 +1,164 @@
+From 66b00bc55ad8b135313af7b4996d1b93e95eb573 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkat@nearhop.com>
+Date: Wed, 11 Feb 2026 20:07:00 +0530
+Subject: [PATCH] hostapd/ubus: Clear bss_mgmt_enable params when  they  are 
+ disabled.
+
+bss_mgmt_enable params -neighbor_report, beacon_report and bss_transition -
+once enabled through the ubus, are not disabled.
+Disable them when they are not set.
+
+Signed-off-by: Venkat Chimata <venkat@nearhop.com>
+---
+ ...-ubus-Clear-bss_mgmt_enable-params-w.patch | 139 ++++++++++++++++++
+ 1 file changed, 139 insertions(+)
+ create mode 100644 package/network/services/hostapd/patches/zzzz-003-Mediatek-hostapd-ubus-Clear-bss_mgmt_enable-params-w.patch
+
+diff --git a/package/network/services/hostapd/patches/zzzz-003-Mediatek-hostapd-ubus-Clear-bss_mgmt_enable-params-w.patch b/package/network/services/hostapd/patches/zzzz-003-Mediatek-hostapd-ubus-Clear-bss_mgmt_enable-params-w.patch
+new file mode 100644
+index 0000000000..828dad2ff8
+--- /dev/null
++++ b/package/network/services/hostapd/patches/zzzz-003-Mediatek-hostapd-ubus-Clear-bss_mgmt_enable-params-w.patch
+@@ -0,0 +1,139 @@
++From 76c7c55020f8ec497642b0e6c8cb0010c86961ff Mon Sep 17 00:00:00 2001
++From: Venkat Chimata <venkat@nearhop.com>
++Date: Fri, 6 Feb 2026 01:39:21 +0530
++Subject: [PATCH] Mediatek / hostapd/ubus: Clear bss_mgmt_enable params when
++ they  are  disabled.
++
++bss_mgmt_enable params -neighbor_report, beacon_report and bss_transition -
++once enabled through the ubus, are not disabled.
++Disable them when they are not set.
++
++Signed-off-by: Venkat Chimata <venkat@nearhop.com>
++---
++ src/ap/ubus.c | 87 ++++++++++++++++++++++++++++++++++++++++++++++-----
++ 1 file changed, 79 insertions(+), 8 deletions(-)
++
++diff --git a/src/ap/ubus.c b/src/ap/ubus.c
++index 0205fa6..76eee03 100644
++--- a/src/ap/ubus.c
+++++ b/src/ap/ubus.c
++@@ -994,6 +994,70 @@ __hostapd_bss_mgmt_enable_f(struct hostapd_data *hapd, int flag)
++ 	}
++ }
++ 
+++static bool
+++__hostapd_bss_mgmt_disable_f(struct hostapd_data *hapd, int flag)
+++{
+++	struct hostapd_bss_config *bss = hapd->conf;
+++	uint32_t flags;
+++
+++	switch (flag) {
+++	case BSS_MGMT_EN_NEIGHBOR:
+++		if (bss->radio_measurements[0] &
+++		    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
+++			bss->radio_measurements[0] &=
+++				~WLAN_RRM_CAPS_NEIGHBOR_REPORT;
+++			return true;
+++		}
+++		return false;
+++	case BSS_MGMT_EN_BEACON:
+++		flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
+++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
+++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
+++
+++		if ((bss->radio_measurements[0] & flags) == flags) {
+++			bss->radio_measurements[0] &= ~(u8) flags;
+++			return true;
+++		}
+++		return false;
+++#ifdef CONFIG_WNM_AP
+++	case BSS_MGMT_EN_BSS_TRANSITION:
+++		if (bss->bss_transition) {
+++			bss->bss_transition = 0;
+++			return true;
+++		}
+++
+++		bss->bss_transition = 0;
+++		return false;
+++#endif
+++	}
+++}
+++
+++static int
+++__hostapd_bss_mgmt_get_f(struct hostapd_data *hapd)
+++{
+++	struct hostapd_bss_config *bss = hapd->conf;
+++	uint32_t beacon_flags;
+++	int flags = 0;
+++
+++
+++	if (bss->radio_measurements[0] &
+++	    WLAN_RRM_CAPS_NEIGHBOR_REPORT) {
+++		flags |= (1 << BSS_MGMT_EN_NEIGHBOR);
+++	}
+++	beacon_flags = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
+++			WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
+++			WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
+++
+++	if ((bss->radio_measurements[0] & beacon_flags) == beacon_flags) {
+++		flags |= (1 << BSS_MGMT_EN_BEACON);
+++	}
+++#ifdef CONFIG_WNM_AP
+++	if (bss->bss_transition) {
+++		flags |= (1 << BSS_MGMT_EN_BSS_TRANSITION);
+++	}
+++#endif
+++	return flags;
+++}
++ static void
++ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
++ {
++@@ -1001,10 +1065,11 @@ __hostapd_bss_mgmt_enable(struct hostapd_data *hapd, uint32_t flags)
++ 	int i;
++ 
++ 	for (i = 0; i < __BSS_MGMT_EN_MAX; i++) {
++-		if (!(flags & (1 << i)))
++-			continue;
++-
++-		update |= __hostapd_bss_mgmt_enable_f(hapd, i);
+++		if (!(flags & (1 << i))) {
+++			update |= __hostapd_bss_mgmt_disable_f(hapd, i);
+++		} else {
+++			update |= __hostapd_bss_mgmt_enable_f(hapd, i);
+++		}
++ 	}
++ 
++ 	if (update)
++@@ -1035,11 +1100,16 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
++ 
++ 	blobmsg_parse(bss_mgmt_enable_policy, __BSS_MGMT_EN_MAX, tb, blob_data(msg), blob_len(msg));
++ 
+++	flags = __hostapd_bss_mgmt_get_f(hapd);
++ 	for (i = 0; i < ARRAY_SIZE(tb); i++) {
++-		if (!tb[i] || !blobmsg_get_bool(tb[i]))
+++		if (!tb[i]) {
++ 			continue;
++-
++-		flags |= (1 << i);
+++		}
+++		if (blobmsg_get_bool(tb[i])) {
+++			flags |= (1 << i);
+++		} else {
+++			flags &= ~(1 << i);
+++		}
++ 	}
++ 
++ 	__hostapd_bss_mgmt_enable(hapd, flags);
++@@ -1049,7 +1119,8 @@ hostapd_bss_mgmt_enable(struct ubus_context *ctx, struct ubus_object *obj,
++ static void
++ hostapd_rrm_nr_enable(struct hostapd_data *hapd)
++ {
++-	__hostapd_bss_mgmt_enable(hapd, 1 << BSS_MGMT_EN_NEIGHBOR);
+++	int flags = __hostapd_bss_mgmt_get_f(hapd);
+++	__hostapd_bss_mgmt_enable(hapd, flags | (1 << BSS_MGMT_EN_NEIGHBOR));
++ }
++ 
++ static int
++-- 
++2.34.1
++
+-- 
+2.34.1
+

--- a/patches-25.12/0104-hostapd-wifi-7-fix-RRM-neighbor-report-value-not-upd.patch
+++ b/patches-25.12/0104-hostapd-wifi-7-fix-RRM-neighbor-report-value-not-upd.patch
@@ -1,0 +1,33 @@
+From 777a360767110e276abe9c39264332b6787077d4 Mon Sep 17 00:00:00 2001
+From: Venkat Chimata <venkat@nearhop.com>
+Date: Sat, 14 Mar 2026 22:24:59 +0530
+Subject: [PATCH] hostapd/wifi-7: fix RRM neighbor report value not updating on
+  hot reload
+
+ - Ensure rrm_neighbor_report is always set based on the current configuration during hot reload.
+ - Prevent previously enabled values from being unintentionally preserved.
+ - Allows both enable and disable transitions to take effect correctly without requiring a full restart.
+
+Signed-off-by: Venkat Chimata <venkat@nearhop.com>
+---
+ .../network/config/wifi-scripts/files/lib/netifd/hostapd.sh   | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+index 5ab6088599..cf4a2b79f4 100644
+--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
++++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+@@ -989,8 +989,8 @@ hostapd_set_bss_options() {
+ 		set_default rrm_beacon_report 0
+ 	fi
+ 
+-	[ "$rrm_neighbor_report" -eq "1" ] && append bss_conf "rrm_neighbor_report=1" "$N"
+-	[ "$rrm_beacon_report" -eq "1" ] && append bss_conf "rrm_beacon_report=1" "$N"
++	append bss_conf "rrm_neighbor_report=$rrm_neighbor_report" "$N"
++	append bss_conf "rrm_beacon_report=$rrm_beacon_report" "$N"
+ 	[ "$rnr" -eq "1" ] && append bss_conf "rnr=1" "$N"
+ 
+ 	json_get_vars ftm_responder stationary_ap lci civic
+-- 
+2.34.1
+


### PR DESCRIPTION
- Ensure rrm_neighbor_report is always set based on the current configuration during hot reload.
 - Prevent previously enabled values from being unintentionally preserved.
 - Allows both enable and disable transitions to take effect correctly without requiring a full restart.

 Fixes WIFI-15303