### PR TITLE
cloud_discover: retain last active config on start if gateway.json is invalid

### DIFF
--- a/feeds/tip/cloud_discovery/files/etc/init.d/cloud_discover
+++ b/feeds/tip/cloud_discovery/files/etc/init.d/cloud_discover
@@ -19,8 +19,10 @@ start_service() {
 	}
 
 	local valid=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["valid"]')
-	[ "$valid" == "true" ] || 
-		/usr/share/ucentral/ucentral.uc /etc/ucentral/ucentral.cfg.0000000001 > /dev/null
+	if [ "$valid" != "true" ]; then
+		active=$(readlink /etc/ucentral/ucentral.active)
+		[ -n "$active" -a -f "$active" ] || /usr/share/ucentral/ucentral.uc /etc/ucentral/ucentral.cfg.0000000001 2>&1 > /dev/null
+	fi
 
 	est_client check
 	[ $? -eq 1 ] && {


### PR DESCRIPTION
Fixes: WIFI-15430

When the gateway config is invalid, prefer the last active config (tracked via /etc/ucentral/ucentral.active symlink) over the default fallback config. Only fall back to ucentral.cfg.0000000001 if no active config symlink exists or the target file is missing.