### PR TITLE
Fixed WIFI-15306:certificates partition fails to mount on rap750w-311a. Need to use UBIFS format certificates on NAND flash.

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -31,14 +31,9 @@ cig,wf672)
 	mmc_dev=$(echo $(find_mmc_part "cert") | sed 's/^.\{5\}//')
 	[ -n "$mmc_dev" ] && mount -t ext4 /dev/$mmc_dev /certificates
 	;;
-sonicfi,rap7*)
-	if [ "$(board_name)" = "sonicfi,rap7110c-341x" ]; then
-		mmc_dev=$(echo $(find_mmc_part "certificates") | sed 's/^.\{5\}//')
-		[ -n "$mmc_dev" ] && mount -t ext4 /dev/$mmc_dev /certificates
-	else
-		mtd=$(find_mtd_index certificates)
-		[ -n "$mtd" ] && mount -t ext4 /dev/mtdblock$mtd /certificates
-	fi
+sonicfi,rap7110c-341x)
+	mmc_dev=$(echo $(find_mmc_part "certificates") | sed 's/^.\{5\}//')
+	[ -n "$mmc_dev" ] && mount -t ext4 /dev/$mmc_dev /certificates
 	;;
 sonicfi,rap6*)
 	mtd=$(find_mtd_index certificates)


### PR DESCRIPTION
Fixed WIFI-15306:certificates partition fails to mount on rap750w-311a. Need to use UBIFS format certificates on NAND flash.