### PR TITLE
dhcpsnoop: capture DHCP Option 12 hostname and expose via ubus leases…

### DIFF
--- a/feeds/ucentral/udhcpsnoop/src/cache.c
+++ b/feeds/ucentral/udhcpsnoop/src/cache.c
@@ -18,7 +18,17 @@ struct mac {
         struct avl_node avl;
 	uint8_t mac[6];
 	uint8_t ip[4];
+	char hostname[64];
 	struct uloop_timeout rebind;
+};
+
+/* Temporary store for hostnames seen in client DHCP Discover/Request packets.
+ * The hostname lives in these client-sent messages (Option 12), not in the
+ * server ACK.  We key by MAC and look it up when the ACK arrives. */
+struct pending_hostname {
+	struct avl_node avl;
+	uint8_t mac[6];
+	char hostname[64];
 };
 
 static int
@@ -27,7 +37,8 @@ avl_mac_cmp(const void *k1, const void *k2, void *ptr)
 	return memcmp(k1, k2, 6);
 }
 
-static struct avl_tree mac_tree = AVL_TREE_INIT(mac_tree, avl_mac_cmp, false, NULL);
+static struct avl_tree mac_tree     = AVL_TREE_INIT(mac_tree,     avl_mac_cmp, false, NULL);
+static struct avl_tree pending_tree = AVL_TREE_INIT(pending_tree, avl_mac_cmp, false, NULL);
 
 static void
 cache_expire(struct uloop_timeout *t)
@@ -38,10 +49,34 @@ cache_expire(struct uloop_timeout *t)
 	free(mac);
 }
 
+/* Called from dev.c for Discover and Request packets to stash the hostname
+ * sent by the client before we see the server's ACK. */
 void
-cache_entry(void *_msg, uint32_t rebind)
+cache_pending_hostname(const uint8_t *chaddr, const char *hostname)
+{
+	struct pending_hostname *p;
+
+	if (!hostname || !hostname[0])
+		return;
+
+	p = avl_find_element(&pending_tree, chaddr, p, avl);
+	if (!p) {
+		p = malloc(sizeof(*p));
+		if (!p)
+			return;
+		memset(p, 0, sizeof(*p));
+		memcpy(p->mac, chaddr, 6);
+		p->avl.key = p->mac;
+		avl_insert(&pending_tree, &p->avl);
+	}
+	snprintf(p->hostname, sizeof(p->hostname), "%s", hostname);
+}
+
+void
+cache_entry(void *_msg, uint32_t rebind, const char *hostname)
 {
 	struct dhcpv4_message *msg = (struct dhcpv4_message *) _msg;
+	struct pending_hostname *p;
 	struct mac *mac;
 
 	mac = avl_find_element(&mac_tree, msg->chaddr, mac, avl);
@@ -57,6 +92,17 @@ cache_entry(void *_msg, uint32_t rebind)
 		avl_insert(&mac_tree, &mac->avl);
 	}
 	memcpy(mac->ip, &msg->yiaddr.s_addr, 4);
+
+	/* Prefer hostname from the ACK itself (rare), otherwise use the one
+	 * captured from the client's earlier Discover/Request. */
+	if (hostname && hostname[0]) {
+		snprintf(mac->hostname, sizeof(mac->hostname), "%s", hostname);
+	} else {
+		p = avl_find_element(&pending_tree, msg->chaddr, p, avl);
+		if (p && p->hostname[0])
+			snprintf(mac->hostname, sizeof(mac->hostname), "%s", p->hostname);
+	}
+
 	uloop_timeout_set(&mac->rebind, rebind * 1000);
 }
 
@@ -73,5 +119,26 @@ cache_dump(struct blob_buf *b)
 		snprintf(ip, sizeof(ip), IP_FMT, IP_VAR(mac->ip));
 
 		blobmsg_add_string(b, addr, ip);
