### PR TITLE
hostapd / bandwidth: Correct handling of RADIUS-assigned bandwidth limits

### DIFF
--- a/patches-25.12/0061-hostapd-add-WISPr-rate-limit-propagation-over-FT.patch
+++ b/patches-25.12/0061-hostapd-add-WISPr-rate-limit-propagation-over-FT.patch
@@ -7,9 +7,10 @@ Carry RADIUS-assigned bandwidth values in FT RRB frames so rate-limit
 information follows the station during fast roaming.
 
 Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Venkat Chimata <venkat@nearhop.com>
 ---
- .../hostapd/patches/zzz-0001-wispr-ft.patch   | 549 ++++++++++++++++++
- 1 file changed, 549 insertions(+)
+ .../hostapd/patches/zzz-0001-wispr-ft.patch   | 579 ++++++++++++++++++
+ 1 file changed, 579 insertions(+)
  create mode 100644 package/network/services/hostapd/patches/zzz-0001-wispr-ft.patch
 
 diff --git a/package/network/services/hostapd/patches/zzz-0001-wispr-ft.patch b/package/network/services/hostapd/patches/zzz-0001-wispr-ft.patch
@@ -17,7 +18,7 @@ new file mode 100644
 index 0000000000..fb16f783d9
 --- /dev/null
 +++ b/package/network/services/hostapd/patches/zzz-0001-wispr-ft.patch
-@@ -0,0 +1,549 @@
+@@ -0,0 +1,579 @@
 +WISPr rate-limit propagation over 802.11r FT
 +
 +Carries RADIUS-assigned bandwidth (WISPr) values inside FT RRB frames
@@ -567,6 +568,36 @@ index 0000000000..fb16f783d9
 + 		goto out;
 + 
 + 	wpa_ft_rrb_oui_send(wpa_auth, src_addr,
++--- a/src/ap/ieee802_11.c
+++++ b/src/ap/ieee802_11.c
++@@ -2662,6 +2662,7 @@ int ieee802_11_set_radius_info(struct ho
++ 		ap_sta_no_session_timeout(hapd, sta);
++ 	}
++ 
+++	os_memcpy(sta->bandwidth, info->bandwidth, sizeof(sta->bandwidth));
++ 	return 0;
++ }
++ 
++--- a/src/ap/ieee802_11_auth.c
+++++ b/src/ap/ieee802_11_auth.c
++@@ -577,6 +577,7 @@ hostapd_acl_recv_radius(struct radius_ms
++ 				os_memcpy(info->radius_cui, buf, len);
++ 		}
++ 
+++		radius_msg_get_wispr(msg, info->bandwidth);
++ 		if (hapd->conf->wpa_psk_radius == PSK_RADIUS_REQUIRED &&
++ 		    !info->psk)
++ 			cache->accepted = HOSTAPD_ACL_REJECT;
++--- a/src/ap/ieee802_11_auth.h
+++++ b/src/ap/ieee802_11_auth.h
++@@ -23,6 +23,7 @@ struct radius_sta {
++ 	struct hostapd_sta_wpa_psk_short *psk;
++ 	char *identity;
++ 	char *radius_cui;
+++	u32 bandwidth[2];
++ };
++ 
++ int hostapd_check_acl(struct hostapd_data *hapd, const u8 *addr,
 -- 
 2.34.1
 


### PR DESCRIPTION
Description:
Hostapd successfully parsed the uplink and downlink bandwidth attributes from the RADIUS server, but the values were not being propagated correctly into sta_info. As a result, the bandwidth information was missing in the UBUS events sent to ucentral-event.

Fix:
Ensure the parsed bandwidth values are correctly passed to sta_info so they
are included in subsequent UBUS notifications.

Tests Performed:
Configured per-client bandwidth limits on the RADIUS server and verified that:

The AP enforces the configured uplink/downlink limits, and
The correct bandwidth values appear in the UBUS events.

Fixes WIFI-15338