### PR TITLE
WIFI-15489-WF-189-add-speed-limit-condition-to-rtl8261n-for-WF-189-WAN-port

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/files-6.6/drivers/net/phy/rtk/rtk_phy.c
+++ b/feeds/qca-wifi-7/ipq53xx/files-6.6/drivers/net/phy/rtk/rtk_phy.c
@@ -5,6 +5,7 @@
  */
 
 #include <linux/module.h>
+#include <linux/of.h>
 #include <linux/phy.h>
 #include <linux/ethtool.h>
 #include <linux/netdevice.h>
@@ -101,6 +102,9 @@ static int rtl826xb_get_features(struct phy_device *phydev)
     {
         /* support 10G modes */
         case RTK_PHYLIB_RTL8261N:
+            if (priv->limit_10g)
+                linkmode_clear_bit(ETHTOOL_LINK_MODE_10000baseT_Full_BIT,
+                           phydev->supported);
             break;
         default:
             linkmode_clear_bit(ETHTOOL_LINK_MODE_10000baseT_Full_BIT,
@@ -157,6 +161,15 @@ static int rtl826xb_probe(struct phy_device *phydev)
         }
     }
     priv->isBasePort = (phydev->drv->phy_id == REALTEK_PHY_ID_RTL8261N) ? (1) : (((phydev->mdio.addr % 4) == 0) ? (1) : (0));
+
+    if (phydev->drv->phy_id == REALTEK_PHY_ID_RTL8261N) {
+        struct device_node *mdio_node = phydev->mdio.dev.of_node
+                                        ? phydev->mdio.dev.of_node->parent
+                                        : NULL;
+        if (mdio_node && of_property_read_bool(mdio_node, "limit_rtlphy_10g_ablity"))
+            priv->limit_10g = 1;
+    }
+
     phydev->priv = priv;
 
     return 0;

--- a/feeds/qca-wifi-7/ipq53xx/files-6.6/drivers/net/phy/rtk/rtk_phylib.h
+++ b/feeds/qca-wifi-7/ipq53xx/files-6.6/drivers/net/phy/rtk/rtk_phylib.h
@@ -181,6 +181,7 @@ typedef struct rtk_macsec_port_info_s
 struct rtk_phy_priv {
     rtk_phylib_phy_t phytype;
     uint8 isBasePort;
+    uint8 limit_10g;  /* set if DTS mdio node has limit_rtlphy_10g_ablity */
     rt_phy_patch_db_t *patch;
     rtk_macsec_port_info_t *macsec;
 };


### PR DESCRIPTION
	WF-189 WAN port does not use 10G mode, we add limit_rtlphy_10g_ablity to DTS and check it in RTL code.