+	}
+}
+
+void
+cache_dump_full(struct blob_buf *b)
+{
+	struct mac *mac;
+
+	avl_for_each_element(&mac_tree, mac, avl) {
+		char addr[18];
+		char ip[16];
+		void *entry;
+
+		snprintf(addr, sizeof(addr), MAC_FMT, MAC_VAR(mac->mac));
+		snprintf(ip, sizeof(ip), IP_FMT, IP_VAR(mac->ip));
+
+		entry = blobmsg_open_table(b, addr);
+		blobmsg_add_string(b, "ip", ip);
+		if (mac->hostname[0])
+			blobmsg_add_string(b, "hostname", mac->hostname);
+		blobmsg_close_table(b, entry);
 	}
 }

--- a/feeds/ucentral/udhcpsnoop/src/dev.c
+++ b/feeds/ucentral/udhcpsnoop/src/dev.c
@@ -19,6 +19,7 @@
 #include <libubox/avl-cmp.h>
 
 #include "dhcpsnoop.h"
+#include "msg.h"
 
 #define APPEND(_buf, _ofs, _format, ...) _ofs += snprintf(_buf + _ofs, sizeof(_buf) - _ofs, _format, ##__VA_ARGS__)
 
@@ -95,6 +96,7 @@ dhcpsnoop_packet_cb(struct packet *pkt)
 	const char *type;
 	bool ipv6 = false;
 	uint32_t rebind = 0;
+	char hostname[64] = {};
 
 inside_tunnel:
 	eth = pkt_pull(pkt, sizeof(*eth));
@@ -154,7 +156,8 @@ inside_tunnel:
 	port = ntohs(udp->uh_sport);
 
 	if (!ipv6)
-		type = dhcpsnoop_parse_ipv4(pkt->buffer, pkt->len, port, &rebind);
+		type = dhcpsnoop_parse_ipv4(pkt->buffer, pkt->len, port, &rebind,
+					    hostname, sizeof(hostname));
 	else
 		type = dhcpsnoop_parse_ipv6(pkt->buffer, pkt->len, port);
 
@@ -162,8 +165,13 @@ inside_tunnel:
 		return;
 
 	dhcpsnoop_ubus_notify(type, pkt->buffer, pkt->len);
-	if (!ipv6 && !strcmp(type, "ack") && rebind)
-		cache_entry(pkt->buffer, rebind);
+	if (!ipv6) {
+		const struct dhcpv4_message *dmsg = pkt->buffer;
+		if ((!strcmp(type, "discover") || !strcmp(type, "request")) && hostname[0])
+			cache_pending_hostname(dmsg->chaddr, hostname);
+		if (!strcmp(type, "ack") && rebind)
+			cache_entry(pkt->buffer, rebind, hostname);
+	}
 }
 
 static void

--- a/feeds/ucentral/udhcpsnoop/src/dhcp.c
+++ b/feeds/ucentral/udhcpsnoop/src/dhcp.c
@@ -6,12 +6,16 @@
 #include "dhcpsnoop.h"
 #include "msg.h"
 
-const char *dhcpsnoop_parse_ipv4(const void *buf, size_t len, uint16_t port, uint32_t *expire)
+const char *dhcpsnoop_parse_ipv4(const void *buf, size_t len, uint16_t port,
+				  uint32_t *expire, char *hostname, size_t hostname_len)
 {
 	const struct dhcpv4_message *msg = buf;
 	const uint8_t *pos, *end;
 	uint32_t leasetime = 0, rebind = 0, renew = 0;
 	char type = 0;
+
+	if (hostname && hostname_len > 0)
+		hostname[0] = '\0';
 
 	if (port != 67 && port != 68)
 		return NULL;
@@ -61,6 +65,16 @@ const char *dhcpsnoop_parse_ipv4(const void *buf, size_t len, uint16_t port, uin
 			if (opt[1] != 4)
 				continue;
 			renew = *((uint32_t *) &opt[2]);
+			break;
+		case DHCPV4_OPT_HOSTNAME:
+			/* Option 12 is a plain string, not NUL-terminated */
+			if (hostname && hostname_len > 0 && opt[1] > 0) {
+				size_t copy_len = opt[1];
+				if (copy_len >= hostname_len)
+					copy_len = hostname_len - 1;
+				memcpy(hostname, &opt[2], copy_len);
+				hostname[copy_len] = '\0';
+			}
 			break;
 		}
 	}

