### PR TITLE
WIFI-15433: Improve the log backup functionality for ucentral-pstore.

### DIFF
--- a/feeds/ucentral/ucentral-state/Makefile
+++ b/feeds/ucentral/ucentral-state/Makefile
@@ -24,6 +24,7 @@ define Package/ucentral-state/install
 	$(INSTALL_BIN) ./files/ucentral-pstore $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/ucentral-state.init $(1)/etc/init.d/ucentral-state
 	$(INSTALL_BIN) ./files/ucentral-state.config $(1)/etc/config/state
+	$(INSTALL_BIN) ./files/log-helper.config $(1)/etc/config/log-helper
 endef
 
 $(eval $(call BuildPackage,ucentral-state))

--- a/feeds/ucentral/ucentral-state/files/log-helper.config
+++ b/feeds/ucentral/ucentral-state/files/log-helper.config
@@ -1,0 +1,18 @@
+config log-helper 'global'
+	option enabled '1'
+
+	# Directory in overlay file system for backed up files.
+	option backup_dir 'backup_storage'
+
+	# Free space safety margin in KB.
+	# A backup will be skipped if available space of overlay is less than (file_size + threshold).
+	option space_threshold '2048'
+
+	# To specify the maximum number of rotations.
+	option max_rotations '3'
+
+	option backup_file 'backup.tgz'
+
+	list file_list '/sys/fs/pstore/dmesg-ramoops-0'
+	list file_list '/sys/fs/pstore/console-ramoops-0'
+	list file_list '/sys/fs/pstore/pmsg-ramoops-0'

--- a/feeds/ucentral/ucentral-state/files/ucentral-pstore
+++ b/feeds/ucentral/ucentral-state/files/ucentral-pstore
@@ -2,7 +2,229 @@
 
 'use strict';
 
+import * as uci from 'uci';
 import * as fs from 'fs';
