### PR TITLE
Fixes for issues in ATH13.1

### DIFF
--- a/feeds/qca-wifi-7/hostapd/Makefile
+++ b/feeds/qca-wifi-7/hostapd/Makefile
@@ -808,6 +808,8 @@ define Package/hostapd-common/install
 	$(INSTALL_BIN) ./files/wps-hotplug.sh $(1)/etc/rc.button/wps
 	$(INSTALL_DATA) ./files/wpad_acl.json $(1)/usr/share/acl.d
 	$(INSTALL_DATA) ./files/wpad.json $(1)/etc/capabilities
+	$(INSTALL_BIN) ./files/mpskd $(1)/usr/share/hostap/
+	$(INSTALL_BIN) ./files/mpskd.init $(1)/etc/init.d/mpskd
 endef
 
 define Package/hostapd/install

--- a/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/files/hostapd.uc
+++ b/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/files/hostapd.uc
@@ -352,6 +352,7 @@ function iface_macaddr_init(phydev, config, macaddr_list)
 {
 	let macaddr_data = {
 		num_global: config.num_global_macaddr ?? 1,
+		macaddr_base: config.macaddr_base,
 		mbssid: config.mbssid ?? 0,
 	};
 
@@ -828,6 +829,8 @@ function iface_load_config(phy, radio, filename)
 		if (val[0] == "#num_global_macaddr" ||
 		    val[0] == "mbssid")
 			config[substr(val[0], 1)] = int(val[1]);
+		else if (val[0] == "#macaddr_base")
+			config[substr(val[0], 1)] = val[1];
 
 		push(config.radio.data, line);
 	}

--- a/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/files/wpa_supplicant.uc
+++ b/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/files/wpa_supplicant.uc
@@ -141,7 +141,7 @@ function prepare_config(config, radio)
 	return { config };
 }
 
