### PR TITLE
After upgrading WiFi 5 APs to v2.11.2, using Insta server certificates not able to perform RTTY

### DIFF
--- a/feeds/ucentral/rtty/files/rtty.init
+++ b/feeds/ucentral/rtty/files/rtty.init
@@ -51,7 +51,7 @@ start_rtty() {
 	procd_set_param command $BIN -h $host -I "$id" -a
 	[ -n "$port" ] && procd_append_param command -p "$port"
 	[ -n "$description" ] && procd_append_param command -d "$description"
-	[ "$ssl" = "1" ] && procd_append_param command -s -c /etc/ucentral/opertional.pem -k /etc/ucentral/key.pem
+	[ "$ssl" = "1" ] && procd_append_param command -s -c /etc/ucentral/operational.pem -k /etc/ucentral/key.pem
 	[ -n "$token" ] && procd_append_param command -t "$token"
 	[ "$verbose" = "1" ] && procd_append_param command -v
 	[ "$timeout" -eq "0" ] || procd_append_param command -e $timeout

--- a/feeds/ucentral/rtty/files/rtty.init
+++ b/feeds/ucentral/rtty/files/rtty.init
@@ -51,7 +51,7 @@ start_rtty() {
 	procd_set_param command $BIN -h $host -I "$id" -a
 	[ -n "$port" ] && procd_append_param command -p "$port"
 	[ -n "$description" ] && procd_append_param command -d "$description"
-	[ "$ssl" = "1" ] && procd_append_param command -s -c /etc/ucentral/cert.pem -k /etc/ucentral/key.pem
+	[ "$ssl" = "1" ] && procd_append_param command -s -c /etc/ucentral/opertional.pem -k /etc/ucentral/key.pem
 	[ -n "$token" ] && procd_append_param command -t "$token"
 	[ "$verbose" = "1" ] && procd_append_param command -v
 	[ "$timeout" -eq "0" ] || procd_append_param command -e $timeout


### PR DESCRIPTION
After upgrading WiFi 5 APs to v2.11.2, using Insta server certificates not able to perform RTTY