### PR TITLE
WIFI-15485-CIG-WF-189H-wifi-board-id-issue

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189h.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-cig-wf189h.dts
@@ -907,7 +907,7 @@
 	qcom,caldb-addr = <0x51100000 0x51100000 0x51100000 0x0 0x0 0x0>;
 	qcom,umac-irq-reset-addr = <0x10000884>;
 	qcom,caldb-size = <0x500000>;
-	qcom,board_id = <0x091>;
+	qcom,board_id = <0x0b1>;
 	mem-region = <&q6_qcn6432_data_2>;
 	memory-region = <&q6_qcn6432_data_2>, <&q6_mem_regions>, <&m3_dump_qcn6432_2>,
 			<&mlo_global_mem0>, <&q6_qcn6432_etr_2>;


### PR DESCRIPTION
	CIG WF-189H Due to radio issues caused by the board ID in DTS used in 189h, the board ID has been corrected