### PR TITLE
WIFI-15459 WIFI-7 NAND flash boot failure on next branch

### DIFF
--- a/patches-25.12/0106-fix-ubi-rootfs-name-issue.patch
+++ b/patches-25.12/0106-fix-ubi-rootfs-name-issue.patch
@@ -1,0 +1,75 @@
+From c77b6ba6cc34a16dac8768d05e18501b818224a5 Mon Sep 17 00:00:00 2001
+From: "Justin.Guo" <guoxijun@actiontec.com>
+Date: Wed, 18 Mar 2026 16:02:27 +0800
+Subject: [PATCH] fix ubi rootfs name issue
+
+Signed-off-by: Justin.Guo <guoxijun@actiontec.com>
+---
+ include/image-commands.mk |  1 +
+ scripts/ubinize-image.sh  | 11 +++++++++--
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+ mode change 100644 => 100755 include/image-commands.mk
+ mode change 100755 => 100644 scripts/ubinize-image.sh
+
+diff --git a/include/image-commands.mk b/include/image-commands.mk
+old mode 100644
+new mode 100755
+index 30cfd00f97..d327ec8244
+--- a/include/image-commands.mk
++++ b/include/image-commands.mk
+@@ -140,6 +140,7 @@ define Build/append-ubi
+ 	sh $(TOPDIR)/scripts/ubinize-image.sh \
+ 		$(if $(UBOOTENV_IN_UBI),--uboot-env) \
+ 		$(if $(KERNEL_IN_UBI),--kernel $(IMAGE_KERNEL)) \
++		$(if $(ROOTFSNAME_IN_UBI),--rootfs_name $(ROOTFSNAME_IN_UBI)) \
+ 		$(foreach part,$(UBINIZE_PARTS),--part $(part)) \
+ 		--rootfs $(IMAGE_ROOTFS) \
+ 		$@.tmp \
+diff --git a/scripts/ubinize-image.sh b/scripts/ubinize-image.sh
+old mode 100755
+new mode 100644
+index d8b8cd3ae2..1c9d0e5634
+--- a/scripts/ubinize-image.sh
++++ b/scripts/ubinize-image.sh
+@@ -7,6 +7,7 @@ ubootenv=""
+ ubinize_param=""
+ kernel=""
+ rootfs=""
++rootfs_name="rootfs"
+ outfile=""
+ err=""
+ ubinize_seq=""
+@@ -90,7 +91,7 @@ ubilayout() {
+ 			rootsize="$( round_up "$( stat -c%s "$2" )" 1024 )"
+ 			;;
+ 		esac
+-		ubivol $vol_id rootfs "$2" "$autoresize" "$rootsize"
++		ubivol $vol_id "$rootfs_name" "$2" "$autoresize" "$rootsize"
+ 
+ 		vol_id=$(( vol_id + 1 ))
+ 		[ "$rootfs_type" = "ubifs" ] || ubivol $vol_id rootfs_data "" 1
+@@ -122,6 +123,12 @@ while [ "$1" ]; do
+ 		shift
+ 		continue
+ 		;;
++	"--rootfs_name")
++		rootfs_name="$2"
++		shift
++		shift
++		continue
++		;;
+ 	"--part")
+ 		parts="$parts $2"
+ 		shift
+@@ -143,7 +150,7 @@ while [ "$1" ]; do
+ done
+ 
+ if [ ! -r "$rootfs" ] && [ ! -r "$kernel" ] && [ ! "$parts" ] && [ ! "$outfile" ]; then
+-	echo "syntax: $0 [--uboot-env] [--part <name>=<file>] [--kernel kernelimage] [--rootfs rootfsimage] out [ubinize opts]"
++	echo "syntax: $0 [--uboot-env] [--part <name>=<file>] [--kernel kernelimage] [--rootfs_name volume_name] [--rootfs rootfsimage] out [ubinize opts]"
+ 	exit 1
+ fi
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
	qca-wifi-7: QCA UBI rootfs require the rootfs to be named "ubi_rootfs".
			this patch adds support for the rootfs name.