### PR TITLE
rrmd: Add 5 sec delay before checking channel switch status

### DIFF
--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
@@ -348,6 +348,9 @@ function hostapd_switch_channel(msg) {
 }
 
 function switch_status_check(iface, dfs_enabled_5g_flag) {
+    // add a 5 sec delay regardless of DFS being enabled or not
+    sleep(5);
+
     // need to wait for radio 5GHz interface to be UP, when DFS is enabled
     if (dfs_enabled_5g_flag == 1) {
         ulog_info(`[%s] 5G radio might need some time to be UP (DFS enabled) \n`, iface);


### PR DESCRIPTION
Fixes: WIFI-15488

Add a 5-second delay before checking channel switch status. hostapd may still be processing the switch even on non-DFS/non-weather channels, causing the script to incorrectly report a failed channel switch.