--- a/feeds/ucentral/udhcpsnoop/src/dhcpsnoop.h
+++ b/feeds/ucentral/udhcpsnoop/src/dhcpsnoop.h
@@ -23,10 +23,13 @@ void dhcpsnoop_ubus_init(void);
 void dhcpsnoop_ubus_done(void);
 void dhcpsnoop_ubus_notify(const char *type, const uint8_t *msg, size_t len);
 
-const char *dhcpsnoop_parse_ipv4(const void *buf, size_t len, uint16_t port, uint32_t *rebind);
+const char *dhcpsnoop_parse_ipv4(const void *buf, size_t len, uint16_t port, uint32_t *rebind,
+				  char *hostname, size_t hostname_len);
 const char *dhcpsnoop_parse_ipv6(const void *buf, size_t len, uint16_t port);
 
-void cache_entry(void *msg, uint32_t rebind);
+void cache_pending_hostname(const uint8_t *chaddr, const char *hostname);
+void cache_entry(void *msg, uint32_t rebind, const char *hostname);
 void cache_dump(struct blob_buf *b);
+void cache_dump_full(struct blob_buf *b);
 
 #endif

--- a/feeds/ucentral/udhcpsnoop/src/ubus.c
+++ b/feeds/ucentral/udhcpsnoop/src/ubus.c
@@ -76,11 +76,26 @@ dhcpsnoop_ubus_dump(struct ubus_context *ctx, struct ubus_object *obj,
 	return 0;
 }
 
+static int
+dhcpsnoop_ubus_leases(struct ubus_context *ctx, struct ubus_object *obj,
+		      struct ubus_request_data *req, const char *method,
+		      struct blob_attr *msg)
+{
+	blob_buf_init(&b, 0);
+
+	cache_dump_full(&b);
+
+	ubus_send_reply(ctx, req, b.head);
+
+	return 0;
+}
+
 static const struct ubus_method dhcpsnoop_methods[] = {
 	UBUS_METHOD("config", dhcpsnoop_ubus_config, dhcpsnoop_config_policy),
 	UBUS_METHOD("add_devices", dhcpsnoop_ubus_add_devices, dhcpsnoop_config_policy),
 	UBUS_METHOD_NOARG("check_devices", dhcpsnoop_ubus_check_devices),
 	UBUS_METHOD_NOARG("dump", dhcpsnoop_ubus_dump),
+	UBUS_METHOD_NOARG("leases", dhcpsnoop_ubus_leases),
 };
 
 static struct ubus_object_type dhcpsnoop_object_type =


### PR DESCRIPTION
… method

DHCP clients send their hostname in Option 12 (DHCPHOSTNAME) inside Discover and Request packets, not in the server's ACK. Add support for capturing this hostname and associating it with the MAC/IP entry in the cache.

The approach:
- Parse Option 12 from all DHCP packets in dhcpsnoop_parse_ipv4()
- On Discover/Request, stash the hostname in a pending AVL tree keyed by MAC (cache_pending_hostname). This is necessary because the client sends the hostname, but the server's ACK does not echo it back.
- On ACK, look up the pending hostname by MAC and store it alongside the IP in the main cache entry.

Add a new ubus method 'leases' that returns each tracked client as a nested table with 'ip' and 'hostname' (when known) fields:

  {
    "96:f7:20:1e:55:70": { "ip": "192.168.50.86", "hostname": "iPhone" }
  }

The existing 'dump' method is unchanged so current consumers are unaffected. The new 'leases' method is intended for consumers that need the full lease information including hostname.

Fixes WIFI-15393