### PR TITLE
staging-WIFI-15349-Senao-and-Cybertan211G-11r-is-not-enabling-for-proto-psk2-radius

### DIFF
--- a/profiles/sonicfi_rap630w-211g.yml
+++ b/profiles/sonicfi_rap630w-211g.yml
@@ -9,6 +9,7 @@ feeds:
     path: ../../feeds/mediatek-sdk
 include:
   - ucentral-ap
+  - hostapd
 packages:
   - mediatek
 diffconfig: |


### PR DESCRIPTION
…sk2-radius"

Referring to edgecore_eap112, we use the package: feeds/hostapd to replace the original openwrt hostapd package. Because it already includes many hostapd fixes

Fixes: WIFI-15349