### PR TITLE
ucentral-client: fix hostname validation

### DIFF
--- a/feeds/ucentral/libwebsockets/patches/200-openssl-x509-truncate-CN-in-presence-of-other-attr.patch
+++ b/feeds/ucentral/libwebsockets/patches/200-openssl-x509-truncate-CN-in-presence-of-other-attr.patch
@@ -1,0 +1,49 @@
+From 975ef85e3fc478dc96b19d9862a1ade383fe48f8 Mon Sep 17 00:00:00 2001
+From: Arif Alam <arif.alam@netexperience.com>
+Date: Thu, 12 Mar 2026 09:53:21 -0400
+Subject: [PATCH] openssl: x509: truncate CN in presence of other attr
+
+Backport of upstream commit 5124ffe9d431ca866ef90cb6f5167a837fdc4840.
+https://github.com/warmcat/libwebsockets/issues/2542
+
+Signed-off-by: Arif Alam <arif.alam@netexperience.com>
+---
+ lib/tls/openssl/openssl-x509.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/lib/tls/openssl/openssl-x509.c b/lib/tls/openssl/openssl-x509.c
+index 185a84a8..df324aa0 100644
+--- a/lib/tls/openssl/openssl-x509.c
++++ b/lib/tls/openssl/openssl-x509.c
+@@ -77,7 +77,8 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
+ {
+ 	X509_NAME *xn;
+ #if !defined(LWS_PLAT_OPTEE)
+-	char *p;
++	char *p, *p1;
++	size_t rl;
+ #endif
+ 
+ 	if (!x509)
+@@ -112,8 +113,16 @@ lws_tls_openssl_cert_info(X509 *x509, enum lws_tls_cert_info type,
+ 			return -1;
+ 		X509_NAME_oneline(xn, buf->ns.name, (int)len - 2);
+ 		p = strstr(buf->ns.name, "/CN=");
+-		if (p)
+-			memmove(buf->ns.name, p + 4, strlen(p + 4) + 1);
++		if (p) {
++			p += 4;
++			p1 = strchr(p, '/');
++			if (p1)
++				rl = (size_t)(p1 - p);
++			else
++				rl = strlen(p);
++			memmove(buf->ns.name, p, rl);
++			buf->ns.name[rl] = '\0';
++		}
+ 		buf->ns.len = (int)strlen(buf->ns.name);
+ 		return 0;
+ #endif
+-- 
+2.53.0
+

--- a/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
+++ b/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
@@ -63,6 +63,8 @@ start_service() {
 	[ "$debug" -eq 0 ] || procd_append_param command -d
 	[ "$insecure" -eq 0 ] || procd_append_param command -i
 	[ -n "$cert" -a -n "$ca" ] && procd_append_param command -c $cert -C $ca
+	hostname_validate=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["hostname_validate"]')
+	[ "$hostname_validate" = "0" ] || procd_append_param command -h
 	[ -z "$(mount | grep 'tmpfs on / type tmpfs')" ] || procd_append_param command -r
 	procd_append_param command -b "$boot_cause"
 	procd_append_param command -f "$(cat /tmp/ucentral.version)"


### PR DESCRIPTION
- Wire hostname validation enable / disable to hostname_validate flag in gateway.json

- Fix hostname validation check when server cert Subject CN has other attributes like Organization in case of Insta server certs: subject=CN=*.example.com, O=ExampleInc. Fix backported to libwebsockets from: https://github.com/warmcat/libwebsockets/commit/5124ffe9d431ca866ef90cb6f5167a837fdc4840

Fixes WIFI-15384