### PR TITLE
ramoops dts for udaya a6-id2

### DIFF
--- a/feeds/ipq807x_v5.4/ipq50xx/patches/001-add-ramoops-udaya-a6-id2-dts.patch
+++ b/feeds/ipq807x_v5.4/ipq50xx/patches/001-add-ramoops-udaya-a6-id2-dts.patch
@@ -1,0 +1,31 @@
+--- files/arch/arm64/boot/dts/qcom/qcom-ipq5018-udaya-a6-id2.dts.orig	2026-04-08 17:24:49.918253550 +0530
++++ files/arch/arm64/boot/dts/qcom/qcom-ipq5018-udaya-a6-id2.dts	2026-04-08 17:27:47.652290635 +0530
+@@ -154,6 +154,14 @@
+ 			no-map;
+ 			reg = <0x0 0x4F000000 0x0 0x100000>;
+ 		};
++
++		ramoops: ramoops@4F100000 {
++			compatible = "ramoops";
++			reg = <0x0 0x4F100000 0x0 0x100000>;
++			record-size  = <0x40000>;
++			console-size = <0x40000>;
++			pmsg-size    = <0x20000>;
++		};
+ 	#else
+ 	/*                 512MB/1GB Profiles
+ 	 * +==========+==============+=========================+
+@@ -288,6 +296,13 @@
+ 			reg = <0x0 0x4F800000 0x0 0x500000>;
+ 		};
+ 
++		ramoops: ramoops@4FD00000 {
++			compatible = "ramoops";
++			reg = <0x0 0x4FD00000 0x0 0x100000>;
++			record-size  = <0x40000>;
++			console-size = <0x40000>;
++			pmsg-size    = <0x20000>;
++		};
+ 	#endif
+ 	};
+ 


### PR DESCRIPTION
Udaya_A6_ID2: Crash logs not getting saved in Pstore

https://telecominfraproject.atlassian.net/browse/WIFI-15423