### PR TITLE
WIFI-15392 fix RAP630W-311G compilation error in next branch

### DIFF
--- a/feeds/ucentral/poe/src/tps23861-poe-ctrl.c
+++ b/feeds/ucentral/poe/src/tps23861-poe-ctrl.c
@@ -9,6 +9,7 @@
 #include <unistd.h>		/* UNIX standard function definitions */
 #include <fcntl.h>		/* File control definitions */
 #include <errno.h>		/* Error number definitions */
+#include <stdlib.h>		/* Standard library function definitions */
 #include <sys/ioctl.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>  /* uapi/linux/i2c-dev.h */


### PR DESCRIPTION
RAP630W-311G compilation will fail in branch next

tps23861-poe-ctrl.c:188:32: error: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  188 |                         port = atoi(optarg);
      |           
TIP upgrade OpenWrt to version 25.12, which imposes stricter compilation checks, the atoi function requires an explicit inclusion of the <stdlib.h> header file. This header needs to be included in tps23861-poe-ctrl.c.