-function set_config(config_name, phy_name, radio, num_global_macaddr, config_list)
+function set_config(config_name, phy_name, radio, num_global_macaddr, macaddr_base, config_list)
 {
 	let phy = wpas.data.config[config_name];
 
@@ -156,6 +156,7 @@ function set_config(config_name, phy_name, radio, num_global_macaddr, config_lis
 
 	phy.radio = radio;
 	phy.num_global_macaddr = num_global_macaddr;
+	phy.macaddr_base = macaddr_base;
 
 	let values = [];
 	for (let config in config_list)
@@ -179,7 +180,10 @@ function start_pending(phy_name)
 	}
 
 	let macaddr_list = wpas.data.macaddr_list[phy_name];
-	phydev.macaddr_init(macaddr_list, { num_global: phy.num_global_macaddr });
+	phydev.macaddr_init(macaddr_list, {
+		num_global: phy.num_global_macaddr,
+		macaddr_base: phy.macaddr_base,
+	});
 
 	for (let ifname in phy.data)
 		iface_start(phydev, phy.data[ifname]);
@@ -272,6 +276,7 @@ let main_obj = {
 			phy: "",
 			radio: 0,
 			num_global_macaddr: 0,
+			macaddr_base: "",
 			is_ml: false,
 			config: [],
 			defer: true,
@@ -289,7 +294,7 @@ let main_obj = {
 
 			try {
 				if (req.args.config)
-					set_config(phy, req.args.phy, req.args.radio, req.args.num_global_macaddr, req.args.config);
+					set_config(phy, req.args.phy, req.args.radio, req.args.num_global_macaddr, req.args.macaddr_base, req.args.config);
 
 				if (!req.args.defer) {
 					start_pending(phy);

--- a/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t04-ubus_notify_authorized.patch
+++ b/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t04-ubus_notify_authorized.patch
@@ -1,0 +1,22 @@
+diff --git a/src/ap/ubus.c b/src/ap/ubus.c
+index 4d87ed5..6c35dbd 100644
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -1859,6 +1859,17 @@ void hostapd_ubus_notify_authorized(struct hostapd_data *hapd, struct sta_info *
+ 	if (auth_alg)
+ 		blobmsg_add_string(&b, "auth-alg", auth_alg);
+ 
++	if (sta->vlan_id)
++		blobmsg_add_u32(&b, "vlan", sta->vlan_id);
++	blobmsg_add_string(&b, "ifname", hapd->conf->iface);
++	if (sta->bandwidth[0] || sta->bandwidth[1]) {
++		void *r = blobmsg_open_array(&b, "rate-limit");
++
++		blobmsg_add_u32(&b, "", sta->bandwidth[0]);
++		blobmsg_add_u32(&b, "", sta->bandwidth[1]);
++		blobmsg_close_array(&b, r);
++	}
++
+ 	if (reassoc)
+ 		blobmsg_add_macaddr(&b, "origin", sta->origin_ap);
+ 	blobmsg_printf(&b, "target", MACSTR, MAC2STR(hapd->conf->bssid));

--- a/feeds/qca-wifi-7/iwinfo/files-iwinfo/usr/share/ucode/iwinfo.uc
+++ b/feeds/qca-wifi-7/iwinfo/files-iwinfo/usr/share/ucode/iwinfo.uc
@@ -414,7 +414,7 @@ export function info(name) {
 			channel_offset: data.hardware.channel_offset || 'none',
 		};
 
-		if (!data.wiphy_freq) {
+		if (data.mlo_links) {
 			dev.channel = format_channel(data.mlo_links[0].wiphy_freq);
 			dev.freq = format_frequency(data.mlo_links[0].wiphy_freq);
 			dev.center_freq1 = format_channel(data.mlo_links[0].center_freq1) || 'unknown';

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -779,6 +779,7 @@ hostapd_set_bss_options() {
 				wireless_setup_vif_failed INVALID_WPA_PSK
 				return 1
 			fi
+			[ -z "$wpa_psk_file" ] && set_default wpa_psk_file /var/run/hostapd-"$ifname".psk
 			[ -n "$wpa_psk_file" ] && {
 				[ -e "$wpa_psk_file" ] || touch "$wpa_psk_file"
 				append bss_conf "wpa_psk_file=$wpa_psk_file" "$N"
@@ -1130,7 +1131,7 @@ hostapd_set_bss_options() {
 		) > "$_macfile"
 	}
 
-	([ -n "$vlan_possible"] && [ -n "$dynamic_vlan" ]) && {
+	([ -n "$vlan_possible" ] && [ -n "$dynamic_vlan" ]) && {
 		json_get_vars vlan_naming vlan_tagged_interface vlan_bridge vlan_file vlan_no_bridge
 		set_default vlan_naming 1
 		[ -z "$vlan_file" ] && set_default vlan_file /var/run/hostapd-"$ifname".vlan

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/netifd-wireless.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/netifd-wireless.sh
@@ -239,8 +239,8 @@ wireless_vif_parse_encryption() {
 		*ccmp256) wpa_cipher="CCMP-256";;
 		*gcmp | *sae-ext-key | akm24*) wpa_cipher="GCMP CCMP GCMP-256";;
 		*gcmp256 | wpa3-192*) wpa_cipher="GCMP-256";;
-		*aes|*ccmp| psk2 | wpa2 | sae* | owe | dpp) wpa_cipher="CCMP";;
-		*tkip | wpa | psk) wpa_cipher="TKIP";;
+		*aes|*ccmp| psk2 | wpa2 | psk | wpa | sae* | owe | dpp) wpa_cipher="CCMP";;
+		*tkip) wpa_cipher="TKIP";;
 	esac
 
 	# Examples:

--- a/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/common.uc
+++ b/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/common.uc
@@ -246,9 +246,12 @@ const phy_proto = {
 		if (!base_mask)
 			return null;
 
+		if (base_mask == "00:00:00:00:00:00")
+			base_mask = "ff:ff:ff:ff:ff:ff";
+
 		if (data.macaddr_base)
 			base_addr = data.macaddr_base;
-		else if (base_mask == "00:00:00:00:00:00" &&
+		else if (base_mask == "ff:ff:ff:ff:ff:ff" &&
 		    (radio_idx > 0 || idx >= num_global)) {
 			let addrs = split(phy_sysfs_file(phy, "addresses"), "\n");
 
@@ -261,7 +264,6 @@ const phy_proto = {
 				if (idx < length(addrs))
 					return addrs[idx];
 			}
-			base_mask = "ff:ff:ff:ff:ff:ff";
 		}
 
 		if (!idx && !mbssid)

--- a/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
+++ b/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
@@ -94,6 +94,7 @@ function wiphy_detect() {
 		let info = {
 			antenna_rx: phy.wiphy_antenna_avail_rx,
 			antenna_tx: phy.wiphy_antenna_avail_tx,
+			reconf: true,
 			bands: {},
 		};
 		let multi_radio = {};


### PR DESCRIPTION
**Changes:**
	wifi-scripts:
		- Generating different macaddr for interfaces
		- Updating proper value to wpa in hostapd configuration when security mode is configured as psk
		- Updating wpa_psk_file and vlan_file in the hostapd configuration when multi-psk is configured
	hostapd:
		- Copying mpskd to the rootfs

**Fixes:** WIFI-15425, WIFI-15427, WIFI-15435, WIFI-15437, WIFI-15441