+
+const DEFAULT_BACKUP_DIR = "backup_storage";
+const DEFAULT_BACKUP_FILE = "backup.tgz";
+const DEFAULT_MAX_ROTATIONS = 3;
+const DEFAULT_SPACE_THRESH = 2048;
+const UCI_CONFIG_FILE = "log-helper";
+
+// Log function that sends messages to syslog via logger command
+function log(level, message) {
+    let log_msg = sprintf('ucentral-pstore: %s: %s', level, message);
+    system('logger -t ucentral-pstore "' + level + ': ' + message + '"');
+    // Also print to console for immediate feedback
+    print(log_msg + '\n');
+}
+
+function file_exists(path) {
+    let ret = system("test -f '" + path + "'");
+    return ret === 0;
+}
+
+function rotate_logs(base_log_path, max_rotations) {
+    if (max_rotations <= 1) {
+        log('ERROR', "max_rotations must be greater than 1: " + max_rotations);
+        return false;
+    }
+
+    let log_path = base_log_path;
+
+    if (!file_exists(log_path)) {
+        return true; // File not found, nothing to rotate
+    }
+
+    // Rename files in reverse order (from max_rotations-1 down to 1)
+    // This moves .2 to .3, .1 to .2, etc.
+    for (let i = max_rotations - 1; i >= 1; i--) {
+        let src = log_path + "." + i;
+        let dest = log_path + "." + (i + 1);
+
+        if (file_exists(src)) {
+            fs.rename(src, dest);
+        }
+    }
+
+    // Rename the base file to .1
+    if (file_exists(log_path)) {
+        fs.rename(log_path, log_path + ".1");
+    }
+
+    // Remove the oldest backup file (at position max_rotations + 1)
+    // This keeps max_rotations backup files (.1 through .max_rotations)
+    let oldest = log_path + "." + (max_rotations + 1);
+    if (file_exists(oldest)) {
+        fs.unlink(oldest);
+    }
+
+    return true;
+}
+
+function move_file(src_path, dest_dir) {
+    let dest_path = dest_dir + "/" + fs.basename(src_path);
+    log('INFO', "Moving backup file to " + dest_path);
+    let cmd = "mv '" + src_path + "' '" + dest_path + "'";
+    let ret = system(cmd);
+    if (ret === 0) {
+        log('INFO', "Move successful");
+        return true;
+    } else {
+        log('ERROR', "Failed to move " + src_path + " to " + dest_path + " (code: " + ret + ")");
+        return false;
+    }
+}
+
+function get_available_space_kb(target_dir) {
+    if (!target_dir) {
+        return -1;  // Cannot check without target directory
+    }
+
+    // Try to get available space using 'df' command
+    let tmp_file = "/tmp/.df_" + time();
+    let cmd = "df -k '" + target_dir + "' 2>/dev/null | tail -1 | awk '{print $4}'";
+
+    if (system(cmd + " > '" + tmp_file + "' 2>/dev/null") !== 0) {
+        log('INFO', "Cannot determine available space, skipping check");
+        return -1;
+    }
+
+    let available_kb = -1;
+    try {
+        let fd = fs.open(tmp_file, "r");
+        if (fd) {
+            let line = fd.read("line");
+            if (line) {
+                available_kb = +trim(line);
+            }
+            fd.close();
+        }
+    } catch (e) {
+        log('ERROR', "Failed to read df output: " + e);
+    }
+
+    try {
+        fs.unlink(tmp_file);
+    } catch (e) {}
+
+    return available_kb > 0 ? available_kb : -1;
+}
+
+function do_backup() {
+    let ctx = uci.cursor();
+    let pkg = ctx.get_all(UCI_CONFIG_FILE);
+    if (!pkg) {
+        log('ERROR', "Failed to load UCI config: " + UCI_CONFIG_FILE);
+        return;
+    }
+
+    let global = pkg.global;
+    if (!global) {
+        log('ERROR', "UCI section 'global' not found in " + UCI_CONFIG_FILE);
+        return;
+    }
+
+    // Build file list (only existing files)
+    let file_list = [];
+    let cfg_files = global.file_list;
+    if (type(cfg_files) === "string") {
+        cfg_files = [cfg_files];
+    }
+
+    if (type(cfg_files) === "array") {
+        let i = 0;
+        while (i < length(cfg_files)) {
+            let f = cfg_files[i];
+            if (file_exists(f)) {
+                // Strip leading '/' for tar command
+                let rel = f;
+                if (substr(f, 0, 1) === "/") {
+                    rel = substr(f, 1);
+                } else {
+                    // For relative paths, keep them as-is
+                    rel = f;
+                }
+                push(file_list, rel);
+            } else {
+                log('WARN', "Backup source file not found: " + f);
+            }
+            i++;
+        }
+    }
+
+    if (length(file_list) === 0) {
+        log('INFO', "No backup source files exist, nothing to do");
+        return;
+    }
+
+    log('INFO', "Found " + length(file_list) + " file(s) to backup");
+
+    // Get backup dir
+    let backup_dir = global.backup_dir || DEFAULT_BACKUP_DIR;
+    if (substr(backup_dir, 0, 1) !== "/") {
+        backup_dir = "/" + backup_dir;
+    }
+    try {
+        fs.mkdir(backup_dir, 0755);
+    } catch (e) {
+        log('ERROR', "Failed to create backup directory " + backup_dir + ": " + e);
+        return;
+    }
+
+    // Get backup file
+    let backup_file_name = global.backup_file || DEFAULT_BACKUP_FILE;
+    let backup_file = backup_dir + "/" + backup_file_name;
+    let tmp_file = "/tmp/" + backup_file_name;
+
+    // Create tar from existing files with proper escaping
+    let tar_files = "";
+    for (let i = 0; i < length(file_list); i++) {
+        tar_files += " '" + file_list[i] + "'";
+    }
+    let cmd = "tar -C / -czf '" + tmp_file + "'" + tar_files;
+    log('INFO', "Creating backup archive");
+    let ret = system(cmd);
+    if (ret !== 0) {
+        log('ERROR', "Tar command failed with code: " + ret);
+        return;
+    }
+
+    // Check space
+    let available_kb = get_available_space_kb(backup_dir);
+    let space_threshold = global.space_threshold ? +global.space_threshold : DEFAULT_SPACE_THRESH;
+    
+    let file_stat = fs.stat(tmp_file);
+    if (!file_stat) {
+        log('ERROR', "Failed to stat backup file: " + tmp_file);
+        return;
+    }
+    
+    let file_kb = file_stat.size / 1024;
+    if (available_kb > 0 && available_kb < (file_kb + space_threshold)) {
+        log('ERROR', "Insufficient space. Available: " + available_kb + "KB, Required: " + (file_kb + space_threshold) + "KB");
+        fs.unlink(tmp_file);
+        return;
+    } else if (available_kb < 0) {
+        log('WARN', "Space check unavailable, proceeding anyway (backup size: " + file_kb + "KB)");
+    } else {
+        log('INFO', "Space check passed (available: " + available_kb + "KB, needed: " + (file_kb + space_threshold) + "KB)");
+    }
+
+    // Rotate
+    let max_rotations = global.max_rotations ? +global.max_rotations : DEFAULT_MAX_ROTATIONS;
+    if (max_rotations > 1 && file_exists(backup_file)) {
+        log('INFO', "Rotating backup files (keeping " + max_rotations + " versions)");
+        rotate_logs(backup_file, max_rotations);
+    }
+
+    // Move
+    if (move_file(tmp_file, backup_dir)) {
+        log('INFO', "Successfully backed up to " + backup_file);
+    } else {
+        log('ERROR', "Failed to move file to backup directory");
+    }
+}
 
 function move_to_json(src, dst) {
 	if (!fs.stat(src))
@@ -24,6 +246,9 @@ function move_to_json(src, dst) {
 	fd.write(msg);
 	fd.close();
 }
+
+// backup logs on startup to backup_storage
+do_backup();
 
 move_to_json('/sys/fs/pstore/dmesg-ramoops-0', '/tmp/crashlog');
 move_to_json('/sys/fs/pstore/console-ramoops-0', '/tmp/consolelog');

--- a/feeds/ucentral/ucentral-state/files/ucentral-state.init
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state.init
@@ -5,7 +5,25 @@ START=80
 USE_PROCD=1
 PROG=/usr/sbin/ucentral-state
 
+#add directory that need to be preserved during OpenWRT sysupgrade
+check_upgrade_conf() {
+	dir="$1"
+
+	grep -q ${dir} /etc/sysupgrade.conf
+	[ $? -ne 0 ] && {
+		echo "/${dir}/" >> /etc/sysupgrade.conf
+	}
+}
+
 start_service() {
+	local enabled
+	config_load log-helper
+	config_get_bool enabled global enabled 0
+	[ ${enabled} -eq 0 ] && return 1
+
+	config_get backup_dir global backup_dir "backup_storage"
+	check_upgrade_conf ${backup_dir}
+	
 	procd_open_instance
 	procd_set_param command "$PROG"
 	procd_set_param respawn 3600 1 0


### PR DESCRIPTION
Convert the C source code from https://telecominfraproject.atlassian.net/browse/WIFI-14917 and https://github.com/Telecominfraproject/wlan-ap/pull/945 into ucode, and add it to ucentral-pstore.
The following features have been added to ucentral-pstore:

1. Added UCI configuration for the log-helper.
2. Created the backup_storage directory and configured persistence for files under this directory.
3. Compressed and archived logs from the pstore directory into the /tmp directory.
4. Checked whether the partition where backup_storage resides has sufficient remaining space to store the new compressed log archive.
5. Moved the compressed log archive to backup_storage. If an old compressed log archive already exists in backup_storage, rename and move the old one (e.g., append suffixes 1, 2, 3, etc.). If the renamed suffix exceeds MAX_ROTATIONS, delete the oldest compressed log archive.