### PR TITLE
ucentral-pstore: Disable printing processed lines

### DIFF
--- a/feeds/ucentral/ucentral-state/files/ucentral-pstore
+++ b/feeds/ucentral/ucentral-state/files/ucentral-pstore
@@ -23,7 +23,6 @@ function move_to_json(src, dst) {
 	msg[fs.basename(dst)] = lines;
 	fd.write(msg);
 	fd.close();
-	print(lines);
 }
 
 move_to_json('/sys/fs/pstore/dmesg-ramoops-0', '/tmp/crashlog');


### PR DESCRIPTION
When processing huge console log and dmesg files printing lines hanged execution blocking ucentral-state startup process.

It seems stdout is mainly for debug purposes and lines are printed after we store file, so it is safe to disable print as file is already processed and can be examined.

Fixes: WIFI-15356