### PR TITLE
Disable energy-detect CCA on HaLow interface bring-up

### DIFF
--- a/feeds/morse/netifd-morse/lib/netifd/wireless/morse.sh
+++ b/feeds/morse/netifd-morse/lib/netifd/wireless/morse.sh
@@ -366,6 +366,7 @@ drv_morse_setup() {
 	if [ -n "$ifname" ]; then
 		morse_cli -i $ifname ampdu $ampdu
 		[ -n "$bss_color" ] && morse_cli -i $ifname bsscolor $bss_color
+		morsectrl -i $ifname edconfig energy ignore || logger -t morse "edconfig energy ignore failed"
 	fi
 
 	if [ -n "$forced_listen_interval" ]

--- a/feeds/morse/utils/morsecli/Makefile
+++ b/feeds/morse/utils/morsecli/Makefile
@@ -33,7 +33,6 @@ define Package/morsecli
   DEPENDS:= +kmod-morse +libnl
   FILES:=\
 	$(PKG_BUILD_DIR)/morse_cli
-  PROVIDES:=morsectrl
 endef
 
 MAKE_FLAGS += \

--- a/feeds/morse/utils/morsectrl/Makefile
+++ b/feeds/morse/utils/morsectrl/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright 2023 Morse Micro
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=morsectrl
+PKG_RELEASE:=1
+PKG_VERSION:=1.12.4
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=
+
+PKG_MAINTAINER:=Morse Micro <info@morsemicro.com>
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/morsectrl
+  SECTION:=utils
+  CATEGORY:=Network
+  TITLE:=Morse Micro WIFI HaLow chip control tool
+  DEPENDS:= +kmod-morse +libnl
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+endef
+
+MAKE_FLAGS += \
+    MORSECTRL_VERSION_STRING=$(PKG_VERSION) \
+    CONFIG_MORSE_TRANS_NL80211=1 \
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/libnl3 -Wno-error=maybe-uninitialized
+
+define Package/morsectrl/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/morsectrl $(1)/sbin/
+endef
+
+$(eval $(call BuildPackage,morsectrl))

--- a/feeds/morse/utils/morsectrl/src/Makefile
+++ b/feeds/morse/utils/morsectrl/src/Makefile
@@ -1,0 +1,178 @@
+#
+# Copyright 2020-2023 Morse Micro
+#
+
+# Note: this will default to hiding away the command lines of executed commands to make
+#       the console output easier to read.
+#       This can be disabled by overriding V to a value other than 0.
+V ?= 0
+
+ifeq ($(V),0)
+Q = @
+endif
+
+
+override MORSECTRL_VERSION_STRING = "rel_1_12_4_2024_Jun_11"
+DEFAULT_INTERFACE_NAME ?= "wlan0"
+
+MORSECTRL_CFLAGS = $(CFLAGS)
+MORSECTRL_CFLAGS += -Wall -Werror
+MORSECTRL_CFLAGS += -DMORSECTRL_VERSION_STRING="\"$(MORSECTRL_VERSION_STRING)\""
+MORSECTRL_CFLAGS += -DDEFAULT_INTERFACE_NAME="\"$(DEFAULT_INTERFACE_NAME)\""
+MORSECTRL_LDFLAGS = $(LDFLAGS)
+
+DEPS := $(wildcard *.h)
+DEPS += $(wildcard */*.h)
+
+SRCS := morsectrl.c
+SRCS += config_file.c
+SRCS += elf_file.c
+SRCS += offchip_statistics.c
+SRCS += command.c
+SRCS += version.c
+SRCS += hw_version.c
+SRCS += stats.c
+SRCS += channel.c
+SRCS += bsscolor.c
+SRCS += utilities.c
+SRCS += ampdu.c
+SRCS += raw.c
+SRCS += health.c
+SRCS += cts_self_ps.c
+SRCS += long_sleep.c
+SRCS += duty_cycle.c
+SRCS += stats_format_regular.c
+SRCS += stats_format_json.c
+SRCS += coredump.c
+SRCS += opclass.c
+SRCS += tx_pkt_lifetime_us.c
+SRCS += maxampdulen.c
+SRCS += macaddr.c
+SRCS += reset.c
+SRCS += wakeaction.c
+SRCS += standby.c
+SRCS += mpsw.c
+SRCS += dhcpc.c
+SRCS += keep_alive.c
+SRCS += tcp_keepalive.c
+SRCS += vendor_ie.c
+SRCS += twt.c
+SRCS += cac.c
+SRCS += ecsa.c
+SRCS += mbssid.c
+SRCS += mesh_config.c
+SRCS += mbca.c
+SRCS += params.c
+SRCS += uapsd.c
+SRCS += dynamic_peering.c
+SRCS += li.c
+SRCS += whitelist.c
+SRCS += arp_periodic_refresh.c
+SRCS += otp.c
+
+SRCS += transport/transport.c
+
+LIB_SRCS += argtable3/argtable3.c
+
+WIN_LIB_SRCS += win/strsep.c
+LINUX_SRCS += gpioctrl.c
+
+LINUX_LDFLAGS += -lm
+ifeq ($(CONFIG_MORSE_STATIC),1)
+	MORSECTRL_LDFLAGS += -static
+endif
+
+WIN_LDFLAGS += -lws2_32
+
+ifeq ($(CONFIG_MORSE_TRANS_NL80211),1)
+	ifeq ($(CFLAGS),)
+		LINUX_CFLAGS += -I${SYSROOT}/usr/include/libnl3
+	endif
+
+	LINUX_LDFLAGS += -lnl-3 -lnl-genl-3 -lpthread
+	LINUX_CFLAGS += -DENABLE_TRANS_NL80211
+	LINUX_SRCS += transport/nl80211.c
+endif
+
+ifeq ($(CONFIG_MORSE_TRANS_UART_SLIP),1)
+	SRCS += transport/slip.c
+	SRCS += transport/uart_slip.c
+	LINUX_SRCS += transport/uart_linux.c
+	WIN_SRCS += transport/uart_win.c
+endif
+
+ifeq ($(CONFIG_MORSE_TRANS_FTDI_SPI),1)
+	SRCS += transport/ftdi_spi.c
+	SRCS += transport/sdio_over_spi.c
+	LIB_SRCS += transport/libmpsse/source/ftdi_i2c.c
+	LIB_SRCS += transport/libmpsse/source/ftdi_infra.c
+	LIB_SRCS += transport/libmpsse/source/ftdi_mid.c
+	LIB_SRCS += transport/libmpsse/source/ftdi_spi.c
+	LIB_SRCS += transport/libmpsse/source/memcpy.c
+
+	MAJOR_VERSION = 1
+	MINOR_VERSION = 0
+	BUILD_VERSION = 3
+	MORSECTRL_CFLAGS += -DFTDIMPSSE_STATIC
+	MORSECTRL_CFLAGS += -DENABLE_TRANS_FTDI_SPI
+	MORSECTRL_CFLAGS += -DFT_VER_MAJOR=$(MAJOR_VERSION)
+	MORSECTRL_CFLAGS += -DFT_VER_MINOR=$(MINOR_VERSION)
+	MORSECTRL_CFLAGS += -DFT_VER_BUILD=$(BUILD_VERSION)
+	MORSECTRL_CFLAGS += -Itransport/libmpsse/include
+	MORSECTRL_CFLAGS += -Itransport/libmpsse/libftd2xx
+	MORSECTRL_CFLAGS += -Itransport/libmpsse/source
+	MORSECTRL_LDFLAGS += -Wl,--wrap=memcpy
+
+	LINUX_CFLAGS += -D_GNU_SOURCE
+	LINUX_LDFLAGS += -lpthread -lrt -ldl
+endif
+
+
+MORSE_CLI_CFLAGS = $(MORSECTRL_CFLAGS)
+MORSE_CLI_LDFLAGS = $(MORSECTRL_LDFLAGS)
+
+MORSE_CLI_CFLAGS += -DMORSE_CLIENT
+
+# Set Windows Vista as the minimum supported windows version
+WIN_CFLAGS += -DMORSE_WIN_BUILD -D__USE_MINGW_ANSI_STDIO -D_WIN32_WINNT=0x0600
+WIN_CC ?= x86_64-w64-mingw32-gcc
+
+SRCS += $(LIB_SRCS)
+WIN_SRCS += $(WIN_LIB_SRCS)
+LINUX_SRCS += $(LINUX_LIB_SRCS)
+
+all: morse_cli
+
+clean:
+	rm -rf morsectrl morse_cli *.exe output
+	find . -iname '*.o' -exec rm {} \;
+
+include morsectrl.mk
+
+# As noted in transport.c, the default transport is the first transport linked. Therefore we
+# put LINUX_SRCS before SRCS so that nl80211 has higher priority.
+CLIENT_OBJS = $(patsubst %.c, %_cli.o, $(LINUX_SRCS) $(SRCS))
+CLIENT_OBJS_WIN = $(patsubst %.c, %_cli_win.o, $(SRCS) $(WIN_SRCS))
+
+%_cli.o: %.c $(DEPS)
+	@echo Compiling $<
+	$(Q) $(CC) $(MORSE_CLI_CFLAGS) $(LINUX_CFLAGS) -c -o $@ $<
+
+morse_cli: $(CLIENT_OBJS)
+	@echo Linking $@
+	$(Q) $(CC) $(MORSE_CLI_CFLAGS) $(LINUX_CFLAGS) -o $@ $^ \
+		$(MORSE_CLI_LDFLAGS) $(LINUX_LDFLAGS)
+
+
+%_cli_win.o: %.c $(DEPS)
+	@echo Compiling $<
+	$(Q) $(WIN_CC) $(MORSE_CLI_CFLAGS) $(WIN_CFLAGS) -c -o $@ $<
+
+morse_cli_win: $(CLIENT_OBJS_WIN)
+	@echo Linking $@
+	$(Q) $(WIN_CC) $(MORSE_CLI_CFLAGS) $(WIN_CFLAGS) -o morse_cli $^ \
+		$(MORSE_CLI_LDFLAGS) $(WIN_LDFLAGS)
+
+install_cli:
+	@echo Installing morse_cli to /usr/bin
+	$(Q) cp morse_cli /usr/bin

--- a/feeds/morse/utils/morsectrl/src/README
+++ b/feeds/morse/utils/morsectrl/src/README
@@ -1,0 +1,7 @@
+this tool was built for buildroot auto-grab 
+
+if you want to manually install make sure you have libnl 3 or run
+    $ sudo apt install libnl-3-dev libnl-genl-3-dev 
+then
+    - make all
+    - make install

--- a/feeds/morse/utils/morsectrl/src/agc_gaincode.c
+++ b/feeds/morse/utils/morsectrl/src/agc_gaincode.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "command.h"
+#include "utilities.h"
+
+#define GAINCODE_MIN 0
+#define GAINCODE_MAX 20
+
+struct PACKED command_set_agc_gaincode
+{
+    /* set gain code */
+    uint32_t agc_gain_code;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tset_agc_gaincode [auto | <value>]\n");
+    mctrl_print("\t\tset gain code for testing (value)\n");
+    mctrl_print("\t\tuse 'auto' to enable AGC\n");
+    mctrl_print("\t\tuse 'mask_rssi3' to mask agc rssi counter 3\n");
+}
+
+int set_agc_gaincode(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t gain_code;
+    struct command_set_agc_gaincode *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    if (!strcmp(argv[1], "auto"))
+    {
+       gain_code = UINT8_MAX;
+    }
+    else if (!strcmp(argv[1], "mask_rssi3"))
+    {
+        gain_code = UINT8_MAX - 1;
+    }
+    else if (str_to_uint32_range(argv[1], &gain_code, GAINCODE_MIN, GAINCODE_MAX))
+    {
+        mctrl_err("Invalid gain code value '%s', expected range [%d, %d]\n",
+                argv[1], GAINCODE_MIN, GAINCODE_MAX);
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_agc_gaincode);
+    cmd->agc_gain_code = gain_code;
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_AGC_GAIN_CODE,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set agc gain code \n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(set_agc_gaincode, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/ampdu.c
+++ b/feeds/morse/utils/morsectrl/src/ampdu.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+
+struct PACKED set_ampdu_command
+{
+    uint8_t ampdu_enabled;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tampdu [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' will enable AMPDU sessions. Must be run before association.\n");
+    mctrl_print("\t\t\t\t'disable' will disable AMPDU sessions. Must be run before association.\n");
+}
+
+int ampdu(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enabled;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    struct set_ampdu_command *cmd;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_ampdu_command);
+    cmd->ampdu_enabled = 0;
+
+    enabled = expression_to_int(argv[1]);
+
+    if (enabled == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->ampdu_enabled = enabled;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_AMPDU,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set AMPDU mode\n");
+    }
+    else
+    {
+        mctrl_print("\tAMPDU Mode: %s\n",
+            (cmd->ampdu_enabled) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(ampdu, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/antenna.c
+++ b/feeds/morse/utils/morsectrl/src/antenna.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_antenna_command
+{
+    /** \ref enum fem_antenna */
+    uint32_t tx_antenna;
+    /** \ref enum fem_antenna */
+    uint32_t rx_antenna;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tantenna <tx_antenna> <rx_antenna>\n");
+    mctrl_print("\t\t1-2\t\tTX antenna select\n");
+    mctrl_print("\t\t1-2\t\tRX antenna select\n");
+}
+
+int antenna(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t tx_antenna, rx_antenna;
+    struct set_antenna_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 3)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    if (str_to_uint32_range(argv[1], &tx_antenna, 1, 2))
+    {
+        mctrl_err("Invalid tx antenna, must be 1 (antenna 1), 2 (antenna 2)\n");
+        return -1;
+    }
+
+    if (str_to_uint32_range(argv[2], &rx_antenna, 1, 2))
+    {
+        mctrl_err("Invalid rx antenna, must be  1 (antenna 1), 2 (antenna 2)\n");
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_antenna_command);
+    cmd->tx_antenna = htole32(tx_antenna);
+    cmd->rx_antenna = htole32(rx_antenna);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_ANTENNA,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set antenna\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(antenna, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/argtable3/argtable3.c
+++ b/feeds/morse/utils/morsectrl/src/argtable3/argtable3.c
@@ -1,0 +1,6350 @@
+/*******************************************************************************
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#define ARG_AMALGAMATION
+
+/*******************************************************************************
+ * argtable3_private: Declares private types, constants, and interfaces
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 2013-2019 Tom G. Huang
+ * <tomghuang@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#ifndef ARG_UTILS_H
+#define ARG_UTILS_H
+
+#include <stdlib.h>
+
+#ifndef ARG_ENABLE_TRACE
+#define ARG_ENABLE_TRACE 0
+#endif /* ARG_ENABLE_TRACE */
+
+#ifndef ARG_ENABLE_LOG
+#define ARG_ENABLE_LOG 1
+#endif /* ARG_ENABLE_LOG */
+
+/* Use the embedded getopt as the system getopt(3) */
+#ifndef ARG_REPLACE_GETOPT
+#define ARG_REPLACE_GETOPT 1
+#endif /* ARG_REPLACE_GETOPT */
+
+/* Size of the buffer pre-allocated for dynamic strings.
+ * If the length exceeds this size, the buffer will be dynamically allocated.
+ */
+#ifndef ARG_DSTR_SIZE
+#define ARG_DSTR_SIZE 200
+#endif /* ARG_DSTR_SIZE */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    ARG_ERR_MINCOUNT = 1,
+    ARG_ERR_MAXCOUNT,
+    ARG_ERR_BADINT,
+    ARG_ERR_OVERFLOW,
+    ARG_ERR_BADDOUBLE,
+    ARG_ERR_BADDATE,
+    ARG_ERR_REGNOMATCH,
+    ARG_ERR_NOTENOUGH,
+    ARG_ERR_TOOMANY
+};
+
+typedef void(arg_panicfn)(const char* fmt, ...);
+
+#if defined(_MSC_VER)
+#define ARG_TRACE(x)                                               \
+    __pragma(warning(push)) __pragma(warning(disable : 4127)) do { \
+        if (ARG_ENABLE_TRACE)                                      \
+            dbg_printf x;                                          \
+    }                                                              \
+    while (0)                                                      \
+    __pragma(warning(pop))
+
+#define ARG_LOG(x)                                                 \
+    __pragma(warning(push)) __pragma(warning(disable : 4127)) do { \
+        if (ARG_ENABLE_LOG)                                        \
+            dbg_printf x;                                          \
+    }                                                              \
+    while (0)                                                      \
+    __pragma(warning(pop))
+#else
+#define ARG_TRACE(x)          \
+    do {                      \
+        if (ARG_ENABLE_TRACE) \
+            dbg_printf x;     \
+    } while (0)
+
+#define ARG_LOG(x)          \
+    do {                    \
+        if (ARG_ENABLE_LOG) \
+            dbg_printf x;   \
+    } while (0)
+#endif
+
+/*
+ * Rename a few generic names to unique names.
+ * They can be a problem for the platforms like NuttX, where
+ * the namespace is flat for everything including apps and libraries.
+ */
+#define	xmalloc argtable3_xmalloc
+#define	xcalloc argtable3_xcalloc
+#define	xrealloc argtable3_xrealloc
+#define	xfree argtable3_xfree
+
+extern void dbg_printf(const char* fmt, ...);
+extern void arg_set_panic(arg_panicfn* proc);
+extern void* xmalloc(size_t size);
+extern void* xcalloc(size_t count, size_t size);
+extern void* xrealloc(void* ptr, size_t size);
+extern void xfree(void* ptr);
+extern long int strtol0X(const char* str, const char** endptr, char X, int base);
+
+struct arg_hashtable_entry {
+    void *k, *v;
+    unsigned int h;
+    struct arg_hashtable_entry* next;
+};
+
+typedef struct arg_hashtable {
+    unsigned int tablelength;
+    struct arg_hashtable_entry** table;
+    unsigned int entrycount;
+    unsigned int loadlimit;
+    unsigned int primeindex;
+    unsigned int (*hashfn)(const void* k);
+    int (*eqfn)(const void* k1, const void* k2);
+} arg_hashtable_t;
+
+/**
+ * @brief Create a hash table.
+ *
+ * @param   minsize   minimum initial size of hash table
+ * @param   hashfn    function for hashing keys
+ * @param   eqfn      function for determining key equality
+ * @return            newly created hash table or NULL on failure
+ */
+arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*));
+
+/**
+ * @brief This function will cause the table to expand if the insertion would take
+ * the ratio of entries to table size over the maximum load factor.
+ *
+ * This function does not check for repeated insertions with a duplicate key.
+ * The value returned when using a duplicate key is undefined -- when
+ * the hash table changes size, the order of retrieval of duplicate key
+ * entries is reversed.
+ * If in doubt, remove before insert.
+ *
+ * @param   h   the hash table to insert into
+ * @param   k   the key - hash table claims ownership and will free on removal
+ * @param   v   the value - does not claim ownership
+ * @return      non-zero for successful insertion
+ */
+void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v);
+
+#define ARG_DEFINE_HASHTABLE_INSERT(fnname, keytype, valuetype) \
+    int fnname(arg_hashtable_t* h, keytype* k, valuetype* v) { return arg_hashtable_insert(h, k, v); }
+
+/**
+ * @brief Search the specified key in the hash table.
+ *
+ * @param   h   the hash table to search
+ * @param   k   the key to search for  - does not claim ownership
+ * @return      the value associated with the key, or NULL if none found
+ */
+void* arg_hashtable_search(arg_hashtable_t* h, const void* k);
+
+#define ARG_DEFINE_HASHTABLE_SEARCH(fnname, keytype, valuetype) \
+    valuetype* fnname(arg_hashtable_t* h, keytype* k) { return (valuetype*)(arg_hashtable_search(h, k)); }
+
+/**
+ * @brief Remove the specified key from the hash table.
+ *
+ * @param   h   the hash table to remove the item from
+ * @param   k   the key to search for  - does not claim ownership
+ */
+void arg_hashtable_remove(arg_hashtable_t* h, const void* k);
+
+#define ARG_DEFINE_HASHTABLE_REMOVE(fnname, keytype, valuetype) \
+    void fnname(arg_hashtable_t* h, keytype* k) { arg_hashtable_remove(h, k); }
+
+/**
+ * @brief Return the number of keys in the hash table.
+ *
+ * @param   h   the hash table
+ * @return      the number of items stored in the hash table
+ */
+unsigned int arg_hashtable_count(arg_hashtable_t* h);
+
+/**
+ * @brief Change the value associated with the key.
+ *
+ * function to change the value associated with a key, where there already
+ * exists a value bound to the key in the hash table.
+ * Source due to Holger Schemel.
+ *
+ * @name        hashtable_change
+ * @param   h   the hash table
+ * @param       key
+ * @param       value
+ */
+int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v);
+
+/**
+ * @brief Free the hash table and the memory allocated for each key-value pair.
+ *
+ * @param   h            the hash table
+ * @param   free_values  whether to call 'free' on the remaining values
+ */
+void arg_hashtable_destroy(arg_hashtable_t* h, int free_values);
+
+typedef struct arg_hashtable_itr {
+    arg_hashtable_t* h;
+    struct arg_hashtable_entry* e;
+    struct arg_hashtable_entry* parent;
+    unsigned int index;
+} arg_hashtable_itr_t;
+
+arg_hashtable_itr_t* arg_hashtable_itr_create(arg_hashtable_t* h);
+
+void arg_hashtable_itr_destroy(arg_hashtable_itr_t* itr);
+
+/**
+ * @brief Return the value of the (key,value) pair at the current position.
+ */
+extern void* arg_hashtable_itr_key(arg_hashtable_itr_t* i);
+
+/**
+ * @brief Return the value of the (key,value) pair at the current position.
+ */
+extern void* arg_hashtable_itr_value(arg_hashtable_itr_t* i);
+
+/**
+ * @brief Advance the iterator to the next element. Returns zero if advanced to end of table.
+ */
+int arg_hashtable_itr_advance(arg_hashtable_itr_t* itr);
+
+/**
+ * @brief Remove current element and advance the iterator to the next element.
+ */
+int arg_hashtable_itr_remove(arg_hashtable_itr_t* itr);
+
+/**
+ * @brief Search and overwrite the supplied iterator, to point to the entry matching the supplied key.
+ *
+ * @return  Zero if not found.
+ */
+int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void* k);
+
+#define ARG_DEFINE_HASHTABLE_ITERATOR_SEARCH(fnname, keytype) \
+    int fnname(arg_hashtable_itr_t* i, arg_hashtable_t* h, keytype* k) { return (arg_hashtable_iterator_search(i, h, k)); }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+/*******************************************************************************
+ * arg_utils: Implements memory, panic, and other utility functions
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 2013-2019 Tom G. Huang
+ * <tomghuang@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void panic(const char* fmt, ...);
+static arg_panicfn* s_panic = panic;
+
+void dbg_printf(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+}
+
+static void panic(const char* fmt, ...) {
+    va_list args;
+    char* s;
+
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+    s = getenv("EF_DUMPCORE");
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+    if (s != NULL && *s != '\0') {
+        abort();
+    } else {
+        exit(EXIT_FAILURE);
+    }
+}
+
+void arg_set_panic(arg_panicfn* proc) {
+    s_panic = proc;
+}
+
+void* xmalloc(size_t size) {
+    void* ret = malloc(size);
+    if (!ret) {
+        s_panic("Out of memory!\n");
+    }
+    return ret;
+}
+
+void* xcalloc(size_t count, size_t size) {
+    size_t allocated_count = count && size ? count : 1;
+    size_t allocated_size = count && size ? size : 1;
+    void* ret = calloc(allocated_count, allocated_size);
+    if (!ret) {
+        s_panic("Out of memory!\n");
+    }
+    return ret;
+}
+
+void* xrealloc(void* ptr, size_t size) {
+    size_t allocated_size = size ? size : 1;
+    void* ret = realloc(ptr, allocated_size);
+    if (!ret) {
+        s_panic("Out of memory!\n");
+    }
+    return ret;
+}
+
+void xfree(void* ptr) {
+    free(ptr);
+}
+
+static void merge(void* data, int esize, int i, int j, int k, arg_comparefn* comparefn) {
+    char* a = (char*)data;
+    char* m;
+    int ipos, jpos, mpos;
+
+    /* Initialize the counters used in merging. */
+    ipos = i;
+    jpos = j + 1;
+    mpos = 0;
+
+    /* Allocate storage for the merged elements. */
+    m = (char*)xmalloc((size_t)(esize * ((k - i) + 1)));
+
+    /* Continue while either division has elements to merge. */
+    while (ipos <= j || jpos <= k) {
+        if (ipos > j) {
+            /* The left division has no more elements to merge. */
+            while (jpos <= k) {
+                memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
+                jpos++;
+                mpos++;
+            }
+
+            continue;
+        } else if (jpos > k) {
+            /* The right division has no more elements to merge. */
+            while (ipos <= j) {
+                memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
+                ipos++;
+                mpos++;
+            }
+
+            continue;
+        }
+
+        /* Append the next ordered element to the merged elements. */
+        if (comparefn(&a[ipos * esize], &a[jpos * esize]) < 0) {
+            memcpy(&m[mpos * esize], &a[ipos * esize], (size_t)esize);
+            ipos++;
+            mpos++;
+        } else {
+            memcpy(&m[mpos * esize], &a[jpos * esize], (size_t)esize);
+            jpos++;
+            mpos++;
+        }
+    }
+
+    /* Prepare to pass back the merged data. */
+    memcpy(&a[i * esize], m, (size_t)(esize * ((k - i) + 1)));
+    xfree(m);
+}
+
+void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* comparefn) {
+    int j;
+
+    /* Stop the recursion when no more divisions can be made. */
+    if (i < k) {
+        /* Determine where to divide the elements. */
+        j = (int)(((i + k - 1)) / 2);
+
+        /* Recursively sort the two divisions. */
+        arg_mgsort(data, size, esize, i, j, comparefn);
+        arg_mgsort(data, size, esize, j + 1, k, comparefn);
+        merge(data, esize, i, j, k, comparefn);
+    }
+}
+
+/* strtol0x() is like strtol() except that the numeric string is    */
+/* expected to be prefixed by "0X" where X is a user supplied char. */
+/* The string may optionally be prefixed by white space and + or -  */
+/* as in +0X123 or -0X123.                                          */
+/* Once the prefix has been scanned, the remainder of the numeric   */
+/* string is converted using strtol() with the given base.          */
+/* eg: to parse hex str="-0X12324", specify X='X' and base=16.      */
+/* eg: to parse oct str="+0o12324", specify X='O' and base=8.       */
+/* eg: to parse bin str="-0B01010", specify X='B' and base=2.       */
+/* Failure of conversion is indicated by result where *endptr==str. */
+long int strtol0X(const char* str, const char** endptr, char X, int base) {
+    long int val;          /* stores result */
+    int s = 1;             /* sign is +1 or -1 */
+    const char* ptr = str; /* ptr to current position in str */
+
+    /* skip leading whitespace */
+    while (isspace((int)(*ptr)))
+        ptr++;
+    /* printf("1) %s\n",ptr); */
+
+    /* scan optional sign character */
+    switch (*ptr) {
+        case '+':
+            ptr++;
+            s = 1;
+            break;
+        case '-':
+            ptr++;
+            s = -1;
+            break;
+        default:
+            s = 1;
+            break;
+    }
+    /* printf("2) %s\n",ptr); */
+
+    /* '0X' prefix */
+    if ((*ptr++) != '0') {
+        /* printf("failed to detect '0'\n"); */
+        *endptr = str;
+        return 0;
+    }
+    /* printf("3) %s\n",ptr); */
+    if (toupper(*ptr++) != toupper(X)) {
+        /* printf("failed to detect '%c'\n",X); */
+        *endptr = str;
+        return 0;
+    }
+    /* printf("4) %s\n",ptr); */
+
+    /* attempt conversion on remainder of string using strtol() */
+    val = strtol(ptr, (char**)endptr, base);
+    if (*endptr == ptr) {
+        /* conversion failed */
+        *endptr = str;
+        return 0;
+    }
+
+    /* success */
+    return s * val;
+}
+/*******************************************************************************
+ * arg_hashtable: Implements the hash table utilities
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 2013-2019 Tom G. Huang
+ * <tomghuang@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * This hash table module is adapted from the C hash table implementation by
+ * Christopher Clark. Here is the copyright notice from the library:
+ *
+ * Copyright (c) 2002, Christopher Clark
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the original author; nor the names of any contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Credit for primes table: Aaron Krowne
+ * http://br.endernet.org/~akrowne/
+ * http://planetmath.org/encyclopedia/GoodHashTablePrimes.html
+ */
+static const unsigned int primes[] = {53,       97,       193,      389,       769,       1543,      3079,      6151,      12289,
+                                      24593,    49157,    98317,    196613,    393241,    786433,    1572869,   3145739,   6291469,
+                                      12582917, 25165843, 50331653, 100663319, 201326611, 402653189, 805306457, 1610612741};
+const unsigned int prime_table_length = sizeof(primes) / sizeof(primes[0]);
+const float max_load_factor = (float)0.65;
+
+static unsigned int enhanced_hash(arg_hashtable_t* h, const void* k) {
+    /*
+     * Aim to protect against poor hash functions by adding logic here.
+     * The logic is taken from Java 1.4 hash table source.
+     */
+    unsigned int i = h->hashfn(k);
+    i += ~(i << 9);
+    i ^= ((i >> 14) | (i << 18)); /* >>> */
+    i += (i << 4);
+    i ^= ((i >> 10) | (i << 22)); /* >>> */
+    return i;
+}
+
+static unsigned int index_for(unsigned int tablelength, unsigned int hashvalue) {
+    return (hashvalue % tablelength);
+}
+
+arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*)) {
+    arg_hashtable_t* h;
+    unsigned int pindex;
+    unsigned int size = primes[0];
+
+    /* Check requested hash table isn't too large */
+    if (minsize > (1u << 30))
+        return NULL;
+
+    /*
+     * Enforce size as prime. The reason is to avoid clustering of values
+     * into a small number of buckets (yes, distribution). A more even
+     *  distributed hash table will perform more consistently.
+     */
+    for (pindex = 0; pindex < prime_table_length; pindex++) {
+        if (primes[pindex] > minsize) {
+            size = primes[pindex];
+            break;
+        }
+    }
+
+    h = (arg_hashtable_t*)xmalloc(sizeof(arg_hashtable_t));
+    h->table = (struct arg_hashtable_entry**)xmalloc(sizeof(struct arg_hashtable_entry*) * size);
+    memset(h->table, 0, size * sizeof(struct arg_hashtable_entry*));
+    h->tablelength = size;
+    h->primeindex = pindex;
+    h->entrycount = 0;
+    h->hashfn = hashfn;
+    h->eqfn = eqfn;
+    h->loadlimit = (unsigned int)ceil(size * (double)max_load_factor);
+    return h;
+}
+
+static int arg_hashtable_expand(arg_hashtable_t* h) {
+    /* Double the size of the table to accommodate more entries */
+    struct arg_hashtable_entry** newtable;
+    struct arg_hashtable_entry* e;
+    unsigned int newsize;
+    unsigned int i;
+    unsigned int index;
+
+    /* Check we're not hitting max capacity */
+    if (h->primeindex == (prime_table_length - 1))
+        return 0;
+    newsize = primes[++(h->primeindex)];
+
+    newtable = (struct arg_hashtable_entry**)xmalloc(sizeof(struct arg_hashtable_entry*) * newsize);
+    memset(newtable, 0, newsize * sizeof(struct arg_hashtable_entry*));
+    /*
+     * This algorithm is not 'stable': it reverses the list
+     * when it transfers entries between the tables
+     */
+    for (i = 0; i < h->tablelength; i++) {
+        while (NULL != (e = h->table[i])) {
+            h->table[i] = e->next;
+            index = index_for(newsize, e->h);
+            e->next = newtable[index];
+            newtable[index] = e;
+        }
+    }
+
+    xfree(h->table);
+    h->table = newtable;
+    h->tablelength = newsize;
+    h->loadlimit = (unsigned int)ceil(newsize * (double)max_load_factor);
+    return -1;
+}
+
+unsigned int arg_hashtable_count(arg_hashtable_t* h) {
+    return h->entrycount;
+}
+
+void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v) {
+    /* This method allows duplicate keys - but they shouldn't be used */
+    unsigned int index;
+    struct arg_hashtable_entry* e;
+    if ((h->entrycount + 1) > h->loadlimit) {
+        /*
+         * Ignore the return value. If expand fails, we should
+         * still try cramming just this value into the existing table
+         * -- we may not have memory for a larger table, but one more
+         * element may be ok. Next time we insert, we'll try expanding again.
+         */
+        arg_hashtable_expand(h);
+    }
+    e = (struct arg_hashtable_entry*)xmalloc(sizeof(struct arg_hashtable_entry));
+    e->h = enhanced_hash(h, k);
+    index = index_for(h->tablelength, e->h);
+    e->k = k;
+    e->v = v;
+    e->next = h->table[index];
+    h->table[index] = e;
+    h->entrycount++;
+}
+
+void* arg_hashtable_search(arg_hashtable_t* h, const void* k) {
+    struct arg_hashtable_entry* e;
+    unsigned int hashvalue;
+    unsigned int index;
+
+    hashvalue = enhanced_hash(h, k);
+    index = index_for(h->tablelength, hashvalue);
+    e = h->table[index];
+    while (e != NULL) {
+        /* Check hash value to short circuit heavier comparison */
+        if ((hashvalue == e->h) && (h->eqfn(k, e->k)))
+            return e->v;
+        e = e->next;
+    }
+    return NULL;
+}
+
+void arg_hashtable_remove(arg_hashtable_t* h, const void* k) {
+    /*
+     * TODO: consider compacting the table when the load factor drops enough,
+     *       or provide a 'compact' method.
+     */
+
+    struct arg_hashtable_entry* e;
+    struct arg_hashtable_entry** pE;
+    unsigned int hashvalue;
+    unsigned int index;
+
+    hashvalue = enhanced_hash(h, k);
+    index = index_for(h->tablelength, hashvalue);
+    pE = &(h->table[index]);
+    e = *pE;
+    while (NULL != e) {
+        /* Check hash value to short circuit heavier comparison */
+        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+            *pE = e->next;
+            h->entrycount--;
+            xfree(e->k);
+            xfree(e->v);
+            xfree(e);
+            return;
+        }
+        pE = &(e->next);
+        e = e->next;
+    }
+}
+
+void arg_hashtable_destroy(arg_hashtable_t* h, int free_values) {
+    unsigned int i;
+    struct arg_hashtable_entry *e, *f;
+    struct arg_hashtable_entry** table = h->table;
+    if (free_values) {
+        for (i = 0; i < h->tablelength; i++) {
+            e = table[i];
+            while (NULL != e) {
+                f = e;
+                e = e->next;
+                xfree(f->k);
+                xfree(f->v);
+                xfree(f);
+            }
+        }
+    } else {
+        for (i = 0; i < h->tablelength; i++) {
+            e = table[i];
+            while (NULL != e) {
+                f = e;
+                e = e->next;
+                xfree(f->k);
+                xfree(f);
+            }
+        }
+    }
+    xfree(h->table);
+    xfree(h);
+}
+
+arg_hashtable_itr_t* arg_hashtable_itr_create(arg_hashtable_t* h) {
+    unsigned int i;
+    unsigned int tablelength;
+
+    arg_hashtable_itr_t* itr = (arg_hashtable_itr_t*)xmalloc(sizeof(arg_hashtable_itr_t));
+    itr->h = h;
+    itr->e = NULL;
+    itr->parent = NULL;
+    tablelength = h->tablelength;
+    itr->index = tablelength;
+    if (0 == h->entrycount)
+        return itr;
+
+    for (i = 0; i < tablelength; i++) {
+        if (h->table[i] != NULL) {
+            itr->e = h->table[i];
+            itr->index = i;
+            break;
+        }
+    }
+    return itr;
+}
+
+void arg_hashtable_itr_destroy(arg_hashtable_itr_t* itr) {
+    xfree(itr);
+}
+
+void* arg_hashtable_itr_key(arg_hashtable_itr_t* i) {
+    return i->e->k;
+}
+
+void* arg_hashtable_itr_value(arg_hashtable_itr_t* i) {
+    return i->e->v;
+}
+
+int arg_hashtable_itr_advance(arg_hashtable_itr_t* itr) {
+    unsigned int j;
+    unsigned int tablelength;
+    struct arg_hashtable_entry** table;
+    struct arg_hashtable_entry* next;
+
+    if (itr->e == NULL)
+        return 0; /* stupidity check */
+
+    next = itr->e->next;
+    if (NULL != next) {
+        itr->parent = itr->e;
+        itr->e = next;
+        return -1;
+    }
+
+    tablelength = itr->h->tablelength;
+    itr->parent = NULL;
+    if (tablelength <= (j = ++(itr->index))) {
+        itr->e = NULL;
+        return 0;
+    }
+
+    table = itr->h->table;
+    while (NULL == (next = table[j])) {
+        if (++j >= tablelength) {
+            itr->index = tablelength;
+            itr->e = NULL;
+            return 0;
+        }
+    }
+
+    itr->index = j;
+    itr->e = next;
+    return -1;
+}
+
+int arg_hashtable_itr_remove(arg_hashtable_itr_t* itr) {
+    struct arg_hashtable_entry* remember_e;
+    struct arg_hashtable_entry* remember_parent;
+    int ret;
+
+    /* Do the removal */
+    if ((itr->parent) == NULL) {
+        /* element is head of a chain */
+        itr->h->table[itr->index] = itr->e->next;
+    } else {
+        /* element is mid-chain */
+        itr->parent->next = itr->e->next;
+    }
+    /* itr->e is now outside the hashtable */
+    remember_e = itr->e;
+    itr->h->entrycount--;
+    xfree(remember_e->k);
+    xfree(remember_e->v);
+
+    /* Advance the iterator, correcting the parent */
+    remember_parent = itr->parent;
+    ret = arg_hashtable_itr_advance(itr);
+    if (itr->parent == remember_e) {
+        itr->parent = remember_parent;
+    }
+    xfree(remember_e);
+    return ret;
+}
+
+int arg_hashtable_itr_search(arg_hashtable_itr_t* itr, arg_hashtable_t* h, void* k) {
+    struct arg_hashtable_entry* e;
+    struct arg_hashtable_entry* parent;
+    unsigned int hashvalue;
+    unsigned int index;
+
+    hashvalue = enhanced_hash(h, k);
+    index = index_for(h->tablelength, hashvalue);
+
+    e = h->table[index];
+    parent = NULL;
+    while (e != NULL) {
+        /* Check hash value to short circuit heavier comparison */
+        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+            itr->index = index;
+            itr->e = e;
+            itr->parent = parent;
+            itr->h = h;
+            return -1;
+        }
+        parent = e;
+        e = e->next;
+    }
+    return 0;
+}
+
+int arg_hashtable_change(arg_hashtable_t* h, void* k, void* v) {
+    struct arg_hashtable_entry* e;
+    unsigned int hashvalue;
+    unsigned int index;
+
+    hashvalue = enhanced_hash(h, k);
+    index = index_for(h->tablelength, hashvalue);
+    e = h->table[index];
+    while (e != NULL) {
+        /* Check hash value to short circuit heavier comparison */
+        if ((hashvalue == e->h) && (h->eqfn(k, e->k))) {
+            xfree(e->v);
+            e->v = v;
+            return -1;
+        }
+        e = e->next;
+    }
+    return 0;
+}
+/*******************************************************************************
+ * arg_dstr: Implements the dynamic string utilities
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 2013-2019 Tom G. Huang
+ * <tomghuang@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+#define START_VSNBUFF 16
+
+/*
+ * This dynamic string module is adapted from TclResult.c in the Tcl library.
+ * Here is the copyright notice from the library:
+ *
+ * This software is copyrighted by the Regents of the University of
+ * California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
+ * Corporation and other parties.  The following terms apply to all files
+ * associated with the software unless explicitly disclaimed in
+ * individual files.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions. No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+ * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ * ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+ * DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+ * IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+ * NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ * MODIFICATIONS.
+ *
+ * GOVERNMENT USE: If you are acquiring this software on behalf of the
+ * U.S. government, the Government shall have only "Restricted Rights"
+ * in the software and related documentation as defined in the Federal
+ * Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
+ * are acquiring the software on behalf of the Department of Defense, the
+ * software shall be classified as "Commercial Computer Software" and the
+ * Government shall have only "Restricted Rights" as defined in Clause
+ * 252.227-7014 (b) (3) of DFARs.  Notwithstanding the foregoing, the
+ * authors grant the U.S. Government and others acting in its behalf
+ * permission to use and distribute the software in accordance with the
+ * terms specified in this license.
+ */
+
+typedef struct _internal_arg_dstr {
+    char* data;
+    arg_dstr_freefn* free_proc;
+    char sbuf[ARG_DSTR_SIZE + 1];
+    char* append_data;
+    int append_data_size;
+    int append_used;
+} _internal_arg_dstr_t;
+
+static void setup_append_buf(arg_dstr_t res, int newSpace);
+
+arg_dstr_t arg_dstr_create(void) {
+    _internal_arg_dstr_t* h = (_internal_arg_dstr_t*)xmalloc(sizeof(_internal_arg_dstr_t));
+    memset(h, 0, sizeof(_internal_arg_dstr_t));
+    h->sbuf[0] = 0;
+    h->data = h->sbuf;
+    h->free_proc = ARG_DSTR_STATIC;
+    return h;
+}
+
+void arg_dstr_destroy(arg_dstr_t ds) {
+    if (ds == NULL)
+        return;
+
+    arg_dstr_reset(ds);
+    xfree(ds);
+    return;
+}
+
+void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc) {
+    int length;
+    register arg_dstr_freefn* old_free_proc = ds->free_proc;
+    char* old_result = ds->data;
+
+    if (str == NULL) {
+        ds->sbuf[0] = 0;
+        ds->data = ds->sbuf;
+        ds->free_proc = ARG_DSTR_STATIC;
+    } else if (free_proc == ARG_DSTR_VOLATILE) {
+        length = (int)strlen(str);
+        if (length > ARG_DSTR_SIZE) {
+            ds->data = (char*)xmalloc((unsigned)length + 1);
+            ds->free_proc = ARG_DSTR_DYNAMIC;
+        } else {
+            ds->data = ds->sbuf;
+            ds->free_proc = ARG_DSTR_STATIC;
+        }
+        strcpy(ds->data, str);
+    } else {
+        ds->data = str;
+        ds->free_proc = free_proc;
+    }
+
+    /*
+     * If the old result was dynamically-allocated, free it up. Do it here,
+     * rather than at the beginning, in case the new result value was part of
+     * the old result value.
+     */
+
+    if ((old_free_proc != 0) && (old_result != ds->data)) {
+        if (old_free_proc == ARG_DSTR_DYNAMIC) {
+            xfree(old_result);
+        } else {
+            (*old_free_proc)(old_result);
+        }
+    }
+
+    if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
+        xfree(ds->append_data);
+        ds->append_data = NULL;
+        ds->append_data_size = 0;
+    }
+}
+
+char* arg_dstr_cstr(arg_dstr_t ds) /* Interpreter whose result to return. */
+{
+    return ds->data;
+}
+
+void arg_dstr_cat(arg_dstr_t ds, const char* str) {
+    setup_append_buf(ds, (int)strlen(str) + 1);
+    memcpy(ds->data + strlen(ds->data), str, strlen(str));
+}
+
+void arg_dstr_catc(arg_dstr_t ds, char c) {
+    setup_append_buf(ds, 2);
+    memcpy(ds->data + strlen(ds->data), &c, 1);
+}
+
+/*
+ * The logic of the `arg_dstr_catf` function is adapted from the `bformat`
+ * function in The Better String Library by Paul Hsieh. Here is the copyright
+ * notice from the library:
+ *
+ * Copyright (c) 2014, Paul Hsieh
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of bstrlib nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...) {
+    va_list arglist;
+    char* buff;
+    int n, r;
+    size_t slen;
+
+    if (fmt == NULL)
+        return;
+
+    /* Since the length is not determinable beforehand, a search is
+       performed using the truncating "vsnprintf" call (to avoid buffer
+       overflows) on increasing potential sizes for the output result. */
+
+    if ((n = (int)(2 * strlen(fmt))) < START_VSNBUFF)
+        n = START_VSNBUFF;
+
+    buff = (char*)xmalloc((size_t)(n + 2));
+    memset(buff, 0, (size_t)(n + 2));
+
+    for (;;) {
+        va_start(arglist, fmt);
+        r = vsnprintf(buff, (size_t)(n + 1), fmt, arglist);
+        va_end(arglist);
+
+        slen = strlen(buff);
+        if (slen < (size_t)n)
+            break;
+
+        if (r > n)
+            n = r;
+        else
+            n += n;
+
+        xfree(buff);
+        buff = (char*)xmalloc((size_t)(n + 2));
+        memset(buff, 0, (size_t)(n + 2));
+    }
+
+    arg_dstr_cat(ds, buff);
+    xfree(buff);
+}
+
+static void setup_append_buf(arg_dstr_t ds, int new_space) {
+    int total_space;
+
+    /*
+     * Make the append buffer larger, if that's necessary, then copy the
+     * data into the append buffer and make the append buffer the official
+     * data.
+     */
+    if (ds->data != ds->append_data) {
+        /*
+         * If the buffer is too big, then free it up so we go back to a
+         * smaller buffer. This avoids tying up memory forever after a large
+         * operation.
+         */
+        if (ds->append_data_size > 500) {
+            xfree(ds->append_data);
+            ds->append_data = NULL;
+            ds->append_data_size = 0;
+        }
+        ds->append_used = (int)strlen(ds->data);
+    } else if (ds->data[ds->append_used] != 0) {
+        /*
+         * Most likely someone has modified a result created by
+         * arg_dstr_cat et al. so that it has a different size. Just
+         * recompute the size.
+         */
+        ds->append_used = (int)strlen(ds->data);
+    }
+
+    total_space = new_space + ds->append_used;
+    if (total_space >= ds->append_data_size) {
+        char* newbuf;
+
+        if (total_space < 100) {
+            total_space = 200;
+        } else {
+            total_space *= 2;
+        }
+        newbuf = (char*)xmalloc((unsigned)total_space);
+        memset(newbuf, 0, (size_t)total_space);
+        strcpy(newbuf, ds->data);
+        if (ds->append_data != NULL) {
+            xfree(ds->append_data);
+        }
+        ds->append_data = newbuf;
+        ds->append_data_size = total_space;
+    } else if (ds->data != ds->append_data) {
+        strcpy(ds->append_data, ds->data);
+    }
+
+    arg_dstr_free(ds);
+    ds->data = ds->append_data;
+}
+
+void arg_dstr_free(arg_dstr_t ds) {
+    if (ds->free_proc != NULL) {
+        if (ds->free_proc == ARG_DSTR_DYNAMIC) {
+            xfree(ds->data);
+        } else {
+            (*ds->free_proc)(ds->data);
+        }
+        ds->free_proc = NULL;
+    }
+}
+
+void arg_dstr_reset(arg_dstr_t ds) {
+    arg_dstr_free(ds);
+    if ((ds->append_data != NULL) && (ds->append_data_size > 0)) {
+        xfree(ds->append_data);
+        ds->append_data = NULL;
+        ds->append_data_size = 0;
+    }
+
+    ds->data = ds->sbuf;
+    ds->sbuf[0] = 0;
+}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+/*	$NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $	*/
+/*	$FreeBSD$ */
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-NetBSD
+ *
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ARG_REPLACE_GETOPT == 1
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+/*
+ * GNU-like getopt_long()/getopt_long_only() with 4.4BSD optreset extension.
+ * getopt() is declared here too for GNU programs.
+ */
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+	/* name of long option */
+	const char *name;
+	/*
+	 * one of no_argument, required_argument, and optional_argument:
+	 * whether option takes an argument
+	 */
+	int has_arg;
+	/* if not NULL, set *flag to val when option found */
+	int *flag;
+	/* if flag not NULL, value to set *flag to; else return value */
+	int val;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int	getopt_long(int, char * const *, const char *,
+	const struct option *, int *);
+int	getopt_long_only(int, char * const *, const char *,
+	const struct option *, int *);
+#ifndef _GETOPT_DECLARED
+#define	_GETOPT_DECLARED
+int getopt(int, char * const [], const char *);
+
+extern char *optarg;			/* getopt(3) external variables */
+extern int optind, opterr, optopt;
+#endif
+#ifndef _OPTRESET_DECLARED
+#define	_OPTRESET_DECLARED
+extern int optreset;			/* getopt(3) external variable */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+ 
+#endif /* !_GETOPT_H_ */
+
+#endif /* ARG_REPLACE_GETOPT == 1 */
+/*	$OpenBSD: getopt_long.c,v 1.26 2013/06/08 22:47:56 millert Exp $	*/
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+
+/*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "argtable3.h"
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#if ARG_REPLACE_GETOPT == 1
+
+#ifndef ARG_AMALGAMATION
+#include "arg_getopt.h"
+#endif
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define GNU_COMPATIBLE		/* Be more compatible, configure's use us! */
+
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';	/* character checked for validity */
+int	optreset;		/* reset getopt */
+char *optarg;		/* argument associated with option */
+
+#define PRINT_ERROR	((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE	0x01	/* permute non-options to the end of argv */
+#define FLAG_ALLARGS	0x02	/* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY	0x04	/* operate as getopt_long_only */
+
+/* return values */
+#define	BADCH		(int)'?'
+#define	BADARG		((*options == ':') ? (int)':' : (int)'?')
+#define	INORDER 	(int)1
+
+#define	EMSG		""
+
+#ifdef GNU_COMPATIBLE
+#define NO_PREFIX	(-1)
+#define D_PREFIX	0
+#define DD_PREFIX	1
+#define W_PREFIX	2
+#endif
+
+static int getopt_internal(int, char * const *, const char *,
+			   const struct option *, int *, int);
+static int parse_long_options(char * const *, const char *,
+			      const struct option *, int *, int, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char illoptchar[] = "illegal option -- %c"; /* From P1003.2 */
+#ifdef GNU_COMPATIBLE
+static int dash_prefix = NO_PREFIX;
+static const char gnuoptchar[] = "invalid option -- %c";
+
+static const char recargstring[] = "option `%s%s' requires an argument";
+static const char ambig[] = "option `%s%.*s' is ambiguous";
+static const char noarg[] = "option `%s%.*s' doesn't allow an argument";
+static const char illoptstring[] = "unrecognized option `%s%s'";
+#else
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptstring[] = "unknown option -- %s";
+#endif
+
+#ifdef _WIN32
+
+/*
+ * Windows needs warnx().  We change the definition though:
+ *  1. (another) global is defined, opterrmsg, which holds the error message
+ *  2. errors are always printed out on stderr w/o the program name
+ * Note that opterrmsg always gets set no matter what opterr is set to.  The
+ * error message will not be printed if opterr is 0 as usual.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#define MAX_OPTERRMSG_SIZE 128
+
+extern char opterrmsg[MAX_OPTERRMSG_SIZE];
+char opterrmsg[MAX_OPTERRMSG_SIZE]; /* buffer for the last error message */
+
+static void warnx(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+
+    /*
+     * Make sure opterrmsg is always zero-terminated despite the _vsnprintf()
+     * implementation specifics and manually suppress the warning.
+     */
+    memset(opterrmsg, 0, sizeof(opterrmsg));
+    if (fmt != NULL)
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+        _vsnprintf_s(opterrmsg, sizeof(opterrmsg), sizeof(opterrmsg) - 1, fmt, ap);
+#else
+        _vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
+#endif
+
+    va_end(ap);
+
+#ifdef _MSC_VER
+#pragma warning(suppress : 6053)
+#endif
+    fprintf(stderr, "%s\n", opterrmsg);
+}
+
+#else
+#include <err.h>
+#endif /*_WIN32*/
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end,
+	char * const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int
+parse_long_options(char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int short_too, int flags)
+{
+	char *current_argv, *has_equal;
+#ifdef GNU_COMPATIBLE
+	char *current_dash;
+#endif
+	size_t current_argv_len;
+	int i, match, exact_match, second_partial_match;
+
+	current_argv = place;
+#ifdef GNU_COMPATIBLE
+	switch (dash_prefix) {
+		case D_PREFIX:
+			current_dash = "-";
+			break;
+		case DD_PREFIX:
+			current_dash = "--";
+			break;
+		case W_PREFIX:
+			current_dash = "-W ";
+			break;
+		default:
+			current_dash = "";
+			break;
+	}
+#endif
+	match = -1;
+	exact_match = 0;
+	second_partial_match = 0;
+
+	optind++;
+
+	if ((has_equal = strchr(current_argv, '=')) != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = (size_t)(has_equal - current_argv);
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name,
+		    current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			exact_match = 1;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1)	/* first partial match */
+			match = i;
+		else if ((flags & FLAG_LONGONLY) ||
+			 long_options[i].has_arg !=
+			     long_options[match].has_arg ||
+			 long_options[i].flag != long_options[match].flag ||
+			 long_options[i].val != long_options[match].val)
+			second_partial_match = 1;
+	}
+	if (!exact_match && second_partial_match) {
+		/* ambiguous abbreviation */
+		if (PRINT_ERROR)
+			warnx(ambig,
+#ifdef GNU_COMPATIBLE
+			     current_dash,
+#endif
+			     (int)current_argv_len,
+			     current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (match != -1) {		/* option found */
+		if (long_options[match].has_arg == no_argument
+		    && has_equal) {
+			if (PRINT_ERROR)
+				warnx(noarg,
+#ifdef GNU_COMPATIBLE
+				     current_dash,
+#endif
+				     (int)current_argv_len,
+				     current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+#ifdef GNU_COMPATIBLE
+			return (BADCH);
+#else
+			return (BADARG);
+#endif
+		}
+		if (long_options[match].has_arg == required_argument ||
+		    long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg ==
+			    required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument)
+		    && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				warnx(recargstring,
+#ifdef GNU_COMPATIBLE
+				    current_dash,
+#endif
+				    current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else {			/* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			warnx(illoptstring,
+#ifdef GNU_COMPATIBLE
+			      current_dash,
+#endif
+			      current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int
+getopt_internal(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx, int flags)
+{
+	char *oli;				/* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 */
+	if (posixly_correct == -1 || optreset) {
+#if defined(_WIN32) && ((defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__)))
+		size_t requiredSize;
+		getenv_s(&requiredSize, NULL, 0, "POSIXLY_CORRECT");
+		posixly_correct = requiredSize != 0;
+#else
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+#endif
+	}
+
+	if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	else if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		if (*(place = nargv[optind]) != '-' ||
+#ifdef GNU_COMPATIBLE
+		    place[1] == '\0') {
+#else
+		    (place[1] == '\0' && strchr(options, '-') == NULL)) {
+#endif
+			place = EMSG;		/* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] &&
+	    (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+#ifdef GNU_COMPATIBLE
+		dash_prefix = D_PREFIX;
+#endif
+		if (*place == '-') {
+			place++;		/* --foo long option */
+			if (*place == '\0')
+				return (BADARG);	/* malformed option */
+#ifdef GNU_COMPATIBLE
+			dash_prefix = DD_PREFIX;
+#endif
+		} else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1;		/* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, short_too, flags);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (optchar == (int)'-' && *place != '\0') ||
+	    (oli = strchr(options, optchar)) == NULL) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+#ifdef GNU_COMPATIBLE
+		if (PRINT_ERROR)
+			warnx(posixly_correct ? illoptchar : gnuoptchar,
+			      optchar);
+#else
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+#endif
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place)			/* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else				/* white space */
+			place = nargv[optind];
+#ifdef GNU_COMPATIBLE
+		dash_prefix = W_PREFIX;
+#endif
+		optchar = parse_long_options(nargv, options, long_options,
+		    idx, 0, flags);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int
+getopt(int nargc, char * const *nargv, const char *options)
+{
+
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long_only(int nargc, char * const *nargv, const char *options,
+	const struct option *long_options, int *idx)
+{
+
+	return (getopt_internal(nargc, nargv, options, long_options, idx,
+	    FLAG_PERMUTE|FLAG_LONGONLY));
+}
+
+#endif /* ARG_REPLACE_GETOPT == 1 */
+/*******************************************************************************
+ * arg_date: Implements the date command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+char* arg_strptime(const char* buf, const char* fmt, struct tm* tm);
+
+static void arg_date_resetfn(struct arg_date* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static int arg_date_scanfn(struct arg_date* parent, const char* argval) {
+    int errorcode = 0;
+
+    if (parent->count == parent->hdr.maxcount) {
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* no argument value was given, leave parent->tmval[] unaltered but still count it */
+        parent->count++;
+    } else {
+        const char* pend;
+        struct tm tm = parent->tmval[parent->count];
+
+        /* parse the given argument value, store result in parent->tmval[] */
+        pend = arg_strptime(argval, parent->format, &tm);
+        if (pend && pend[0] == '\0')
+            parent->tmval[parent->count++] = tm;
+        else
+            errorcode = ARG_ERR_BADDATE;
+    }
+
+    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static int arg_date_checkfn(struct arg_date* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+
+    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static void arg_date_errorfn(struct arg_date* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        case ARG_ERR_BADDATE: {
+            struct tm tm;
+            char buff[200];
+
+            arg_dstr_catf(ds, "illegal timestamp format \"%s\"\n", argval);
+            memset(&tm, 0, sizeof(tm));
+            arg_strptime("1999-12-31 23:59:59", "%F %H:%M:%S", &tm);
+            strftime(buff, sizeof(buff), parent->format, &tm);
+            arg_dstr_catf(ds, "correct format is \"%s\"\n", buff);
+            break;
+        }
+    }
+}
+
+struct arg_date* arg_date0(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary) {
+    return arg_daten(shortopts, longopts, format, datatype, 0, 1, glossary);
+}
+
+struct arg_date* arg_date1(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary) {
+    return arg_daten(shortopts, longopts, format, datatype, 1, 1, glossary);
+}
+
+struct arg_date*
+arg_daten(const char* shortopts, const char* longopts, const char* format, const char* datatype, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_date* result;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    /* default time format is the national date format for the locale */
+    if (!format)
+        format = "%x";
+
+    nbytes = sizeof(struct arg_date)         /* storage for struct arg_date */
+             + (size_t)maxcount * sizeof(struct tm); /* storage for tmval[maxcount] array */
+
+    /* allocate storage for the arg_date struct + tmval[] array.    */
+    /* we use calloc because we want the tmval[] array zero filled. */
+    result = (struct arg_date*)xcalloc(1, nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : format;
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_date_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_date_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_date_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_date_errorfn;
+
+    /* store the tmval[maxcount] array immediately after the arg_date struct */
+    result->tmval = (struct tm*)(result + 1);
+
+    /* init the remaining arg_date member variables */
+    result->count = 0;
+    result->format = format;
+
+    ARG_TRACE(("arg_daten() returns %p\n", result));
+    return result;
+}
+
+/*-
+ * Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code was contributed to The NetBSD Foundation by Klaus Klein.
+ * Heavily optimised by David Laight
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include <time.h>
+
+/*
+ * We do not implement alternate representations. However, we always
+ * check whether a given modifier is allowed for a certain conversion.
+ */
+#define ALT_E 0x01
+#define ALT_O 0x02
+#define LEGAL_ALT(x)           \
+    {                          \
+        if (alt_format & ~(x)) \
+            return (0);        \
+    }
+#define TM_YEAR_BASE (1900)
+
+static int conv_num(const char**, int*, int, int);
+
+static const char* day[7] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+
+static const char* abday[7] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+static const char* mon[12] = {"January", "February", "March",     "April",   "May",      "June",
+                              "July",    "August",   "September", "October", "November", "December"};
+
+static const char* abmon[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+static const char* am_pm[2] = {"AM", "PM"};
+
+static int arg_strcasecmp(const char* s1, const char* s2) {
+    const unsigned char* us1 = (const unsigned char*)s1;
+    const unsigned char* us2 = (const unsigned char*)s2;
+    while (tolower(*us1) == tolower(*us2++))
+        if (*us1++ == '\0')
+            return 0;
+
+    return tolower(*us1) - tolower(*--us2);
+}
+
+static int arg_strncasecmp(const char* s1, const char* s2, size_t n) {
+    if (n != 0) {
+        const unsigned char* us1 = (const unsigned char*)s1;
+        const unsigned char* us2 = (const unsigned char*)s2;
+        do {
+            if (tolower(*us1) != tolower(*us2++))
+                return tolower(*us1) - tolower(*--us2);
+
+            if (*us1++ == '\0')
+                break;
+        } while (--n != 0);
+    }
+
+    return 0;
+}
+
+char* arg_strptime(const char* buf, const char* fmt, struct tm* tm) {
+    char c;
+    const char* bp;
+    size_t len = 0;
+    int alt_format, i, split_year = 0;
+
+    bp = buf;
+
+    while ((c = *fmt) != '\0') {
+        /* Clear `alternate' modifier prior to new conversion. */
+        alt_format = 0;
+
+        /* Eat up white-space. */
+        if (isspace(c)) {
+            while (isspace((int)(*bp)))
+                bp++;
+
+            fmt++;
+            continue;
+        }
+
+        if ((c = *fmt++) != '%')
+            goto literal;
+
+    again:
+        switch (c = *fmt++) {
+            case '%': /* "%%" is converted to "%". */
+            literal:
+                if (c != *bp++)
+                    return (0);
+                break;
+
+            /*
+             * "Alternative" modifiers. Just set the appropriate flag
+             * and start over again.
+             */
+            case 'E': /* "%E?" alternative conversion modifier. */
+                LEGAL_ALT(0);
+                alt_format |= ALT_E;
+                goto again;
+
+            case 'O': /* "%O?" alternative conversion modifier. */
+                LEGAL_ALT(0);
+                alt_format |= ALT_O;
+                goto again;
+
+            /*
+             * "Complex" conversion rules, implemented through recursion.
+             */
+            case 'c': /* Date and time, using the locale's format. */
+                LEGAL_ALT(ALT_E);
+                bp = arg_strptime(bp, "%x %X", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'D': /* The date as "%m/%d/%y". */
+                LEGAL_ALT(0);
+                bp = arg_strptime(bp, "%m/%d/%y", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'R': /* The time as "%H:%M". */
+                LEGAL_ALT(0);
+                bp = arg_strptime(bp, "%H:%M", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'r': /* The time in 12-hour clock representation. */
+                LEGAL_ALT(0);
+                bp = arg_strptime(bp, "%I:%M:%S %p", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'T': /* The time as "%H:%M:%S". */
+                LEGAL_ALT(0);
+                bp = arg_strptime(bp, "%H:%M:%S", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'X': /* The time, using the locale's format. */
+                LEGAL_ALT(ALT_E);
+                bp = arg_strptime(bp, "%H:%M:%S", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            case 'x': /* The date, using the locale's format. */
+                LEGAL_ALT(ALT_E);
+                bp = arg_strptime(bp, "%m/%d/%y", tm);
+                if (!bp)
+                    return (0);
+                break;
+
+            /*
+             * "Elementary" conversion rules.
+             */
+            case 'A': /* The day of week, using the locale's form. */
+            case 'a':
+                LEGAL_ALT(0);
+                for (i = 0; i < 7; i++) {
+                    /* Full name. */
+                    len = strlen(day[i]);
+                    if (arg_strncasecmp(day[i], bp, len) == 0)
+                        break;
+
+                    /* Abbreviated name. */
+                    len = strlen(abday[i]);
+                    if (arg_strncasecmp(abday[i], bp, len) == 0)
+                        break;
+                }
+
+                /* Nothing matched. */
+                if (i == 7)
+                    return (0);
+
+                tm->tm_wday = i;
+                bp += len;
+                break;
+
+            case 'B': /* The month, using the locale's form. */
+            case 'b':
+            case 'h':
+                LEGAL_ALT(0);
+                for (i = 0; i < 12; i++) {
+                    /* Full name. */
+                    len = strlen(mon[i]);
+                    if (arg_strncasecmp(mon[i], bp, len) == 0)
+                        break;
+
+                    /* Abbreviated name. */
+                    len = strlen(abmon[i]);
+                    if (arg_strncasecmp(abmon[i], bp, len) == 0)
+                        break;
+                }
+
+                /* Nothing matched. */
+                if (i == 12)
+                    return (0);
+
+                tm->tm_mon = i;
+                bp += len;
+                break;
+
+            case 'C': /* The century number. */
+                LEGAL_ALT(ALT_E);
+                if (!(conv_num(&bp, &i, 0, 99)))
+                    return (0);
+
+                if (split_year) {
+                    tm->tm_year = (tm->tm_year % 100) + (i * 100);
+                } else {
+                    tm->tm_year = i * 100;
+                    split_year = 1;
+                }
+                break;
+
+            case 'd': /* The day of month. */
+            case 'e':
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_mday, 1, 31)))
+                    return (0);
+                break;
+
+            case 'k': /* The hour (24-hour clock representation). */
+                LEGAL_ALT(0);
+            /* FALLTHROUGH */
+            case 'H':
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_hour, 0, 23)))
+                    return (0);
+                break;
+
+            case 'l': /* The hour (12-hour clock representation). */
+                LEGAL_ALT(0);
+            /* FALLTHROUGH */
+            case 'I':
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_hour, 1, 12)))
+                    return (0);
+                if (tm->tm_hour == 12)
+                    tm->tm_hour = 0;
+                break;
+
+            case 'j': /* The day of year. */
+                LEGAL_ALT(0);
+                if (!(conv_num(&bp, &i, 1, 366)))
+                    return (0);
+                tm->tm_yday = i - 1;
+                break;
+
+            case 'M': /* The minute. */
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_min, 0, 59)))
+                    return (0);
+                break;
+
+            case 'm': /* The month. */
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &i, 1, 12)))
+                    return (0);
+                tm->tm_mon = i - 1;
+                break;
+
+            case 'p': /* The locale's equivalent of AM/PM. */
+                LEGAL_ALT(0);
+                /* AM? */
+                if (arg_strcasecmp(am_pm[0], bp) == 0) {
+                    if (tm->tm_hour > 11)
+                        return (0);
+
+                    bp += strlen(am_pm[0]);
+                    break;
+                }
+                /* PM? */
+                else if (arg_strcasecmp(am_pm[1], bp) == 0) {
+                    if (tm->tm_hour > 11)
+                        return (0);
+
+                    tm->tm_hour += 12;
+                    bp += strlen(am_pm[1]);
+                    break;
+                }
+
+                /* Nothing matched. */
+                return (0);
+
+            case 'S': /* The seconds. */
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_sec, 0, 61)))
+                    return (0);
+                break;
+
+            case 'U': /* The week of year, beginning on sunday. */
+            case 'W': /* The week of year, beginning on monday. */
+                LEGAL_ALT(ALT_O);
+                /*
+                 * XXX This is bogus, as we can not assume any valid
+                 * information present in the tm structure at this
+                 * point to calculate a real value, so just check the
+                 * range for now.
+                 */
+                if (!(conv_num(&bp, &i, 0, 53)))
+                    return (0);
+                break;
+
+            case 'w': /* The day of week, beginning on sunday. */
+                LEGAL_ALT(ALT_O);
+                if (!(conv_num(&bp, &tm->tm_wday, 0, 6)))
+                    return (0);
+                break;
+
+            case 'Y': /* The year. */
+                LEGAL_ALT(ALT_E);
+                if (!(conv_num(&bp, &i, 0, 9999)))
+                    return (0);
+
+                tm->tm_year = i - TM_YEAR_BASE;
+                break;
+
+            case 'y': /* The year within 100 years of the epoch. */
+                LEGAL_ALT(ALT_E | ALT_O);
+                if (!(conv_num(&bp, &i, 0, 99)))
+                    return (0);
+
+                if (split_year) {
+                    tm->tm_year = ((tm->tm_year / 100) * 100) + i;
+                    break;
+                }
+                split_year = 1;
+                if (i <= 68)
+                    tm->tm_year = i + 2000 - TM_YEAR_BASE;
+                else
+                    tm->tm_year = i + 1900 - TM_YEAR_BASE;
+                break;
+
+            /*
+             * Miscellaneous conversions.
+             */
+            case 'n': /* Any kind of white-space. */
+            case 't':
+                LEGAL_ALT(0);
+                while (isspace((int)(*bp)))
+                    bp++;
+                break;
+
+            default: /* Unknown/unsupported conversion. */
+                return (0);
+        }
+    }
+
+    /* LINTED functional specification */
+    return ((char*)bp);
+}
+
+static int conv_num(const char** buf, int* dest, int llim, int ulim) {
+    int result = 0;
+
+    /* The limit also determines the number of valid digits. */
+    int rulim = ulim;
+
+    if (**buf < '0' || **buf > '9')
+        return (0);
+
+    do {
+        result *= 10;
+        result += *(*buf)++ - '0';
+        rulim /= 10;
+    } while ((result * 10 <= ulim) && rulim && **buf >= '0' && **buf <= '9');
+
+    if (result < llim || result > ulim)
+        return (0);
+
+    *dest = result;
+    return (1);
+}
+/*******************************************************************************
+ * arg_dbl: Implements the double command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+
+static void arg_dbl_resetfn(struct arg_dbl* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static int arg_dbl_scanfn(struct arg_dbl* parent, const char* argval) {
+    int errorcode = 0;
+
+    if (parent->count == parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent argument value unaltered but still count the argument. */
+        parent->count++;
+    } else {
+        double val;
+        char* end;
+
+        /* extract double from argval into val */
+        val = strtod(argval, &end);
+
+        /* if success then store result in parent->dval[] array otherwise return error*/
+        if (*end == 0)
+            parent->dval[parent->count++] = val;
+        else
+            errorcode = ARG_ERR_BADDOUBLE;
+    }
+
+    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static int arg_dbl_checkfn(struct arg_dbl* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+
+    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static void arg_dbl_errorfn(struct arg_dbl* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        case ARG_ERR_BADDOUBLE:
+            arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+    }
+}
+
+struct arg_dbl* arg_dbl0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_dbln(shortopts, longopts, datatype, 0, 1, glossary);
+}
+
+struct arg_dbl* arg_dbl1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_dbln(shortopts, longopts, datatype, 1, 1, glossary);
+}
+
+struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_dbl* result;
+    size_t addr;
+    size_t rem;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_dbl)             /* storage for struct arg_dbl */
+             + (size_t)(maxcount + 1) * sizeof(double); /* storage for dval[maxcount] array plus one extra for padding to memory boundary */
+
+    result = (struct arg_dbl*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : "<double>";
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_dbl_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_dbl_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_dbl_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_dbl_errorfn;
+
+    /* Store the dval[maxcount] array on the first double boundary that
+     * immediately follows the arg_dbl struct. We do the memory alignment
+     * purely for SPARC and Motorola systems. They require floats and
+     * doubles to be aligned on natural boundaries.
+     */
+    addr = (size_t)(result + 1);
+    rem = addr % sizeof(double);
+    result->dval = (double*)(addr + sizeof(double) - rem);
+    ARG_TRACE(("addr=%p, dval=%p, sizeof(double)=%d rem=%d\n", addr, result->dval, (int)sizeof(double), (int)rem));
+
+    result->count = 0;
+
+    ARG_TRACE(("arg_dbln() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_end: Implements the error handling utilities
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+
+static void arg_end_resetfn(struct arg_end* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static void arg_end_errorfn(void* parent, arg_dstr_t ds, int error, const char* argval, const char* progname) {
+    /* suppress unreferenced formal parameter warning */
+    (void)parent;
+
+    progname = progname ? progname : "";
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (error) {
+        case ARG_ELIMIT:
+            arg_dstr_cat(ds, "too many errors to display");
+            break;
+        case ARG_EMALLOC:
+            arg_dstr_cat(ds, "insufficient memory");
+            break;
+        case ARG_ENOMATCH:
+            arg_dstr_catf(ds, "unexpected argument \"%s\"", argval);
+            break;
+        case ARG_EMISSARG:
+            arg_dstr_catf(ds, "option \"%s\" requires an argument", argval);
+            break;
+        case ARG_ELONGOPT:
+            arg_dstr_catf(ds, "invalid option \"%s\"", argval);
+            break;
+        default:
+            arg_dstr_catf(ds, "invalid option \"-%c\"", error);
+            break;
+    }
+
+    arg_dstr_cat(ds, "\n");
+}
+
+struct arg_end* arg_end(int maxcount) {
+    size_t nbytes;
+    struct arg_end* result;
+
+    nbytes = sizeof(struct arg_end) + (size_t)maxcount * sizeof(int) /* storage for int error[maxcount] array*/
+             + (size_t)maxcount * sizeof(void*)                      /* storage for void* parent[maxcount] array */
+             + (size_t)maxcount * sizeof(char*);                     /* storage for char* argval[maxcount] array */
+
+    result = (struct arg_end*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_TERMINATOR;
+    result->hdr.shortopts = NULL;
+    result->hdr.longopts = NULL;
+    result->hdr.datatype = NULL;
+    result->hdr.glossary = NULL;
+    result->hdr.mincount = 1;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_end_resetfn;
+    result->hdr.scanfn = NULL;
+    result->hdr.checkfn = NULL;
+    result->hdr.errorfn = (arg_errorfn*)arg_end_errorfn;
+
+    /* store error[maxcount] array immediately after struct arg_end */
+    result->error = (int*)(result + 1);
+
+    /* store parent[maxcount] array immediately after error[] array */
+    result->parent = (void**)(result->error + maxcount);
+
+    /* store argval[maxcount] array immediately after parent[] array */
+    result->argval = (const char**)(result->parent + maxcount);
+
+    ARG_TRACE(("arg_end(%d) returns %p\n", maxcount, result));
+    return result;
+}
+
+void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname) {
+    int i;
+    ARG_TRACE(("arg_errors()\n"));
+    for (i = 0; i < end->count; i++) {
+        struct arg_hdr* errorparent = (struct arg_hdr*)(end->parent[i]);
+        if (errorparent->errorfn)
+            errorparent->errorfn(end->parent[i], ds, end->error[i], end->argval[i], progname);
+    }
+}
+
+void arg_print_errors(FILE* fp, struct arg_end* end, const char* progname) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_errors_ds(ds, end, progname);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+/*******************************************************************************
+ * arg_file: Implements the file command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef WIN32
+#define FILESEPARATOR1 '\\'
+#define FILESEPARATOR2 '/'
+#else
+#define FILESEPARATOR1 '/'
+#define FILESEPARATOR2 '/'
+#endif
+
+static void arg_file_resetfn(struct arg_file* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+/* Returns ptr to the base filename within *filename */
+static const char* arg_basename(const char* filename) {
+    const char *result = NULL, *result1, *result2;
+
+    /* Find the last occurrence of eother file separator character. */
+    /* Two alternative file separator chars are supported as legal  */
+    /* file separators but not both together in the same filename.  */
+    result1 = (filename ? strrchr(filename, FILESEPARATOR1) : NULL);
+    result2 = (filename ? strrchr(filename, FILESEPARATOR2) : NULL);
+
+    if (result2)
+        result = result2 + 1; /* using FILESEPARATOR2 (the alternative file separator) */
+
+    if (result1)
+        result = result1 + 1; /* using FILESEPARATOR1 (the preferred file separator) */
+
+    if (!result)
+        result = filename; /* neither file separator was found so basename is the whole filename */
+
+    /* special cases of "." and ".." are not considered basenames */
+    if (result && (strcmp(".", result) == 0 || strcmp("..", result) == 0))
+        result = filename + strlen(filename);
+
+    return result;
+}
+
+/* Returns ptr to the file extension within *basename */
+static const char* arg_extension(const char* basename) {
+    /* find the last occurrence of '.' in basename */
+    const char* result = (basename ? strrchr(basename, '.') : NULL);
+
+    /* if no '.' was found then return pointer to end of basename */
+    if (basename && !result)
+        result = basename + strlen(basename);
+
+    /* special case: basenames with a single leading dot (eg ".foo") are not considered as true extensions */
+    if (basename && result == basename)
+        result = basename + strlen(basename);
+
+    /* special case: empty extensions (eg "foo.","foo..") are not considered as true extensions */
+    if (basename && result && strlen(result) == 1)
+        result = basename + strlen(basename);
+
+    return result;
+}
+
+static int arg_file_scanfn(struct arg_file* parent, const char* argval) {
+    int errorcode = 0;
+
+    if (parent->count == parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent arguiment value unaltered but still count the argument. */
+        parent->count++;
+    } else {
+        parent->filename[parent->count] = argval;
+        parent->basename[parent->count] = arg_basename(argval);
+        parent->extension[parent->count] =
+                arg_extension(parent->basename[parent->count]); /* only seek extensions within the basename (not the file path)*/
+        parent->count++;
+    }
+
+    ARG_TRACE(("%s4:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static int arg_file_checkfn(struct arg_file* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+
+    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static void arg_file_errorfn(struct arg_file* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        default:
+            arg_dstr_catf(ds, "unknown error at \"%s\"\n", argval);
+    }
+}
+
+struct arg_file* arg_file0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_filen(shortopts, longopts, datatype, 0, 1, glossary);
+}
+
+struct arg_file* arg_file1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_filen(shortopts, longopts, datatype, 1, 1, glossary);
+}
+
+struct arg_file* arg_filen(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_file* result;
+    int i;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_file)     /* storage for struct arg_file */
+             + sizeof(char*) * (size_t)maxcount  /* storage for filename[maxcount] array */
+             + sizeof(char*) * (size_t)maxcount  /* storage for basename[maxcount] array */
+             + sizeof(char*) * (size_t)maxcount; /* storage for extension[maxcount] array */
+
+    result = (struct arg_file*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.glossary = glossary;
+    result->hdr.datatype = datatype ? datatype : "<file>";
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_file_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_file_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_file_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_file_errorfn;
+
+    /* store the filename,basename,extension arrays immediately after the arg_file struct */
+    result->filename = (const char**)(result + 1);
+    result->basename = result->filename + maxcount;
+    result->extension = result->basename + maxcount;
+    result->count = 0;
+
+    /* foolproof the string pointers by initialising them with empty strings */
+    for (i = 0; i < maxcount; i++) {
+        result->filename[i] = "";
+        result->basename[i] = "";
+        result->extension[i] = "";
+    }
+
+    ARG_TRACE(("arg_filen() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_int: Implements the int command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <ctype.h>
+#include <limits.h>
+#include <stdlib.h>
+
+static void arg_int_resetfn(struct arg_int* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+/* Returns 1 if str matches suffix (case insensitive).    */
+/* Str may contain trailing whitespace, but nothing else. */
+static int detectsuffix(const char* str, const char* suffix) {
+    /* scan pairwise through strings until mismatch detected */
+    while (toupper(*str) == toupper(*suffix)) {
+        /* printf("'%c' '%c'\n", *str, *suffix); */
+
+        /* return 1 (success) if match persists until the string terminator */
+        if (*str == '\0')
+            return 1;
+
+        /* next chars */
+        str++;
+        suffix++;
+    }
+    /* printf("'%c' '%c' mismatch\n", *str, *suffix); */
+
+    /* return 0 (fail) if the matching did not consume the entire suffix */
+    if (*suffix != 0)
+        return 0; /* failed to consume entire suffix */
+
+    /* skip any remaining whitespace in str */
+    while (isspace((int)(*str)))
+        str++;
+
+    /* return 1 (success) if we have reached end of str else return 0 (fail) */
+    return (*str == '\0') ? 1 : 0;
+}
+
+static int arg_int_scanfn(struct arg_int* parent, const char* argval) {
+    int errorcode = 0;
+
+    if (parent->count == parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent arguiment value unaltered but still count the argument. */
+        parent->count++;
+    } else {
+        long int val;
+        const char* end;
+
+        /* attempt to extract hex integer (eg: +0x123) from argval into val conversion */
+        val = strtol0X(argval, &end, 'X', 16);
+        if (end == argval) {
+            /* hex failed, attempt octal conversion (eg +0o123) */
+            val = strtol0X(argval, &end, 'O', 8);
+            if (end == argval) {
+                /* octal failed, attempt binary conversion (eg +0B101) */
+                val = strtol0X(argval, &end, 'B', 2);
+                if (end == argval) {
+                    /* binary failed, attempt decimal conversion with no prefix (eg 1234) */
+                    val = strtol(argval, (char**)&end, 10);
+                    if (end == argval) {
+                        /* all supported number formats failed */
+                        return ARG_ERR_BADINT;
+                    }
+                }
+            }
+        }
+
+        /* Safety check for integer overflow. WARNING: this check    */
+        /* achieves nothing on machines where size(int)==size(long). */
+        if (val > INT_MAX || val < INT_MIN)
+            errorcode = ARG_ERR_OVERFLOW;
+
+        /* Detect any suffixes (KB,MB,GB) and multiply argument value appropriately. */
+        /* We need to be mindful of integer overflows when using such big numbers.   */
+        if (detectsuffix(end, "KB")) /* kilobytes */
+        {
+            if (val > (INT_MAX / 1024) || val < (INT_MIN / 1024))
+                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+            else
+                val *= 1024;                /* 1KB = 1024 */
+        } else if (detectsuffix(end, "MB")) /* megabytes */
+        {
+            if (val > (INT_MAX / 1048576) || val < (INT_MIN / 1048576))
+                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+            else
+                val *= 1048576;             /* 1MB = 1024*1024 */
+        } else if (detectsuffix(end, "GB")) /* gigabytes */
+        {
+            if (val > (INT_MAX / 1073741824) || val < (INT_MIN / 1073741824))
+                errorcode = ARG_ERR_OVERFLOW; /* Overflow would occur if we proceed */
+            else
+                val *= 1073741824; /* 1GB = 1024*1024*1024 */
+        } else if (!detectsuffix(end, ""))
+            errorcode = ARG_ERR_BADINT; /* invalid suffix detected */
+
+        /* if success then store result in parent->ival[] array */
+        if (errorcode == 0)
+            parent->ival[parent->count++] = (int)val;
+    }
+
+    /* printf("%s:scanfn(%p,%p) returns %d\n",__FILE__,parent,argval,errorcode); */
+    return errorcode;
+}
+
+static int arg_int_checkfn(struct arg_int* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+    /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
+    return errorcode;
+}
+
+static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        case ARG_ERR_BADINT:
+            arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_OVERFLOW:
+            arg_dstr_cat(ds, "integer overflow at option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, " ");
+            arg_dstr_catf(ds, "(%s is too large)\n", argval);
+            break;
+    }
+}
+
+struct arg_int* arg_int0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_intn(shortopts, longopts, datatype, 0, 1, glossary);
+}
+
+struct arg_int* arg_int1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_intn(shortopts, longopts, datatype, 1, 1, glossary);
+}
+
+struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_int* result;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_int)    /* storage for struct arg_int */
+             + (size_t)maxcount * sizeof(int); /* storage for ival[maxcount] array */
+
+    result = (struct arg_int*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : "<int>";
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_int_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_int_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_int_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_int_errorfn;
+
+    /* store the ival[maxcount] array immediately after the arg_int struct */
+    result->ival = (int*)(result + 1);
+    result->count = 0;
+
+    ARG_TRACE(("arg_intn() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_csi: Implements the comma separated integer command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ * Copyright 2023 Morse Micro
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <ctype.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void arg_csi_resetfn(struct arg_csi* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static int arg_csi_scanfn(struct arg_csi* parent, const char* argval) {
+    int errorcode = 0;
+    const char *head = argval;
+
+    if (parent->count >= parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent argument value unaltered but still count the argument. */
+    } else {
+        int num_vals;
+        for (num_vals = 0; num_vals < parent->num_vals; num_vals++) {
+            long int val;
+            const char* end;
+
+            if (!head || head[0] == '\0') {
+                return ARG_ERR_NOTENOUGH;
+            }
+
+            /* attempt to extract hex integer (eg: +0x123) from argval into val conversion */
+            val = strtol0X(head, &end, 'X', 16);
+            if (end == head) {
+                /* hex failed, attempt octal conversion (eg +0o123) */
+                val = strtol0X(head, &end, 'O', 8);
+                if (end == head) {
+                    /* octal failed, attempt binary conversion (eg +0B101) */
+                    val = strtol0X(head, &end, 'B', 2);
+                    if (end == head) {
+                        /* binary failed, attempt decimal conversion with no prefix (eg 1234) */
+                        val = strtol(head, (char**)&end, 10);
+                        if (end == head) {
+                            /* all supported number formats failed */
+                            return ARG_ERR_BADINT;
+                        }
+                    }
+                }
+            }
+
+            /* Safety check for integer overflow. WARNING: this check    */
+            /* achieves nothing on machines where size(int)==size(long). */
+            if (val > INT_MAX || val < INT_MIN)
+                return ARG_ERR_OVERFLOW;
+
+            /* if success then store result in parent->ival[] array */
+            if (errorcode == 0) {
+                parent->ival[parent->count][num_vals] = (int)val;
+                head = strchr(head, ',');
+                if (head)
+                    head++;
+            }
+        }
+    }
+
+    /* if we still have a head, there are too many commas and therefore params. */
+    if (head)
+        errorcode = ARG_ERR_TOOMANY;
+
+    if (errorcode == 0)
+        parent->count++;
+
+    /* printf("%s:scanfn(%p,%p) returns %d\n",__FILE__,parent,argval,errorcode); */
+    return errorcode;
+}
+
+static int arg_csi_checkfn(struct arg_csi* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+    /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
+    return errorcode;
+}
+
+static void arg_csi_errorfn(struct arg_csi* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        case ARG_ERR_BADINT:
+            arg_dstr_catf(ds, "invalid argument \"%s\" to option ", argval);
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_OVERFLOW:
+            arg_dstr_cat(ds, "integer overflow at option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, " ");
+            arg_dstr_catf(ds, "(%s is too large)\n", argval);
+            break;
+
+        case ARG_ERR_NOTENOUGH:
+            arg_dstr_cat(ds, "not enough comma separated values seen ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            arg_dstr_catf(ds, "(need %d)\n", parent->num_vals);
+            break;
+
+        case ARG_ERR_TOOMANY:
+            arg_dstr_cat(ds, "too many comma separated values seen ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            arg_dstr_catf(ds, "(need %d)\n", parent->num_vals);
+            break;
+    }
+}
+
+struct arg_csi* arg_csi0(const char* shortopts, const char* longopts, const char* datatype, int num_vals, const char* glossary) {
+    return arg_csin(shortopts, longopts, datatype, num_vals, 0, 1, glossary);
+}
+
+struct arg_csi* arg_csi1(const char* shortopts, const char* longopts, const char* datatype, int num_vals, const char* glossary) {
+    return arg_csin(shortopts, longopts, datatype, num_vals, 1, 1, glossary);
+}
+
+struct arg_csi* arg_csin(const char* shortopts, const char* longopts, const char* datatype, int num_vals, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_csi* result;
+    int i;
+    int *data_start;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_csi)    /* storage for struct arg_csi */
+             + ((size_t)maxcount * sizeof(int*)) /* storage for ival[maxcount] */
+             + ((size_t)maxcount * (size_t)num_vals * sizeof(int)); /* storage for ival[maxcount][num_vals] array */
+
+    result = (struct arg_csi*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : "<int>,...";
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_csi_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_csi_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_csi_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_csi_errorfn;
+
+    /* store the ival[maxcount] array immediately after the arg_csi struct */
+    result->ival = (int**)(result + 1);
+    /* store the data after the pointers to each var */
+    data_start = (int*)&result->ival[maxcount];
+
+    for (i = 0; i < maxcount; i++) {
+        result->ival[i] = &data_start[i * num_vals];
+    }
+
+    result->count = 0;
+    result->num_vals = num_vals;
+
+    ARG_TRACE(("arg_csin() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_lit: Implements the literature command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+
+static void arg_lit_resetfn(struct arg_lit* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static int arg_lit_scanfn(struct arg_lit* parent, const char* argval) {
+    int errorcode = 0;
+    if (parent->count < parent->hdr.maxcount)
+        parent->count++;
+    else
+        errorcode = ARG_ERR_MAXCOUNT;
+
+    ARG_TRACE(("%s:scanfn(%p,%s) returns %d\n", __FILE__, parent, argval, errorcode));
+    return errorcode;
+}
+
+static int arg_lit_checkfn(struct arg_lit* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static void arg_lit_errorfn(struct arg_lit* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_catf(ds, "%s: missing option ", progname);
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            arg_dstr_cat(ds, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_catf(ds, "%s: extraneous option ", progname);
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+    }
+
+    ARG_TRACE(("%s:errorfn(%p, %p, %d, %s, %s)\n", __FILE__, parent, ds, errorcode, argval, progname));
+}
+
+struct arg_lit* arg_lit0(const char* shortopts, const char* longopts, const char* glossary) {
+    return arg_litn(shortopts, longopts, 0, 1, glossary);
+}
+
+struct arg_lit* arg_lit1(const char* shortopts, const char* longopts, const char* glossary) {
+    return arg_litn(shortopts, longopts, 1, 1, glossary);
+}
+
+struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincount, int maxcount, const char* glossary) {
+    struct arg_lit* result;
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    result = (struct arg_lit*)xmalloc(sizeof(struct arg_lit));
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = 0;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = NULL;
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_lit_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_lit_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_lit_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_lit_errorfn;
+
+    /* init local variables */
+    result->count = 0;
+
+    ARG_TRACE(("arg_litn() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_rem: Implements the rem command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+
+struct arg_rem* arg_rem(const char* datatype, const char* glossary) {
+    struct arg_rem* result = (struct arg_rem*)xmalloc(sizeof(struct arg_rem));
+
+    result->hdr.flag = 0;
+    result->hdr.shortopts = NULL;
+    result->hdr.longopts = NULL;
+    result->hdr.datatype = datatype;
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = 1;
+    result->hdr.maxcount = 1;
+    result->hdr.parent = result;
+    result->hdr.resetfn = NULL;
+    result->hdr.scanfn = NULL;
+    result->hdr.checkfn = NULL;
+    result->hdr.errorfn = NULL;
+
+    ARG_TRACE(("arg_rem() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_rex: Implements the regex command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _TREX_H_
+#define _TREX_H_
+
+/*
+ * This module uses the T-Rex regular expression library to implement the regex
+ * logic. Here is the copyright notice of the library:
+ *
+ * Copyright (C) 2003-2006 Alberto Demichelis
+ *
+ * This software is provided 'as-is', without any express
+ * or implied warranty. In no event will the authors be held
+ * liable for any damages arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for
+ * any purpose, including commercial applications, and to alter
+ * it and redistribute it freely, subject to the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented;
+ *      you must not claim that you wrote the original software.
+ *      If you use this software in a product, an acknowledgment
+ *      in the product documentation would be appreciated but
+ *      is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such,
+ *      and must not be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any
+ *      source distribution.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TRexChar char
+#define MAX_CHAR 0xFF
+#define _TREXC(c) (c)
+#define trex_strlen strlen
+#define trex_printf printf
+
+#ifndef TREX_API
+#define TREX_API extern
+#endif
+
+#define TRex_True 1
+#define TRex_False 0
+
+#define TREX_ICASE ARG_REX_ICASE
+
+typedef unsigned int TRexBool;
+typedef struct TRex TRex;
+
+typedef struct {
+    const TRexChar* begin;
+    int len;
+} TRexMatch;
+
+#if defined(__clang__)
+TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) __attribute__((optnone));
+#elif defined(__GNUC__)
+TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) __attribute__((optimize(0)));
+#else
+TREX_API TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags);
+#endif
+TREX_API void trex_free(TRex* exp);
+TREX_API TRexBool trex_match(TRex* exp, const TRexChar* text);
+TREX_API TRexBool trex_search(TRex* exp, const TRexChar* text, const TRexChar** out_begin, const TRexChar** out_end);
+TREX_API TRexBool
+trex_searchrange(TRex* exp, const TRexChar* text_begin, const TRexChar* text_end, const TRexChar** out_begin, const TRexChar** out_end);
+TREX_API int trex_getsubexpcount(TRex* exp);
+TREX_API TRexBool trex_getsubexp(TRex* exp, int n, TRexMatch* subexp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+struct privhdr {
+    const char* pattern;
+    int flags;
+};
+
+static void arg_rex_resetfn(struct arg_rex* parent) {
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    parent->count = 0;
+}
+
+static int arg_rex_scanfn(struct arg_rex* parent, const char* argval) {
+    int errorcode = 0;
+    const TRexChar* error = NULL;
+    TRex* rex = NULL;
+    TRexBool is_match = TRex_False;
+
+    if (parent->count == parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent argument value unaltered but still count the argument. */
+        parent->count++;
+    } else {
+        struct privhdr* priv = (struct privhdr*)parent->hdr.priv;
+
+        /* test the current argument value for a match with the regular expression */
+        /* if a match is detected, record the argument value in the arg_rex struct */
+
+        rex = trex_compile(priv->pattern, &error, priv->flags);
+        is_match = trex_match(rex, argval);
+        if (!is_match)
+            errorcode = ARG_ERR_REGNOMATCH;
+        else
+            parent->sval[parent->count++] = argval;
+
+        trex_free(rex);
+    }
+
+    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static int arg_rex_checkfn(struct arg_rex* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+#if 0
+    struct privhdr *priv = (struct privhdr*)parent->hdr.priv;
+
+    /* free the regex "program" we constructed in resetfn */
+    regfree(&(priv->regex));
+
+    /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
+#endif
+    return errorcode;
+}
+
+static void arg_rex_errorfn(struct arg_rex* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        case ARG_ERR_REGNOMATCH:
+            arg_dstr_cat(ds, "illegal value  ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+
+        default: {
+        #if 0
+            char errbuff[256];
+            regerror(errorcode, NULL, errbuff, sizeof(errbuff));
+            printf("%s\n", errbuff);
+        #endif
+        } break;
+    }
+}
+
+struct arg_rex* arg_rex0(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary) {
+    return arg_rexn(shortopts, longopts, pattern, datatype, 0, 1, flags, glossary);
+}
+
+struct arg_rex* arg_rex1(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary) {
+    return arg_rexn(shortopts, longopts, pattern, datatype, 1, 1, flags, glossary);
+}
+
+struct arg_rex* arg_rexn(const char* shortopts,
+                         const char* longopts,
+                         const char* pattern,
+                         const char* datatype,
+                         int mincount,
+                         int maxcount,
+                         int flags,
+                         const char* glossary) {
+    size_t nbytes;
+    struct arg_rex* result;
+    struct privhdr* priv;
+    int i;
+    const TRexChar* error = NULL;
+    TRex* rex = NULL;
+
+    if (!pattern) {
+        printf("argtable: ERROR - illegal regular expression pattern \"(NULL)\"\n");
+        printf("argtable: Bad argument table.\n");
+        return NULL;
+    }
+
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_rex)      /* storage for struct arg_rex */
+             + sizeof(struct privhdr)    /* storage for private arg_rex data */
+             + (size_t)maxcount * sizeof(char*); /* storage for sval[maxcount] array */
+
+    /* init the arg_hdr struct */
+    result = (struct arg_rex*)xmalloc(nbytes);
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : pattern;
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_rex_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_rex_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_rex_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_rex_errorfn;
+
+    /* store the arg_rex_priv struct immediately after the arg_rex struct */
+    result->hdr.priv = result + 1;
+    priv = (struct privhdr*)(result->hdr.priv);
+    priv->pattern = pattern;
+    priv->flags = flags;
+
+    /* store the sval[maxcount] array immediately after the arg_rex_priv struct */
+    result->sval = (const char**)(priv + 1);
+    result->count = 0;
+
+    /* foolproof the string pointers by initializing them to reference empty strings */
+    for (i = 0; i < maxcount; i++)
+        result->sval[i] = "";
+
+    /* here we construct and destroy a regex representation of the regular
+     * expression for no other reason than to force any regex errors to be
+     * trapped now rather than later. If we don't, then errors may go undetected
+     * until an argument is actually parsed.
+     */
+
+    rex = trex_compile(priv->pattern, &error, priv->flags);
+    if (rex == NULL) {
+        ARG_LOG(("argtable: %s \"%s\"\n", error ? error : _TREXC("undefined"), priv->pattern));
+        ARG_LOG(("argtable: Bad argument table.\n"));
+    }
+
+    trex_free(rex);
+
+    ARG_TRACE(("arg_rexn() returns %p\n", result));
+    return result;
+}
+
+/* see copyright notice in trex.h */
+#include <ctype.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _UINCODE
+#define scisprint iswprint
+#define scstrlen wcslen
+#define scprintf wprintf
+#define _SC(x) L(x)
+#else
+#define scisprint isprint
+#define scstrlen strlen
+#define scprintf printf
+#define _SC(x) (x)
+#endif
+
+#ifdef ARG_REX_DEBUG
+#include <stdio.h>
+
+static const TRexChar* g_nnames[] = {_SC("NONE"),    _SC("OP_GREEDY"), _SC("OP_OR"),     _SC("OP_EXPR"),   _SC("OP_NOCAPEXPR"),
+                                     _SC("OP_DOT"),  _SC("OP_CLASS"),  _SC("OP_CCLASS"), _SC("OP_NCLASS"), _SC("OP_RANGE"),
+                                     _SC("OP_CHAR"), _SC("OP_EOL"),    _SC("OP_BOL"),    _SC("OP_WB")};
+
+#endif
+#define OP_GREEDY (MAX_CHAR + 1)  /*  * + ? {n} */
+#define OP_OR (MAX_CHAR + 2)
+#define OP_EXPR (MAX_CHAR + 3)       /* parentesis () */
+#define OP_NOCAPEXPR (MAX_CHAR + 4)  /* parentesis (?:) */
+#define OP_DOT (MAX_CHAR + 5)
+#define OP_CLASS (MAX_CHAR + 6)
+#define OP_CCLASS (MAX_CHAR + 7)
+#define OP_NCLASS (MAX_CHAR + 8)  /* negates class the [^ */
+#define OP_RANGE (MAX_CHAR + 9)
+#define OP_CHAR (MAX_CHAR + 10)
+#define OP_EOL (MAX_CHAR + 11)
+#define OP_BOL (MAX_CHAR + 12)
+#define OP_WB (MAX_CHAR + 13)
+
+#define TREX_SYMBOL_ANY_CHAR ('.')
+#define TREX_SYMBOL_GREEDY_ONE_OR_MORE ('+')
+#define TREX_SYMBOL_GREEDY_ZERO_OR_MORE ('*')
+#define TREX_SYMBOL_GREEDY_ZERO_OR_ONE ('?')
+#define TREX_SYMBOL_BRANCH ('|')
+#define TREX_SYMBOL_END_OF_STRING ('$')
+#define TREX_SYMBOL_BEGINNING_OF_STRING ('^')
+#define TREX_SYMBOL_ESCAPE_CHAR ('\\')
+
+typedef int TRexNodeType;
+
+typedef struct tagTRexNode {
+    TRexNodeType type;
+    int left;
+    int right;
+    int next;
+} TRexNode;
+
+struct TRex {
+    const TRexChar* _eol;
+    const TRexChar* _bol;
+    const TRexChar* _p;
+    int _first;
+    int _op;
+    TRexNode* _nodes;
+    int _nallocated;
+    int _nsize;
+    int _nsubexpr;
+    TRexMatch* _matches;
+    int _currsubexp;
+    void* _jmpbuf;
+    const TRexChar** _error;
+    int _flags;
+};
+
+static int trex_list(TRex* exp);
+
+static int trex_newnode(TRex* exp, TRexNodeType type) {
+    TRexNode n;
+    int newid;
+    n.type = type;
+    n.next = n.right = n.left = -1;
+    if (type == OP_EXPR)
+        n.right = exp->_nsubexpr++;
+    if (exp->_nallocated < (exp->_nsize + 1)) {
+        exp->_nallocated *= 2;
+        exp->_nodes = (TRexNode*)xrealloc(exp->_nodes, (size_t)exp->_nallocated * sizeof(TRexNode));
+    }
+    exp->_nodes[exp->_nsize++] = n;
+    newid = exp->_nsize - 1;
+    return (int)newid;
+}
+
+static void trex_error(TRex* exp, const TRexChar* error) {
+    if (exp->_error)
+        *exp->_error = error;
+    longjmp(*((jmp_buf*)exp->_jmpbuf), -1);
+}
+
+static void trex_expect(TRex* exp, int n) {
+    if ((*exp->_p) != n)
+        trex_error(exp, _SC("expected paren"));
+    exp->_p++;
+}
+
+static TRexChar trex_escapechar(TRex* exp) {
+    if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
+        exp->_p++;
+        switch (*exp->_p) {
+            case 'v':
+                exp->_p++;
+                return '\v';
+            case 'n':
+                exp->_p++;
+                return '\n';
+            case 't':
+                exp->_p++;
+                return '\t';
+            case 'r':
+                exp->_p++;
+                return '\r';
+            case 'f':
+                exp->_p++;
+                return '\f';
+            default:
+                return (*exp->_p++);
+        }
+    } else if (!scisprint((int)(*exp->_p)))
+        trex_error(exp, _SC("letter expected"));
+    return (*exp->_p++);
+}
+
+static int trex_charclass(TRex* exp, int classid) {
+    int n = trex_newnode(exp, OP_CCLASS);
+    exp->_nodes[n].left = classid;
+    return n;
+}
+
+static int trex_charnode(TRex* exp, TRexBool isclass) {
+    TRexChar t;
+    if (*exp->_p == TREX_SYMBOL_ESCAPE_CHAR) {
+        exp->_p++;
+        switch (*exp->_p) {
+            case 'n':
+                exp->_p++;
+                return trex_newnode(exp, '\n');
+            case 't':
+                exp->_p++;
+                return trex_newnode(exp, '\t');
+            case 'r':
+                exp->_p++;
+                return trex_newnode(exp, '\r');
+            case 'f':
+                exp->_p++;
+                return trex_newnode(exp, '\f');
+            case 'v':
+                exp->_p++;
+                return trex_newnode(exp, '\v');
+            case 'a':
+            case 'A':
+            case 'w':
+            case 'W':
+            case 's':
+            case 'S':
+            case 'd':
+            case 'D':
+            case 'x':
+            case 'X':
+            case 'c':
+            case 'C':
+            case 'p':
+            case 'P':
+            case 'l':
+            case 'u': {
+                t = *exp->_p;
+                exp->_p++;
+                return trex_charclass(exp, t);
+            }
+            case 'b':
+            case 'B':
+                if (!isclass) {
+                    int node = trex_newnode(exp, OP_WB);
+                    exp->_nodes[node].left = *exp->_p;
+                    exp->_p++;
+                    return node;
+                }
+                /* fall through */
+            default:
+                t = *exp->_p;
+                exp->_p++;
+                return trex_newnode(exp, t);
+        }
+    } else if (!scisprint((int)(*exp->_p))) {
+        trex_error(exp, _SC("letter expected"));
+    }
+    t = *exp->_p;
+    exp->_p++;
+    return trex_newnode(exp, t);
+}
+static int trex_class(TRex* exp) {
+    int ret = -1;
+    int first = -1, chain;
+    if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
+        ret = trex_newnode(exp, OP_NCLASS);
+        exp->_p++;
+    } else
+        ret = trex_newnode(exp, OP_CLASS);
+
+    if (*exp->_p == ']')
+        trex_error(exp, _SC("empty class"));
+    chain = ret;
+    while (*exp->_p != ']' && exp->_p != exp->_eol) {
+        if (*exp->_p == '-' && first != -1) {
+            int r, t;
+            if (*exp->_p++ == ']')
+                trex_error(exp, _SC("unfinished range"));
+            r = trex_newnode(exp, OP_RANGE);
+            if (first > *exp->_p)
+                trex_error(exp, _SC("invalid range"));
+            if (exp->_nodes[first].type == OP_CCLASS)
+                trex_error(exp, _SC("cannot use character classes in ranges"));
+            exp->_nodes[r].left = exp->_nodes[first].type;
+            t = trex_escapechar(exp);
+            exp->_nodes[r].right = t;
+            exp->_nodes[chain].next = r;
+            chain = r;
+            first = -1;
+        } else {
+            if (first != -1) {
+                int c = first;
+                exp->_nodes[chain].next = c;
+                chain = c;
+                first = trex_charnode(exp, TRex_True);
+            } else {
+                first = trex_charnode(exp, TRex_True);
+            }
+        }
+    }
+    if (first != -1) {
+        int c = first;
+        exp->_nodes[chain].next = c;
+        chain = c;
+        first = -1;
+    }
+    /* hack? */
+    exp->_nodes[ret].left = exp->_nodes[ret].next;
+    exp->_nodes[ret].next = -1;
+    return ret;
+}
+
+static int trex_parsenumber(TRex* exp) {
+    int ret = *exp->_p - '0';
+    int positions = 10;
+    exp->_p++;
+    while (isdigit((int)(*exp->_p))) {
+        ret = ret * 10 + (*exp->_p++ - '0');
+        if (positions == 1000000000)
+            trex_error(exp, _SC("overflow in numeric constant"));
+        positions *= 10;
+    };
+    return ret;
+}
+
+static int trex_element(TRex* exp) {
+    int ret = -1;
+    switch (*exp->_p) {
+        case '(': {
+            int expr, newn;
+            exp->_p++;
+
+            if (*exp->_p == '?') {
+                exp->_p++;
+                trex_expect(exp, ':');
+                expr = trex_newnode(exp, OP_NOCAPEXPR);
+            } else
+                expr = trex_newnode(exp, OP_EXPR);
+            newn = trex_list(exp);
+            exp->_nodes[expr].left = newn;
+            ret = expr;
+            trex_expect(exp, ')');
+        } break;
+        case '[':
+            exp->_p++;
+            ret = trex_class(exp);
+            trex_expect(exp, ']');
+            break;
+        case TREX_SYMBOL_END_OF_STRING:
+            exp->_p++;
+            ret = trex_newnode(exp, OP_EOL);
+            break;
+        case TREX_SYMBOL_ANY_CHAR:
+            exp->_p++;
+            ret = trex_newnode(exp, OP_DOT);
+            break;
+        default:
+            ret = trex_charnode(exp, TRex_False);
+            break;
+    }
+
+    {
+        TRexBool isgreedy = TRex_False;
+        unsigned short p0 = 0, p1 = 0;
+        switch (*exp->_p) {
+            case TREX_SYMBOL_GREEDY_ZERO_OR_MORE:
+                p0 = 0;
+                p1 = 0xFFFF;
+                exp->_p++;
+                isgreedy = TRex_True;
+                break;
+            case TREX_SYMBOL_GREEDY_ONE_OR_MORE:
+                p0 = 1;
+                p1 = 0xFFFF;
+                exp->_p++;
+                isgreedy = TRex_True;
+                break;
+            case TREX_SYMBOL_GREEDY_ZERO_OR_ONE:
+                p0 = 0;
+                p1 = 1;
+                exp->_p++;
+                isgreedy = TRex_True;
+                break;
+            case '{':
+                exp->_p++;
+                if (!isdigit((int)(*exp->_p)))
+                    trex_error(exp, _SC("number expected"));
+                p0 = (unsigned short)trex_parsenumber(exp);
+                /*******************************/
+                switch (*exp->_p) {
+                    case '}':
+                        p1 = p0;
+                        exp->_p++;
+                        break;
+                    case ',':
+                        exp->_p++;
+                        p1 = 0xFFFF;
+                        if (isdigit((int)(*exp->_p))) {
+                            p1 = (unsigned short)trex_parsenumber(exp);
+                        }
+                        trex_expect(exp, '}');
+                        break;
+                    default:
+                        trex_error(exp, _SC(", or } expected"));
+                }
+                /*******************************/
+                isgreedy = TRex_True;
+                break;
+        }
+        if (isgreedy) {
+            int nnode = trex_newnode(exp, OP_GREEDY);
+            exp->_nodes[nnode].left = ret;
+            exp->_nodes[nnode].right = ((p0) << 16) | p1;
+            ret = nnode;
+        }
+    }
+    if ((*exp->_p != TREX_SYMBOL_BRANCH) && (*exp->_p != ')') && (*exp->_p != TREX_SYMBOL_GREEDY_ZERO_OR_MORE) &&
+        (*exp->_p != TREX_SYMBOL_GREEDY_ONE_OR_MORE) && (*exp->_p != '\0')) {
+        int nnode = trex_element(exp);
+        exp->_nodes[ret].next = nnode;
+    }
+
+    return ret;
+}
+
+static int trex_list(TRex* exp) {
+    int ret = -1, e;
+    if (*exp->_p == TREX_SYMBOL_BEGINNING_OF_STRING) {
+        exp->_p++;
+        ret = trex_newnode(exp, OP_BOL);
+    }
+    e = trex_element(exp);
+    if (ret != -1) {
+        exp->_nodes[ret].next = e;
+    } else
+        ret = e;
+
+    if (*exp->_p == TREX_SYMBOL_BRANCH) {
+        int temp, tright;
+        exp->_p++;
+        temp = trex_newnode(exp, OP_OR);
+        exp->_nodes[temp].left = ret;
+        tright = trex_list(exp);
+        exp->_nodes[temp].right = tright;
+        ret = temp;
+    }
+    return ret;
+}
+
+static TRexBool trex_matchcclass(int cclass, TRexChar c) {
+    switch (cclass) {
+        case 'a':
+            return isalpha(c) ? TRex_True : TRex_False;
+        case 'A':
+            return !isalpha(c) ? TRex_True : TRex_False;
+        case 'w':
+            return (isalnum(c) || c == '_') ? TRex_True : TRex_False;
+        case 'W':
+            return (!isalnum(c) && c != '_') ? TRex_True : TRex_False;
+        case 's':
+            return isspace(c) ? TRex_True : TRex_False;
+        case 'S':
+            return !isspace(c) ? TRex_True : TRex_False;
+        case 'd':
+            return isdigit(c) ? TRex_True : TRex_False;
+        case 'D':
+            return !isdigit(c) ? TRex_True : TRex_False;
+        case 'x':
+            return isxdigit(c) ? TRex_True : TRex_False;
+        case 'X':
+            return !isxdigit(c) ? TRex_True : TRex_False;
+        case 'c':
+            return iscntrl(c) ? TRex_True : TRex_False;
+        case 'C':
+            return !iscntrl(c) ? TRex_True : TRex_False;
+        case 'p':
+            return ispunct(c) ? TRex_True : TRex_False;
+        case 'P':
+            return !ispunct(c) ? TRex_True : TRex_False;
+        case 'l':
+            return islower(c) ? TRex_True : TRex_False;
+        case 'u':
+            return isupper(c) ? TRex_True : TRex_False;
+    }
+    return TRex_False; /*cannot happen*/
+}
+
+static TRexBool trex_matchclass(TRex* exp, TRexNode* node, TRexChar c) {
+    do {
+        switch (node->type) {
+            case OP_RANGE:
+                if (exp->_flags & TREX_ICASE) {
+                    if (c >= toupper(node->left) && c <= toupper(node->right))
+                        return TRex_True;
+                    if (c >= tolower(node->left) && c <= tolower(node->right))
+                        return TRex_True;
+                } else {
+                    if (c >= node->left && c <= node->right)
+                        return TRex_True;
+                }
+                break;
+            case OP_CCLASS:
+                if (trex_matchcclass(node->left, c))
+                    return TRex_True;
+                break;
+            default:
+                if (exp->_flags & TREX_ICASE) {
+                    if (c == tolower(node->type) || c == toupper(node->type))
+                        return TRex_True;
+                } else {
+                    if (c == node->type)
+                        return TRex_True;
+                }
+        }
+    } while ((node->next != -1) && ((node = &exp->_nodes[node->next]) != NULL));
+    return TRex_False;
+}
+
+static const TRexChar* trex_matchnode(TRex* exp, TRexNode* node, const TRexChar* str, TRexNode* next) {
+    TRexNodeType type = node->type;
+    switch (type) {
+        case OP_GREEDY: {
+            /* TRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : NULL; */
+            TRexNode* greedystop = NULL;
+            int p0 = (node->right >> 16) & 0x0000FFFF, p1 = node->right & 0x0000FFFF, nmaches = 0;
+            const TRexChar *s = str, *good = str;
+
+            if (node->next != -1) {
+                greedystop = &exp->_nodes[node->next];
+            } else {
+                greedystop = next;
+            }
+
+            while ((nmaches == 0xFFFF || nmaches < p1)) {
+                const TRexChar* stop;
+                if ((s = trex_matchnode(exp, &exp->_nodes[node->left], s, greedystop)) == NULL)
+                    break;
+                nmaches++;
+                good = s;
+                if (greedystop) {
+                    /* checks that 0 matches satisfy the expression(if so skips) */
+                    /* if not would always stop(for instance if is a '?') */
+                    if (greedystop->type != OP_GREEDY || (greedystop->type == OP_GREEDY && ((greedystop->right >> 16) & 0x0000FFFF) != 0)) {
+                        TRexNode* gnext = NULL;
+                        if (greedystop->next != -1) {
+                            gnext = &exp->_nodes[greedystop->next];
+                        } else if (next && next->next != -1) {
+                            gnext = &exp->_nodes[next->next];
+                        }
+                        stop = trex_matchnode(exp, greedystop, s, gnext);
+                        if (stop) {
+                            /* if satisfied stop it */
+                            if (p0 == p1 && p0 == nmaches)
+                                break;
+                            else if (nmaches >= p0 && p1 == 0xFFFF)
+                                break;
+                            else if (nmaches >= p0 && nmaches <= p1)
+                                break;
+                        }
+                    }
+                }
+
+                if (s >= exp->_eol)
+                    break;
+            }
+            if (p0 == p1 && p0 == nmaches)
+                return good;
+            else if (nmaches >= p0 && p1 == 0xFFFF)
+                return good;
+            else if (nmaches >= p0 && nmaches <= p1)
+                return good;
+            return NULL;
+        }
+        case OP_OR: {
+            const TRexChar* asd = str;
+            TRexNode* temp = &exp->_nodes[node->left];
+            while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
+                if (temp->next != -1)
+                    temp = &exp->_nodes[temp->next];
+                else
+                    return asd;
+            }
+            asd = str;
+            temp = &exp->_nodes[node->right];
+            while ((asd = trex_matchnode(exp, temp, asd, NULL)) != NULL) {
+                if (temp->next != -1)
+                    temp = &exp->_nodes[temp->next];
+                else
+                    return asd;
+            }
+            return NULL;
+            break;
+        }
+        case OP_EXPR:
+        case OP_NOCAPEXPR: {
+            TRexNode* n = &exp->_nodes[node->left];
+            const TRexChar* cur = str;
+            int capture = -1;
+            if (node->type != OP_NOCAPEXPR && node->right == exp->_currsubexp) {
+                capture = exp->_currsubexp;
+                exp->_matches[capture].begin = cur;
+                exp->_currsubexp++;
+            }
+
+            do {
+                TRexNode* subnext = NULL;
+                if (n->next != -1) {
+                    subnext = &exp->_nodes[n->next];
+                } else {
+                    subnext = next;
+                }
+                if ((cur = trex_matchnode(exp, n, cur, subnext)) == NULL) {
+                    if (capture != -1) {
+                        exp->_matches[capture].begin = 0;
+                        exp->_matches[capture].len = 0;
+                    }
+                    return NULL;
+                }
+            } while ((n->next != -1) && ((n = &exp->_nodes[n->next]) != NULL));
+
+            if (capture != -1)
+                exp->_matches[capture].len = (int)(cur - exp->_matches[capture].begin);
+            return cur;
+        }
+        case OP_WB:
+            if ((str == exp->_bol && !isspace((int)(*str))) || (str == exp->_eol && !isspace((int)(*(str - 1)))) || (!isspace((int)(*str)) && isspace((int)(*(str + 1)))) ||
+                (isspace((int)(*str)) && !isspace((int)(*(str + 1))))) {
+                return (node->left == 'b') ? str : NULL;
+            }
+            return (node->left == 'b') ? NULL : str;
+        case OP_BOL:
+            if (str == exp->_bol)
+                return str;
+            return NULL;
+        case OP_EOL:
+            if (str == exp->_eol)
+                return str;
+            return NULL;
+        case OP_DOT: {
+            str++;
+        }
+            return str;
+        case OP_NCLASS:
+        case OP_CLASS:
+            if (trex_matchclass(exp, &exp->_nodes[node->left], *str) ? (type == OP_CLASS ? TRex_True : TRex_False)
+                                                                     : (type == OP_NCLASS ? TRex_True : TRex_False)) {
+                str++;
+                return str;
+            }
+            return NULL;
+        case OP_CCLASS:
+            if (trex_matchcclass(node->left, *str)) {
+                str++;
+                return str;
+            }
+            return NULL;
+        default: /* char */
+            if (exp->_flags & TREX_ICASE) {
+                if (*str != tolower(node->type) && *str != toupper(node->type))
+                    return NULL;
+            } else {
+                if (*str != node->type)
+                    return NULL;
+            }
+            str++;
+            return str;
+    }
+}
+
+/* public api */
+TRex* trex_compile(const TRexChar* pattern, const TRexChar** error, int flags) {
+    TRex* exp = (TRex*)xmalloc(sizeof(TRex));
+    exp->_eol = exp->_bol = NULL;
+    exp->_p = pattern;
+    exp->_nallocated = (int)(scstrlen(pattern) * sizeof(TRexChar));
+    exp->_nodes = (TRexNode*)xmalloc((size_t)exp->_nallocated * sizeof(TRexNode));
+    exp->_nsize = 0;
+    exp->_matches = 0;
+    exp->_nsubexpr = 0;
+    exp->_first = trex_newnode(exp, OP_EXPR);
+    exp->_error = error;
+    exp->_jmpbuf = xmalloc(sizeof(jmp_buf));
+    exp->_flags = flags;
+    if (setjmp(*((jmp_buf*)exp->_jmpbuf)) == 0) {
+        int res = trex_list(exp);
+        exp->_nodes[exp->_first].left = res;
+        if (*exp->_p != '\0')
+            trex_error(exp, _SC("unexpected character"));
+#ifdef ARG_REX_DEBUG
+        {
+            int nsize, i;
+            nsize = exp->_nsize;
+            scprintf(_SC("\n"));
+            for (i = 0; i < nsize; i++) {
+                if (exp->_nodes[i].type > MAX_CHAR)
+                    scprintf(_SC("[%02d] %10s "), i, g_nnames[exp->_nodes[i].type - MAX_CHAR]);
+                else
+                    scprintf(_SC("[%02d] %10c "), i, exp->_nodes[i].type);
+                scprintf(_SC("left %02d right %02d next %02d\n"), exp->_nodes[i].left, exp->_nodes[i].right, exp->_nodes[i].next);
+            }
+            scprintf(_SC("\n"));
+        }
+#endif
+        exp->_matches = (TRexMatch*)xmalloc((size_t)exp->_nsubexpr * sizeof(TRexMatch));
+        memset(exp->_matches, 0, (size_t)exp->_nsubexpr * sizeof(TRexMatch));
+    } else {
+        trex_free(exp);
+        return NULL;
+    }
+    return exp;
+}
+
+void trex_free(TRex* exp) {
+    if (exp) {
+        xfree(exp->_nodes);
+        xfree(exp->_jmpbuf);
+        xfree(exp->_matches);
+        xfree(exp);
+    }
+}
+
+TRexBool trex_match(TRex* exp, const TRexChar* text) {
+    const TRexChar* res = NULL;
+    exp->_bol = text;
+    exp->_eol = text + scstrlen(text);
+    exp->_currsubexp = 0;
+    res = trex_matchnode(exp, exp->_nodes, text, NULL);
+    if (res == NULL || res != exp->_eol)
+        return TRex_False;
+    return TRex_True;
+}
+
+TRexBool trex_searchrange(TRex* exp, const TRexChar* text_begin, const TRexChar* text_end, const TRexChar** out_begin, const TRexChar** out_end) {
+    const TRexChar* cur = NULL;
+    int node = exp->_first;
+    if (text_begin >= text_end)
+        return TRex_False;
+    exp->_bol = text_begin;
+    exp->_eol = text_end;
+    do {
+        cur = text_begin;
+        while (node != -1) {
+            exp->_currsubexp = 0;
+            cur = trex_matchnode(exp, &exp->_nodes[node], cur, NULL);
+            if (!cur)
+                break;
+            node = exp->_nodes[node].next;
+        }
+        text_begin++;
+    } while (cur == NULL && text_begin != text_end);
+
+    if (cur == NULL)
+        return TRex_False;
+
+    --text_begin;
+
+    if (out_begin)
+        *out_begin = text_begin;
+    if (out_end)
+        *out_end = cur;
+    return TRex_True;
+}
+
+TRexBool trex_search(TRex* exp, const TRexChar* text, const TRexChar** out_begin, const TRexChar** out_end) {
+    return trex_searchrange(exp, text, text + scstrlen(text), out_begin, out_end);
+}
+
+int trex_getsubexpcount(TRex* exp) {
+    return exp->_nsubexpr;
+}
+
+TRexBool trex_getsubexp(TRex* exp, int n, TRexMatch* subexp) {
+    if (n < 0 || n >= exp->_nsubexpr)
+        return TRex_False;
+    *subexp = exp->_matches[n];
+    return TRex_True;
+}
+/*******************************************************************************
+ * arg_str: Implements the str command-line option
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <stdlib.h>
+
+static void arg_str_resetfn(struct arg_str* parent) {
+    int i;
+
+    ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
+    for (i = 0; i < parent->count; i++) {
+        parent->sval[i] = "";
+    }
+    parent->count = 0;
+}
+
+static int arg_str_scanfn(struct arg_str* parent, const char* argval) {
+    int errorcode = 0;
+
+    if (parent->count == parent->hdr.maxcount) {
+        /* maximum number of arguments exceeded */
+        errorcode = ARG_ERR_MAXCOUNT;
+    } else if (!argval) {
+        /* a valid argument with no argument value was given. */
+        /* This happens when an optional argument value was invoked. */
+        /* leave parent argument value unaltered but still count the argument. */
+        parent->count++;
+    } else {
+        parent->sval[parent->count++] = argval;
+    }
+
+    ARG_TRACE(("%s:scanfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static int arg_str_checkfn(struct arg_str* parent) {
+    int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
+
+    ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
+    return errorcode;
+}
+
+static void arg_str_errorfn(struct arg_str* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    const char* shortopts = parent->hdr.shortopts;
+    const char* longopts = parent->hdr.longopts;
+    const char* datatype = parent->hdr.datatype;
+
+    /* make argval NULL safe */
+    argval = argval ? argval : "";
+
+    arg_dstr_catf(ds, "%s: ", progname);
+    switch (errorcode) {
+        case ARG_ERR_MINCOUNT:
+            arg_dstr_cat(ds, "missing option ");
+            arg_print_option_ds(ds, shortopts, longopts, datatype, "\n");
+            break;
+
+        case ARG_ERR_MAXCOUNT:
+            arg_dstr_cat(ds, "excess option ");
+            arg_print_option_ds(ds, shortopts, longopts, argval, "\n");
+            break;
+    }
+}
+
+struct arg_str* arg_str0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_strn(shortopts, longopts, datatype, 0, 1, glossary);
+}
+
+struct arg_str* arg_str1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary) {
+    return arg_strn(shortopts, longopts, datatype, 1, 1, glossary);
+}
+
+struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
+    size_t nbytes;
+    struct arg_str* result;
+    int i;
+
+    /* should not allow this stupid error */
+    /* we should return an error code warning this logic error */
+    /* foolproof things by ensuring maxcount is not less than mincount */
+    maxcount = (maxcount < mincount) ? mincount : maxcount;
+
+    nbytes = sizeof(struct arg_str)      /* storage for struct arg_str */
+             + (size_t)maxcount * sizeof(char*); /* storage for sval[maxcount] array */
+
+    result = (struct arg_str*)xmalloc(nbytes);
+
+    /* init the arg_hdr struct */
+    result->hdr.flag = ARG_HASVALUE;
+    result->hdr.shortopts = shortopts;
+    result->hdr.longopts = longopts;
+    result->hdr.datatype = datatype ? datatype : "<string>";
+    result->hdr.glossary = glossary;
+    result->hdr.mincount = mincount;
+    result->hdr.maxcount = maxcount;
+    result->hdr.parent = result;
+    result->hdr.resetfn = (arg_resetfn*)arg_str_resetfn;
+    result->hdr.scanfn = (arg_scanfn*)arg_str_scanfn;
+    result->hdr.checkfn = (arg_checkfn*)arg_str_checkfn;
+    result->hdr.errorfn = (arg_errorfn*)arg_str_errorfn;
+
+    /* store the sval[maxcount] array immediately after the arg_str struct */
+    result->sval = (const char**)(result + 1);
+    result->count = 0;
+
+    /* foolproof the string pointers by initializing them to reference empty strings */
+    for (i = 0; i < maxcount; i++)
+        result->sval[i] = "";
+
+    ARG_TRACE(("arg_strn() returns %p\n", result));
+    return result;
+}
+/*******************************************************************************
+ * arg_cmd: Provides the sub-command mechanism
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 2013-2019 Tom G. Huang
+ * <tomghuang@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_MODULE_VERSION_SIZE 128
+
+static arg_hashtable_t* s_hashtable = NULL;
+static char* s_module_name = NULL;
+static int s_mod_ver_major = 0;
+static int s_mod_ver_minor = 0;
+static int s_mod_ver_patch = 0;
+static char* s_mod_ver_tag = NULL;
+static char* s_mod_ver = NULL;
+
+void arg_set_module_name(const char* name) {
+    size_t slen;
+
+    xfree(s_module_name);
+    slen = strlen(name);
+    s_module_name = (char*)xmalloc(slen + 1);
+    memset(s_module_name, 0, slen + 1);
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncpy_s(s_module_name, slen + 1, name, slen);
+#else
+    memcpy(s_module_name, name, slen);
+#endif
+}
+
+void arg_set_module_version(int major, int minor, int patch, const char* tag) {
+    size_t slen_tag, slen_ds;
+    arg_dstr_t ds;
+
+    s_mod_ver_major = major;
+    s_mod_ver_minor = minor;
+    s_mod_ver_patch = patch;
+
+    xfree(s_mod_ver_tag);
+    slen_tag = strlen(tag);
+    s_mod_ver_tag = (char*)xmalloc(slen_tag + 1);
+    memset(s_mod_ver_tag, 0, slen_tag + 1);
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncpy_s(s_mod_ver_tag, slen_tag + 1, tag, slen_tag);
+#else
+    memcpy(s_mod_ver_tag, tag, slen_tag);
+#endif
+
+    ds = arg_dstr_create();
+    arg_dstr_catf(ds, "%d.", s_mod_ver_major);
+    arg_dstr_catf(ds, "%d.", s_mod_ver_minor);
+    arg_dstr_catf(ds, "%d.", s_mod_ver_patch);
+    arg_dstr_cat(ds, s_mod_ver_tag);
+
+    xfree(s_mod_ver);
+    slen_ds = strlen(arg_dstr_cstr(ds));
+    s_mod_ver = (char*)xmalloc(slen_ds + 1);
+    memset(s_mod_ver, 0, slen_ds + 1);
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncpy_s(s_mod_ver, slen_ds + 1, arg_dstr_cstr(ds), slen_ds);
+#else
+    memcpy(s_mod_ver, arg_dstr_cstr(ds), slen_ds);
+#endif
+
+    arg_dstr_destroy(ds);
+}
+
+static unsigned int hash_key(const void* key) {
+    const char* str = (const char*)key;
+    int c;
+    unsigned int hash = 5381;
+
+    while ((c = *str++) != 0)
+        hash = ((hash << 5) + hash) + (unsigned int)c; /* hash * 33 + c */
+
+    return hash;
+}
+
+static int equal_keys(const void* key1, const void* key2) {
+    char* k1 = (char*)key1;
+    char* k2 = (char*)key2;
+    return (0 == strcmp(k1, k2));
+}
+
+void arg_cmd_init(void) {
+    s_hashtable = arg_hashtable_create(32, hash_key, equal_keys);
+}
+
+void arg_cmd_uninit(void) {
+    arg_hashtable_destroy(s_hashtable, 1);
+}
+
+void arg_cmd_register(const char* name, arg_cmdfn* proc, const char* description) {
+    arg_cmd_info_t* cmd_info;
+    size_t slen_name;
+    void* k;
+
+    assert(strlen(name) < ARG_CMD_NAME_LEN);
+    assert(strlen(description) < ARG_CMD_DESCRIPTION_LEN);
+
+    /* Check if the command already exists. */
+    /* If the command exists, replace the existing command. */
+    /* If the command doesn't exist, insert the command. */
+    cmd_info = (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, name);
+    if (cmd_info) {
+        arg_hashtable_remove(s_hashtable, name);
+        cmd_info = NULL;
+    }
+
+    cmd_info = (arg_cmd_info_t*)xmalloc(sizeof(arg_cmd_info_t));
+    memset(cmd_info, 0, sizeof(arg_cmd_info_t));
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncpy_s(cmd_info->name, ARG_CMD_NAME_LEN, name, strlen(name));
+    strncpy_s(cmd_info->description, ARG_CMD_DESCRIPTION_LEN, description, strlen(description));
+#else
+    memcpy(cmd_info->name, name, strlen(name));
+    memcpy(cmd_info->description, description, strlen(description));
+#endif
+
+    cmd_info->proc = proc;
+
+    slen_name = strlen(name);
+    k = xmalloc(slen_name + 1);
+    memset(k, 0, slen_name + 1);
+
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+    strncpy_s((char*)k, slen_name + 1, name, slen_name);
+#else
+    memcpy((char*)k, name, slen_name);
+#endif
+
+    arg_hashtable_insert(s_hashtable, k, cmd_info);
+}
+
+void arg_cmd_unregister(const char* name) {
+    arg_hashtable_remove(s_hashtable, name);
+}
+
+int arg_cmd_dispatch(const char* name, int argc, char* argv[], arg_dstr_t res) {
+    arg_cmd_info_t* cmd_info = arg_cmd_info(name);
+
+    assert(cmd_info != NULL);
+    assert(cmd_info->proc != NULL);
+
+    return cmd_info->proc(argc, argv, res);
+}
+
+arg_cmd_info_t* arg_cmd_info(const char* name) {
+    return (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, name);
+}
+
+unsigned int arg_cmd_count(void) {
+    return arg_hashtable_count(s_hashtable);
+}
+
+arg_cmd_itr_t arg_cmd_itr_create(void) {
+    return (arg_cmd_itr_t)arg_hashtable_itr_create(s_hashtable);
+}
+
+int arg_cmd_itr_advance(arg_cmd_itr_t itr) {
+    return arg_hashtable_itr_advance((arg_hashtable_itr_t*)itr);
+}
+
+char* arg_cmd_itr_key(arg_cmd_itr_t itr) {
+    return (char*)arg_hashtable_itr_key((arg_hashtable_itr_t*)itr);
+}
+
+arg_cmd_info_t* arg_cmd_itr_value(arg_cmd_itr_t itr) {
+    return (arg_cmd_info_t*)arg_hashtable_itr_value((arg_hashtable_itr_t*)itr);
+}
+
+void arg_cmd_itr_destroy(arg_cmd_itr_t itr) {
+    arg_hashtable_itr_destroy((arg_hashtable_itr_t*)itr);
+}
+
+int arg_cmd_itr_search(arg_cmd_itr_t itr, void* k) {
+    return arg_hashtable_itr_search((arg_hashtable_itr_t*)itr, s_hashtable, k);
+}
+
+static const char* module_name(void) {
+    if (s_module_name == NULL || strlen(s_module_name) == 0)
+        return "<name>";
+
+    return s_module_name;
+}
+
+static const char* module_version(void) {
+    if (s_mod_ver == NULL || strlen(s_mod_ver) == 0)
+        return "0.0.0.0";
+
+    return s_mod_ver;
+}
+
+void arg_make_get_help_msg(arg_dstr_t res) {
+    arg_dstr_catf(res, "%s v%s\n", module_name(), module_version());
+    arg_dstr_catf(res, "Please type '%s help' to get more information.\n", module_name());
+}
+
+void arg_make_help_msg(arg_dstr_t ds, char* cmd_name, void** argtable) {
+    arg_cmd_info_t* cmd_info = (arg_cmd_info_t*)arg_hashtable_search(s_hashtable, cmd_name);
+    if (cmd_info) {
+        arg_dstr_catf(ds, "%s: %s\n", cmd_name, cmd_info->description);
+    }
+
+    arg_dstr_cat(ds, "Usage:\n");
+    arg_dstr_catf(ds, "  %s", module_name());
+
+    arg_print_syntaxv_ds(ds, argtable, "\n \nAvailable options:\n");
+    arg_print_glossary_ds(ds, argtable, "  %-23s %s\n");
+
+    arg_dstr_cat(ds, "\n");
+}
+
+void arg_make_syntax_err_msg(arg_dstr_t ds, void** argtable, struct arg_end* end) {
+    arg_print_errors_ds(ds, end, module_name());
+    arg_dstr_cat(ds, "Usage: \n");
+    arg_dstr_catf(ds, "  %s", module_name());
+    arg_print_syntaxv_ds(ds, argtable, "\n");
+    arg_dstr_cat(ds, "\n");
+}
+
+int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerrors, void** argtable, struct arg_end* end, int* exitcode) {
+    /* help handling
+     * note: '-h|--help' takes precedence over error reporting
+     */
+    if (help > 0) {
+        arg_make_help_msg(ds, name, argtable);
+        *exitcode = EXIT_SUCCESS;
+        return 1;
+    }
+
+    /* syntax error handling */
+    if (nerrors > 0) {
+        arg_make_syntax_err_msg(ds, argtable, end);
+        *exitcode = EXIT_FAILURE;
+        return 1;
+    }
+
+    return 0;
+}
+/*******************************************************************************
+ * argtable3: Implements the main interfaces of the library
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include "argtable3.h"
+
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#if ARG_REPLACE_GETOPT == 1
+#include "arg_getopt.h"
+#else
+#include <getopt.h>
+#endif
+#else
+#if ARG_REPLACE_GETOPT == 0
+#include <getopt.h>
+#endif
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
+#include <assert.h>
+#include <ctype.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void arg_register_error(struct arg_end* end, void* parent, int error, const char* argval) {
+    /* printf("arg_register_error(%p,%p,%d,%s)\n",end,parent,error,argval); */
+    if (end->count < end->hdr.maxcount) {
+        end->error[end->count] = error;
+        end->parent[end->count] = parent;
+        end->argval[end->count] = argval;
+        end->count++;
+    } else {
+        end->error[end->hdr.maxcount - 1] = ARG_ELIMIT;
+        end->parent[end->hdr.maxcount - 1] = end;
+        end->argval[end->hdr.maxcount - 1] = NULL;
+    }
+}
+
+/*
+ * Return index of first table entry with a matching short option
+ * or -1 if no match was found.
+ */
+static int find_shortoption(struct arg_hdr** table, char shortopt) {
+    int tabindex;
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        if (table[tabindex]->shortopts && strchr(table[tabindex]->shortopts, shortopt))
+            return tabindex;
+    }
+    return -1;
+}
+
+struct longoptions {
+    int getoptval;
+    int noptions;
+    struct option* options;
+};
+
+#if 0
+static
+void dump_longoptions(struct longoptions * longoptions)
+{
+    int i;
+    printf("getoptval = %d\n", longoptions->getoptval);
+    printf("noptions  = %d\n", longoptions->noptions);
+    for (i = 0; i < longoptions->noptions; i++)
+    {
+        printf("options[%d].name    = \"%s\"\n",
+               i,
+               longoptions->options[i].name);
+        printf("options[%d].has_arg = %d\n", i, longoptions->options[i].has_arg);
+        printf("options[%d].flag    = %p\n", i, longoptions->options[i].flag);
+        printf("options[%d].val     = %d\n", i, longoptions->options[i].val);
+    }
+}
+#endif
+
+static struct longoptions* alloc_longoptions(struct arg_hdr** table) {
+    struct longoptions* result;
+    size_t nbytes;
+    int noptions = 1;
+    size_t longoptlen = 0;
+    int tabindex;
+    int option_index = 0;
+    char* store;
+
+    /*
+     * Determine the total number of option structs required
+     * by counting the number of comma separated long options
+     * in all table entries and return the count in noptions.
+     * note: noptions starts at 1 not 0 because we getoptlong
+     * requires a NULL option entry to terminate the option array.
+     * While we are at it, count the number of chars required
+     * to store private copies of all the longoption strings
+     * and return that count in logoptlen.
+     */
+    tabindex = 0;
+    do {
+        const char* longopts = table[tabindex]->longopts;
+        longoptlen += (longopts ? strlen(longopts) : 0) + 1;
+        while (longopts) {
+            noptions++;
+            longopts = strchr(longopts + 1, ',');
+        }
+    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+    /*printf("%d long options consuming %d chars in total\n",noptions,longoptlen);*/
+
+    /* allocate storage for return data structure as: */
+    /* (struct longoptions) + (struct options)[noptions] + char[longoptlen] */
+    nbytes = sizeof(struct longoptions) + sizeof(struct option) * (size_t)noptions + longoptlen;
+    result = (struct longoptions*)xmalloc(nbytes);
+
+    result->getoptval = 0;
+    result->noptions = noptions;
+    result->options = (struct option*)(result + 1);
+    store = (char*)(result->options + noptions);
+
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        const char* longopts = table[tabindex]->longopts;
+
+        while (longopts && *longopts) {
+            char* storestart = store;
+
+            /* copy progressive longopt strings into the store */
+            while (*longopts != 0 && *longopts != ',')
+                *store++ = *longopts++;
+            *store++ = 0;
+            if (*longopts == ',')
+                longopts++;
+            /*fprintf(stderr,"storestart=\"%s\"\n",storestart);*/
+
+            result->options[option_index].name = storestart;
+            result->options[option_index].flag = &(result->getoptval);
+            result->options[option_index].val = tabindex;
+            if (table[tabindex]->flag & ARG_HASOPTVALUE)
+                result->options[option_index].has_arg = 2;
+            else if (table[tabindex]->flag & ARG_HASVALUE)
+                result->options[option_index].has_arg = 1;
+            else
+                result->options[option_index].has_arg = 0;
+
+            option_index++;
+        }
+    }
+    /* terminate the options array with a zero-filled entry */
+    result->options[option_index].name = 0;
+    result->options[option_index].has_arg = 0;
+    result->options[option_index].flag = 0;
+    result->options[option_index].val = 0;
+
+    /*dump_longoptions(result);*/
+    return result;
+}
+
+static char* alloc_shortoptions(struct arg_hdr** table) {
+    char* result;
+    size_t len = 2;
+    int tabindex;
+    char* res;
+
+    /* determine the total number of option chars required */
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        struct arg_hdr* hdr = table[tabindex];
+        len += 4 * (hdr->shortopts ? strlen(hdr->shortopts) : 0);
+    }
+
+    result = xmalloc(len);
+
+    res = result;
+    /* Add a leading + so getopt doesn't reorder argv */
+    *res++ = '+';
+    /* add a leading ':' so getopt return codes distinguish    */
+    /* unrecognised option and options missing argument values */
+    *res++ = ':';
+
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        struct arg_hdr* hdr = table[tabindex];
+        const char* shortopts = hdr->shortopts;
+        while (shortopts && *shortopts) {
+            *res++ = *shortopts++;
+            if (hdr->flag & ARG_HASVALUE)
+                *res++ = ':';
+            if (hdr->flag & ARG_HASOPTVALUE)
+                *res++ = ':';
+        }
+    }
+    /* null terminate the string */
+    *res = 0;
+
+    /*printf("alloc_shortoptions() returns \"%s\"\n",(result?result:"NULL"));*/
+    return result;
+}
+
+/* return index of the table terminator entry */
+static int arg_endindex(struct arg_hdr** table) {
+    int tabindex = 0;
+    while (!(table[tabindex]->flag & ARG_TERMINATOR))
+        tabindex++;
+    return tabindex;
+}
+
+static void arg_parse_tagged(int argc, char** argv, struct arg_hdr** table, struct arg_end* endtable) {
+    struct longoptions* longoptions;
+    char* shortoptions;
+    int copt;
+
+    /*printf("arg_parse_tagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
+
+    /* allocate short and long option arrays for the given opttable[].   */
+    /* if the allocs fail then put an error msg in the last table entry. */
+    longoptions = alloc_longoptions(table);
+    shortoptions = alloc_shortoptions(table);
+
+    /*dump_longoptions(longoptions);*/
+
+    /* reset getopts internal option-index to zero, and disable error reporting */
+    optind = 0;
+    opterr = 0;
+
+    /* fetch and process args using getopt_long */
+#ifdef ARG_LONG_ONLY
+    while ((copt = getopt_long_only(argc, argv, shortoptions, longoptions->options, NULL)) != -1) {
+#else
+    while ((copt = getopt_long(argc, argv, shortoptions, longoptions->options, NULL)) != -1) {
+#endif
+        /*
+           printf("optarg='%s'\n",optarg);
+           printf("optind=%d\n",optind);
+           printf("copt=%c\n",(char)copt);
+           printf("optopt=%c (%d)\n",optopt, (int)(optopt));
+         */
+        switch (copt) {
+            case 0: {
+                int tabindex = longoptions->getoptval;
+                void* parent = table[tabindex]->parent;
+                /*printf("long option detected from argtable[%d]\n", tabindex);*/
+                /* We have come across a item that the user wants us to stop parsing after
+                 * probably a sub-command */
+                if (table[tabindex]->flag & ARG_STOPPARSE)
+                {
+                    return;
+                }
+                if (optarg && optarg[0] == 0 && (table[tabindex]->flag & ARG_HASVALUE)) {
+                    /* printf(": long option %s requires an argument\n",argv[optind-1]); */
+                    arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
+                    /* continue to scan the (empty) argument value to enforce argument count checking */
+                }
+                if (table[tabindex]->scanfn) {
+                    int errorcode = table[tabindex]->scanfn(parent, optarg);
+                    if (errorcode != 0)
+                        arg_register_error(endtable, parent, errorcode, optarg);
+                }
+            } break;
+
+            case '?':
+                /*
+                 * getopt_long() found an unrecognised short option.
+                 * if it was a short option its value is in optopt
+                 * if it was a long option then optopt=0
+                 */
+                switch (optopt) {
+                    case 0:
+                        /*printf("?0 unrecognised long option %s\n",argv[optind-1]);*/
+                        arg_register_error(endtable, endtable, ARG_ELONGOPT, argv[optind - 1]);
+                        break;
+                    default:
+                        /*printf("?* unrecognised short option '%c'\n",optopt);*/
+                        arg_register_error(endtable, endtable, optopt, NULL);
+                        break;
+                }
+                break;
+
+            case ':':
+                /*
+                 * getopt_long() found an option with its argument missing.
+                 */
+                /*printf(": option %s requires an argument\n",argv[optind-1]); */
+                arg_register_error(endtable, endtable, ARG_EMISSARG, argv[optind - 1]);
+                break;
+
+            default: {
+                /* getopt_long() found a valid short option */
+                int tabindex = find_shortoption(table, (char)copt);
+                /*printf("short option detected from argtable[%d]\n", tabindex);*/
+                if (tabindex == -1) {
+                    /* should never get here - but handle it just in case */
+                    /*printf("unrecognised short option %d\n",copt);*/
+                    arg_register_error(endtable, endtable, copt, NULL);
+                } else {
+                    if (table[tabindex]->scanfn) {
+                        void* parent = table[tabindex]->parent;
+                        int errorcode = table[tabindex]->scanfn(parent, optarg);
+                        if (errorcode != 0)
+                            arg_register_error(endtable, parent, errorcode, optarg);
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    xfree(shortoptions);
+    xfree(longoptions);
+}
+
+static int arg_parse_find_stop(int argc, char** argv, struct arg_hdr** table, struct arg_end* endtable) {
+    int tabindex = 0;
+    while (!(table[tabindex]->flag & ARG_TERMINATOR))
+    {
+        void* parent;
+        int errorcode;
+
+        /* if we have exhausted our argv[optind] entries then we have finished */
+        if (optind >= argc) {
+            return argc;
+        }
+
+        /* skip table entries with non-null long or short options (they are not untagged entries) */
+        if (table[tabindex]->longopts || table[tabindex]->shortopts) {
+            tabindex++;
+            continue;
+        }
+
+        /* skip table entries with NULL scanfn */
+        if (!(table[tabindex]->scanfn)) {
+            tabindex++;
+            continue;
+        }
+
+        /* attempt to scan the current argv[optind] with the current     */
+        /* table[tabindex] entry. If it succeeds then keep it, otherwise */
+        /* try again with the next table[] entry.                        */
+        parent = table[tabindex]->parent;
+        errorcode = table[tabindex]->scanfn(parent, argv[optind]);
+        if (errorcode == 0) {
+            if (table[tabindex]->flag & ARG_STOPPARSE)
+            {
+                return (optind + 1) > argc ? argc : (optind + 1);
+            }
+            /* success, move onto next argv[optind] but stay with same table[tabindex] */
+            optind++;
+        } else {
+            /* failure, try same argv[optind] with next table[tabindex] entry */
+            tabindex++;
+        }
+    }
+
+    return argc;
+}
+static void arg_parse_untagged(int argc, char** argv, struct arg_hdr** table, struct arg_end* endtable) {
+    int tabindex = 0;
+    int errorlast = 0;
+    const char* optarglast = NULL;
+    void* parentlast = NULL;
+
+    /*printf("arg_parse_untagged(%d,%p,%p,%p)\n",argc,argv,table,endtable);*/
+    while (!(table[tabindex]->flag & ARG_TERMINATOR)) {
+        void* parent;
+        int errorcode;
+
+        /* if we have exhausted our argv[optind] entries then we have finished */
+        if (optind >= argc) {
+            /*printf("arg_parse_untagged(): argv[] exhausted\n");*/
+            return;
+        }
+
+        /* skip table entries with non-null long or short options (they are not untagged entries) */
+        if (table[tabindex]->longopts || table[tabindex]->shortopts) {
+            /*printf("arg_parse_untagged(): skipping argtable[%d] (tagged argument)\n",tabindex);*/
+            tabindex++;
+            continue;
+        }
+
+        /* skip table entries with NULL scanfn */
+        if (!(table[tabindex]->scanfn)) {
+            /*printf("arg_parse_untagged(): skipping argtable[%d] (NULL scanfn)\n",tabindex);*/
+            tabindex++;
+            continue;
+        }
+
+        /* attempt to scan the current argv[optind] with the current     */
+        /* table[tabindex] entry. If it succeeds then keep it, otherwise */
+        /* try again with the next table[] entry.                        */
+        parent = table[tabindex]->parent;
+        errorcode = table[tabindex]->scanfn(parent, argv[optind]);
+        if (errorcode == 0) {
+            if (table[tabindex]->flag & ARG_STOPPARSE)
+            {
+                table[tabindex]->idx = optind;
+                return;
+
+            }
+            /* success, move onto next argv[optind] but stay with same table[tabindex] */
+            /*printf("arg_parse_untagged(): argtable[%d] successfully matched\n",tabindex);*/
+            optind++;
+
+            /* clear the last tentative error */
+            errorlast = 0;
+        } else {
+            /* failure, try same argv[optind] with next table[tabindex] entry */
+            /*printf("arg_parse_untagged(): argtable[%d] failed match\n",tabindex);*/
+            tabindex++;
+
+            /* remember this as a tentative error we may wish to reinstate later */
+            errorlast = errorcode;
+            optarglast = argv[optind];
+            parentlast = parent;
+        }
+    }
+
+    /* if a tenative error still remains at this point then register it as a proper error */
+    if (errorlast) {
+        arg_register_error(endtable, parentlast, errorlast, optarglast);
+        optind++;
+    }
+
+    /* only get here when not all argv[] entries were consumed */
+    /* register an error for each unused argv[] entry */
+    while (optind < argc) {
+        /*printf("arg_parse_untagged(): argv[%d]=\"%s\" not consumed\n",optind,argv[optind]);*/
+        arg_register_error(endtable, endtable, ARG_ENOMATCH, argv[optind++]);
+    }
+
+    return;
+}
+
+static void arg_parse_check(struct arg_hdr** table, struct arg_end* endtable) {
+    int tabindex = 0;
+    /* printf("arg_parse_check()\n"); */
+    do {
+        if (table[tabindex]->checkfn) {
+            void* parent = table[tabindex]->parent;
+            int errorcode = table[tabindex]->checkfn(parent);
+            if (errorcode != 0)
+                arg_register_error(endtable, parent, errorcode, NULL);
+        }
+    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+}
+
+static void arg_reset(void** argtable) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int tabindex = 0;
+    /*printf("arg_reset(%p)\n",argtable);*/
+    do {
+        if (table[tabindex]->resetfn)
+            table[tabindex]->resetfn(table[tabindex]->parent);
+    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+}
+
+int arg_parse(int argc, char** argv, void** argtable) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    struct arg_end* endtable;
+    int endindex;
+    char** argvcopy = NULL;
+    int i;
+
+    /*printf("arg_parse(%d,%p,%p)\n",argc,argv,argtable);*/
+
+    /* reset any argtable data from previous invocations */
+    arg_reset(argtable);
+
+    /* locate the first end-of-table marker within the array */
+    endindex = arg_endindex(table);
+    endtable = (struct arg_end*)table[endindex];
+
+    /* Special case of argc==0.  This can occur on Texas Instruments DSP. */
+    /* Failure to trap this case results in an unwanted NULL result from  */
+    /* the malloc for argvcopy (next code block).                         */
+    if (argc == 0) {
+        /* We must still perform post-parse checks despite the absence of command line arguments */
+        arg_parse_check(table, endtable);
+
+        /* Now we are finished */
+        return endtable->count;
+    }
+
+    argvcopy = (char**)xmalloc(sizeof(char*) * (size_t)(argc + 1));
+
+    /*
+        Fill in the local copy of argv[]. We need a local copy
+        because getopt rearranges argv[] which adversely affects
+        susbsequent parsing attempts.
+        */
+    for (i = 0; i < argc; i++)
+        argvcopy[i] = argv[i];
+
+    argvcopy[argc] = NULL;
+
+    /* parse the command line (local copy) for tagged options */
+    arg_parse_tagged(argc, argvcopy, table, endtable);
+
+    int stop = arg_parse_find_stop(argc, argvcopy, table, endtable);
+
+    arg_reset((void **)table);
+
+    /* parse the command line (local copy) for tagged options */
+    arg_parse_tagged(stop, argvcopy, table, endtable);
+    /* parse the command line (local copy) for untagged options */
+    arg_parse_untagged(stop, argvcopy, table, endtable);
+
+    /* if no errors so far then perform post-parse checks otherwise dont bother */
+    if (endtable->count == 0)
+        arg_parse_check(table, endtable);
+
+    /* release the local copt of argv[] */
+    xfree(argvcopy);
+
+    return endtable->count;
+}
+
+/*
+ * Concatenate contents of src[] string onto *pdest[] string.
+ * The *pdest pointer is altered to point to the end of the
+ * target string and *pndest is decremented by the same number
+ * of chars.
+ * Does not append more than *pndest chars into *pdest[]
+ * so as to prevent buffer overruns.
+ * Its something like strncat() but more efficient for repeated
+ * calls on the same destination string.
+ * Example of use:
+ *   char dest[30] = "good"
+ *   size_t ndest = sizeof(dest);
+ *   char *pdest = dest;
+ *   arg_char(&pdest,"bye ",&ndest);
+ *   arg_char(&pdest,"cruel ",&ndest);
+ *   arg_char(&pdest,"world!",&ndest);
+ * Results in:
+ *   dest[] == "goodbye cruel world!"
+ *   ndest  == 10
+ */
+static void arg_cat(char** pdest, const char* src, size_t* pndest) {
+    char* dest = *pdest;
+    char* end = dest + *pndest;
+
+    /*locate null terminator of dest string */
+    while (dest < end-1 && *dest != 0)
+        dest++;
+
+    /* concat src string to dest string */
+    while (dest < end-1 && *src != 0)
+        *dest++ = *src++;
+
+    /* null terminate dest string */
+    *dest = 0;
+
+    /* update *pdest and *pndest */
+    *pndest = (size_t)(end - dest);
+    *pdest = dest;
+}
+
+static void arg_cat_option(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue) {
+    if (shortopts) {
+        char option[3];
+
+        /* note: option array[] is initialiazed dynamically here to satisfy   */
+        /* a deficiency in the watcom compiler wrt static array initializers. */
+        option[0] = '-';
+        option[1] = shortopts[0];
+        option[2] = 0;
+
+        arg_cat(&dest, option, &ndest);
+        if (datatype) {
+            arg_cat(&dest, " ", &ndest);
+            if (optvalue) {
+                arg_cat(&dest, "[", &ndest);
+                arg_cat(&dest, datatype, &ndest);
+                arg_cat(&dest, "]", &ndest);
+            } else
+                arg_cat(&dest, datatype, &ndest);
+        }
+    } else if (longopts) {
+        size_t ncspn;
+
+        /* add "--" tag prefix */
+        arg_cat(&dest, "--", &ndest);
+
+        /* add comma separated option tag */
+        ncspn = strcspn(longopts, ",");
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+        strncat_s(dest, ndest, longopts, (ncspn < ndest) ? ncspn : ndest);
+#else
+        strncat(dest, longopts, (ncspn < ndest) ? ncspn : ndest);
+#endif
+
+        if (datatype) {
+            arg_cat(&dest, "=", &ndest);
+            if (optvalue) {
+                arg_cat(&dest, "[", &ndest);
+                arg_cat(&dest, datatype, &ndest);
+                arg_cat(&dest, "]", &ndest);
+            } else
+                arg_cat(&dest, datatype, &ndest);
+        }
+    } else if (datatype) {
+        if (optvalue) {
+            arg_cat(&dest, "[", &ndest);
+            arg_cat(&dest, datatype, &ndest);
+            arg_cat(&dest, "]", &ndest);
+        } else
+            arg_cat(&dest, datatype, &ndest);
+    }
+}
+
+static void arg_cat_optionv(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue, const char* separator) {
+    separator = separator ? separator : "";
+
+    if (shortopts) {
+        const char* c = shortopts;
+        while (*c) {
+            /* "-a|-b|-c" */
+            char shortopt[3];
+
+            /* note: shortopt array[] is initialiazed dynamically here to satisfy */
+            /* a deficiency in the watcom compiler wrt static array initializers. */
+            shortopt[0] = '-';
+            shortopt[1] = *c;
+            shortopt[2] = 0;
+
+            arg_cat(&dest, shortopt, &ndest);
+            if (*++c)
+                arg_cat(&dest, separator, &ndest);
+        }
+    }
+
+    /* put separator between long opts and short opts */
+    if (shortopts && longopts)
+        arg_cat(&dest, separator, &ndest);
+
+    if (longopts) {
+        const char* c = longopts;
+        while (*c) {
+            size_t ncspn;
+
+            /* add "--" tag prefix */
+            arg_cat(&dest, "--", &ndest);
+
+            /* add comma separated option tag */
+            ncspn = strcspn(c, ",");
+#if (defined(__STDC_LIB_EXT1__) && defined(__STDC_WANT_LIB_EXT1__)) || (defined(__STDC_SECURE_LIB__) && defined(__STDC_WANT_SECURE_LIB__))
+            strncat_s(dest, ndest, c, (ncspn < ndest) ? ncspn : ndest);
+#else
+            strncat(dest, c, (ncspn < ndest) ? ncspn : ndest);
+#endif
+            c += ncspn;
+
+            /* add given separator in place of comma */
+            if (*c == ',') {
+                arg_cat(&dest, separator, &ndest);
+                c++;
+            }
+        }
+    }
+
+    if (datatype) {
+        if (longopts)
+            arg_cat(&dest, "=", &ndest);
+        else if (shortopts)
+            arg_cat(&dest, " ", &ndest);
+
+        if (optvalue) {
+            arg_cat(&dest, "[", &ndest);
+            arg_cat(&dest, datatype, &ndest);
+            arg_cat(&dest, "]", &ndest);
+        } else
+            arg_cat(&dest, datatype, &ndest);
+    }
+}
+
+void arg_print_option_ds(arg_dstr_t ds, const char* shortopts, const char* longopts, const char* datatype, const char* suffix) {
+    char syntax[200] = "";
+    suffix = suffix ? suffix : "";
+
+    /* there is no way of passing the proper optvalue for optional argument values here, so we must ignore it */
+    arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, 0, "|");
+
+    arg_dstr_cat(ds, syntax);
+    arg_dstr_cat(ds, (char*)suffix);
+}
+
+/* this function should be deprecated because it doesn't consider optional argument values (ARG_HASOPTVALUE) */
+void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, const char* datatype, const char* suffix) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_option_ds(ds, shortopts, longopts, datatype, suffix);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+/*
+ * Print a GNU style [OPTION] string in which all short options that
+ * do not take argument values are presented in abbreviated form, as
+ * in: -xvfsd, or -xvf[sd], or [-xvsfd]
+ */
+static void arg_print_gnuswitch_ds(arg_dstr_t ds, struct arg_hdr** table) {
+    int tabindex;
+    const char* format1 = " -%c";
+    const char* format2 = " [-%c";
+    const char* suffix = "";
+
+    /* print all mandatory switches that are without argument values */
+    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        /* skip optional options */
+        if (table[tabindex]->mincount < 1)
+            continue;
+
+        /* skip non-short options */
+        if (table[tabindex]->shortopts == NULL)
+            continue;
+
+        /* skip options that take argument values */
+        if (table[tabindex]->flag & ARG_HASVALUE)
+            continue;
+
+        /* print the short option (only the first short option char, ignore multiple choices)*/
+        arg_dstr_catf(ds, format1, table[tabindex]->shortopts[0]);
+        format1 = "%c";
+        format2 = "[%c";
+    }
+
+    /* print all optional switches that are without argument values */
+    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        /* skip mandatory args */
+        if (table[tabindex]->mincount > 0)
+            continue;
+
+        /* skip args without short options */
+        if (table[tabindex]->shortopts == NULL)
+            continue;
+
+        /* skip args with values */
+        if (table[tabindex]->flag & ARG_HASVALUE)
+            continue;
+
+        /* print first short option */
+        arg_dstr_catf(ds, format2, table[tabindex]->shortopts[0]);
+        format2 = "%c";
+        suffix = "]";
+    }
+
+    arg_dstr_catf(ds, "%s", suffix);
+}
+
+void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int i, tabindex;
+
+    /* print GNU style [OPTION] string */
+    arg_print_gnuswitch_ds(ds, table);
+
+    /* print remaining options in abbreviated style */
+    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        char syntax[200] = "";
+        const char *shortopts, *longopts, *datatype;
+
+        /* skip short options without arg values (they were printed by arg_print_gnu_switch) */
+        if (table[tabindex]->shortopts && !(table[tabindex]->flag & ARG_HASVALUE))
+            continue;
+
+        shortopts = table[tabindex]->shortopts;
+        longopts = table[tabindex]->longopts;
+        datatype = table[tabindex]->datatype;
+        arg_cat_option(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE);
+
+        if (strlen(syntax) > 0) {
+            /* print mandatory instances of this option */
+            for (i = 0; i < table[tabindex]->mincount; i++) {
+                arg_dstr_cat(ds, " ");
+                arg_dstr_cat(ds, syntax);
+            }
+
+            /* print optional instances enclosed in "[..]" */
+            switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
+                case 0:
+                    break;
+                case 1:
+                    arg_dstr_cat(ds, " [");
+                    arg_dstr_cat(ds, syntax);
+                    arg_dstr_cat(ds, "]");
+                    break;
+                case 2:
+                    arg_dstr_cat(ds, " [");
+                    arg_dstr_cat(ds, syntax);
+                    arg_dstr_cat(ds, "]");
+                    arg_dstr_cat(ds, " [");
+                    arg_dstr_cat(ds, syntax);
+                    arg_dstr_cat(ds, "]");
+                    break;
+                default:
+                    arg_dstr_cat(ds, " [");
+                    arg_dstr_cat(ds, syntax);
+                    arg_dstr_cat(ds, "]...");
+                    break;
+            }
+        }
+    }
+
+    if (suffix) {
+        arg_dstr_cat(ds, (char*)suffix);
+    }
+}
+
+void arg_print_syntax(FILE* fp, void** argtable, const char* suffix) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_syntax_ds(ds, argtable, suffix);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+void arg_print_syntaxv_ds(arg_dstr_t ds, void** argtable, const char* suffix) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int i, tabindex;
+
+    /* print remaining options in abbreviated style */
+    for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        char syntax[200] = "";
+        const char *shortopts, *longopts, *datatype;
+
+        shortopts = table[tabindex]->shortopts;
+        longopts = table[tabindex]->longopts;
+        datatype = table[tabindex]->datatype;
+        arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, "|");
+
+        /* print mandatory options */
+        for (i = 0; i < table[tabindex]->mincount; i++) {
+            arg_dstr_cat(ds, " ");
+            arg_dstr_cat(ds, syntax);
+        }
+
+        /* print optional args enclosed in "[..]" */
+        switch (table[tabindex]->maxcount - table[tabindex]->mincount) {
+            case 0:
+                break;
+            case 1:
+                arg_dstr_cat(ds, " [");
+                arg_dstr_cat(ds, syntax);
+                arg_dstr_cat(ds, "]");
+                break;
+            case 2:
+                arg_dstr_cat(ds, " [");
+                arg_dstr_cat(ds, syntax);
+                arg_dstr_cat(ds, "]");
+                arg_dstr_cat(ds, " [");
+                arg_dstr_cat(ds, syntax);
+                arg_dstr_cat(ds, "]");
+                break;
+            default:
+                arg_dstr_cat(ds, " [");
+                arg_dstr_cat(ds, syntax);
+                arg_dstr_cat(ds, "]...");
+                break;
+        }
+    }
+
+    if (suffix) {
+        arg_dstr_cat(ds, (char*)suffix);
+    }
+}
+
+void arg_print_syntaxv(FILE* fp, void** argtable, const char* suffix) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_syntaxv_ds(ds, argtable, suffix);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+void arg_print_glossary_ds(arg_dstr_t ds, void** argtable, const char* format) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int tabindex;
+
+    format = format ? format : "  %-20s %s\n";
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        if (table[tabindex]->glossary) {
+            char syntax[200] = "";
+            const char* shortopts = table[tabindex]->shortopts;
+            const char* longopts = table[tabindex]->longopts;
+            const char* datatype = table[tabindex]->datatype;
+            const char* glossary = table[tabindex]->glossary;
+            arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
+            arg_dstr_catf(ds, format, syntax, glossary);
+        }
+    }
+}
+
+void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_glossary_ds(ds, argtable, format);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+/**
+ * Print a piece of text formatted, which means in a column with a
+ * left and a right margin. The lines are wrapped at whitspaces next
+ * to right margin. The function does not indent the first line, but
+ * only the following ones.
+ *
+ * See description of arg_print_formatted below.
+ */
+static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const unsigned rmargin, const char* text) {
+    const unsigned int textlen = (unsigned int)strlen(text);
+    unsigned int line_start = 0;
+    unsigned int line_end = textlen;
+    const unsigned int colwidth = (rmargin - lmargin) + 1;
+
+    assert(strlen(text) < UINT_MAX);
+
+    /* Someone doesn't like us... */
+    if (line_end < line_start) {
+        arg_dstr_catf(ds, "%s\n", text);
+    }
+
+    while (line_end > line_start) {
+        /* Eat leading white spaces. This is essential because while
+           wrapping lines, there will often be a whitespace at beginning
+           of line. Preserve newlines */
+        while (isspace((int)(*(text + line_start))) && *(text + line_start) != '\n') {
+            line_start++;
+        }
+
+        /* Find last whitespace, that fits into line */
+        if (line_end - line_start > colwidth) {
+            line_end = line_start + colwidth;
+
+            while ((line_end > line_start) && !isspace((int)(*(text + line_end)))) {
+                line_end--;
+            }
+
+            /* If no whitespace could be found, eg. the text is one long word, break the word */
+            if (line_end == line_start) {
+                /* Set line_end to previous value */
+                line_end = line_start + colwidth;
+            } else {
+                /* Consume trailing spaces, except newlines */
+                while ((line_end > line_start) && isspace((int)(*(text + line_end))) && *(text + line_start) != '\n') {
+                    line_end--;
+                }
+
+                /* Restore the last non-space character */
+                line_end++;
+            }
+        }
+
+        /* Output line of text */
+        while (line_start < line_end) {
+            char c = *(text + line_start);
+
+            /* If character is newline stop printing, skip this character, as a newline will be printed below. */
+            if (c == '\n') {
+                line_start++;
+                break;
+            }
+
+            arg_dstr_catc(ds, c);
+            line_start++;
+        }
+        arg_dstr_cat(ds, "\n");
+
+        /* Initialize another line */
+        if (line_end < textlen) {
+            unsigned i;
+
+            for (i = 0; i < lmargin; i++) {
+                arg_dstr_cat(ds, " ");
+            }
+
+            line_end = textlen;
+        }
+    } /* lines of text */
+}
+
+/**
+ * Print a piece of text formatted, which means in a column with a
+ * left and a right margin. The lines are wrapped at whitspaces next
+ * to right margin. The function does not indent the first line, but
+ * only the following ones.
+ *
+ * Example:
+ * arg_print_formatted( fp, 0, 5, "Some text that doesn't fit." )
+ * will result in the following output:
+ *
+ * Some
+ * text
+ * that
+ * doesn'
+ * t fit.
+ *
+ * Too long lines will be wrapped in the middle of a word.
+ *
+ * arg_print_formatted( fp, 2, 7, "Some text that doesn't fit." )
+ * will result in the following output:
+ *
+ * Some
+ *   text
+ *   that
+ *   doesn'
+ *   t fit.
+ *
+ * As you see, the first line is not indented. This enables output of
+ * lines, which start in a line where output already happened.
+ *
+ * Author: Uli Fouquet
+ */
+void arg_print_formatted(FILE* fp, const unsigned lmargin, const unsigned rmargin, const char* text) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_formatted_ds(ds, lmargin, rmargin, text);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+/**
+ * Prints the glossary in strict GNU format.
+ * Differences to arg_print_glossary() are:
+ *   - wraps lines after 80 chars
+ *   - indents lines without shortops
+ *   - does not accept formatstrings
+ *
+ * Contributed by Uli Fouquet
+ */
+void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int tabindex;
+
+    for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
+        if (table[tabindex]->glossary) {
+            char syntax[200] = "";
+            const char* shortopts = table[tabindex]->shortopts;
+            const char* longopts = table[tabindex]->longopts;
+            const char* datatype = table[tabindex]->datatype;
+            const char* glossary = table[tabindex]->glossary;
+
+            if (!shortopts && longopts) {
+                /* Indent trailing line by 4 spaces... */
+                memset(syntax, ' ', 4);
+                *(syntax + 4) = '\0';
+            }
+
+            arg_cat_optionv(syntax, sizeof(syntax) - 1, shortopts, longopts, datatype, table[tabindex]->flag & ARG_HASOPTVALUE, ", ");
+
+            /* If syntax fits not into column, print glossary in new line... */
+            if (strlen(syntax) > 25) {
+                arg_dstr_catf(ds, "  %-25s %s\n", syntax, "");
+                *syntax = '\0';
+            }
+
+            arg_dstr_catf(ds, "  %-25s ", syntax);
+            arg_print_formatted_ds(ds, 28, 79, glossary);
+        }
+    } /* for each table entry */
+
+    arg_dstr_cat(ds, "\n");
+}
+
+void arg_print_glossary_gnu(FILE* fp, void** argtable) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_glossary_gnu_ds(ds, argtable);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
+}
+
+/**
+ * Checks the argtable[] array for NULL entries and returns 1
+ * if any are found, zero otherwise.
+ */
+int arg_nullcheck(void** argtable) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int tabindex;
+    /*printf("arg_nullcheck(%p)\n",argtable);*/
+
+    if (!table)
+        return 1;
+
+    tabindex = 0;
+    do {
+        /*printf("argtable[%d]=%p\n",tabindex,argtable[tabindex]);*/
+        if (!table[tabindex])
+            return 1;
+    } while (!(table[tabindex++]->flag & ARG_TERMINATOR));
+
+    return 0;
+}
+
+/*
+ * arg_free() is deprecated in favour of arg_freetable() due to a flaw in its design.
+ * The flaw results in memory leak in the (very rare) case that an intermediate
+ * entry in the argtable array failed its memory allocation while others following
+ * that entry were still allocated ok. Those subsequent allocations will not be
+ * deallocated by arg_free().
+ * Despite the unlikeliness of the problem occurring, and the even unlikelier event
+ * that it has any deliterious effect, it is fixed regardless by replacing arg_free()
+ * with the newer arg_freetable() function.
+ * We still keep arg_free() for backwards compatibility.
+ */
+void arg_free(void** argtable) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    int tabindex = 0;
+    int flag;
+    /*printf("arg_free(%p)\n",argtable);*/
+    do {
+        /*
+           if we encounter a NULL entry then somewhat incorrectly we presume
+           we have come to the end of the array. It isnt strictly true because
+           an intermediate entry could be NULL with other non-NULL entries to follow.
+           The subsequent argtable entries would then not be freed as they should.
+         */
+        if (table[tabindex] == NULL)
+            break;
+
+        flag = table[tabindex]->flag;
+        xfree(table[tabindex]);
+        table[tabindex++] = NULL;
+
+    } while (!(flag & ARG_TERMINATOR));
+}
+
+/* frees each non-NULL element of argtable[], where n is the size of the number of entries in the array */
+void arg_freetable(void** argtable, size_t n) {
+    struct arg_hdr** table = (struct arg_hdr**)argtable;
+    size_t tabindex = 0;
+    /*printf("arg_freetable(%p)\n",argtable);*/
+    for (tabindex = 0; tabindex < n; tabindex++) {
+        if (table[tabindex] == NULL)
+            continue;
+
+        xfree(table[tabindex]);
+        table[tabindex] = NULL;
+    };
+}
+
+#if 0
+#ifdef _WIN32
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    return TRUE;
+    UNREFERENCED_PARAMETER(hinstDLL);
+    UNREFERENCED_PARAMETER(fdwReason);
+    UNREFERENCED_PARAMETER(lpvReserved);
+}
+#endif
+#endif

--- a/feeds/morse/utils/morsectrl/src/argtable3/argtable3.h
+++ b/feeds/morse/utils/morsectrl/src/argtable3/argtable3.h
@@ -1,0 +1,292 @@
+/*******************************************************************************
+ * argtable3: Declares the main interfaces of the library
+ *
+ * This file is part of the argtable3 library.
+ *
+ * Copyright (C) 1998-2001,2003-2011,2013 Stewart Heitmann
+ * <sheitmann@users.sourceforge.net>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of STEWART HEITMANN nor the  names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL STEWART HEITMANN BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#ifndef ARGTABLE3
+#define ARGTABLE3
+
+#include <stdio.h> /* FILE */
+#include <time.h>  /* struct tm */
+#include <ctype.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ARG_REX_ICASE 1
+
+/* Maximum length of the command name */
+#ifndef ARG_CMD_NAME_LEN
+#define ARG_CMD_NAME_LEN 100
+#endif /* ARG_CMD_NAME_LEN */
+
+/* Maximum length of the command description */
+#ifndef ARG_CMD_DESCRIPTION_LEN
+#define ARG_CMD_DESCRIPTION_LEN 256
+#endif /* ARG_CMD_DESCRIPTION_LEN */
+
+/* bit masks for arg_hdr.flag */
+enum { ARG_TERMINATOR = 0x1, ARG_HASVALUE = 0x2, ARG_HASOPTVALUE = 0x4, ARG_STOPPARSE = 0x8 };
+
+#if defined(_WIN32)
+  #if defined(argtable3_EXPORTS)
+    #define ARG_EXTERN __declspec(dllexport)
+  #elif defined(argtable3_IMPORTS)
+    #define ARG_EXTERN __declspec(dllimport)
+  #else
+    #define ARG_EXTERN
+  #endif
+#else
+  #define ARG_EXTERN
+#endif
+
+typedef struct _internal_arg_dstr* arg_dstr_t;
+typedef void* arg_cmd_itr_t;
+
+typedef void(arg_resetfn)(void* parent);
+typedef int(arg_scanfn)(void* parent, const char* argval);
+typedef int(arg_checkfn)(void* parent);
+typedef void(arg_errorfn)(void* parent, arg_dstr_t ds, int error, const char* argval, const char* progname);
+typedef void(arg_dstr_freefn)(char* buf);
+typedef int(arg_cmdfn)(int argc, char* argv[], arg_dstr_t res);
+typedef int(arg_comparefn)(const void* k1, const void* k2);
+
+/*
+ * The arg_hdr struct defines properties that are common to all arg_xxx structs.
+ * The argtable library requires each arg_xxx struct to have an arg_hdr
+ * struct as its first data member.
+ * The argtable library functions then use this data to identify the
+ * properties of the command line option, such as its option tags,
+ * datatype string, and glossary strings, and so on.
+ * Moreover, the arg_hdr struct contains pointers to custom functions that
+ * are provided by each arg_xxx struct which perform the tasks of parsing
+ * that particular arg_xxx arguments, performing post-parse checks, and
+ * reporting errors.
+ * These functions are private to the individual arg_xxx source code
+ * and the pointers to them are initiliased by that arg_xxx struct's
+ * constructor function. The user could alter them after construction
+ * if desired, but the original intention is for them to be set by the
+ * constructor and left unaltered.
+ */
+typedef struct arg_hdr {
+    char flag;             /* Modifier flags: ARG_TERMINATOR, ARG_HASVALUE. */
+    int idx;               /* Index where this value was observed if ARG_STOPPARSE flag is set */
+    const char* shortopts; /* String defining the short options */
+    const char* longopts;  /* String defining the long options */
+    const char* datatype;  /* Description of the argument data type */
+    const char* glossary;  /* Description of the option as shown by arg_print_glossary function */
+    int mincount;          /* Minimum number of occurences of this option accepted */
+    int maxcount;          /* Maximum number of occurences if this option accepted */
+    void* parent;          /* Pointer to parent arg_xxx struct */
+    arg_resetfn* resetfn;  /* Pointer to parent arg_xxx reset function */
+    arg_scanfn* scanfn;    /* Pointer to parent arg_xxx scan function */
+    arg_checkfn* checkfn;  /* Pointer to parent arg_xxx check function */
+    arg_errorfn* errorfn;  /* Pointer to parent arg_xxx error function */
+    void* priv;            /* Pointer to private header data for use by arg_xxx functions */
+} arg_hdr_t;
+
+typedef struct arg_rem {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+} arg_rem_t;
+
+typedef struct arg_lit {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+} arg_lit_t;
+
+typedef struct arg_int {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+    int* ival;          /* Array of parsed argument values */
+} arg_int_t;
+
+/* Comma-separated integers, e.g. 1,2,3,4  */
+typedef struct arg_csi {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+    int num_vals;       /* Number of values per arg */
+    int** ival;          /* Array of parsed argument values */
+} arg_csi_t;
+
+typedef struct arg_dbl {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+    double* dval;       /* Array of parsed argument values */
+} arg_dbl_t;
+
+typedef struct arg_str {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+    const char** sval;  /* Array of parsed argument values */
+} arg_str_t;
+
+typedef struct arg_rex {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    int count;          /* Number of matching command line args */
+    const char** sval;  /* Array of parsed argument values */
+} arg_rex_t;
+
+typedef struct arg_file {
+    struct arg_hdr hdr;     /* The mandatory argtable header struct */
+    int count;              /* Number of matching command line args*/
+    const char** filename;  /* Array of parsed filenames  (eg: /home/foo.bar) */
+    const char** basename;  /* Array of parsed basenames  (eg: foo.bar) */
+    const char** extension; /* Array of parsed extensions (eg: .bar) */
+} arg_file_t;
+
+typedef struct arg_date {
+    struct arg_hdr hdr; /* The mandatory argtable header struct */
+    const char* format; /* strptime format string used to parse the date */
+    int count;          /* Number of matching command line args */
+    struct tm* tmval;   /* Array of parsed time values */
+} arg_date_t;
+
+enum { ARG_ELIMIT = 1, ARG_EMALLOC, ARG_ENOMATCH, ARG_ELONGOPT, ARG_EMISSARG };
+typedef struct arg_end {
+    struct arg_hdr hdr;  /* The mandatory argtable header struct */
+    int count;           /* Number of errors encountered */
+    int* error;          /* Array of error codes */
+    void** parent;       /* Array of pointers to offending arg_xxx struct */
+    const char** argval; /* Array of pointers to offending argv[] string */
+} arg_end_t;
+
+typedef struct arg_cmd_info {
+    char name[ARG_CMD_NAME_LEN];
+    char description[ARG_CMD_DESCRIPTION_LEN];
+    arg_cmdfn* proc;
+} arg_cmd_info_t;
+
+/**** arg_xxx constructor functions *********************************/
+
+ARG_EXTERN struct arg_rem* arg_rem(const char* datatype, const char* glossary);
+
+ARG_EXTERN struct arg_lit* arg_lit0(const char* shortopts, const char* longopts, const char* glossary);
+ARG_EXTERN struct arg_lit* arg_lit1(const char* shortopts, const char* longopts, const char* glossary);
+ARG_EXTERN struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_int* arg_int0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_int* arg_int1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+
+/* Comma-separated integers, e.g. 1,2,3,4  */
+ARG_EXTERN struct arg_csi* arg_csi0(const char* shortopts, const char* longopts, const char* datatype, int num_args, const char* glossary);
+ARG_EXTERN struct arg_csi* arg_csi1(const char* shortopts, const char* longopts, const char* datatype, int num_args, const char* glossary);
+ARG_EXTERN struct arg_csi* arg_csin(const char* shortopts, const char* longopts, const char* datatype, int num_args, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_dbl* arg_dbl0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_dbl* arg_dbl1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_str* arg_str0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_str* arg_str1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_rex* arg_rex0(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary);
+ARG_EXTERN struct arg_rex* arg_rex1(const char* shortopts, const char* longopts, const char* pattern, const char* datatype, int flags, const char* glossary);
+ARG_EXTERN struct arg_rex* arg_rexn(const char* shortopts,
+                         const char* longopts,
+                         const char* pattern,
+                         const char* datatype,
+                         int mincount,
+                         int maxcount,
+                         int flags,
+                         const char* glossary);
+
+ARG_EXTERN struct arg_file* arg_file0(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_file* arg_file1(const char* shortopts, const char* longopts, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_file* arg_filen(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_date* arg_date0(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_date* arg_date1(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary);
+ARG_EXTERN struct arg_date* arg_daten(const char* shortopts, const char* longopts, const char* format, const char* datatype, int mincount, int maxcount, const char* glossary);
+
+ARG_EXTERN struct arg_end* arg_end(int maxcount);
+
+#define ARG_DSTR_STATIC ((arg_dstr_freefn*)0)
+#define ARG_DSTR_VOLATILE ((arg_dstr_freefn*)1)
+#define ARG_DSTR_DYNAMIC ((arg_dstr_freefn*)3)
+
+/**** other functions *******************************************/
+ARG_EXTERN int arg_nullcheck(void** argtable);
+ARG_EXTERN int arg_parse(int argc, char** argv, void** argtable);
+ARG_EXTERN void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, const char* datatype, const char* suffix);
+ARG_EXTERN void arg_print_syntax(FILE* fp, void** argtable, const char* suffix);
+ARG_EXTERN void arg_print_syntaxv(FILE* fp, void** argtable, const char* suffix);
+ARG_EXTERN void arg_print_glossary(FILE* fp, void** argtable, const char* format);
+ARG_EXTERN void arg_print_glossary_gnu(FILE* fp, void** argtable);
+ARG_EXTERN void arg_print_errors(FILE* fp, struct arg_end* end, const char* progname);
+ARG_EXTERN void arg_print_option_ds(arg_dstr_t ds, const char* shortopts, const char* longopts, const char* datatype, const char* suffix);
+ARG_EXTERN void arg_print_syntax_ds(arg_dstr_t ds, void** argtable, const char* suffix);
+ARG_EXTERN void arg_print_syntaxv_ds(arg_dstr_t ds, void** argtable, const char* suffix);
+ARG_EXTERN void arg_print_glossary_ds(arg_dstr_t ds, void** argtable, const char* format);
+ARG_EXTERN void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable);
+ARG_EXTERN void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname);
+ARG_EXTERN void arg_print_formatted(FILE *fp, const unsigned lmargin, const unsigned rmargin, const char *text);
+ARG_EXTERN void arg_freetable(void** argtable, size_t n);
+
+ARG_EXTERN arg_dstr_t arg_dstr_create(void);
+ARG_EXTERN void arg_dstr_destroy(arg_dstr_t ds);
+ARG_EXTERN void arg_dstr_reset(arg_dstr_t ds);
+ARG_EXTERN void arg_dstr_free(arg_dstr_t ds);
+ARG_EXTERN void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc);
+ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, const char* str);
+ARG_EXTERN void arg_dstr_catc(arg_dstr_t ds, char c);
+ARG_EXTERN void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...);
+ARG_EXTERN char* arg_dstr_cstr(arg_dstr_t ds);
+
+ARG_EXTERN void arg_cmd_init(void);
+ARG_EXTERN void arg_cmd_uninit(void);
+ARG_EXTERN void arg_cmd_register(const char* name, arg_cmdfn* proc, const char* description);
+ARG_EXTERN void arg_cmd_unregister(const char* name);
+ARG_EXTERN int arg_cmd_dispatch(const char* name, int argc, char* argv[], arg_dstr_t res);
+ARG_EXTERN unsigned int arg_cmd_count(void);
+ARG_EXTERN arg_cmd_info_t* arg_cmd_info(const char* name);
+ARG_EXTERN arg_cmd_itr_t arg_cmd_itr_create(void);
+ARG_EXTERN void arg_cmd_itr_destroy(arg_cmd_itr_t itr);
+ARG_EXTERN int arg_cmd_itr_advance(arg_cmd_itr_t itr);
+ARG_EXTERN char* arg_cmd_itr_key(arg_cmd_itr_t itr);
+ARG_EXTERN arg_cmd_info_t* arg_cmd_itr_value(arg_cmd_itr_t itr);
+ARG_EXTERN int arg_cmd_itr_search(arg_cmd_itr_t itr, void* k);
+ARG_EXTERN void arg_mgsort(void* data, int size, int esize, int i, int k, arg_comparefn* comparefn);
+ARG_EXTERN void arg_make_get_help_msg(arg_dstr_t res);
+ARG_EXTERN void arg_make_help_msg(arg_dstr_t ds, char* cmd_name, void** argtable);
+ARG_EXTERN void arg_make_syntax_err_msg(arg_dstr_t ds, void** argtable, struct arg_end* end);
+ARG_EXTERN int arg_make_syntax_err_help_msg(arg_dstr_t ds, char* name, int help, int nerrors, void** argtable, struct arg_end* end, int* exitcode);
+ARG_EXTERN void arg_set_module_name(const char* name);
+ARG_EXTERN void arg_set_module_version(int major, int minor, int patch, const char* tag);
+
+/**** deprecated functions, for back-compatibility only ********/
+ARG_EXTERN void arg_free(void** argtable);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/feeds/morse/utils/morsectrl/src/arp_periodic_refresh.c
+++ b/feeds/morse/utils/morsectrl/src/arp_periodic_refresh.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "morsectrl.h"
+#include "command.h"
+#include "utilities.h"
+
+/** Max ARP refresh period in seconds, calculated to prevent overflow after
+ * conversion to milliseconds
+ */
+#define ARP_REFRESH_MAX_PERIOD_S  (UINT32_MAX / 1000)
+
+struct PACKED arp_periodic_params
+{
+    uint32_t refresh_period_s;
+    ipv4_addr_t destination_ip;
+    uint8_t  send_as_garp;
+};
+
+struct PACKED command_set_arp_periodic_refresh_req
+{
+    struct arp_periodic_params config;
+};
+
+static struct
+{
+    struct arg_int *arp_refresh_period_s;
+    struct arg_str *destination_address;
+    struct arg_lit *send_as_garp;
+} args;
+
+
+int arp_periodic_refresh_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args,
+          "Configure the firmware to send a periodic ARP packet",
+          args.arp_refresh_period_s = arg_int1("t", NULL, "<period>",
+            "Period in seconds between ARP transmissions. A value of 0 disables the feature."),
+          args.destination_address = arg_str0("d", NULL, "<dest IP>",
+             "IP in dotted decimal notation - target protocol address field of the ARP request"),
+          args.send_as_garp = arg_lit0("g", NULL,
+                                  "Send as a Gratuitous ARP (GARP) instead of an ARP request"));
+    return 0;
+}
+
+
+int arp_periodic_refresh(struct morsectrl *mors, int argc, char *argv[])
+{
+    struct command_set_arp_periodic_refresh_req *cmd_set;
+
+    struct morsectrl_transport_buff *cmd_set_tbuff;
+    struct morsectrl_transport_buff *rsp_set_tbuff;
+
+    ipv4_addr_t temp_ip;
+
+    cmd_set_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_set));
+    rsp_set_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    int ret = 0;
+
+    if (!cmd_set_tbuff || !rsp_set_tbuff)
+        goto exit;
+
+    cmd_set = TBUFF_TO_CMD(cmd_set_tbuff, struct command_set_arp_periodic_refresh_req);
+
+    if (args.arp_refresh_period_s->count)
+    {
+        if (args.arp_refresh_period_s->ival[0] > ARP_REFRESH_MAX_PERIOD_S)
+        {
+            ret = EINVAL;
+            mctrl_err("Max refresh period is %d\n", ARP_REFRESH_MAX_PERIOD_S);
+            goto exit;
+        }
+        cmd_set->config.refresh_period_s = args.arp_refresh_period_s->ival[0];
+    }
+    else
+    {
+        ret = EINVAL;
+        mctrl_err("ARP refresh period not entered\n");
+        goto exit;
+    }
+
+    if (args.destination_address->count)
+    {
+       ret = str_to_ip(*args.destination_address->sval, &temp_ip);
+       if (ret)
+       {
+          mctrl_err("Failed to parse IP address: %s\n", *args.destination_address->sval);
+          goto exit;
+       }
+       cmd_set->config.destination_ip = temp_ip;
+    }
+    else if (cmd_set->config.refresh_period_s)
+    {
+        ret = EINVAL;
+        mctrl_err("Destination IP address not entered\n");
+        goto exit;
+    }
+
+
+    if (args.send_as_garp->count)
+    {
+        cmd_set->config.send_as_garp = 1;
+    }
+    else
+    {
+       cmd_set->config.send_as_garp = 0;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_ARP_PERIODIC_REFRESH,
+                                 cmd_set_tbuff, rsp_set_tbuff);
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set arp periodic refresh params: error(%d)\n", ret);
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_set_tbuff);
+    morsectrl_transport_buff_free(rsp_set_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(arp_periodic_refresh, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);
+

--- a/feeds/morse/utils/morsectrl/src/bcn_rssi_threshold.c
+++ b/feeds/morse/utils/morsectrl/src/bcn_rssi_threshold.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_bcn_rssi_threshold_command
+{
+    /** The threshold in dB */
+    uint8_t threshold_db;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tbcn_rssi_threshold <value>\tselect in between '0-100'dB to set threshold\n");
+}
+
+int bcn_rssi_threshold(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct set_bcn_rssi_threshold_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint8_t threshold_db;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_bcn_rssi_threshold_command);
+
+    if (str_to_uint8_range(argv[1], &threshold_db, 0, 100))
+    {
+        mctrl_err("Invalid value [0 to 100]\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->threshold_db = threshold_db;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_BCN_RSSI_THRESHOLD,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set beacon rssi change threshold\n");
+    }
+    else
+    {
+        mctrl_print("\tBeacon RSSI change  Threshold set to : %d dB\n", (cmd->threshold_db));
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(bcn_rssi_threshold, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/bsscolor.c
+++ b/feeds/morse/utils/morsectrl/src/bsscolor.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_bss_color
+{
+    /** The BSS color */
+    uint8_t bss_color;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tbsscolor <color>\tsets the BSS color (0-7)\n");
+}
+
+int bsscolor(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t color;
+    struct set_bss_color *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(0));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_bss_color);
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint32_range(argv[1], &color, 0, 7) < 0)
+    {
+        mctrl_err("Setup command is not valid\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->bss_color = htole32(color);
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_BSS_COLOR,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set bss color\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(bsscolor, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/bw.c
+++ b/feeds/morse/utils/morsectrl/src/bw.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "channel.h"
+
+#define BANDWIDTH_DEFAULT 0xFF
+#define PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT 0xFF
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tbw <value>\t\tsets bandwidth(1|2|4|8)\n");
+    mctrl_print("\t\t\t\tor reads current bandwidth if no arguments were given\n");
+}
+
+int bw(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint8_t bw;
+    struct command_set_channel_req *cmd;
+    struct command_get_channel_cfm *resp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_channel_req);
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct  command_get_channel_cfm);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_FULL_CHANNEL,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    if (argc == 1)
+    {
+        mctrl_print("Current bw is (%d) \n", resp->operating_channel_bw_mhz);
+    }
+    else
+    {
+        if (argc != 2)
+        {
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        if (str_to_uint8(argv[1], &bw) ||
+                !((bw == 1) || (bw == 2) || (bw == 4) || (bw == 8) || (bw == 16)))
+        {
+            mctrl_err("Invalid bandwidth.\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        cmd->operating_channel_freq_hz = resp->operating_channel_freq_hz;
+        cmd->operating_channel_bw_mhz = bw;
+        cmd->primary_channel_bw_mhz = BANDWIDTH_DEFAULT;
+        cmd->primary_1mhz_channel_index = PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT;
+        cmd->dot11_mode = 0; /* TODO */
+
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_CHANNEL,
+                                     cmd_tbuff, rsp_tbuff);
+    }
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set bw: error(%d)\n", ret);
+    }
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(bw, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/cac.c
+++ b/feeds/morse/utils/morsectrl/src/cac.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+enum cac_command {
+    CAC_COMMAND_DISABLE = 0,
+    CAC_COMMAND_ENABLE = 1
+};
+
+struct PACKED command_cac_req {
+    /** CAC subcommand */
+    uint8_t cmd;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print(
+        "\tcac [enable|disable]\tenable Centralized Authentication Control on a STA interface\n");
+    mctrl_print("\t\t\t\tdo not use - for internal use by wpa_supplicant\n");
+}
+
+int cac(struct morsectrl *mors, int argc, char *argv[])
+{
+    int cmd;
+    int ret = -1;
+    struct command_cac_req *cac_req = NULL;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cac_req));
+    if (!cmd_tbuff)
+    {
+        goto exit;
+    }
+
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+    if (!rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    cac_req = TBUFF_TO_CMD(cmd_tbuff, struct command_cac_req);
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd = expression_to_int(argv[1]);
+    if (cmd < 0)
+    {
+        mctrl_err("Invalid CAC command '%s'\n", argv[1]);
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cac_req->cmd = cmd ? CAC_COMMAND_ENABLE : CAC_COMMAND_DISABLE;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_CAC_SET, cmd_tbuff,
+            rsp_tbuff);
+
+exit:
+    if (cmd_tbuff)
+    {
+        morsectrl_transport_buff_free(cmd_tbuff);
+    }
+
+    if (rsp_tbuff)
+    {
+        morsectrl_transport_buff_free(rsp_tbuff);
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(cac, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/capabilities.c
+++ b/feeds/morse/utils/morsectrl/src/capabilities.c
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+
+#include "command.h"
+#include "utilities.h"
+
+#define S1G_CAPABILITY_FLAGS_WIDTH 4
+#define SET_S1G_CAP_FLAGS          BIT(0)
+#define SET_S1G_CAP_AMPDU_MSS      BIT(1)
+#define SET_S1G_CAP_BEAM_STS       BIT(2)
+#define SET_S1G_CAP_NUM_SOUND_DIMS BIT(3)
+#define SET_S1G_CAP_MAX_AMPDU_LEXP BIT(4)
+
+struct PACKED mm_capabilities
+{
+    /** Capability flags */
+    uint32_t flags[S1G_CAPABILITY_FLAGS_WIDTH];
+    /** The minimum A-MPDU start spacing required by firmware.*/
+    uint8_t ampdu_mss;
+    /** The beamformee STS capability value */
+    uint8_t beamformee_sts_capability;
+    /** Number of sounding dimensions */
+    uint8_t number_sounding_dimensions;
+    /** The maximum A-MPDU length. This is the exponent value such that
+     * (2^(13 + exponent) - 1) is the length
+     */
+    uint8_t maximum_ampdu_length_exponent;
+};
+
+struct PACKED command_set_capabilities_req
+{
+    struct mm_capabilities capabilities;
+    /** Which caps we are setting */
+    uint8_t set_caps;
+};
+
+struct PACKED command_get_capabilities_req
+{
+};
+
+struct PACKED command_get_capabilities_cfm
+{
+    struct mm_capabilities capabilities;
+    /** Morse custom MMSS (Minimum MPDU Start Spacing) offset */
+    uint8_t morse_mmss_offset;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tcapabilities [options]\tget or set the device capabilties manifest\n");
+    mctrl_print("\t\tget capabilities if no options supplied, or\n");
+    mctrl_print("\t\tset the 128-bit capabilities flags via four 32bit fields:\n");
+    mctrl_print("\t\t\t-f <field 1> <field 2> <field 3> <field 4>\n");
+    mctrl_print("\t\tset AMPDU capabilities:\n");
+    mctrl_print("\t\t\t-a <ampdu minimum start spacing> <ampdu max length exponent>\n");
+    mctrl_print("\t\tset beamformee STS value:\n");
+    mctrl_print("\t\t\t-b <beamformee STS value>\n");
+    mctrl_print("\t\tset number of sounding dimensions:\n");
+    mctrl_print("\t\t\t-s <number of sounding dimensions>\n");
+}
+
+static void print_capabs(struct morsectrl *mors,
+    struct command_get_capabilities_cfm *rsp_get_capabs)
+{
+    struct mm_capabilities *capabs = &rsp_get_capabs->capabilities;
+
+    mctrl_print("Interface: %s\n", morsectrl_transport_get_ifname(mors->transport));
+
+    for (int i = 0; i < MORSE_ARRAY_SIZE(capabs->flags); i++)
+        mctrl_print("Flags %u: 0x%x\n", i, capabs->flags[i]);
+    mctrl_print("A-MPDU MSS: %u\n", capabs->ampdu_mss);
+    mctrl_print("Maximum A-MPDU length exponent: %u\n",
+        capabs->maximum_ampdu_length_exponent);
+    mctrl_print("Beamformee STS cap: %u\n",
+        capabs->beamformee_sts_capability);
+    mctrl_print("Number of sounding dimensions: %u\n",
+        capabs->number_sounding_dimensions);
+    mctrl_print("Custom MMSS (Minimum MPDU Start Spacing) offset: %u\n",
+        rsp_get_capabs->morse_mmss_offset);
+    return;
+}
+
+/* Only call this function when parsing arguments in a getopt while loop context */
+static int parse_capability_flag_args(char *argv[], int argc,
+                                      struct command_set_capabilities_req *cmd)
+{
+    int ret = 0;
+    int flag_idx = 0;
+    char *endptr;
+
+    cmd->set_caps |= SET_S1G_CAP_FLAGS;
+    /* Get the args manually - requires decrementing the optind */
+    optind--;
+    for (; optind < argc && *argv[optind] != '-'; optind++)
+    {
+        if (flag_idx == S1G_CAPABILITY_FLAGS_WIDTH)
+            break;
+        if (!argv[optind] || *argv[optind] == '-')
+        {
+            mctrl_err("Not enough args for -f");
+            ret = -1;
+            return ret;
+        }
+        errno = 0;
+        cmd->capabilities.flags[flag_idx] = htole32(strtol(argv[optind], &endptr, 0));
+        if (errno == ERANGE || endptr == argv[optind])
+        {
+            mctrl_err("Error when parsing capability flag %d\n", flag_idx + 1);
+            ret = -1;
+            return ret;
+        }
+        flag_idx++;
+    }
+    return 0;
+}
+
+static int parse_ampdu_flag_args(char *argv[],
+                                 struct command_set_capabilities_req *cmd)
+{
+    int ret = 0;
+    uint8_t tmp;
+
+    cmd->set_caps |= SET_S1G_CAP_AMPDU_MSS;
+    if (str_to_uint8(optarg, &tmp))
+    {
+        mctrl_err("Invalid AMPDU minimum start spacing\n");
+        ret = -1;
+        return ret;
+    }
+    cmd->capabilities.ampdu_mss = tmp;
+
+    if (!argv[optind] || *argv[optind] == '-')
+    {
+        mctrl_err("Not enough args for -a\n");
+        ret = -1;
+        return ret;
+    }
+    cmd->set_caps |= SET_S1G_CAP_MAX_AMPDU_LEXP;
+
+    if (str_to_uint8(argv[optind], &tmp))
+    {
+        mctrl_err("Invalid AMPDU max length exponent\n");
+        ret = -1;
+        return ret;
+    }
+    cmd->capabilities.maximum_ampdu_length_exponent = tmp;
+
+    /* Need to manually increment the optind after getting the second sub-arg */
+    optind++;
+    return ret;
+}
+
+int capabilities(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    bool is_get = false;
+    uint8_t tmp;
+    struct command_get_capabilities_req *cmd_get_capabs;
+    struct command_get_capabilities_cfm *rsp_get_capabs;
+    struct command_set_capabilities_req *cmd_set_capabs;
+    struct morsectrl_transport_buff *cmd_get_tbuff;
+    struct morsectrl_transport_buff *rsp_get_tbuff;
+    struct morsectrl_transport_buff *cmd_set_tbuff;
+    struct morsectrl_transport_buff *rsp_set_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_get_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_get_capabs));
+    rsp_get_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp_get_capabs));
+    cmd_set_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_set_capabs));
+    rsp_set_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_get_tbuff || !rsp_get_tbuff || !cmd_set_tbuff || !rsp_set_tbuff)
+        goto exit;
+
+    cmd_set_capabs = TBUFF_TO_CMD(cmd_set_tbuff, struct command_set_capabilities_req);
+    cmd_get_capabs = TBUFF_TO_CMD(cmd_get_tbuff, struct command_get_capabilities_req);
+    rsp_get_capabs = TBUFF_TO_RSP(rsp_get_tbuff, struct command_get_capabilities_cfm);
+
+    memset(cmd_set_capabs, 0, sizeof(*cmd_set_capabs));
+    memset(cmd_get_capabs, 0, sizeof(*cmd_get_capabs));
+
+    if (argc == 1)
+        is_get = true;
+
+    while ((option = getopt(argc, argv, "f:a:b:s:")) != -1)
+    {
+        switch (option)
+        {
+        case 'f' :
+            ret = parse_capability_flag_args(argv, argc, cmd_set_capabs);
+            if (ret < 0)
+                goto exit;
+            break;
+        case 'a' :
+            ret = parse_ampdu_flag_args(argv, cmd_set_capabs);
+            if (ret < 0)
+                goto exit;
+            break;
+        case 'b' :
+            cmd_set_capabs->set_caps |= SET_S1G_CAP_BEAM_STS;
+            if (str_to_uint8(optarg, &tmp))
+            {
+                mctrl_err("Invalid beamformee STS value\n");
+                ret = -1;
+                goto exit;
+            }
+            cmd_set_capabs->capabilities.beamformee_sts_capability = tmp;
+            break;
+        case 's' :
+            cmd_set_capabs->set_caps |= SET_S1G_CAP_NUM_SOUND_DIMS;
+            if (str_to_uint8(optarg, &tmp))
+            {
+                mctrl_err("Invalid number of sounding dimensions\n");
+                ret = -1;
+                goto exit;
+            }
+            cmd_set_capabs->capabilities.number_sounding_dimensions = tmp;
+            break;
+        default:
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+    if (is_get)
+    {
+        ret = morsectrl_send_command(mors->transport,
+                                     MORSE_COMMAND_GET_CAPABILITIES,
+                                     cmd_get_tbuff, rsp_get_tbuff);
+
+        if (ret >= 0)
+            print_capabs(mors, rsp_get_capabs);
+    }
+    else
+    {
+        ret = morsectrl_send_command(mors->transport,
+                                     MORSE_TEST_SET_CAPABILITIES,
+                                     cmd_set_tbuff, rsp_set_tbuff);
+    }
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set capabilities\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_set_tbuff);
+    morsectrl_transport_buff_free(rsp_set_tbuff);
+    morsectrl_transport_buff_free(cmd_get_tbuff);
+    morsectrl_transport_buff_free(rsp_get_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(capabilities, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/chan_query.c
+++ b/feeds/morse/utils/morsectrl/src/chan_query.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "channel.h"
+#include "utilities.h"
+
+#define MAX_AVAIL_CHANNELS      (UINT8_MAX)
+
+struct PACKED command_get_available_channels_cfm
+{
+    uint32_t num_channels;
+    struct PACKED {
+        uint32_t frequency_khz;
+        uint8_t channel_5g;
+        uint8_t channel_s1g;
+        uint8_t bandwidth_mhz;
+    } channels[MAX_AVAIL_CHANNELS];
+};
+
+static void usage(void)
+{
+    mctrl_print("\tchan_query [options]\n"
+           "\t\t\t\treturns a list of available channels\n"
+           "\t\t-j \t\tprint available channels in JSON format\n");
+}
+
+int chan_query(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_get_available_channels_cfm *query_cfm;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    bool json = false;
+
+    if (argc == 0)
+    {
+        usage();
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*query_cfm));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        goto err;
+    }
+
+    query_cfm = TBUFF_TO_RSP(rsp_tbuff, struct command_get_available_channels_cfm);
+
+    if (argc < 3)
+    {
+        int option;
+        while ((option = getopt(argc, argv, "j")) != -1)
+        {
+            switch (option)
+            {
+                case 'j' :
+                    json = true;
+                    break;
+                case '?' :
+                    usage();
+                    goto err;
+                default :
+                    mctrl_err("Invalid argument\n");
+                    usage();
+                    goto err;
+            }
+        }
+    }
+    else
+    {
+        mctrl_err("Invalid argument\n");
+        usage();
+        goto err;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_AVAILABLE_CHANNELS,
+            cmd_tbuff, rsp_tbuff);
+
+    if (ret < 0)
+    {
+        mctrl_err("Failed to query available channels");
+        goto err;
+    }
+
+    if (json)
+    {
+        mctrl_print("[");
+
+        for (int i = 0; i < query_cfm->num_channels; i++)
+        {
+            mctrl_print("%s{\"s1g_channel\":%u,"
+                    "\"center_frequency_khz\": %u,"
+                    "\"bandwidth_mhz\": %u,"
+                    "\"5g_channel\": %u}",
+                    i == 0 ? "" : ",",
+                    query_cfm->channels[i].channel_s1g, query_cfm->channels[i].frequency_khz,
+                    query_cfm->channels[i].bandwidth_mhz, query_cfm->channels[i].channel_5g);
+        }
+
+        mctrl_print("]\n");
+    }
+    else
+    {
+        mctrl_print("Channel  Center Freq (kHz)  BW (MHz)  5g Mapped Channel\n");
+
+        for (int i = 0; i < query_cfm->num_channels; i++)
+        {
+            mctrl_print("%7u  %17u  %8u  %17u\n",
+                    query_cfm->channels[i].channel_s1g, query_cfm->channels[i].frequency_khz,
+                    query_cfm->channels[i].bandwidth_mhz, query_cfm->channels[i].channel_5g);
+        }
+    }
+
+
+err:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(chan_query, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/channel.c
+++ b/feeds/morse/utils/morsectrl/src/channel.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "channel.h"
+#include "transport/transport.h"
+
+static struct
+{
+    struct arg_lit *all_channels;
+    struct arg_int *frequency;
+    struct arg_int *operating_bandwidth;
+    struct arg_int *primary_bandwidth;
+    struct arg_int *primary_idx;
+    struct arg_lit *ignore_reg_power;
+    struct arg_lit *json_format;
+} args;
+
+int channel_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Set or get channel parameters",
+                     args.all_channels = arg_lit0("a", NULL, "prints all the channel "
+                                                  "information i.e. full, DTIM, and current"),
+                     args.frequency = arg_int0("c", NULL, "<freq>",
+                                               "channel frequency in kHz"),
+                     args.operating_bandwidth = arg_int0("o", NULL, "<operating BW>",
+                                                         "operating bandwidth in MHz"),
+                     args.primary_bandwidth = arg_int0("p", NULL, "<primary BW>",
+                                                       "primary bandwidth in MHz"),
+                     args.primary_idx = arg_int0("n", NULL, "<primary chan index>",
+                                                 "primary 1 MHz channel index"),
+                     #ifndef MORSE_CLIENT
+                     args.ignore_reg_power = arg_lit0("r", NULL, "ignores regulatory max tx power"),
+                     #endif
+                     args.json_format = arg_lit0("j", NULL,
+                                                 "prints full channel information in easily "
+                                                 "parsable JSON format"));
+    return 0;
+}
+
+int channel(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t freq_khz = 0;
+    uint8_t op_channel_bandwidth = BANDWIDTH_DEFAULT;
+    uint8_t primary_channel_bandwidth = BANDWIDTH_DEFAULT;
+    uint8_t primary_1mhz_channel_index = PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT;
+    struct command_set_channel_req *cmd_set;
+    struct command_get_channel_cfm *resp_get;
+    bool set_freq = false;
+    bool get_all_channels = false;
+    bool json = false;
+    uint8_t s1g_chan_power = 1;
+    struct morsectrl_transport_buff *cmd_set_tbuff;
+    struct morsectrl_transport_buff *rsp_set_tbuff;
+    struct morsectrl_transport_buff *cmd_get_tbuff;
+    struct morsectrl_transport_buff *rsp_get_tbuff;
+
+    cmd_set_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_set));
+    rsp_set_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+    cmd_get_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_get_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp_get));
+
+    if (!cmd_set_tbuff || !rsp_set_tbuff || !cmd_get_tbuff || !rsp_get_tbuff)
+        goto exit;
+
+    cmd_set = TBUFF_TO_CMD(cmd_set_tbuff, struct command_set_channel_req);
+    resp_get = TBUFF_TO_RSP(rsp_get_tbuff, struct command_get_channel_cfm);
+
+    if (args.frequency->count)
+    {
+        freq_khz = args.frequency->ival[0];
+        set_freq = true;
+    }
+
+    if (args.operating_bandwidth->count)
+    {
+        op_channel_bandwidth = args.operating_bandwidth->ival[0];
+        set_freq = true;
+    }
+
+    if (args.primary_bandwidth->count)
+    {
+        primary_channel_bandwidth = args.primary_bandwidth->ival[0];
+        set_freq = true;
+    }
+
+    if (args.primary_idx->count)
+    {
+        primary_1mhz_channel_index = args.primary_idx->ival[0];
+        set_freq = true;
+    }
+
+    json = (args.json_format->count > 0);
+
+    get_all_channels = (args.all_channels->count > 0);
+
+#ifndef MORSE_CLIENT
+    s1g_chan_power = (args.ignore_reg_power > 0);
+#endif
+
+    if (set_freq)
+    {
+        if (!freq_khz)
+        {
+            mctrl_err("Channel frequency [-c] option must be specified\n");
+            goto exit;
+        }
+
+        cmd_set->operating_channel_freq_hz = htole32(KHZ_TO_HZ(freq_khz));
+        cmd_set->operating_channel_bw_mhz = op_channel_bandwidth;
+        cmd_set->primary_channel_bw_mhz = primary_channel_bandwidth;
+        cmd_set->primary_1mhz_channel_index = primary_1mhz_channel_index;
+        cmd_set->dot11_mode = 0; /* TODO */
+        cmd_set->s1g_chan_power = s1g_chan_power;
+
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_CHANNEL,
+                                     cmd_set_tbuff, rsp_set_tbuff);
+
+        if (ret < 0)
+        {
+            mctrl_err("Failed to set channel: error(%d)\n", ret);
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_FULL_CHANNEL,
+                                 cmd_get_tbuff, rsp_get_tbuff);
+
+    if (ret < 0)
+    {
+        mctrl_err("Failed to get channel frequency: error(%d)\n", ret);
+        goto exit;
+    }
+    if (json)
+    {
+        mctrl_print("{\n" \
+               "    \"channel_frequency\":%d,\n" \
+               "    \"channel_op_bw\":%d,\n" \
+               "    \"channel_primary_bw\":%d,\n" \
+               "    \"channel_index\":%d,\n" \
+               "    \"bw_mhz\":%d\n" \
+               "}\n",
+               (resp_get->operating_channel_freq_hz / 1000),
+               resp_get->operating_channel_bw_mhz,
+               resp_get->primary_channel_bw_mhz,
+               resp_get->primary_1mhz_channel_index,
+               resp_get->operating_channel_bw_mhz);
+    }
+    else
+    {
+        mctrl_print("Full Channel Information\n" \
+               "\tOperating Frequency: %d kHz\n" \
+               "\tOperating BW: %d MHz\n" \
+               "\tPrimary BW: %d MHz\n" \
+               "\tPrimary Channel Index: %d\n",
+               (resp_get->operating_channel_freq_hz / 1000),
+               resp_get->operating_channel_bw_mhz,
+               resp_get->primary_channel_bw_mhz,
+               resp_get->primary_1mhz_channel_index);
+    }
+
+    if (get_all_channels)
+    {
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_DTIM_CHANNEL,
+                                     cmd_get_tbuff, rsp_get_tbuff);
+        if (ret < 0)
+        {
+            mctrl_err("Failed to get channel frequency: error(%d)\n", ret);
+            goto exit;
+        }
+
+        mctrl_print("DTIM Channel Information\n" \
+               "\tOperating Frequency: %d kHz\n" \
+               "\tOperating BW: %d MHz\n" \
+               "\tPrimary BW: %d MHz\n" \
+               "\tPrimary Channel Index: %d\n",
+               (resp_get->operating_channel_freq_hz / 1000),
+               resp_get->operating_channel_bw_mhz,
+               resp_get->primary_channel_bw_mhz,
+               resp_get->primary_1mhz_channel_index);
+
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_CURRENT_CHANNEL,
+                                     cmd_get_tbuff, rsp_get_tbuff);
+        if (ret < 0)
+        {
+            mctrl_err("Failed to get channel frequency: error(%d)\n", ret);
+            goto exit;
+        }
+
+        mctrl_print("Current Channel Information\n" \
+               "\tOperating Frequency: %d kHz\n" \
+               "\tOperating BW: %d MHz\n" \
+               "\tPrimary BW: %d MHz\n" \
+               "\tPrimary Channel Index: %d\n",
+               (resp_get->operating_channel_freq_hz / 1000),
+               resp_get->operating_channel_bw_mhz,
+               resp_get->primary_channel_bw_mhz,
+               resp_get->primary_1mhz_channel_index);
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_set_tbuff);
+    morsectrl_transport_buff_free(rsp_set_tbuff);
+    morsectrl_transport_buff_free(cmd_get_tbuff);
+    morsectrl_transport_buff_free(rsp_get_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(channel, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/channel.h
+++ b/feeds/morse/utils/morsectrl/src/channel.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#pragma once
+
+#define BANDWIDTH_DEFAULT                   0xFF
+#define FREQUENCY_DEFAULT                   0xFFFFFFFF
+#define PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT  0xFF
+#define MIN_FREQ_KHZ                        750000
+#define MAX_FREQ_KHZ                        950000
+
+#define KHZ_TO_HZ(x) (x * 1000)
+
+/** Set channel command, used in channel and bandwidth commands */
+struct PACKED command_set_channel_req
+{
+    /** Centre frequency of the operating channel */
+    uint32_t operating_channel_freq_hz;
+
+    /** Operating channel bandwidth in MHz */
+    uint8_t operating_channel_bw_mhz;
+
+    /** Primary channel bandwidth in MHz */
+    uint8_t primary_channel_bw_mhz;
+
+    /** 1MHz channel index (see morse_firmware host_api.h for explanation) */
+    uint8_t primary_1mhz_channel_index;
+
+    /** dot11 protocol mode */
+    uint8_t dot11_mode;
+
+    /** Set to 1 to apply S1G regulatory max power, 0 otherwise */
+    uint8_t s1g_chan_power;
+};
+
+struct PACKED command_get_channel_cfm
+{
+    /** Centre frequency of the operating channel */
+    uint32_t operating_channel_freq_hz;
+
+    /** Operating channel bandwidth in MHz */
+    uint8_t operating_channel_bw_mhz;
+
+    /** Primary channel bandwidth in MHz */
+    uint8_t primary_channel_bw_mhz;
+
+    /**
+     * The index of the 1MHz channel within the operating channel.
+     * This is a value 0 for 1MHz channel, 0-1 for 2MHz,
+     * 0-3 for 4MHz, 0-7 for 8MHz and 0-15 for 16MHz.
+     */
+    uint8_t primary_1mhz_channel_index;
+};

--- a/feeds/morse/utils/morsectrl/src/command.c
+++ b/feeds/morse/utils/morsectrl/src/command.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+#include "utilities.h"
+
+#include "command.h"
+
+#define MORSECTRL_CMD_REQ_FLAG      (BIT(0))
+
+int morsectrl_send_command(struct morsectrl_transport *transport,
+                           int message_id,
+                           struct morsectrl_transport_buff *cmd,
+                           struct morsectrl_transport_buff *resp)
+{
+    int ret = 0;
+    struct command *command;
+    struct response *response;
+
+    if (!cmd || !resp)
+    {
+        ret = -ENOMEM;
+        goto exit;
+    }
+
+    command = (struct command *)cmd->data;
+    memset(&command->hdr, 0, sizeof(command->hdr));
+    command->hdr.message_id = htole16(message_id);
+    command->hdr.len = htole16(cmd->data_len - sizeof(struct command));
+    command->hdr.flags = MORSECTRL_CMD_REQ_FLAG;
+    response = (struct response *)resp->data;
+
+    ret = morsectrl_transport_send(transport, cmd, resp);
+
+    if (ret < 0)
+    {
+        morsectrl_transport_debug(transport, "Message failed %d\n", ret);
+        goto exit;
+    }
+
+    ret = le32toh(response->status);
+    if (ret)
+    {
+        if (ret != 110)
+        {
+            morsectrl_transport_debug(transport, "Command failed\n");
+        }
+
+        goto exit;
+    }
+
+exit:
+    return ret;
+} // NOLINT - checkstyle.py seems to think this brace is in the wrong place.

--- a/feeds/morse/utils/morsectrl/src/command.h
+++ b/feeds/morse/utils/morsectrl/src/command.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef MORSE_WIN_BUILD
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
+#include "portable_endian.h"
+#include "morsectrl.h"
+
+#define PACKED __attribute__((packed))
+
+/*
+ * The header for a command
+ */
+struct PACKED command_hdr
+{
+    /** Flags - used between host and firmware */
+    uint16_t flags;
+    /** Message ID - from enum morse_commands_id */
+    uint16_t message_id;
+    /** Command length excluding the header */
+    uint16_t len;
+    /** Host sequence id - used between host and firmware only */
+    uint16_t host_id;
+    /** Interface id - set by the host and copied into the response */
+    uint16_t vif_id;
+    /** Padding for word alignment */
+    uint16_t pad;
+};
+
+struct PACKED command
+{
+    /** The request command starts with a header */
+    struct command_hdr hdr;
+    /** An opaque data pointer */
+    uint8_t data[0];
+};
+
+struct PACKED response
+{
+    /** The confirm header */
+    struct command_hdr hdr;
+    /** The status of the of the command. @see morse_error_t */
+    uint32_t status;
+    /** An opaque data pointer */
+    uint8_t data[0];
+};
+
+/**
+ *  Host to firmware/driver messages
+ *
+ * @note you must hardcode the values here, and they must all be unique
+ */
+enum morse_commands_id
+{
+    MORSE_COMMAND_SET_CHANNEL = 0x0001,
+    MORSE_COMMAND_GET_VERSION = 0x0002,
+    MORSE_COMMAND_SET_TXPOWER = 0x0003,
+    MORSE_COMMAND_ADD_INTERFACE = 0x0004,
+    MORSE_COMMAND_REMOVE_INTERFACE = 0x0005,
+    MORSE_COMMAND_BSS_CONFIG = 0x0006,
+    MORSE_COMMAND_APP_STATS_LOG_DEPRECATED = 0x0007,
+    MORSE_COMMAND_APP_STATS_LOG = 0x2007,
+    MORSE_COMMAND_APP_STATS_RESET = 0x2008,
+    MORSE_COMMAND_RPG = 0x0009,
+    MORSE_COMMAND_CFG_SCAN = 0x0010,
+    MORSE_COMMAND_SET_QOS_PARAMS = 0x0011,
+    MORSE_COMMAND_GET_QOS_PARAMS = 0x0012,
+    MORSE_COMMAND_GET_FULL_CHANNEL = 0x0013,
+    MORSE_COMMAND_SET_STA_STATE = 0x0014,
+    MORSE_COMMAND_SET_BSS_COLOR = 0x0015,
+    MORSE_COMMAND_TURBO = 0x0018,
+    MORSE_COMMAND_HEALTH_CHECK = 0x0019,
+    MORSE_COMMAND_SET_CTS_SELF_PS = 0x001A,
+    MORSE_COMMAND_SET_DTIM_CHANNEL_CHANGE = 0x001B,
+    MORSE_COMMAND_GET_DTIM_CHANNEL = 0x001C,
+    MORSE_COMMAND_GET_CURRENT_CHANNEL = 0x001D,
+    MORSE_COMMAND_SET_LONG_SLEEP_CONFIG = 0x0021,
+    MORSE_COMMAND_SET_DUTY_CYCLE = 0x00022,
+    MORSE_COMMAND_GET_DUTY_CYCLE = 0x00023,
+    MORSE_COMMAND_GET_CAPABILITIES = 0x00025,
+    MORSE_COMMAND_INSTALL_TWT_AGREEMENT = 0x00026,
+    MORSE_COMMAND_REMOVE_TWT_AGREEMENT = 0x00027,
+    MORSE_COMMAND_GET_TSF = 0x00028,
+    MORSE_COMMAND_MAC_ADDR = 0x0029,
+    MORSE_COMMAND_MPSW_CONFIG = 0x0030,
+    MORSE_COMMAND_STANDBY_MODE = 0x0031,
+    MORSE_COMMAND_DHCP_OFFLOAD = 0x0032,
+    MORSE_COMMAND_SET_KEEP_ALIVE_OFFLOAD = 0x0033,
+    MORSE_COMMAND_GET_SET_GENERIC_PARAM = 0x003E,
+    MORSE_COMMAND_UAPSD_CONFIG = 0x0040,
+    MORSE_COMMAND_SET_WHITELIST = 0x0045,
+    MORSE_COMMAND_ARP_PERIODIC_REFRESH = 0x0046,
+    MORSE_COMMAND_SET_TCP_KEEPALIVE = 0x00047,
+
+    MORSE_COMMAND_MAC_STATS_LOG_DEPRECATED = 0x000C,
+    MORSE_COMMAND_MAC_STATS_LOG = 0x200C,
+    MORSE_COMMAND_MAC_STATS_RESET = 0x200D,
+    MORSE_COMMAND_UPHY_STATS_LOG_DEPRECATED = 0x000E,
+    MORSE_COMMAND_UPHY_STATS_LOG = 0x200E,
+    MORSE_COMMAND_UPHY_STATS_RESET = 0x200F,
+
+    /* Temporary Commands that may be removed later */
+    MORSE_COMMAND_SET_MODULATION = 0x1000,
+    MORSE_COMMAND_GET_RSSI = 0x1002,
+    MORSE_COMMAND_SET_IFS = 0x1003,
+    MORSE_COMMAND_SET_FEM_SETTINGS = 0x1005,
+    MORSE_COMMAND_SET_TXOP = 0x1008,
+    MORSE_COMMAND_SET_CONTROL_RESPONSE = 0x1009,
+    MORSE_COMMAND_CFG_ACI_SCAN = 0X001F,
+    MORSE_COMMAND_SET_PERIODIC_CAL = 0x100A,
+    MORSE_COMMAND_SET_BCN_RSSI_THRESHOLD = 0x100B,
+    MORSE_COMMAND_SET_TX_PKT_LIFETIME_US = 0x100C,
+    MORSE_COMMAND_SET_PHYSM_WATCHDOG = 0x100D,
+
+    /* Commands to driver */
+    MORSE_COMMAND_DRIVER_START = 0xA000,
+    MORSE_COMMAND_SET_STA_TYPE = 0xA000,
+    MORSE_COMMAND_SET_ENC_MODE = 0xA001,
+    MORSE_COMMAND_SET_LISTEN_INTERVAL = 0xA003,
+    MORSE_COMMAND_SET_AMPDU = 0xA004,
+    MORSE_COMMAND_SET_RAW_DEPRECATED = 0xA005,
+    MORSE_COMMAND_COREDUMP = 0xA006,
+    MORSE_COMMAND_SET_S1G_OP_CLASS = 0xA007,
+    MORSE_COMMAND_SEND_WAKE_ACTION_FRAME = 0xA008,
+    MORSE_COMMAND_VENDOR_IE_CONFIG = 0xA009,
+    MORSE_COMMAND_TWT_SET_CONF = 0xA010,
+    MORSE_COMMAND_GET_AVAILABLE_CHANNELS = 0xA011,
+    MORSE_COMMAND_SET_ECSA_S1G_INFO = 0xA012,
+    MORSE_COMMAND_GET_HW_VERSION = 0xA013,
+    MORSE_COMMAND_CAC_SET = 0xA014,
+    MORSE_COMMAND_DRIVER_SET_DUTY_CYCLE = 0xA015,
+    MORSE_COMMAND_MBSSID_INFO = 0xA016,
+    MORSE_COMMAND_OCS_REQ = 0xA017,
+    MORSE_COMMAND_MESH_CONFIG = 0xA018,
+    MORSE_COMMAND_MBCA_SET_CONF = 0xA019,
+    MORSE_COMMAND_DYNAMIC_PEERING_SET_CONF = 0xA020,
+    MORSE_COMMAND_CONFIG_RAW = 0xA021,
+    MORSE_COMMAND_DRIVER_END,
+
+    /** Test commands start at 0x8000 */
+    MORSE_TEST_COMMAND_START_SAMPLEPLAY = 0x8002,
+    MORSE_TEST_COMMAND_STOP_SAMPLEPLAY = 0x8003,
+    MORSE_TEST_COMMAND_SET_RESPONSE_INDICATION = 0x8007,
+    MORSE_TEST_COMMAND_SET_MAC_ACK_TIMEOUT = 0x8008,
+    MORSE_TEST_COMMAND_SET_TRANSMISSION_RATE = 0x8009,
+    MORSE_TEST_COMMAND_ENERGY_DETECTION_MODE = 0x8023,
+    MORSE_TEST_COMMAND_SET_NDP_PROBE_SUPPORT = 0x800C,
+    MORSE_TEST_COMMAND_FORCE_ASSERT = 0x800E,
+    MORSE_TEST_COMMAND_LNA_BYPASS = 0x800F,
+    MORSE_TEST_COMMAND_SET_TX_SCALER = 0x800B,
+    MORSE_TEST_COMMAND_TRANSMIT_CW = 0x8020,
+    MORSE_TEST_COMMAND_OVERRIDE_PA_ON_DELAY = 0x8021,
+    MORSE_TEST_COMMAND_SET_SIG_FIELD_ERROR_EVENT_CONFIG = 0x8011,
+    MORSE_COMMAND_OTP = 0x8014,
+    MORSE_COMMAND_SET_ANTENNA = 0x8015,
+    MORSE_TEST_COMMAND_SET_MAX_AMPDU_LENGTH = 0x8016,
+    MORSE_TEST_COMMAND_TDC_PG_DISABLE = 0x8017,
+    MORSE_TEST_COMMAND_DUMP_HW_KEYS = 0x8018,
+    MORSE_TEST_COMMAND_PHY_DEAF = 0x8019,
+    MORSE_TEST_COMMAND_SET_FSG = 0x8022,
+    MORSE_TEST_SET_CAPABILITIES = 0x8118,
+    MORSE_TEST_COMMAND_TX_PWR_ADJ = 0x8119,
+    MORSE_TEST_COMMAND_SET_AGC_GAIN_CODE = 0x811A,
+    MORSE_TEST_COMMAND_GPIO = 0x811B,
+};
+
+/**
+ * Error numbers the FW may return from commands
+ * Defined here as errno numbers are not portable across architectures
+ */
+enum morse_cmd_return_code {
+    MORSE_RET_SUCCESS     = 0,
+    MORSE_RET_EPERM       = -1,
+    MORSE_RET_ENXIO       = -6,
+    MORSE_RET_ENOMEM      = -12,
+    MORSE_RET_EINVAL      = -22,
+};
+
+int morsectrl_send_command(struct morsectrl_transport *transport,
+                           int message_id,
+                           struct morsectrl_transport_buff *cmd,
+                           struct morsectrl_transport_buff *resp);

--- a/feeds/morse/utils/morsectrl/src/config_file.c
+++ b/feeds/morse/utils/morsectrl/src/config_file.c
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+/*
+ * Read a config file and obtain the transport/interface/config options used.
+ *
+ * Values read will not override any provided on the command line.
+ *
+ * Transport and interface values will be stripped off the end and be passed
+ * through. Config options will have the <transport>_ text stripped off the
+ * front and added to a comma separated list (with no whitespace). For an
+ * example see example.config.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+#include "utilities.h"
+
+#define MAX_LINE_LENGTH         (255)
+#define MAX_CFG_LENGTH          (255)
+
+
+static const char *trans_str = "transport";
+static const char *iface_str = "interface";
+
+/**
+ * @brief Remove trailing whitespace from a string.
+ *
+ * @param buff  Buffer containing string to process
+ */
+static void config_file_remove_trailing_ws(char *buff)
+{
+    int ii;
+    int len;
+
+    if (!buff)
+        return;
+
+    len = strlen(buff);
+
+    for (ii = (len - 1); ii >= 0; ii--)
+    {
+        if (!isspace(buff[ii]))
+            return;
+
+        buff[ii] = '\0';
+    }
+}
+
+/**
+ * @brief Remove leading whitespace from a string.
+ *
+ * @param buff  Buffer containing string to process
+ *
+ * @return      NULL if @ref buff is NULL otherwise a pointer to the first non-whitespace non-'='
+ *              character.
+ */
+static const char *config_file_remove_leading_ws(const char *buff)
+{
+    int ii;
+
+    if (!buff)
+        return NULL;
+
+    for (ii = 0; ii < MAX_LINE_LENGTH; ii++)
+    {
+        if (buff[ii] == '=')
+            continue;
+
+        if ((buff[ii] == '\0') || !isspace(buff[ii]))
+            return &buff[ii];
+    }
+
+    return buff;
+}
+
+/**
+ * @brief Copy a string into new memory and remove trailing whitespace.
+ *
+ * @param src   Source string to copy
+ * @param dst   Destination to copy string to
+ *
+ * @return      0 on success otherwise -1
+ */
+static int config_file_passthrough(const char *src, char **dst)
+{
+    const char *ptr;
+
+    if (!dst || !src)
+        return -1;
+
+    if (*dst)
+        free(*dst);
+
+    ptr = strchr(src, '=');
+
+    if (!ptr)
+    {
+        mctrl_err("No '=' in line\n");
+        return -1;
+    }
+
+    ptr = config_file_remove_leading_ws(ptr);
+
+    if (!ptr)
+    {
+        mctrl_err("Option missing after '='\n");
+        return -1;
+    }
+
+    *dst = malloc(strlen(ptr) + 1);
+    if (!(*dst))
+        return -1;
+
+    snprintf(*dst, MAX_CFG_LENGTH, "%s", ptr);
+    config_file_remove_trailing_ws(*dst);
+    return 0;
+}
+
+/**
+ * @brief Parse the transport from a buffer and copy to the output string
+ *
+ * @param buff          Source buffer containing the transport
+ * @param trans_opts    Destination to return allocated string in
+ * @param debug         Whether or not to print debug
+ *
+ * @return              0 on success otherwise -1
+ */
+static int config_file_trans(const char *buff, char **trans_opts, bool debug)
+{
+    int ret = config_file_passthrough(buff, trans_opts);
+
+    if (debug)
+    {
+        if (!ret)
+            mctrl_print("Config file transport: '%s'\n", *trans_opts);
+        else
+            mctrl_print("Config file invalid transport\n");
+    }
+
+    return ret;
+}
+
+/**
+ * @brief Parse the interface from a buffer and copy to the output string
+ *
+ * @param buff          Source buffer containing the interface
+ * @param iface_opts    Destination to return allocated string in
+ * @param debug         Whether or not to print debug
+ *
+ * @return              0 on success otherwise -1
+ */
+static int config_file_iface(const char *buff, char **iface_opts, bool debug)
+{
+    int ret = config_file_passthrough(buff, iface_opts);
+
+    if (debug)
+    {
+        if (!ret)
+            mctrl_print("Config file interface: '%s'\n", *iface_opts);
+        else
+            mctrl_err("Config file invalid interface\n");
+    }
+
+    return ret;
+}
+
+/**
+ * @brief Parse the additional configuration from a buffer and copy to the output string
+ *
+ * @param buff          Source buffer containing the additional configuration
+ * @param cfg_opts      Destination to return allocated string in
+ * @param debug         Whether or not to print debug
+ *
+ * @return              0 on success otherwise -1
+ */
+static int config_file_cfg(char *buff, char **cfg_opts, bool debug)
+{
+    int current_size;
+    int total_size;
+    char *ptr = *cfg_opts;
+
+    if (!ptr)
+    {
+        if (debug)
+            mctrl_print("Config options allocate buffer\n");
+
+        /* Allocate memory and initialise first element to null terminator */
+        ptr = malloc(MAX_CFG_LENGTH);
+
+        if (!ptr)
+            return -1;
+
+        ptr[0] = '\0';
+        *cfg_opts = ptr;
+    }
+
+    config_file_remove_trailing_ws(buff);
+    if (debug)
+        mctrl_print("New config options: '%s'\n", buff);
+
+    current_size = strlen(ptr);
+
+    /* Make sure the extra options fit in the memory. */
+    total_size = current_size + strlen(buff) + 2;
+    if (debug)
+        mctrl_print("Total size after additional option: %d (%d + %d + 2)\n",
+               total_size, current_size, (int) strlen(buff));
+
+    if (total_size > MAX_CFG_LENGTH)
+        return -1;
+
+    /* Add config option separator if not the first option. */
+    if (current_size)
+    {
+        ptr[current_size++] = ',';
+        ptr[current_size] = '\0';
+    }
+
+    snprintf(&ptr[current_size], MAX_CFG_LENGTH - current_size, "%s", buff);
+
+    if (debug)
+        mctrl_print("Config options: '%s'\n", *cfg_opts);
+
+    return 0;
+}
+
+int morsectrl_config_file_parse(const char *file_opts,
+                                char **trans_opts,
+                                char **iface_opts,
+                                char **cfg_opts,
+                                bool debug)
+{
+    int ret = 0;
+    FILE *cfg_file;
+    char *line;
+    char *ptr;
+
+    if (!trans_opts || !iface_opts || !cfg_opts)
+        return -1;
+
+    if (debug)
+        mctrl_print("Start parsing config file\n");
+
+    cfg_file = fopen(file_opts, "r");
+
+    if (cfg_file == NULL)
+        return -1;
+
+    line = malloc(MAX_LINE_LENGTH);
+
+    if (!line)
+    {
+        fclose(cfg_file);
+        return -1;
+    }
+
+    while (fgets(line, MAX_LINE_LENGTH, cfg_file))
+    {
+        if (debug)
+            mctrl_print("Line: %s", line);
+
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+            continue;
+
+        ptr = (char *) config_file_remove_leading_ws(line);
+
+        if (!strncmp(ptr, trans_str, strlen(trans_str)) && !*trans_opts)
+        {
+            ret = config_file_trans(&ptr[strlen(trans_str)], trans_opts, debug);
+            if (ret)
+                break;
+
+            continue;
+        }
+
+        if (!strncmp(ptr, iface_str, strlen(iface_str)) && !*iface_opts)
+        {
+            ret = config_file_iface(&ptr[strlen(iface_str)], iface_opts, debug);
+            if (ret)
+                break;
+
+            continue;
+        }
+
+        if (*trans_opts && !strncmp(ptr, *trans_opts, strlen(*trans_opts)))
+        {
+            ret = config_file_cfg(&ptr[strlen(*trans_opts) + 1], cfg_opts, debug);
+            if (ret)
+            {
+                mctrl_err("Failed to parse config file transport config options\n");
+                break;
+            }
+
+            continue;
+        }
+    }
+
+    fclose(cfg_file);
+    free(line);
+    if (debug)
+        mctrl_print("\nFinished parsing config file\n");
+
+    return ret;
+}

--- a/feeds/morse/utils/morsectrl/src/controlresponse.c
+++ b/feeds/morse/utils/morsectrl/src/controlresponse.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_control_response_command
+{
+    uint8_t direction;
+    uint8_t control_response_bw_mhz;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tcr <direction> <bandwidth>\n");
+    mctrl_print("\t\t\t\tforces control response frames to use the specified bandwidth\n");
+    mctrl_print("\t\t<direction>\tapply to outbound (0) or inbound(1)\n");
+    mctrl_print("\t\t<bandwidth>\tbandwidth (MHz), or 0 to disable\n");
+}
+
+int cr(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint8_t bw_mhz;
+    uint8_t direction;
+    struct set_control_response_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 3)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_control_response_command);
+
+    if (str_to_uint8_range(argv[1], &direction, 0, 1) < 0)
+    {
+        mctrl_err("Invalid direction\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint8_range(argv[2], &bw_mhz, 0, 16) < 0)
+    {
+        mctrl_err("Invalid bandwidth\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    switch (bw_mhz)
+    {
+        case 0:
+        case 1:
+        case 2:
+        case 4:
+        case 8:
+        case 16:
+            break;
+        default:
+            mctrl_err("Invalid value\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+    }
+
+    cmd->control_response_bw_mhz = bw_mhz;
+    cmd->direction = direction;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_CONTROL_RESPONSE,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set cr\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(cr, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/coredump.c
+++ b/feeds/morse/utils/morsectrl/src/coredump.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+
+#include "command.h"
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tcoredump\t\tgenerates a FW coredump through the driver\n"
+           "\t\t\t\twith pattern /var/log/mmcd_hostname_ip_date/\n");
+}
+
+int coredump(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_COREDUMP,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Command coredump error (%d)\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(coredump, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/cts_self_ps.c
+++ b/feeds/morse/utils/morsectrl/src/cts_self_ps.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_cts_self_ps_command
+{
+    /** The flag of this message */
+    uint8_t enable;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tcts_self_ps <value>\t\t'disable' to disable and 'enable' to enable\n");
+}
+
+int cts_self_ps(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enable;
+    struct set_cts_self_ps_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid Command Parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    enable = expression_to_int(argv[1]);
+
+    if (enable == -1)
+    {
+        mctrl_err("Invalid value.\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_cts_self_ps_command);
+    cmd->enable = enable;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_CTS_SELF_PS,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set CTS-to-self PS\n");
+    }
+    else
+    {
+        mctrl_print("\tCTS-to-Self PowerSave: %s\n",
+            (cmd->enable) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(cts_self_ps, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/dhcpc.c
+++ b/feeds/morse/utils/morsectrl/src/dhcpc.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+
+enum dhcp_offload_opcode {
+    /** Enable the DHCP client */
+    MORSE_DHCP_CMD_ENABLE = 0,
+    /** Do a DHCP discovery and obtain a lease */
+    MORSE_DHCP_CMD_DO_DISCOVERY,
+    /** Return the current lease */
+    MORSE_DHCP_CMD_GET_LEASE,
+    /** Clear the current lease */
+    MORSE_DHCP_CMD_CLEAR_LEASE,
+    /** Trigger a renewal of the current lease */
+    MORSE_DHCP_CMD_RENEW_LEASE,
+    /** Trigger a rebinding of the current lease */
+    MORSE_DHCP_CMD_REBIND_LEASE,
+    /** Ask the FW to send a lease update event to the driver */
+    MORSE_DHCP_CMD_SEND_LEASE_UPDATE,
+    /** Force uint32 */
+    DHCP_CMD_LAST = UINT32_MAX
+};
+
+enum dhcp_offload_retcode {
+    /** Command completed successfully */
+    MORSE_DHCP_RET_SUCCESS = 0,
+    /** DHCP Client is disabled */
+    MORSE_DHCP_RET_NOT_ENABLED,
+    /** DHCP Client is already enabled */
+    MORSE_DHCP_RET_ALREADY_ENABLED,
+    /** No current bound lease */
+    MORSE_DHCP_RET_NO_LEASE,
+    /** DHCP client already has a lease */
+    MORSE_DHCP_RET_HAVE_LEASE,
+    /** DHCP client is currently busy (discovering or renewing) */
+    MORSE_DHCP_RET_BUSY,
+
+    /** Force uint32 */
+    MORSE_DHCP_RET_LAST = UINT32_MAX
+};
+
+struct PACKED command_dhcp_req
+{
+    uint32_t opcode;
+};
+
+struct PACKED command_dhcp_cfm
+{
+    uint32_t retcode;
+    ipv4_addr_t my_ip;
+    ipv4_addr_t netmask;
+    ipv4_addr_t router;
+    ipv4_addr_t dns;
+};
+
+static void print_error(enum dhcp_offload_retcode code)
+{
+    switch (code)
+    {
+        case MORSE_DHCP_RET_NOT_ENABLED:
+        {
+            mctrl_err("DHCP client is not enabled\n");
+            break;
+        }
+        case MORSE_DHCP_RET_ALREADY_ENABLED:
+        {
+            mctrl_err("DHCP client is already enabled\n");
+            break;
+        }
+        case MORSE_DHCP_RET_NO_LEASE:
+        {
+            mctrl_err("DHCP client does not have a lease\n");
+            break;
+        }
+        case MORSE_DHCP_RET_HAVE_LEASE:
+        {
+            mctrl_err("DHCP client already has a lease\n");
+            break;
+        }
+        case MORSE_DHCP_RET_BUSY:
+        {
+            mctrl_err("DHCP client is currently performing a discovery or renewal\n");
+            break;
+        }
+
+        default:
+            mctrl_err("DHCP client threw an error: %d\n", code);
+            break;
+    }
+}
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tdhcpc [enable | discover | get | clear | renew | rebind | update]\t");
+    mctrl_print("configure DHCP client\n");
+    mctrl_print("\t\tenable - enable DHCP client\n");
+    mctrl_print("\t\tdiscover - do a discovery and obtain a lease\n");
+    mctrl_print("\t\tget - get the current lease\n");
+    mctrl_print("\t\tclear - clear the current lease\n");
+    mctrl_print("\t\trenew - renew the current lease\n");
+    mctrl_print("\t\trebind - rebind the current lease\n");
+    mctrl_print("\t\tupdate - send a lease update to the driver\n");
+}
+
+int dhcpc(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = 0;
+
+    struct command_dhcp_req *cmd_dhcp;
+    struct command_dhcp_cfm *rsp_dhcp;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_dhcp));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp_dhcp));
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_dhcp = TBUFF_TO_CMD(cmd_tbuff, struct command_dhcp_req);
+    rsp_dhcp = TBUFF_TO_RSP(rsp_tbuff, struct command_dhcp_cfm);
+
+    if (cmd_dhcp == NULL ||
+        rsp_dhcp == NULL)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    /* assume vif_id 0 */
+    memset(cmd_dhcp, 0, sizeof(*cmd_dhcp));
+
+    if (strcmp(argv[1], "enable") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_ENABLE;
+    }
+    else if (strcmp(argv[1], "discover") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_DO_DISCOVERY;
+    }
+    else if (strcmp(argv[1], "get") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_GET_LEASE;
+    }
+    else if (strcmp(argv[1], "clear") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_CLEAR_LEASE;
+    }
+    else if (strcmp(argv[1], "renew") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_RENEW_LEASE;
+    }
+    else if (strcmp(argv[1], "rebind") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_REBIND_LEASE;
+    }
+    else if (strcmp(argv[1], "update") == 0)
+    {
+        cmd_dhcp->opcode = MORSE_DHCP_CMD_SEND_LEASE_UPDATE;
+    }
+    else
+    {
+        ret = -1;
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+                                 MORSE_COMMAND_DHCP_OFFLOAD,
+                                 cmd_tbuff,
+                                 rsp_tbuff);
+
+    if (ret < 0)
+    {
+        mctrl_err("Command error (%d)\n", ret);
+        goto exit;
+    }
+    else if (rsp_dhcp->retcode != MORSE_DHCP_RET_SUCCESS)
+    {
+        print_error(rsp_dhcp->retcode);
+        goto exit;
+    }
+    else
+    {
+        if (cmd_dhcp->opcode == MORSE_DHCP_CMD_GET_LEASE)
+        {
+            mctrl_print("Current DHCP Lease\n");
+            mctrl_print("IP Address: %d.%d.%d.%d\n", rsp_dhcp->my_ip.octet[0],
+                    rsp_dhcp->my_ip.octet[1], rsp_dhcp->my_ip.octet[2], rsp_dhcp->my_ip.octet[3]);
+            mctrl_print("Netmask: %d.%d.%d.%d\n", rsp_dhcp->netmask.octet[0],
+                    rsp_dhcp->netmask.octet[1], rsp_dhcp->netmask.octet[2],
+                    rsp_dhcp->netmask.octet[3]);
+            mctrl_print("Router Address: %d.%d.%d.%d\n", rsp_dhcp->router.octet[0],
+                    rsp_dhcp->router.octet[1], rsp_dhcp->router.octet[2],
+                    rsp_dhcp->router.octet[3]);
+            mctrl_print("DNS Address: %d.%d.%d.%d\n", rsp_dhcp->dns.octet[0],
+                    rsp_dhcp->dns.octet[1], rsp_dhcp->dns.octet[2], rsp_dhcp->dns.octet[3]);
+        }
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(dhcpc, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/dtim_channel.c
+++ b/feeds/morse/utils/morsectrl/src/dtim_channel.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_dtim_channel_command
+{
+    /** The flag of this message */
+    uint8_t  enable;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tdtim_channel_change [enable|disable]\n");
+    mctrl_print("\t\t'enable' to enable dtim-channel switching in powersave\n");
+    mctrl_print("\t\t'disable' to disable dtim-channel switching in powersave\n");
+}
+
+int dtim_channel_change(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enable;
+    struct set_dtim_channel_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid Command Parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    enable = expression_to_int(argv[1]);
+
+    if (enable == -1)
+    {
+        mctrl_err("Invalid value.\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_dtim_channel_command);
+    cmd->enable = enable;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_DTIM_CHANNEL_CHANGE,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set DTIM-Channel change\n");
+    }
+    else
+    {
+        mctrl_print("\tDTIM-Channel change: %s\n",
+            (cmd->enable) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(dtim_channel_change, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/duty_cycle.c
+++ b/feeds/morse/utils/morsectrl/src/duty_cycle.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+/* Limits on duty cycle, expressed in  percent */
+#define DUTY_CYCLE_MIN      (0.01)
+#define DUTY_CYCLE_MAX      (100.0)
+
+#define DUTY_CYCLE_SET_CFG_DUTY_CYCLE         BIT(0)
+#define DUTY_CYCLE_SET_CFG_OMIT_CONTROL_RESP  BIT(1)
+#define DUTY_CYCLE_SET_CFG_EXT                BIT(2)
+#define DUTY_CYCLE_SET_CFG_BURST_RECORD_UNIT  BIT(3)
+
+enum duty_cycle_mode
+{
+    DUTY_CYCLE_MODE_SPREAD = 0,
+    DUTY_CYCLE_MODE_BURST = 1,
+    DUTY_CYCLE_MODE_LAST = DUTY_CYCLE_MODE_BURST,
+};
+
+struct PACKED duty_cycle_configuration
+{
+    /** Omit control responses from duty cycle budget */
+    uint8_t omit_control_responses;
+    /** Target duty cycle in 100th of a %, i.e. 1..10000 */
+    uint32_t duty_cycle;
+};
+
+struct PACKED duty_cycle_set_configuration_ext
+{
+    /** The length of each burst record in the window (us) - applicable in burst mode only */
+    uint32_t burst_record_unit_us;
+    /** Duty cycle mode, see @ref enum duty_cycle_mode */
+    uint8_t mode;
+};
+
+struct PACKED duty_cycle_configuration_ext
+{
+    /** Airtime remaining (us) - applicable in burst mode only */
+    uint32_t airtime_remaining_us;
+    /** Burst window duration (us) - applicable in burst mode only */
+    uint32_t burst_window_duration_us;
+    /** Extension parameters that are configured */
+    struct duty_cycle_set_configuration_ext set;
+};
+
+/** Set duty cycle command */
+struct PACKED command_set_duty_cycle_req
+{
+    struct duty_cycle_configuration config;
+    uint8_t set_cfgs;
+    struct duty_cycle_set_configuration_ext config_ext;
+};
+
+struct PACKED command_get_duty_cycle_cfm
+{
+    struct duty_cycle_configuration config;
+    struct duty_cycle_configuration_ext config_ext;
+};
+
+enum duty_cycle_cmd
+{
+    DUTY_CYCLE_CMD_DISABLE,
+    DUTY_CYCLE_CMD_ENABLE,
+    DUTY_CYCLE_CMD_AIRTIME
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tduty_cycle <command>\tconfigure duty cycle mode. ");
+    mctrl_print("omit command to retrieve settings.\n");
+    mctrl_print("\t\tenable\t<value> [options]\n");
+    mctrl_print("\t\t\t<value> set duty cycle in %% (%.2f-%.2f)\n",
+        DUTY_CYCLE_MIN, DUTY_CYCLE_MAX);
+    mctrl_print("\t\t\t-m <mode> mode of operation (0:spread, 1:burst). ");
+    mctrl_print("default:0\n");
+#if !defined(MORSE_CLIENT)
+    mctrl_print("\t\t\t-u <unit> time unit of each burst record entry (us)\n");
+#endif
+    mctrl_print("\t\t\t-o enables or disables omitting control responses ");
+    mctrl_print("from the duty cycle budget.\n");
+    mctrl_print("\t\tdisable\n");
+    mctrl_print("\t\tairtime\treturn remaining airtime (us), (burst mode only)\n");
+}
+
+static int duty_cycle_parse_cmd(const char *str)
+{
+    if (strcmp("enable", str) == 0)
+        return DUTY_CYCLE_CMD_ENABLE;
+
+    if (strcmp("disable", str) == 0)
+        return DUTY_CYCLE_CMD_DISABLE;
+
+    if (strcmp("airtime", str) == 0)
+        return DUTY_CYCLE_CMD_AIRTIME;
+
+    return -1;
+}
+
+static int get_duty_cycle(struct morsectrl *mors, bool burst_airtime_only)
+{
+    int ret = -1;
+    struct command_set_duty_cycle_req *cmd;
+    struct command_get_duty_cycle_cfm *resp;
+    struct morsectrl_transport_buff *cmd_tbuff =
+        morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    struct morsectrl_transport_buff *rsp_tbuff =
+        morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_duty_cycle_req);
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct command_get_duty_cycle_cfm);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_DUTY_CYCLE,
+                                     cmd_tbuff, rsp_tbuff);
+
+    if (ret < 0)
+    {
+        mctrl_err("Failed to read duty cycle: error (%d)\n", ret);
+        goto exit;
+    }
+
+    if (burst_airtime_only)
+    {
+        if (resp->config_ext.set.mode == DUTY_CYCLE_MODE_BURST)
+        {
+            mctrl_print("%u\n", resp->config_ext.airtime_remaining_us);
+        }
+        else
+        {
+            mctrl_err("Command not supported when in spread mode\n");
+            ret = -1;
+        }
+
+        goto exit;
+    }
+
+    mctrl_print("Mode: %s\n",
+            (resp->config_ext.set.mode == DUTY_CYCLE_MODE_BURST) ? "burst" : "spread");
+    mctrl_print("Configured duty cycle: %.2f%%\n", (float)(resp->config.duty_cycle) / 100);
+    mctrl_print("Control responses omitted from duty cycle calculation: %d\n",
+            resp->config.omit_control_responses);
+
+    if (resp->config_ext.set.mode == DUTY_CYCLE_MODE_BURST)
+    {
+        mctrl_print("Airtime remaining (us): %u\n", resp->config_ext.airtime_remaining_us);
+        mctrl_print("Burst window duration (us): %u\n",
+                resp->config_ext.burst_window_duration_us);
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+static int set_duty_cycle(struct morsectrl *mors, struct duty_cycle_configuration *cfg,
+                          struct duty_cycle_set_configuration_ext *cfg_ext, uint8_t set_cfgs)
+{
+    int ret = -1;
+    struct command_set_duty_cycle_req *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff =
+        morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    struct morsectrl_transport_buff *rsp_tbuff =
+        morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit_set;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_duty_cycle_req);
+
+    memset(cmd, 0, sizeof(*cmd));
+
+    /* Range checked by caller */
+    cmd->set_cfgs = set_cfgs;
+    cmd->config.duty_cycle = cfg->duty_cycle;
+    cmd->config.omit_control_responses = cfg->omit_control_responses;
+
+    if (cmd->set_cfgs & DUTY_CYCLE_SET_CFG_EXT)
+    {
+        cmd->config_ext.mode = cfg_ext->mode;
+        if (cmd->set_cfgs & DUTY_CYCLE_SET_CFG_BURST_RECORD_UNIT)
+        {
+            cmd->config_ext.burst_record_unit_us = cfg_ext->burst_record_unit_us;
+        }
+    }
+
+    /* Send duty cycle command directly to the firmware if driver commands are not supported. */
+    if (morsectrl_transport_has_driver(mors->transport))
+    {
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_DRIVER_SET_DUTY_CYCLE,
+                                     cmd_tbuff, rsp_tbuff);
+    }
+    else
+    {
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_DUTY_CYCLE,
+                                     cmd_tbuff, rsp_tbuff);
+    }
+
+exit_set:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set duty cycle: error (%d)\n", ret);
+    }
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+int duty_cycle(struct morsectrl *mors, int argc, char *argv[])
+{
+    int option;
+    struct duty_cycle_configuration cfg = { 0 };
+    struct duty_cycle_set_configuration_ext cfg_ext = { 0 };
+    uint8_t set_cfgs = 0;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc == 1)
+    {
+        /* No command supplied, user wants to get duty cycle settings */
+        return get_duty_cycle(mors, false);
+    }
+
+    int cmd = duty_cycle_parse_cmd(argv[1]);
+    if (cmd == -1)
+    {
+        mctrl_err("Invalid command\n");
+        usage(mors);
+        return -1;
+    }
+
+    if (cmd == DUTY_CYCLE_CMD_AIRTIME)
+    {
+        /* User want's to get airtime information */
+        return get_duty_cycle(mors, true);
+    }
+    if (cmd == DUTY_CYCLE_CMD_ENABLE)
+    {
+        float duty_cycle;
+
+        if (argc < 3)
+        {
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            return -1;
+        }
+
+        /* Specify what is being set in this command */
+        set_cfgs |= DUTY_CYCLE_SET_CFG_DUTY_CYCLE;
+        set_cfgs |= DUTY_CYCLE_SET_CFG_EXT;
+
+        /* Parse duty cycle settings */
+        duty_cycle = strtof(argv[2], NULL);
+        if ((duty_cycle < (float)DUTY_CYCLE_MIN) || (duty_cycle > (float)DUTY_CYCLE_MAX))
+        {
+            mctrl_err("Invalid duty cycle %f (%.2f-%.2f).\n",
+                    duty_cycle, DUTY_CYCLE_MIN, DUTY_CYCLE_MAX);
+            usage(mors);
+            return -1;
+        }
+
+        cfg.duty_cycle = (uint32_t)(duty_cycle * 100);
+        cfg_ext.mode = DUTY_CYCLE_MODE_SPREAD; /* default mode */
+
+        argc -= 2;
+        argv += 2;
+        while ((option = getopt(argc, argv, "m:u:o")) != -1)
+        {
+            switch (option)
+            {
+                case 'o':
+                {
+                    cfg.omit_control_responses = 1;
+                    set_cfgs |= DUTY_CYCLE_SET_CFG_OMIT_CONTROL_RESP;
+                    break;
+                }
+                case 'm':
+                {
+                    uint8_t val;
+
+                    if (str_to_uint8_range(optarg, &val, 0, DUTY_CYCLE_MODE_LAST) < 0)
+                    {
+                        mctrl_err("Duty cycle mode of operation not valid\n");
+                        usage(mors);
+                        return -1;
+                    }
+
+                    cfg_ext.mode = val;
+                    break;
+                }
+#if !defined(MORSE_CLIENT)
+                case 'u':
+                {
+                    uint32_t val;
+
+                    if (str_to_uint32(optarg, &val) < 0)
+                    {
+                        mctrl_err("Invalid value for the unit of burst mode records\n");
+                        usage(mors);
+                        return -1;
+                    }
+
+                    cfg_ext.burst_record_unit_us = val;
+                    set_cfgs |= DUTY_CYCLE_SET_CFG_BURST_RECORD_UNIT;
+                    break;
+                }
+#endif
+                default:
+                {
+                    mctrl_err("Unknown option to enable command\n");
+                    usage(mors);
+                    return -1;
+                }
+            }
+        }
+    }
+    else if (cmd == DUTY_CYCLE_CMD_DISABLE)
+    {
+        set_cfgs |= DUTY_CYCLE_SET_CFG_DUTY_CYCLE;
+        cfg.duty_cycle = (uint32_t)(100 * 100); /* 100% dc indicates disabled */
+    }
+
+    return set_duty_cycle(mors, &cfg, &cfg_ext, set_cfgs);
+}
+
+MM_CLI_HANDLER(duty_cycle, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/dynamic_peering.c
+++ b/feeds/morse/utils/morsectrl/src/dynamic_peering.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+#define RSSI_MARGIN_MIN 3
+#define RSSI_MARGIN_MAX 30
+#define BLACKLIST_TIMEOUT_MIN 10
+#define BLACKLIST_TIMEOUT_MAX 600
+
+struct PACKED command_set_dynamic_peering_conf {
+    /** Enable or disable mesh dynamic peering */
+    uint8_t enabled;
+
+    /** RSSI margin to consider while selecting a peer to kick out */
+    uint8_t rssi_margin;
+
+    /** Kicked out peer is not allowed connection during this period */
+    uint32_t blacklist_timeout;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print(
+        "\tdynamic_peering [enable|disable] -r <rssi margin> -t <blacklist timeout>\n");
+    mctrl_print("\t\t\t\tEnable/Disable Mesh Dynamic Peering\n");
+    mctrl_print("\t\t\t\tdo not use - for internal use by wpa_supplicant\n");
+    mctrl_print("\t\t-r <value>\tRSSI margin to consider while selecting a peer to kick out");
+    mctrl_print(" min:%u, max:%u\n", RSSI_MARGIN_MIN, RSSI_MARGIN_MAX);
+    mctrl_print("\t\t-t <value>\tblacklist time for a kicked-out peer (seconds)");
+    mctrl_print(" min:%u, max:%u\n", BLACKLIST_TIMEOUT_MIN, BLACKLIST_TIMEOUT_MAX);
+}
+
+int dynamic_peering(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_set_dynamic_peering_conf *dyn_peering_conf = NULL;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+    uint8_t temp;
+    uint32_t timeout;
+    int option;
+    int enabled;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 6)
+    {
+        mctrl_err("Insufficient command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    enabled = expression_to_int(argv[1]);
+    if (enabled < 0)
+    {
+        mctrl_err("Invalid dynamic_peering command '%s'\n", argv[1]);
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*dyn_peering_conf));
+    if (!cmd_tbuff)
+    {
+        goto exit;
+    }
+
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+    if (!rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    dyn_peering_conf = TBUFF_TO_CMD(cmd_tbuff, struct command_set_dynamic_peering_conf);
+    memset(dyn_peering_conf, 0, sizeof(*dyn_peering_conf));
+
+    dyn_peering_conf->enabled = enabled;
+    argc--;
+    argv++;
+    while ((option = getopt(argc, argv, "r:t:")) != -1)
+    {
+        switch (option) {
+        case 'r':
+            if (str_to_uint8_range(optarg, &temp, RSSI_MARGIN_MIN, RSSI_MARGIN_MAX) < 0)
+            {
+                mctrl_err("RSSI margin %u must be within the range min %u : max %u\n",
+                    temp, RSSI_MARGIN_MIN, RSSI_MARGIN_MAX);
+                ret = -1;
+                goto exit;
+            }
+            dyn_peering_conf->rssi_margin = temp;
+            break;
+        case 't':
+            if (str_to_uint32_range(optarg, &timeout, BLACKLIST_TIMEOUT_MIN,
+                BLACKLIST_TIMEOUT_MAX) < 0)
+            {
+                mctrl_err("Blacklist timeout %u must be within the range min %u : max %u\n",
+                    timeout, BLACKLIST_TIMEOUT_MIN, BLACKLIST_TIMEOUT_MAX);
+                ret = -1;
+                goto exit;
+            }
+            dyn_peering_conf->blacklist_timeout = timeout;
+            break;
+        default:
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_DYNAMIC_PEERING_SET_CONF,
+        cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (cmd_tbuff)
+    {
+        morsectrl_transport_buff_free(cmd_tbuff);
+    }
+
+    if (rsp_tbuff)
+    {
+        morsectrl_transport_buff_free(rsp_tbuff);
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(dynamic_peering, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/ecsa.c
+++ b/feeds/morse/utils/morsectrl/src/ecsa.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "channel.h"
+#include "utilities.h"
+
+#define OPCLASS_DEFAULT 0xFF
+
+struct PACKED set_ecsa_command
+{
+    /** Centre frequency of the operating channel */
+    uint32_t operating_channel_freq_hz;
+
+    /** Global Operating class */
+    uint8_t opclass;
+
+    /** Pimary channel bw in MHz */
+    uint8_t primary_channel_bw_mhz;
+
+    /** 1MHz channel index */
+    uint8_t prim_1mhz_ch_idx;
+
+    /** Operating channel bandwidth in MHz */
+    uint8_t operating_channel_bw_mhz;
+
+    /** Global Operating class for primary chan */
+    uint8_t prim_opclass;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tecsa_info [options]\n");
+    mctrl_print("\t\t\t\tSet frequency parameters for ECSA ie in probe response and beacon\n");
+    mctrl_print("\t\t-g <value>\tglobal operating class\n");
+    mctrl_print("\t\t-p <value>\tprimary channel bandwidth in MHz\n");
+    mctrl_print("\t\t-n <value>\tprimary 1MHz channel index\n");
+    mctrl_print("\t\t-o <value>\tOperating channel bandwidth in MHz\n");
+    mctrl_print("\t\t-c <value>\tsets channel frequency in kHz\n");
+    mctrl_print("\t\t-l <value>\tglobal operating class for primary channel\n");
+}
+
+int ecsa_info(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    uint32_t freq_khz = 0;
+    uint8_t primary_channel_bandwidth = BANDWIDTH_DEFAULT;
+    uint8_t op_channel_bandwidth = BANDWIDTH_DEFAULT;
+    uint8_t global_operating_class = OPCLASS_DEFAULT;
+    uint8_t primary_1Mhz_chan_idx = PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT;
+    uint8_t prim_chan_global_op_class = OPCLASS_DEFAULT;
+    struct set_ecsa_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0 || argc != 13)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_ecsa_command);
+    while ((option = getopt(argc, argv, "g:p:n:o:c:l:")) != -1)
+    {
+        switch (option)
+        {
+            case 'g' :
+                if (str_to_uint8(optarg, &global_operating_class))
+                {
+                    mctrl_err("Invalid global operating class\n");
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case 'p' :
+                if (str_to_uint8(optarg, &primary_channel_bandwidth))
+                {
+                    mctrl_err("Invalid primary channel bandwidth\n");
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case 'n' :
+                if (str_to_uint8(optarg, &primary_1Mhz_chan_idx))
+                {
+                    mctrl_err("Invalid primary channel index\n");
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case 'o' :
+                if (str_to_uint8(optarg, &op_channel_bandwidth))
+                {
+                    mctrl_err("Invalid op channel bandwidth\n");
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case 'c' :
+                if (str_to_uint32_range(optarg, &freq_khz, MIN_FREQ_KHZ, MAX_FREQ_KHZ))
+                {
+                    mctrl_err("Invalid channel frequency %d. Must be between %d kHz and %d kHz\n",
+                                freq_khz, MIN_FREQ_KHZ, MAX_FREQ_KHZ);
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case 'l':
+                if (str_to_uint8(optarg, &prim_chan_global_op_class))
+                {
+                    mctrl_err("Invalid primary channel global op class\n");
+                    usage(mors);
+                    goto exit;
+                }
+                break;
+            case '?' :
+                usage(mors);
+                goto exit;
+            default :
+                mctrl_err("Invalid argument\n");
+                usage(mors);
+                goto exit;
+        }
+    }
+
+    if (!freq_khz)
+    {
+        mctrl_err("Channel frequency [-c] option must be specified\n");
+        usage(mors);
+        goto exit;
+    }
+
+    if ((primary_channel_bandwidth == BANDWIDTH_DEFAULT) ||
+        (global_operating_class == OPCLASS_DEFAULT) ||
+        (prim_chan_global_op_class == OPCLASS_DEFAULT) ||
+        (op_channel_bandwidth == BANDWIDTH_DEFAULT) ||
+        (primary_1Mhz_chan_idx == PRIMARY_1MHZ_CHANNEL_INDEX_DEFAULT))
+    {
+        mctrl_err("Invalid input parameters: \n"
+            "* primary_channel_bandwidth %d \n"
+            "* global_operating_class %d \n"
+            "* primary_ch_global_op_class %d \n"
+            "* op_channel_bandwidth %d \n"
+            "* primary_1Mhz_chan_idx %d \n \n",
+            primary_channel_bandwidth,
+            global_operating_class,
+            prim_chan_global_op_class,
+            op_channel_bandwidth,
+            primary_1Mhz_chan_idx);
+        usage(mors);
+        goto exit;
+    }
+
+
+
+    cmd->primary_channel_bw_mhz = primary_channel_bandwidth;
+    cmd->opclass = global_operating_class;
+    cmd->prim_1mhz_ch_idx = primary_1Mhz_chan_idx;
+    cmd->operating_channel_freq_hz = htole32(KHZ_TO_HZ(freq_khz));
+    cmd->operating_channel_bw_mhz = op_channel_bandwidth;
+    cmd->prim_opclass = prim_chan_global_op_class;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_ECSA_S1G_INFO,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set ecsa info\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(ecsa_info, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/edconfig.c
+++ b/feeds/morse/utils/morsectrl/src/edconfig.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 Morse Micro
+ *
+ */
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_energy_detection_mode_req
+{
+    /**
+     * Mode for energy detection:
+     * 0:auto - The default. System will automatically sense the medium and set the energy
+     *          threshold / noise estimate.
+     * 1:static - Set a static value for the specified parameter. The variable `value` must
+     *            be set in this scenario.
+     * 2:ignore - Only valid when param == 0 (energy threshold)
+     *            Energy on air will be ignored when device goes to transmit.
+     * 3:jammer - Only valid when param == 0 (energy threshold)
+     *            Energy on air will be ignored if in-channel jammer is detected.
+     */
+    uint16_t mode;
+
+    /**
+     * Energy detect parameter to target
+     * 0: energy threshold
+     * 1: noise estimate
+     */
+    uint8_t param;
+
+    /** 0 : value is in dbm
+     *  1 : value is linear
+     */
+    uint8_t linear;
+
+    /** If mode is static (1), then this will define the value to assign to specified parameter.
+     *  Must evaluate to a positive linear value (after dBm conversion if applicable)
+    */
+    int16_t value;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tedconfig <target> <command>\n");
+    mctrl_print("\t\t\t\tsets the current mode for DCF energy detection\n");
+    mctrl_print(
+        "\t\t<target> - 'energy' or 'noise' - Change the setting for energy detect threshold or "
+        "noise estimate\n");
+    mctrl_print("\t\t<command> -\n");
+    mctrl_print(
+        "\t\t\t\tautomatic - default, chip will automatically select energy dection threshold or "
+        "noise estimate\n");
+    mctrl_print(
+        "\t\t\t\tstatic [dbm/linear] <threshold> - set a static energy dection threshold or "
+        "noise estimate (in integer dBm or linear)\n");
+    mctrl_print(
+        "\t\t\t\tignore - tell the chip to ignore non-wlan energy completely"
+        "(only valid for 'energy' target)\n");
+    mctrl_print(
+        "\t\t\t\tjammer - tell the chip to ignore non-wlan energy if in-channel jammer is detected"
+        "(only valid for 'energy' target)\n");
+}
+
+int edconfig(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_energy_detection_mode_req *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    char* next;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_energy_detection_mode_req);
+
+    if ( argc < 3 || argc > 5)
+    {
+        mctrl_err("Invalid argument\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    // target checks
+    if (0 == strcmp("energy", argv[1]))
+    {
+        cmd->param = 0;
+    }
+    else if (0 == strcmp("noise", argv[1]))
+    {
+        cmd->param = 1;
+    }
+    else
+    {
+        mctrl_err("Invalid target\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    // mode checks
+    if (0 == strcmp("automatic", argv[2]))
+    {
+        cmd->mode = 0;
+    }
+    else if ( 0 == strcmp("ignore", argv[2]))
+    {
+        cmd->mode = 2;
+    }
+    else if ( 0 == strcmp("jammer", argv[2]))
+    {
+        cmd->mode = 3;
+    }
+    else if ( 0 == strcmp("static", argv[2]) )
+    {
+        if ( argc != 5 )
+        {
+            mctrl_err("Not enough arguments\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        if ( 0 == strcmp("dbm", argv[3]) )
+        {
+            cmd->linear = 0;
+        }
+        else if ( 0 == strcmp("linear", argv[3]) )
+        {
+            cmd->linear = 1;
+        }
+        else
+        {
+            mctrl_err("Invalid static threshold type (specify either 'dbm' or 'linear'\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        cmd->mode = 1;
+        cmd->value = (int16_t)strtol(argv[4], &next, 10);
+
+        if (next == argv[4]) /* valid integer could not be found */
+        {
+            mctrl_err("invalid threshold\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+    else
+    {
+        mctrl_err("Invalid mode\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    // good to go
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_ENERGY_DETECTION_MODE,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to configure energy/noise threshold\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(edconfig, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/elf_file.c
+++ b/feeds/morse/utils/morsectrl/src/elf_file.c
@@ -1,0 +1,624 @@
+/*
+ * Copyright 2022-2023 Morse Micro
+ */
+#ifdef MORSE_WIN_BUILD
+#include "win/elf.h"
+#else
+#include <elf.h>
+#endif
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <libgen.h>
+#include <errno.h>
+
+#include "portable_endian.h"
+#include "elf_file.h"
+#include "utilities.h"
+
+#define HOST_FLASH_BASE_MASK        (0xFFFF0000)
+#define HOST_IFLASH_BASE_ADDR       (0x00400000)
+#define HOST_DFLASH_BASE_ADDR       (0x00C00000)
+#define MAX_NUM_SECTION_HEADERS     (100U)
+
+#define LOAD_BCF_SECTION_TOT    (2) /* board_config section plus regdom section */
+
+static struct
+{
+    struct arg_file *file;
+    struct arg_lit *load_bcf;
+    struct arg_rex *country;
+} args;
+
+/**
+ * @brief Get the ELF32 file header
+ *
+ * @param data Pointer to the start of the ELF file loaded into memory.
+ * @param ehdr Pointer to ELF header struct to populate.
+ * @return      0 on success otherwise relevant error.
+ */
+static int get_file_header(const uint8_t *data, Elf32_Ehdr *ehdr)
+{
+    Elf32_Ehdr *p = (Elf32_Ehdr *)data;
+
+    /* Magic check */
+    if ((p->e_ident[EI_MAG0] != ELFMAG0) ||
+        (p->e_ident[EI_MAG1] != ELFMAG1) ||
+        (p->e_ident[EI_MAG2] != ELFMAG2) ||
+        (p->e_ident[EI_MAG3] != ELFMAG3))
+    {
+        mctrl_err("Magic check failed 0x%02X 0x%02X 0x%02X 0x%02X\n",
+               p->e_ident[EI_MAG0], p->e_ident[EI_MAG1], p->e_ident[EI_MAG2], p->e_ident[EI_MAG3]);
+        return -EBADF;
+    }
+
+    /* elf32 and little endian */
+    if ((p->e_ident[EI_DATA]  != ELFDATA2LSB) ||
+        (p->e_ident[EI_CLASS] != ELFCLASS32))
+    {
+        mctrl_err("ELF not LE and 32bit\n");
+        return -EINVAL;
+    }
+
+    memcpy(ehdr->e_ident, p->e_ident, sizeof(ehdr->e_ident));
+
+    ehdr->e_phoff     = le32toh(p->e_phoff);
+    ehdr->e_phentsize = le16toh(p->e_phentsize);
+    ehdr->e_phnum     = le16toh(p->e_phnum);
+    ehdr->e_shoff = le32toh(p->e_shoff);
+    ehdr->e_shentsize = le16toh(p->e_shentsize);
+    ehdr->e_shnum     = le16toh(p->e_shnum);
+    ehdr->e_shstrndx = le16toh(p->e_shstrndx);
+
+    return 0;
+}
+
+
+/*
+* Get the ii-th section header and fill in the details in shdr
+*/
+static int get_section_header(const uint8_t *data, const Elf32_Ehdr *ehdr, Elf32_Shdr *shdr, int ii)
+{
+    Elf32_Shdr *p = (Elf32_Shdr *)(data + ehdr->e_shoff +
+                       (ii * ehdr->e_shentsize));
+
+    shdr->sh_name = le32toh(p->sh_name);
+    shdr->sh_type = le32toh(p->sh_type);
+    shdr->sh_offset = le32toh(p->sh_offset);
+    shdr->sh_addr = le32toh(p->sh_addr);
+    shdr->sh_size = le32toh(p->sh_size);
+    shdr->sh_flags = le32toh(p->sh_flags);
+
+    return 0;
+}
+
+/**
+ * @brief Load an arbitray section of an ELF file into memory.
+ *
+ * @note This is useful for loading program/section headers or the sections themselves.
+ *
+ * @param infile    The ELF file to load data from.
+ * @param offset    Offset from the start of the ELF file.
+ * @param size      Size of the data to read into memory.
+ * @param buf       Pointer to buffer to read memory into. If the buffer is NULL then one will be
+ *                  allocated.
+ * @return          0 on success otherwise relevant error.
+ */
+static int elf_file_load_binary_data(FILE *infile, Elf32_Off offset, size_t size, uint8_t **buf)
+{
+    size_t octets_read = 0;
+    struct stat file_stats;
+    size_t filesize;
+    bool mallocd = false;
+
+    if (!buf || !infile || fstat(fileno(infile), &file_stats))
+        return -ENOENT;
+
+    filesize = file_stats.st_size;
+
+    if (fseek(infile, offset, SEEK_SET))
+        return -EIO;
+
+    if (!*buf)
+    {
+        *buf = malloc(size);
+        mallocd = true;
+    }
+
+    if (!*buf)
+    {
+        return -ENXIO;
+    }
+
+    if ((filesize - offset) < size)
+    {
+        mctrl_err("Error file read size greater than remaining file size (%d < %d)\n",
+               (int) (filesize - offset), (int) size);
+        mctrl_err("File size, offset, read size: 0x%08x, 0x%08x, 0x%08x\n",
+               (int) filesize, offset, (int) size);
+    }
+
+    while ((octets_read < (filesize - offset)) && (octets_read < size))
+    {
+        octets_read += fread(*buf + octets_read, sizeof(uint8_t),  size - octets_read, infile);
+        if (ferror(infile))
+        {
+            mctrl_err("Error reading file\n");
+            if (mallocd)
+            {
+                free(*buf);
+                *buf = NULL;
+            }
+
+            return -EIO;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Get the program headers from an ELF32 file.
+ *
+ * @param infile    The ELF file to get program headers from.
+ * @param offset    The offset from the start of the ELF file the program headers are located.
+ * @param count     The number of program headers to get.
+ * @return          a pointer to a dynamically allocated array of program headers on success,
+ *                  otherwise NULL.
+ */
+static Elf32_Phdr *elf_file_load_program_headers(FILE *infile, Elf32_Off offset, Elf32_Half count)
+{
+    Elf32_Phdr *phdr = NULL;
+    int ii;
+
+    if (elf_file_load_binary_data(infile, offset, sizeof(*phdr) * count, (uint8_t **)(&phdr)))
+        return NULL;
+
+    /* Fix endianess. */
+    for (ii = 0; ii < count; ii++)
+    {
+        phdr[ii].p_type = le32toh(phdr[ii].p_type);
+        phdr[ii].p_offset = le32toh(phdr[ii].p_offset);
+        phdr[ii].p_vaddr = le32toh(phdr[ii].p_vaddr);
+        phdr[ii].p_paddr = le32toh(phdr[ii].p_paddr);
+        phdr[ii].p_filesz = le32toh(phdr[ii].p_filesz);
+        phdr[ii].p_memsz = le32toh(phdr[ii].p_memsz);
+        phdr[ii].p_align = le32toh(phdr[ii].p_align);
+    }
+
+    return phdr;
+}
+
+/**
+ * @brief Get the section headers from an ELF32 file.
+ *
+ * @param infile    The ELF file to get section headers from.
+ * @param offset    The offset from the start of the ELF file the section headers are located.
+ * @param count     The number of program headers to get.
+ * @return          a pointer to a dynamically allocated array of section headers on success,
+ *                  otherwise NULL.
+ */
+Elf32_Shdr *elf_file_load_section_headers(FILE *infile, Elf32_Off offset, Elf32_Half count)
+{
+    Elf32_Shdr *shdr = NULL;
+    int ii;
+
+    if (elf_file_load_binary_data(infile, offset, sizeof(*shdr) * count, (uint8_t **)(&shdr)))
+        return NULL;
+
+    /* Fix endianess. */
+    for (ii = 0; ii < count; ii++)
+    {
+        shdr[ii].sh_name = le32toh(shdr[ii].sh_name);
+        shdr[ii].sh_type = le32toh(shdr[ii].sh_type);
+        shdr[ii].sh_flags = le32toh(shdr[ii].sh_flags);
+        shdr[ii].sh_addr = le32toh(shdr[ii].sh_addr);
+        shdr[ii].sh_offset = le32toh(shdr[ii].sh_offset);
+        shdr[ii].sh_size = le32toh(shdr[ii].sh_size);
+        shdr[ii].sh_link = le32toh(shdr[ii].sh_link);
+        shdr[ii].sh_info = le32toh(shdr[ii].sh_info);
+        shdr[ii].sh_addralign = le32toh(shdr[ii].sh_addralign);
+        shdr[ii].sh_entsize = le32toh(shdr[ii].sh_entsize);
+    }
+
+    return shdr;
+}
+
+/**
+ * @brief Load the ELF32 header into a given struct.
+ *
+ * @param infile    The ELF file to load the header from.
+ * @param ehdr      Pointer to the ELF header structure to populate.
+ * @return          0 on success, otherwise relevant error.
+ */
+static int load_file_header(FILE *infile, Elf32_Ehdr *ehdr)
+{
+    uint8_t *data = NULL;
+
+    if (elf_file_load_binary_data(infile, 0, sizeof(*ehdr), &data))
+        return -ENOENT;
+
+    if (get_file_header(data, ehdr))
+    {
+        free(data);
+        return -ENXIO;
+    }
+
+    free(data);
+
+    return 0;
+}
+
+/*
+ * Load the offchip statistics from an ELF data structure.
+ *
+ * An array of n_rec struct statistics_offchip_data elements is allocated in the stats_handle.
+ * It is the caller's responsibility to free the array.
+ */
+int morse_stats_load(struct statistics_offchip_data **stats_handle, size_t *n_rec,
+                     const uint8_t *data)
+{
+    int ii;
+    int ret = 0;
+    Elf32_Ehdr ehdr;
+    Elf32_Shdr shdr;
+    Elf32_Shdr sh_strtab;
+    const char *sh_strs;
+
+    if (get_file_header((const uint8_t *)data, &ehdr) != 0) {
+        mctrl_err("Wrong file format\n");
+        return -ENOENT;
+    }
+
+    if (get_section_header(data, &ehdr, &sh_strtab, ehdr.e_shstrndx) != 0) {
+        mctrl_err("Invalid firmware - missing string table\n");
+        return -ENXIO;
+    }
+
+    sh_strs = (const char *)data + sh_strtab.sh_offset;
+
+    /* first run through the ELF file to get the total size of the stats */
+    size_t total_stats_size = 0;
+    for (ii = 0; ii < ehdr.e_shnum; ii++)
+    {
+        if (get_section_header(data, &ehdr, &shdr, ii) != 0)
+            continue;
+
+        if (strstr(sh_strs + shdr.sh_name, "_offchip_"))
+        {
+            total_stats_size += shdr.sh_size;
+        }
+    }
+    void *blob = malloc(total_stats_size);
+    memset(blob, 0, total_stats_size);
+    *n_rec = 0;
+    if (blob)
+    {
+        int offset = 0;
+        for (ii = 0; ii < ehdr.e_shnum; ii++)
+        {
+            if (get_section_header(data, &ehdr, &shdr, ii) != 0)
+                continue;
+
+            if (strstr(sh_strs + shdr.sh_name, "_offchip_"))
+            {
+                memcpy(blob + offset, data + shdr.sh_offset, shdr.sh_size);
+                offset += shdr.sh_size;
+                *n_rec += shdr.sh_size / sizeof(struct statistics_offchip_data);
+            }
+        }
+        *stats_handle = blob;
+    }
+    else
+    {
+        *stats_handle = 0;
+        ret = -ENXIO;
+    }
+    return ret;
+}
+
+static void print_ehdr(Elf32_Ehdr *ehdr)
+{
+    mctrl_print("Elf32_Ehdr:\n");
+    mctrl_print("\te_ident: 0x%02x 0x%02x 0x%02x 0x%02x\n",
+            ehdr->e_ident[EI_MAG0], ehdr->e_ident[EI_MAG1],
+            ehdr->e_ident[EI_MAG2], ehdr->e_ident[EI_MAG3]);
+    /* elf32 and little endian */
+    mctrl_print("\te_ident: 0x%02x\n", ehdr->e_ident[EI_DATA]);
+    mctrl_print("\te_ident: 0x%02x\n", ehdr->e_ident[EI_CLASS]);
+
+    mctrl_print("\te_phoff:     0x%08x\n", ehdr->e_phoff);
+    mctrl_print("\te_phentsize: 0x%08x\n", ehdr->e_phentsize);
+    mctrl_print("\te_phnum:     %u\n", ehdr->e_phnum);
+    mctrl_print("\te_shoff:     0x%08x\n", ehdr->e_shoff);
+    mctrl_print("\te_shentsize: 0x%08x\n", ehdr->e_shentsize);
+    mctrl_print("\te_shnum:     %u\n", ehdr->e_shnum);
+    mctrl_print("\te_shstrndx:  0x%08x\n", ehdr->e_shstrndx);
+}
+
+static void print_phdr(Elf32_Phdr *phdr)
+{
+    mctrl_print("Elf32_Phdr:\n");
+    mctrl_print("\tp_type:   %u\n", phdr->p_type);
+    mctrl_print("\tp_offset: 0x%08x\n", phdr->p_offset);
+    mctrl_print("\tp_vaddr:  0x%08x\n", phdr->p_vaddr);
+    mctrl_print("\tp_paddr:  0x%08x\n", phdr->p_paddr);
+    mctrl_print("\tp_filesz: 0x%08x\n", phdr->p_filesz);
+    mctrl_print("\tp_memsz:  0x%08x\n", phdr->p_memsz);
+    mctrl_print("\tp_align:  %u\n", phdr->p_align);
+}
+
+void print_shdr(Elf32_Shdr *shdr)
+{
+    mctrl_print("Elf32_Shdr:\n");
+    mctrl_print("\tsh_name:      %u\n", shdr->sh_name);
+    mctrl_print("\tsh_type:      %u\n", shdr->sh_type);
+    mctrl_print("\tsh_flags:     0x%08x\n", shdr->sh_flags);
+    mctrl_print("\tsh_addr:      0x%08x\n", shdr->sh_addr);
+    mctrl_print("\tsh_offset:    0x%08x\n", shdr->sh_offset);
+    mctrl_print("\tsh_size:      0x%08x\n", shdr->sh_size);
+    mctrl_print("\tsh_link:      0x%08x\n", shdr->sh_link);
+    mctrl_print("\tsh_info:      %u\n", shdr->sh_info);
+    mctrl_print("\tsh_addralign: %u\n", shdr->sh_addralign);
+    mctrl_print("\tsh_entsize:   0x%08x\n", shdr->sh_entsize);
+}
+
+int load_elf_blob(FILE *firmware, struct morsectrl_transport *transport,
+    int idx, Elf32_Off offset, Elf32_Word size, Elf32_Addr addr)
+{
+    struct morsectrl_transport_buff *write;
+    int ret = 0;
+
+    mctrl_print("Loading ELF blob %d size 0x%08x into chip addr 0x%08x\n",
+           idx, size, addr);
+
+    write = morsectrl_transport_raw_write_alloc(transport, size);
+    if (!write)
+    {
+        mctrl_err("Transport write alloc failed\n");
+        return -ENOMEM;
+    }
+
+    /* Load binary blob directly into a transport buffer. */
+    if (elf_file_load_binary_data(firmware, offset, size, &write->data))
+    {
+        mctrl_err("Load binary failed\n");
+        ret = -ENOENT;
+        goto exit;
+    }
+
+    if (morsectrl_transport_mem_write(transport, write, addr) != 0)
+    {
+        mctrl_err("Mem write failed\n");
+        ret = -ENXIO;
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(write);
+    return ret;
+}
+
+/*
+ * Load a BCF file onto a device.
+ * Only the general (board_config) and regdom section for the
+ * specified Regulatory domain ('country') are loaded.
+ */
+static int load_bcf_sections(struct morsectrl *mors, FILE *firmware, Elf32_Ehdr *ehdr,
+    const char *country)
+{
+    struct morsectrl_transport *transport = mors->transport;
+    Elf32_Off sh_offset[LOAD_BCF_SECTION_TOT] = { 0 };
+    Elf32_Word sh_size[LOAD_BCF_SECTION_TOT] = { 0 };
+    Elf32_Addr addr = 0;
+    Elf32_Shdr sh_strtab;
+    const char *sh_strs;
+    uint8_t *data;
+    int ii;
+    int ret = 0;
+
+    mctrl_print("Trying to load BCF file using country %s\n", country);
+
+    load_file(firmware, &data);
+    if (data == NULL)
+    {
+        mctrl_err("Load file failed\n");
+        return -ENOENT;
+    }
+
+    if (get_section_header(data, ehdr, &sh_strtab, ehdr->e_shstrndx) != 0) {
+        mctrl_err("Invalid firmware - missing string table\n");
+        ret = -ENXIO;
+        goto exit;
+    }
+
+    sh_strs = (const char *)data + sh_strtab.sh_offset;
+
+    /* Sanitise the loop bound with a reasonable number for the section headers */
+    if (ehdr->e_shnum > MAX_NUM_SECTION_HEADERS)
+    {
+        mctrl_err("Exceeded maximum number of section headers\n");
+        ret = -EPERM;
+        goto exit;
+    }
+
+    /* Find the required headers */
+    for (ii = 0; ii < ehdr->e_shnum; ii++)
+    {
+        Elf32_Shdr shdr;
+
+        if (get_section_header(data, ehdr, &shdr, ii) != 0)
+            continue;
+
+        if (strcmp(sh_strs + shdr.sh_name, ".board_config") == 0)
+        {
+            if (mors->debug)
+                mctrl_print("Found section header %s\n", sh_strs + shdr.sh_name);
+
+            addr = shdr.sh_addr;
+            sh_offset[0] = shdr.sh_offset;
+            sh_size[0] = shdr.sh_size;
+        }
+        else if ((strncmp(sh_strs + shdr.sh_name, ".regdom_", strlen(".regdom_")) == 0) &&
+                 (strcmp(sh_strs + shdr.sh_name + strlen(".regdom_"), country) == 0))
+        {
+            if (mors->debug)
+                mctrl_print("Found section header %s\n", sh_strs + shdr.sh_name);
+
+            sh_offset[1] = shdr.sh_offset;
+            sh_size[1] = shdr.sh_size;
+        }
+    }
+
+    if ((sh_offset[0] == 0) || (sh_size[0] == 0))
+    {
+        mctrl_err("Board config section not found\n");
+        ret = -ENXIO;
+        goto exit;
+    }
+
+    if ((addr & HOST_FLASH_BASE_MASK) == 0)
+    {
+        mctrl_err("Board config section address (0x%08x) is invalid\n", addr);
+        ret = -ENXIO;
+        goto exit;
+    }
+
+    if ((sh_offset[1] == 0) || (sh_size[1] == 0))
+    {
+        mctrl_err("Regdom section not found for %s\n", country);
+        ret = -ENXIO;
+        goto exit;
+    }
+
+    for (ii = 0; ii < LOAD_BCF_SECTION_TOT; ii++)
+    {
+        int ret = load_elf_blob(firmware, transport, ii, sh_offset[ii], sh_size[ii], addr);
+        if (ret < 0)
+        {
+            goto exit;
+        }
+        addr += sh_size[ii];
+    }
+
+exit:
+    free(data);
+    return ret;
+}
+
+/*
+ * Load ELF program sections onto a device.
+ */
+static int load_blobs(struct morsectrl *mors, FILE *firmware, Elf32_Ehdr *ehdr)
+{
+    struct morsectrl_transport *transport = mors->transport;
+    Elf32_Phdr *phdr = NULL;
+    int ii;
+    int ret;
+
+    mctrl_print("%d blobs to try to load\n", ehdr->e_phnum);
+
+    phdr = elf_file_load_program_headers(firmware, ehdr->e_phoff, ehdr->e_phentsize *ehdr->e_phnum);
+    if (!phdr)
+    {
+        return -ENXIO;
+    }
+
+    for (ii = 0; ii < ehdr->e_phnum; ii++)
+    {
+        if (mors->debug)
+            print_phdr(&phdr[ii]);
+
+        /* Skip empty or unloadable blobs. Filter out external flash. */
+        if ((phdr[ii].p_type != PT_LOAD) ||
+            (phdr[ii].p_memsz == 0) ||
+            !(phdr[ii].p_flags & (PF_X | PF_W | PF_R)) ||
+            ((phdr[ii].p_paddr & HOST_FLASH_BASE_MASK) == HOST_IFLASH_BASE_ADDR) ||
+            ((phdr[ii].p_paddr & HOST_FLASH_BASE_MASK) == HOST_DFLASH_BASE_ADDR))
+        {
+            mctrl_print("Loading ELF blob %d - unloadable, skipping\n", ii);
+            continue;
+        }
+
+        ret = load_elf_blob(firmware, transport, ii, phdr[ii].p_offset,
+            align_size(phdr[ii].p_memsz, phdr[ii].p_align), phdr[ii].p_paddr);
+        if (ret < 0)
+        {
+            free(phdr);
+            return ret;
+        }
+    }
+
+    free(phdr);
+    return 0;
+}
+
+int load_elf_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Read an ELF file and load it onto a chip",
+                     args.file = arg_file1("f", "file", NULL, "filename of the elf file to load"),
+                     args.load_bcf = arg_lit0("b", "bcf", "load a BCF (Board Configuration File)"),
+                     args.country = arg_rex0("c", "country", "([A-Z]{2})", "country code", 0,
+                                             "BCF country code"));
+    return 0;
+}
+
+int load_elf(struct morsectrl *mors, int argc, char *argv[])
+{
+    FILE *firmware;
+    Elf32_Ehdr ehdr;
+    int ret = 0;
+
+    firmware = fopen(args.file->filename[0], "rb");
+    if (!firmware)
+    {
+        mctrl_err("Failed to open %s\n", args.file->filename[0]);
+        return -ENOENT;
+    }
+
+    if (load_file_header(firmware, &ehdr))
+    {
+        ret = -ENXIO;
+        goto exit;
+    }
+
+    if (mors->debug)
+        print_ehdr(&ehdr);
+
+    if (args.load_bcf->count)
+    {
+        if (args.country->count == 0)
+        {
+            mctrl_err("Country code must be specified for BCF load\n");
+            fclose(firmware);
+            return -EINVAL;
+        }
+        ret = load_bcf_sections(mors, firmware, &ehdr, args.country->sval[0]);
+    }
+    else
+    {
+        if (args.country->count)
+        {
+            mctrl_err("Country code can only be specified for BCF load\n");
+            fclose(firmware);
+            return -EINVAL;
+        }
+        ret = load_blobs(mors, firmware, &ehdr);
+    }
+
+exit:
+    fclose(firmware);
+
+    if (!ret)
+        mctrl_print("ELF successfully loaded\n");
+    else
+        mctrl_err("Failed to load ELF\n");
+
+    return ret;
+}
+
+MM_CLI_HANDLER(load_elf, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/elf_file.h
+++ b/feeds/morse/utils/morsectrl/src/elf_file.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Morse Micro
+ *
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdio.h>
+#include "offchip_statistics.h"
+#include "transport/transport.h"
+
+int morse_stats_load(struct statistics_offchip_data **stats_handle,
+                     size_t *n_rec,
+                     const uint8_t *data);
+
+int load_elf(struct morsectrl *mors, int argc, char *argv[]);

--- a/feeds/morse/utils/morsectrl/src/encmode.c
+++ b/feeds/morse/utils/morsectrl/src/encmode.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_enc_mode_command
+{
+    /* data of this message */
+    uint8_t enc_mode;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tenc_mode <value>\tsets TIM enc_mode to driver\n");
+}
+
+int enc_mode(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct set_enc_mode_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint8_t encmode;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_enc_mode_command);
+
+    if (str_to_uint8(argv[1], &encmode))
+    {
+        mctrl_err("Invalid enc_mode\n");
+        ret = -1;
+        goto exit;
+    }
+    cmd->enc_mode = encmode;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_ENC_MODE,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set ifs\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(enc_mode, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/fem.c
+++ b/feeds/morse/utils/morsectrl/src/fem.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_fem_settings_command
+{
+    /** \ref enum fem_antenna */
+    uint32_t tx_antenna;
+    /** \ref enum fem_antenna */
+    uint32_t rx_antenna;
+    /** Bool, 1=enabled, 0=disabled */
+    uint32_t lna_enabled;
+    /** Bool, 1=enabled, 0=disabled */
+    uint32_t pa_enabled;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tfem <tx_antenna> <rx_antenna> <lna_enable> <pa_enable>\n");
+    mctrl_print("\t\t0~2\t\tTX and RX antenna select (0 for auto, 1 for antenna 1...)\n");
+    mctrl_print("\t\t0~1\t\tRX LNA and TX PA control\n");
+}
+
+int fem(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t tx_antenna, rx_antenna, lna_enabled, pa_enabled;
+    struct set_fem_settings_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 5)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_fem_settings_command);
+
+    if (str_to_uint32_range(argv[1], &tx_antenna, 0, 2))
+    {
+        mctrl_err("Invalid tx antenna, must be 0 (auto), 1 (antenna 1), 2 (antenna 2)\n");
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint32_range(argv[2], &rx_antenna, 0, 2))
+    {
+        mctrl_err("Invalid rx antenna, must be 0 (auto), 1 (antenna 1), 2 (antenna 2)\n");
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint32_range(argv[3], &lna_enabled, 0, 1))
+    {
+        mctrl_err("Invalid FEM LNA setting, must be 0 (disabled) or 1 (enabled)\n");
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint32_range(argv[4], &pa_enabled, 0, 1))
+    {
+        mctrl_err("Invalid FEM PA setting, must be 0 (disabled) or 1 (enabled)\n");
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->tx_antenna = htole32(tx_antenna);
+    cmd->rx_antenna = htole32(rx_antenna);
+    cmd->lna_enabled = htole32(lna_enabled);
+    cmd->pa_enabled = htole32(pa_enabled);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_FEM_SETTINGS,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set FEM settings\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(fem, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/force_assert.c
+++ b/feeds/morse/utils/morsectrl/src/force_assert.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+enum hartid
+{
+    HOST_HARTID = 0,
+    MAC_HARTID = 1,
+    UPHY_HARTID = 2,
+    LPHY_HARTID = 3
+};
+struct PACKED command_force_assert_req
+{
+    /* Target hart to crash with an intended assert */
+    uint32_t hart_id;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tassert <core>\t\tforces the specified core to assert" \
+           "- defaults to mac if no arg\n");
+    mctrl_print("\t\t-a\t\tApp core\n");
+    mctrl_print("\t\t-m\t\tMac core\n");
+    mctrl_print("\t\t-u\t\tUphy core\n");
+    mctrl_print("\t\t-l\t\tLphy core\n");
+}
+
+static int assert(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int hart_id, option;
+    struct command_force_assert_req *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc > 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_force_assert_req);
+
+    if (argc == 1)
+    {
+        hart_id = MAC_HARTID;
+    }
+    else
+    {
+        while ((option = getopt(argc, argv, "amul")) != -1)
+        {
+            switch (option)
+            {
+                case 'a' :
+                    hart_id = HOST_HARTID;
+                    break;
+                case 'm' :
+                    hart_id = MAC_HARTID;
+                    break;
+                case 'u' :
+                    hart_id = UPHY_HARTID;
+                    break;
+                case 'l' :
+                    hart_id = LPHY_HARTID;
+                    break;
+                default:
+                    mctrl_err("Invalid hart\n");
+                    usage(mors);
+                    ret = -1;
+                    goto exit;
+            }
+        }
+    }
+    cmd->hart_id = htole32(hart_id);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_FORCE_ASSERT,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret != -110)
+    {
+        mctrl_err("Chip didn't timeout. Command failed\n");
+        if (ret)
+            mctrl_err("Wrong error code returned: %d\n", ret);
+        ret = -1;
+    }
+    else
+    {
+        ret = 0;
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(assert, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/fsg.c
+++ b/feeds/morse/utils/morsectrl/src/fsg.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+/* Limits on duty cycle, expressed in  percent */
+#define FSG_DUTY_CYCLE_MIN      (0.01)
+#define FSG_DUTY_CYCLE_MAX      (99.99)
+#define FSG_DEFAULT_IFS_US      (160)
+
+struct PACKED command_set_fsg_req
+{
+    /**
+     * The number of rounds that the FSG needs to execute,
+     * (-1) infintie, (0) disable, (> 0) finite
+     */
+    int32_t n_iterations;
+    /**
+     * The duty cycle to maintain given the previously set transmission parameters.
+     * Scaled by 100, (e.g. 98.5% -> 9850)
+     */
+    uint32_t duty_cycle_scaled;
+    /**
+     * The nominal inter-frame spacing between PSDUs. Must be (!= 0). A value of (-1)
+     * will default to SIFS.
+     */
+    int32_t ifs_us;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tFast Symbol Generator (FSG) <command>\n");
+    mctrl_print("\t\tenable <iterations> <duty cycle> [ifs]\n");
+    mctrl_print("\t\t\titerations\tnumber of transmissions, set to -1 for infinite\n");
+    mctrl_print(
+            "\t\t\tduty cycle\tthe duty cycle to maintain between transmissions %%(%.2f-%.2f)\n",
+            FSG_DUTY_CYCLE_MIN, FSG_DUTY_CYCLE_MAX);
+    mctrl_print(
+            "\t\t\tifs       \tinter-frame spacing between PSDUs in microseconds (default:%dus)\n",
+            FSG_DEFAULT_IFS_US);
+    mctrl_print("\t\tdisable\n");
+}
+
+int fsg(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_set_fsg_req *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int32_t n_iterations, ifs_us;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_fsg_req);
+
+    switch (expression_to_int(argv[1]))
+    {
+        case true:
+        {
+            if (argc < 4)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            if (str_to_int32(argv[2], &n_iterations) || n_iterations == 0)
+            {
+                mctrl_err("Invalid iteration value (must be non-zero).\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            cmd->n_iterations = htole32(n_iterations);
+
+            float duty_cycle = strtof(argv[3], NULL);
+            if ((duty_cycle < FSG_DUTY_CYCLE_MIN) || (duty_cycle > FSG_DUTY_CYCLE_MAX))
+            {
+                mctrl_err("Invalid duty cycle %.2f (%.2f-%.2f).\n",
+                       duty_cycle, FSG_DUTY_CYCLE_MIN, FSG_DUTY_CYCLE_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->duty_cycle_scaled = (uint32_t)(duty_cycle * 100);
+            cmd->ifs_us = FSG_DEFAULT_IFS_US;
+            if (argc == 5)
+            {
+                if (str_to_int32(argv[4], &ifs_us))
+                {
+                    mctrl_err("Invalid interframe spacing (us)\n");
+                    ret = -1;
+                    goto exit;
+                }
+                cmd->ifs_us = htole32(ifs_us);
+            }
+            break;
+        }
+        case false:
+        {
+            cmd->n_iterations = 0; /* 0 means disable */
+            break;
+        }
+        default:
+        {
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_FSG,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set fsg\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(fsg, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/gpio.c
+++ b/feeds/morse/utils/morsectrl/src/gpio.c
@@ -1,0 +1,727 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "utilities.h"
+#include "transport/transport.h"
+#include "portable_endian.h"
+
+/** Configure the bitmask for the commands with states defined by gpio_control_cmds_t */
+#define GPIO_CTRL_CMD_MASK  (0b11)
+
+/** Width of the pin_mask found in gpio_config */
+#define PIN_MASK_MAX_WIDTH  (32)
+#define PIN_MASK_MIN_WIDTH  (0)
+
+struct PACKED gpio_config
+{
+    /** Command flags defined by gpio_control_flags_t */
+    uint32_t flags;
+    /** Pin flags specifying which GPIO to configure/fetch */
+    uint32_t pin_mask;
+};
+
+typedef enum
+{
+    /**
+     *  Configure the state for the pins in the mask. If this flag is not set,
+     *  the pins are configured with a LOW state
+     */
+    GPIO_CTRL_FLAG_HIGH         = BIT(2),
+    /**
+     *  Configure the mode for the pins in the mask. If this flag is not set, the pins are
+     *  configured as an INPUT
+     */
+    GPIO_CTRL_FLAG_OUTPUT       = BIT(3),
+    /**
+     *  Configure the drive speed for the pins in the mask. If this flag is not set, the pins are
+     *  configured for a slow drive-speed
+     */
+    GPIO_CTRL_FLAG_SPEED        = BIT(4),
+    /**
+     *  Configure the pins in the mask as pull up resistors. If this flag is not set, the pins are
+     *  configured for no pull up
+     */
+    GPIO_CTRL_FLAG_PULLUP       = BIT(5),
+} gpio_ctrl_flag_t;
+
+/* Enum for types of commands types */
+typedef enum
+{
+    GPIO_CTRL_CMD_STATE      = 1U,
+    GPIO_CTRL_CMD_MODE       = 2U,
+    GPIO_CTRL_CMD_INFO       = 3U,
+} gpio_control_cmds_t;
+
+/**
+ * @brief Checks if the pin exceeds the bitsize of the pin_mask flag
+ * @param pin number which represents the GPIO pin number
+ * @return true if pin is within bitsize of gpio_config parameter pin_mask, false otherwise
+ */
+static inline bool is_valid_pin(int32_t pin)
+{
+    return (pin >= PIN_MASK_MIN_WIDTH && pin < PIN_MASK_MAX_WIDTH) ? true : false;
+}
+
+/**
+ * @brief Checks if the output mode flag is set
+ * @param flags bit flags from gpio_control_flags_t
+ * @return true if output flag is set, false otherwise
+ */
+static inline bool is_mode_output(uint32_t flags)
+{
+    return !!(flags & GPIO_CTRL_FLAG_OUTPUT);
+}
+
+/**
+ * @brief Prints a row with the sizing adjusted to the print_header function.
+ *
+ * @param pin gpio number
+ * @param mode gpio direction
+ * @param state gpio state
+ * @param speed gpio drive speed
+ * @param pullup gpio input pull-up resistor
+ */
+static void print_row(int32_t pin, char *mode, char *state, char *speed, char *pullup, bool json)
+{
+    if (json)
+    {
+        mctrl_print(
+            "{\"Pin\":%d,\"Mode\":\"%s\",\"State\":\"%s\",\"Speed\":\"%s\",\"Pull-up\":\"%s\"}",
+            pin, mode, state, speed, pullup);
+    }
+    else
+    {
+        mctrl_print("%-3d\t%-6s\t%-5s\t%-5s\t%-7s\n", pin, mode, state, speed, pullup);
+    }
+}
+
+/**
+ * @brief Prints a header for the with fields corresponding to GPIO configuration
+ */
+static void print_header(bool json)
+{
+    if (json)
+    {
+        mctrl_print("[");
+    }
+    else
+    {
+        mctrl_print("Pin\tMode\tState\tSpeed\tPull-up\n");
+    }
+}
+
+/**
+ * @brief Prints usage table for command
+ * @param mors morsectrl object
+ */
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tgpio_control <subcmd>\tconfigures GPIO pins or fetch current configuration\n");
+    mctrl_print("\t\tstate [high|low] <pins>\tconfigures state for <pins>\n");
+    mctrl_print("\t\tmode [output|input] [options] <pins>\tconfigures mode for <pins>\n");
+    mctrl_print("\t\t\t\t-s\tsets drive speed to fast (for output mode only)\n");
+    mctrl_print("\t\t\t\t-p\tsets pull-up resistor to enabled (for input mode only)\n");
+    mctrl_print("\t\tinfo [option] <pins>\tgets the current configuration for <pins>\n");
+    mctrl_print("\t\t\t\t-j\tprint configuration of <pins> in JSON format\n");
+    mctrl_print(
+        "\t\tThe <pins> parameter represents the positions of pins and accepts two formats:\n");
+    mctrl_print("\t\t\tSpace-separated decimal numbers. E.g. 0 1 2 represents pins 0, 1, and 2\n");
+    mctrl_print(
+        "\t\t\tHexadecimal bitmask prefixed by '0x'. E.g. 0x07 represents pins 0, 1 and 2\n");
+}
+
+/**
+ * @brief Identifies the command type and sets the appropriate flag
+ *
+ * @param argc argument counter
+ * @param argv string list of arguments
+ * @param cmd flags to set
+ *
+ * @return 1 if success, otherwise negative return code
+ */
+static int get_cmd(int argc, char *argv[], uint32_t *cmd)
+{
+    uint32_t mode;
+
+    if (argc < 2)
+    {
+        mctrl_err("Not enough arguments\n");
+        return -EINVAL;
+    }
+
+    if (strcmp(argv[0], "state") == 0)
+    {
+        mode = GPIO_CTRL_CMD_STATE;
+    }
+    else if (strcmp(argv[0], "mode") == 0)
+    {
+        mode = GPIO_CTRL_CMD_MODE;
+    }
+    else if (strcmp(argv[0], "info") == 0)
+    {
+        mode = GPIO_CTRL_CMD_INFO;
+    }
+    else
+    {
+        mctrl_err("Invalid subcommand - %s\n", argv[0]);
+        return -ENXIO;
+    }
+
+    *cmd |= BMSET(mode, GPIO_CTRL_CMD_MASK);
+
+    return 0;
+}
+
+/**
+ * @brief Sets the pin mask based on the specified action
+ *
+ * @param argc argument counter
+ * @param argv string list of arguments
+ * @param pin_mask pin indices to set and send to the firmware
+ * @param pin_offset different starting locations based on command type
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_pin_handler(int argc, char *argv[], uint32_t *pin_mask)
+{
+    uint64_t pin;
+
+    if (argc == 0)
+    {
+        mctrl_err("Not enough arguments\n");
+        return -EINVAL;
+    }
+
+    for (int i = 0; i < argc; i++)
+    {
+        if (str_to_uint64(argv[i], &pin) < 0)
+        {
+            mctrl_err("Invalid argument - %s\n", argv[i]);
+            return -EINVAL;
+        }
+
+        /* Hexadecimal handler */
+        if (strncasecmp(argv[i], "0x", strlen("0x")) == 0)
+        {
+            /* Check that only one hex mask is provided and no decimal arguments are also present*/
+            if ((i != (argc-1)) || i != 0)
+            {
+                mctrl_err("Too many arguments\n");
+                return -EINVAL;
+            }
+
+            if (pin > UINT32_MAX)
+            {
+                mctrl_err("Invalid hexadecimal string %s - must be between 0x01 and 0x%lX\n",
+                            argv[i], UINT32_MAX);
+                return -EINVAL;
+            }
+
+            *pin_mask = pin;
+            break;
+        }
+
+        /* Decimal handler */
+        if (pin > (PIN_MASK_MAX_WIDTH - 1) || argv[i][0] == '-')
+        {
+            mctrl_err("Pin position %s is invalid - must be between %d and %d\n", argv[i],
+                        PIN_MASK_MIN_WIDTH, (PIN_MASK_MAX_WIDTH-1));
+            return -ENODEV;
+        }
+
+        *pin_mask |= BIT(pin);
+    }
+
+    return 0;
+}
+
+
+/**
+ * @brief Handler for the returned data for the INFO command
+ *
+ * @param req contains information about the command
+ * @param cfm contains the return data
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_cfm_info(struct gpio_config *req, struct gpio_config *cfm, bool json)
+{
+    int32_t pin;
+
+    /* Get first set bit */
+    pin = ctz(req->pin_mask);
+
+    /* If pin index exceeds the bitwidth of the command structure or index does not exist */
+    if (pin < 0 || !is_valid_pin(pin))
+    {
+        return -ENXIO;
+    }
+
+    if (!cfm->pin_mask && !cfm->flags)
+    {
+        print_row(
+            pin,
+            "invalid",
+            "-",
+            "-",
+            "-",
+            json);
+        return 0;
+    }
+
+    if (MORSE_IS_BIT_SET(cfm->pin_mask, pin))
+    {
+        if (is_mode_output(cfm->flags))
+        {
+            print_row(
+                pin,
+                "output",
+                (cfm->flags & GPIO_CTRL_FLAG_HIGH) ? "high" : "low",
+                (cfm->flags & GPIO_CTRL_FLAG_SPEED) ? "fast" : "slow",
+                "-",
+                json);
+        }
+        else
+        {
+            print_row(
+                pin,
+                "input",
+                (cfm->flags & GPIO_CTRL_FLAG_HIGH) ? "high" : "low",
+                "-",
+                (cfm->flags & GPIO_CTRL_FLAG_PULLUP) ? "enabled" : "disabled",
+                json);
+        }
+    }
+    else if (MORSE_IS_BIT_SET(req->pin_mask, pin))
+    {
+        print_row(
+            pin,
+            is_mode_output(cfm->flags) ? "iof" : "none",
+            "-",
+            "-",
+            "-",
+            json);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Handler for the returned data for the mode and state command
+ *
+ * Prints an error message indicating the failed to set pin.
+ *
+ * @param req contains information about the command
+ * @param cfm contains the return data
+ */
+static void gpio_control_cfm_set(struct gpio_config *req, struct gpio_config *cfm)
+{
+    for (int i = PIN_MASK_MIN_WIDTH; i < PIN_MASK_MAX_WIDTH; i++)
+    {
+        if (!MORSE_IS_BIT_SET(cfm->pin_mask, i) && MORSE_IS_BIT_SET(req->pin_mask, i))
+        {
+            mctrl_err("Failed to set pin %d\n", i);
+        }
+    }
+}
+
+/**
+ * @brief Command handler for the returned data
+ *
+ * @param req contains information about the command
+ * @param results contains the return data
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_cfm_handler(struct gpio_config *req, struct gpio_config *results)
+{
+    int ret = 0;
+    struct gpio_config cfm;
+
+    cfm.flags = le32toh(results->flags);
+    cfm.pin_mask = le32toh(results->pin_mask);
+
+    switch (BMGET(req->flags, GPIO_CTRL_CMD_MASK))
+    {
+    case GPIO_CTRL_CMD_STATE:
+        gpio_control_cfm_set(req, &cfm);
+        break;
+    case GPIO_CTRL_CMD_MODE:
+        gpio_control_cfm_set(req, &cfm);
+        break;
+    default:
+        ret = -ESRCH;
+        break;
+    }
+
+    return ret;
+}
+
+/**
+ * @brief Handler for the information command
+ *
+ *  Info command sends individual pins to the firmware due to the command structure. Error handling
+ *  will be self-contained.
+ *
+ * @param argc argument counter
+ * @param argv string list of arguments
+ * @param pin_mask pin indices to set and send to the firmware
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_cmd_info(struct morsectrl *mors, int argc, char *argv[], uint32_t *flags,
+    struct gpio_config *req, struct gpio_config *cfm,
+    struct morsectrl_transport_buff *cmd, struct morsectrl_transport_buff *resp)
+{
+    int ret = 0;
+    int option;
+    int optind_index = optind;
+    uint32_t pin = 0;
+    bool json = false;
+    uint8_t pins;
+    uint8_t count = 1;
+    struct gpio_config results;
+
+    /* JSON mode */
+    argv--;
+    argc++;
+    optind = 1;
+
+    while ((option = getopt(argc, argv, "j")) != -1)
+    {
+        switch (option)
+        {
+        case 'j':
+            json = true;
+            break;
+        default:
+            mctrl_err("Invalid optional arguments\n");
+            return -EINVAL;
+        }
+    }
+
+    argv += optind;
+    argc -= optind;
+    if (argc == 0)
+    {
+        mctrl_err("Not enough arguments\n");
+        return -EINVAL;
+    }
+    optind = optind_index;
+
+    ret = gpio_pin_handler(argc, argv, &pin);
+    if (ret < 0)
+    {
+        return ret;
+    }
+
+    /* Track pin status to determine JSON/header prints */
+    pins = popcount(pin);
+
+    for (int i = PIN_MASK_MIN_WIDTH; i < PIN_MASK_MAX_WIDTH; i++)
+    {
+        if (MORSE_IS_BIT_SET(pin, i))
+        {
+            cfm->flags = 0;
+            cfm->pin_mask = 0;
+            req->pin_mask = htole32(BIT(i));
+            req->flags = htole32(*flags);
+
+            ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_GPIO,
+                                        cmd, resp);
+            /* ENXIO is an invalid pin - do not exit early */
+            if (ret < 0 && ret != MORSE_RET_ENXIO)
+            {
+                mctrl_err("gpio_control cmd failed: error(%d)\n", ret);
+                return ret;
+            }
+
+            ret = 0;
+
+            if (count == 1)
+            {
+                print_header(json);
+            }
+
+            results.flags = le32toh(cfm->flags);
+            results.pin_mask = le32toh(cfm->pin_mask);
+
+            ret = gpio_control_cfm_info(req, &results, json);
+            if (ret < 0)
+            {
+                return ret;
+            }
+
+            if (json)
+            {
+                if (count < pins)
+                {
+                    mctrl_print(",");
+                }
+                else if (count == pins)
+                {
+                    mctrl_print("]");
+                }
+            }
+
+            /*
+             * Response transport buffer length is trimmed when using the FTDI over SPI transport
+             * this causes failures for subsequent commmands which use the same transport as the
+             * resp->data_len is smaller than the required size.
+             */
+            count++;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Handler for the mode command
+ *
+ * If the action is identified as set an additional argument will be parsed and the pin_offset for
+ * the gpio_pin_handler() will be updated. Optional args may need to be parsed.
+ *
+ * @param argc argument counter
+ * @param flags flags to set
+ * @param pin_mask pin to set
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_cmd_mode(int argc, char *argv[], uint32_t *flags,
+                                  uint32_t *pin_mask)
+{
+    int ret = 0;
+    int option;
+    int optind_index = optind;
+    uint16_t pin_offset = 0;
+
+    if ((strcmp(argv[0], "input") == 0))
+    {
+        *flags &= ~GPIO_CTRL_FLAG_OUTPUT;
+    }
+    else if ((strcmp(argv[0], "output") == 0))
+    {
+        *flags |= GPIO_CTRL_FLAG_OUTPUT;
+    }
+    else
+    {
+        mctrl_err("Invalid mode - %s\n", argv[0]);
+        return -ENXIO;
+    }
+
+    /* Setup optind index */
+    optind = 1;
+
+    while ((option = getopt(argc, argv, "ps")) != -1)
+    {
+        switch (option)
+        {
+        case 'p':
+            *flags |= GPIO_CTRL_FLAG_PULLUP;
+            break;
+        case 's':
+            *flags |= GPIO_CTRL_FLAG_SPEED;
+            pin_offset++;
+            break;
+        default:
+            mctrl_err("Invalid optional arguments\n");
+            return -EINVAL;
+        }
+    }
+
+    argv += optind;
+    argc -= optind;
+
+    /* Reset optind index */
+    optind = optind_index;
+
+    ret = gpio_pin_handler(argc, argv, pin_mask);
+
+    return ret;
+}
+
+/**
+ * @brief Handler for the state command
+ *
+ * If the action is identified as set an additional argument will be parsed and the pin_offset for
+ * the gpio_pin_handler() will be updated.
+ *
+ * @param argc argument counter
+ * @param argv string list of arguments
+ * @param flags flags to set
+ * @param pin_mask pin to set
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_cmd_state(int argc, char *argv[], uint32_t *flags,
+                                  uint32_t *pin_mask)
+{
+    int ret = 0;
+
+    if (strcmp(argv[0], "high") == 0)
+    {
+        *flags |= GPIO_CTRL_FLAG_HIGH;
+    }
+    else if (strcmp(argv[0], "low") == 0)
+    {
+        *flags &= ~GPIO_CTRL_FLAG_HIGH;
+    }
+    else
+    {
+        mctrl_err("Invalid state - %s\n", argv[0]);
+        return -ENXIO;
+    }
+
+    argv++;
+    argc--;
+
+    ret = gpio_pin_handler(argc, argv, pin_mask);
+
+    return ret;
+}
+
+/**
+ * @brief Command handler based on the command flag
+ *
+ * @param mors morsectrl object
+ * @param argc argument counter
+ * @param argv string of command arguments
+ * @param req structure to store the command request
+ *
+ * @return 0 if success, otherwise negative return code
+ */
+static int gpio_control_command_handler(
+    struct morsectrl *mors, int argc, char *argv[],
+    struct gpio_config *req, struct gpio_config *cfm,
+    struct morsectrl_transport_buff *cmd, struct morsectrl_transport_buff *resp)
+{
+    int ret = 0;
+    uint32_t flags = 0;
+    uint32_t pin_mask = 0;
+
+    ret = get_cmd(argc, argv, &flags);
+    if (ret < 0)
+    {
+        return ret;
+    }
+    argv++;
+    argc--;
+
+    switch (BMGET(flags, GPIO_CTRL_CMD_MASK))
+    {
+    case GPIO_CTRL_CMD_STATE:
+        ret = gpio_control_cmd_state(argc, argv, &flags, &pin_mask);
+        break;
+    case GPIO_CTRL_CMD_MODE:
+        ret = gpio_control_cmd_mode(argc, argv, &flags, &pin_mask);
+        break;
+    case GPIO_CTRL_CMD_INFO:
+        ret = gpio_control_cmd_info(mors, argc, argv, &flags, req, cfm, cmd, resp);
+        return ret;
+    default:
+        mctrl_err("Invalid command\n");
+        ret = -ENXIO;
+        break;
+    }
+
+    if (ret < 0)
+    {
+        return ret;
+    }
+
+    req->flags = htole32(flags);
+    req->pin_mask = htole32(pin_mask);
+    return ret;
+}
+
+/**
+ * @brief Handler for gpio_control command
+ *
+ * @param mors morsectrl object
+ * @param argc argument counter
+ * @param argv command line string of args
+ *
+ * @return 0 if success, otherwise a negative return code
+ */
+int gpio_control(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = 0;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+    struct gpio_config *req;
+    struct gpio_config *cfm;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return -EINVAL;
+    }
+
+    --argc;
+    ++argv;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*req));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*cfm));
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        ret = -ENOMEM;
+        goto exit;
+    }
+
+    req = TBUFF_TO_CMD(cmd_tbuff, struct gpio_config);
+    cfm = TBUFF_TO_RSP(rsp_tbuff, struct gpio_config);
+
+    ret = gpio_control_command_handler(mors, argc, argv, req, cfm, cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        usage(mors);
+        goto exit;
+    }
+
+    /* Info command is sent in gpio_control_command_handler */
+    if (BMGET(req->flags, GPIO_CTRL_CMD_MASK) == GPIO_CTRL_CMD_INFO)
+    {
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_GPIO,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        /* Print errors generated by the firmware */
+        if (ret == MORSE_RET_EPERM)
+        {
+            mctrl_err("Unable to set all specified pins. Not all pins were in output mode\n");
+        }
+        else if (ret == MORSE_RET_ENXIO)
+        {
+            mctrl_err("Invalid pin\n");
+        }
+        else if (ret == MORSE_RET_EINVAL)
+        {
+            mctrl_err("Invalid command arguments\n");
+        }
+
+        mctrl_err("gpio_control cmd failed: error(%d)\n", ret);
+
+        goto exit;
+    }
+
+    ret = gpio_control_cfm_handler(req, cfm);
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(gpio_control, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/gpioctrl.c
+++ b/feeds/morse/utils/morsectrl/src/gpioctrl.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#include "utilities.h"
+#include "gpioctrl.h"
+
+static int gpio_sysfs_write(int value, const char *entry)
+{
+    char buff[8];
+    int fd;
+
+    fd = open(entry, O_WRONLY);
+    if (fd == -1)
+    {
+        mctrl_err("Unable to open %s\n", entry);
+        return -1;
+    }
+
+    snprintf(buff, sizeof(buff), "%d", value);
+    if (write(fd, buff, 2) != 2)
+    {
+        mctrl_err("Error writing to %s\n", entry);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+
+int gpio_export(int pin)
+{
+    char path_buff[40];
+
+    snprintf(path_buff, sizeof(path_buff), "%s%d", "/sys/class/gpio/gpio", pin);
+    if (!path_exists(path_buff))
+    {
+        return gpio_sysfs_write(pin, "/sys/class/gpio/export");
+    }
+
+    return 0;
+}
+
+int gpio_unexport(int pin)
+{
+    char path_buff[40];
+
+    snprintf(path_buff, sizeof(path_buff), "%s%d", "/sys/class/gpio/gpio", pin);
+    if (path_exists(path_buff))
+    {
+        return gpio_sysfs_write(pin, "/sys/class/gpio/unexport");
+    }
+
+    return 0;
+}
+
+
+int gpio_set_dir(int pin, const char dirc[])
+{
+    char path_buff[40];
+    int fd;
+
+    snprintf(path_buff, sizeof(path_buff), "%s%d%s", "/sys/class/gpio/gpio", pin, "/direction");
+    fd = open(path_buff, O_WRONLY);
+    if (fd == -1)
+    {
+        mctrl_err("Unable to open %s\n", path_buff);
+        return -1;
+    }
+    if (write(fd, dirc , 3) != 3)
+    {
+        mctrl_err("Error writing to %s\n", path_buff);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+
+int gpio_set_val(int pin, int val_int)
+{
+    char path_buff[40];
+    char val[2];
+    int fd;
+
+    snprintf(path_buff, sizeof(path_buff), "%s%d%s", "/sys/class/gpio/gpio", pin, "/value");
+    fd = open(path_buff, O_WRONLY);
+    if (fd == -1)
+    {
+        mctrl_err("Unable to open %s\n", path_buff);
+        return -1;
+    }
+
+    snprintf(val, sizeof(val), "%d", val_int);
+    if (write(fd, val, 1) != 1)
+    {
+        mctrl_err("Error writing to %s\n", path_buff);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+
+int gpio_get_env(char env_var[])
+{
+    char* gpio = getenv(env_var);
+    int tmp;
+
+    if (gpio == NULL)
+    {
+        return -1;
+    }
+    else
+    {
+        if (str_to_int32(gpio, &tmp))
+        {
+            return -1;
+        }
+
+        return tmp;
+    }
+}
+
+int path_exists(char path[])
+{
+    DIR* dir = opendir(path);
+
+    if (dir)
+    {
+        closedir(dir);
+        return 1;
+    }
+
+    return 0;
+}

--- a/feeds/morse/utils/morsectrl/src/gpioctrl.h
+++ b/feeds/morse/utils/morsectrl/src/gpioctrl.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#pragma once
+
+#define RESET_GPIO "MM_RESET_PIN"
+#define JTAG_GPIO "MM_JTAG_PIN"
+
+int gpio_export(int pin);
+int gpio_unexport(int pin);
+
+int gpio_set_dir(int pin, const char dirc[]);
+int gpio_set_val(int pin, int val);
+int gpio_get_env(char env_var[]);
+
+int path_exists(char path[]);
+

--- a/feeds/morse/utils/morsectrl/src/health.c
+++ b/feeds/morse/utils/morsectrl/src/health.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\thealth\tchecks the health status of the cores\n");
+}
+
+int health(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    if (argc != 1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_HEALTH_CHECK,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+        mctrl_err("health check: failed\n");
+    else
+        mctrl_print("health check: success\n");
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(health, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/hw_version.c
+++ b/feeds/morse/utils/morsectrl/src/hw_version.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "morsectrl.h"
+#include "portable_endian.h"
+
+#include "command.h"
+
+/** Structure for a get hw_version confirm */
+struct PACKED get_hw_version_response
+{
+    /** The version string */
+    uint8_t hw_version[64];
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\thw_version\t\tprints hardware version\n");
+}
+
+int hw_version(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct get_hw_version_response *hw_version;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*hw_version));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    hw_version = TBUFF_TO_RSP(rsp_tbuff, struct get_hw_version_response);
+
+    if (argc > 1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_HW_VERSION,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Get hardware version failed %d\n", ret);
+    }
+    else
+    {
+        mctrl_print("HW Version: %s\n", hw_version->hw_version);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(hw_version, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/hwkeydump.c
+++ b/feeds/morse/utils/morsectrl/src/hwkeydump.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+
+#include "command.h"
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\thwkeydump\t\tget FW to dump hw encryption keys to UART\n");
+}
+
+int hwkeydump(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_DUMP_HW_KEYS,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Command hwkeydump error (%d)\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(hwkeydump, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/ifs.c
+++ b/feeds/morse/utils/morsectrl/src/ifs.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+#define IF_SPACING_MIN_US 160
+
+struct PACKED set_ifs_command
+{
+    /** The flags of this message */
+    uint32_t ifs;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tifs <value>\t\tsets interframe spacing in us (min: %uus)\n",
+                    IF_SPACING_MIN_US);
+}
+
+int ifs(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t ifs;
+    struct set_ifs_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_ifs_command);
+    if (str_to_uint32_range(argv[1], &ifs, IF_SPACING_MIN_US, UINT32_MAX))
+    {
+        mctrl_err("Invalid interframe spacing value must be greater than %d\n",
+                    IF_SPACING_MIN_US);
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->ifs = htole32(ifs);
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_IFS,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set ifs\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(ifs, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/io.c
+++ b/feeds/morse/utils/morsectrl/src/io.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+
+#include "command.h"
+
+char *MORSE_IO_DEV_NAMES[] =
+{
+    "/dev/morse_io",
+    "/dev/morsef2", /* Legacy */
+    "/dev/morsef1"  /* Legacy */
+};
+
+static void usage()
+{
+    mctrl_print("\tio [-rh] [-s size] [-f filename] <address> [value]\n");
+    mctrl_print("\t\t-h\t\tprint this message\n"
+           "\t\t-v\t\tenable verbose\n"
+           "\t\t-r\t\tread from chip [default is write]\n"
+           "\t\t-s <size>\tsize of file read/write [default w:filesize r:4]\n"
+           "\t\t-f\t\tfilename read/write to file\n");
+}
+
+static size_t file_size(FILE *fptr)
+{
+    size_t size;
+    fseek(fptr, 0L, SEEK_END);
+    size = ftell(fptr);
+    fseek(fptr, 0L, SEEK_SET);
+    return size;
+}
+
+int io(struct morsectrl *mors, int argc, char *argv[])
+{
+    int fd;
+    int ret  = 0;
+    int tx_bytes = 0;
+    int opt_index, option;
+    int count = 0, size = 0;
+    int dir_write = 1, func = 2, verbose = 0;
+    uint32_t value = 0, address = 0, *data = &value, *buffer = NULL;
+    char *endptr, *filename = NULL;
+    FILE *fptr = NULL;
+
+    /* Reading options */
+    while ((option = getopt(argc, argv, "rhvFs:f:")) != -1)
+    {
+        switch (option)
+        {
+            case 'r' :
+                dir_write = 0;
+                break;
+            case 's' :
+                if (str_to_int32(optarg, &size))
+                {
+                    mctrl_err("Invalid size argument\n");
+                    return -1;
+                }
+                break;
+            case 'f' :
+                filename = optarg;
+                break;
+            case 'v' :
+                verbose = 1;
+                break;
+            case 'h':
+                usage();
+                return 0;
+            case -1:
+                break;
+            default:
+                mctrl_err("Invalid option\n");
+                usage();
+                return -1;
+        }
+    }
+    opt_index = optind;
+
+    /* Reading address */
+    if (opt_index >= argc)
+    {
+        usage();
+        return -1;
+    }
+    address = strtoul(argv[opt_index++], &endptr, 0);
+    if (*endptr != '\0')
+    {
+        mctrl_err("Invalid address\n");
+        usage();
+        return -1;
+    }
+
+    /* Open file */
+    if (filename != NULL)
+    {
+        if (dir_write == 1)
+        {
+            fptr = fopen(filename, "rb");
+        }
+        else
+        {
+            fptr = fopen(filename, "wb");
+        }
+        if (!fptr)
+        {
+            mctrl_err("Couldn't open file\n");
+            return -1;
+        }
+    }
+
+    /* calculate size */
+    if (fptr)
+    {
+        /* if size set use it, else write ? filesize : 4 */
+        size = size ? size : dir_write ? file_size(fptr) : 4;
+    }
+    else
+    {
+        if (size)
+        {
+            mctrl_err("Invalid size. Only set with file access\n");
+            usage();
+            return -1;
+        }
+        size = 4;
+    }
+
+    /* Allocate buffer if required (i.e > 4)*/
+    if (size > 4)
+    {
+        buffer = malloc(size);
+        if (!buffer)
+        {
+            mctrl_err("Failed to allocate memory\n");
+            fclose(fptr);
+            return (-ENOMEM);
+        }
+        data = buffer;
+    }
+
+    /* Read input */
+    if (dir_write == 1)
+    {
+        if (fptr)
+        {
+            /* From input file */
+            fread(data, 1, size, fptr);
+        }
+        else
+        {
+            /* Read from command line */
+            if (opt_index >= argc)
+            {
+                usage();
+                return -1;
+            }
+            value = strtoul(argv[opt_index], &endptr, 0);
+            if (*endptr != '\0')
+            {
+                mctrl_err("Invalid value\n");
+                usage();
+                return -1;
+            }
+        }
+    }
+
+    /* open device */
+    int retries = 0;
+    while (retries < MORSE_ARRAY_SIZE(MORSE_IO_DEV_NAMES))
+    {
+        if ((fd = open(MORSE_IO_DEV_NAMES[retries], O_RDWR)) >= 0)
+        {
+            break;
+        }
+        retries++;
+    }
+    if (retries == MORSE_ARRAY_SIZE(MORSE_IO_DEV_NAMES))
+    {
+        mctrl_err("Failed to open device file\n");
+        return -1;
+    }
+
+    if (verbose)
+    {
+        mctrl_print("%s %d bytes %s Func%d (%s %s)\n",
+           dir_write ? "writing" : "reading",
+           size,
+           dir_write ? "to": "from" ,
+           func,
+           dir_write ? "from" : "to",
+           fptr ? filename : "command line");
+    }
+
+    /* write/read */
+    while (count < size)
+    {
+        ioctl(fd, _IO('k', 1), address + count);
+        tx_bytes = dir_write ? write(fd, data + count, size) : read(fd, data + count, size);
+        if (tx_bytes < 0)
+        {
+            mctrl_err("Failed to %s device\n", dir_write ? "write to" : "read from");
+            return -1;
+        }
+        if (!dir_write)
+        {
+            /* write data */
+            if (fptr)
+            {
+                fwrite(data, 1, tx_bytes, fptr);
+            }
+            else
+            {
+                mctrl_print("0x%08X\n", value);
+            }
+        }
+        count += tx_bytes;
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(io, MM_INTF_NOT_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/jtag.c
+++ b/feeds/morse/utils/morsectrl/src/jtag.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "gpioctrl.h"
+#include "utilities.h"
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tjtag <disable|enable> [GPIO]\n");
+    mctrl_print("\t\t\t\tdisable|enable jtag through RPi GPIO pin\n");
+}
+
+int morsectrl_jtag(int enable, int jtag_gpio)
+{
+    int ret;
+    const char *direction = enable ? "out" : "in";
+
+    ret = gpio_export(jtag_gpio);
+    if (ret)
+    {
+        goto exit;
+    }
+
+    ret = gpio_set_dir(jtag_gpio, direction);
+    if (ret)
+    {
+        goto exit;
+    }
+
+    if (enable)
+    {
+        ret = gpio_set_val(jtag_gpio, 1);
+        if (ret)
+        {
+             goto exit;
+        }
+        sleep_ms(5);
+    }
+
+exit:
+    return ret;
+}
+
+int jtag(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret, jtag_gpio, enable;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 3)
+    {
+        if (argc == 2)
+        {
+            jtag_gpio = gpio_get_env(JTAG_GPIO);
+            if (jtag_gpio == -1)
+            {
+                mctrl_err("Couldn't identify GPIO\n"
+                "Try entering GPIO manually or export %s to your env var\n", JTAG_GPIO);
+                usage(mors);
+                return -1;
+            }
+        }
+        else
+        {
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            return -1;
+        }
+    }
+    else
+    {
+        if (str_to_int32(argv[2], &jtag_gpio))
+        {
+            mctrl_err("Invalid JTAG gpio\n");
+            usage(mors);
+            return -1;
+        }
+    }
+
+    enable = expression_to_int(argv[1]);
+    if (enable == -1)
+    {
+        mctrl_err("Invalid option.\n");
+        usage(mors);
+        return -1;
+    }
+
+    ret = morsectrl_jtag(enable, jtag_gpio);
+    if (ret < 0)
+    {
+        mctrl_err("Failed to enable jtag\n");
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(jtag, MM_INTF_NOT_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/keep_alive.c
+++ b/feeds/morse/utils/morsectrl/src/keep_alive.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_set_keep_alive_offload
+{
+    /** The value of the BSS max idle period as it appears in the IE */
+    uint16_t bss_max_idle_period;
+    /** Set to TRUE to interpret the value of BSS max idle period as per 11ah spec */
+    uint8_t interpret_as_11ah;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tkeepalive <bss max idle period> [-a]\n");
+    mctrl_print("\t\t<bss max idle period>\tthe bss max idle period as seen in IE\n");
+    mctrl_print(
+        "\t\t[-a]                 \toptional, set to interpret idle period as per 11ah spec\n");
+}
+
+int keepalive(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_set_keep_alive_offload *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint16_t bss_max_idle_period;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2 || argc > 3)
+    {
+        mctrl_err("Invalid arguments\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_keep_alive_offload);
+
+    cmd->interpret_as_11ah = false;
+
+    if (str_to_uint16(argv[1], &bss_max_idle_period))
+    {
+        mctrl_err("Invalid bss max idle period: %s\n", argv[1]);
+        ret = -1;
+        goto exit;
+    }
+    cmd->bss_max_idle_period = htole16(bss_max_idle_period);
+
+    if (argc == 3)
+    {
+        if (strcmp(argv[2], "-a") != 0)
+        {
+            mctrl_err("Invalid argument: %s\n", argv[2]);
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        cmd->interpret_as_11ah = true;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_KEEP_ALIVE_OFFLOAD,
+        cmd_tbuff, rsp_tbuff);
+
+    if (ret)
+    {
+        mctrl_err("Failed to send keepalive offload command\n");
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(keepalive, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/li.c
+++ b/feeds/morse/utils/morsectrl/src/li.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+#define UNSCALED_INTERVAL_MAX               ((2 << 14) - 1)
+
+struct PACKED set_li_command
+{
+    /** The flags of this message */
+    uint16_t li;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tli <unscaled_int> <scale_idx>\t\tsets listen interval.\n");
+    mctrl_print("\t\t\t\tScale index: 0=1, 1=10, 2=1000, 3=10000\n");
+    mctrl_print("\t\t\t\tIf the node is an AP this set the max listen interval\n");
+}
+
+int li(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t unscaled_interval;
+    uint8_t scale_idx;
+    struct set_li_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 3)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_li_command);
+
+    if (str_to_uint32_range(argv[1], &unscaled_interval, 0, UNSCALED_INTERVAL_MAX))
+    {
+        mctrl_err("Invalid unscaled interval\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    if (str_to_uint8(argv[2], &scale_idx))
+    {
+        mctrl_err("Invalid scale index\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    /* Max is same as mask */
+    cmd->li = htole32((unscaled_interval & UNSCALED_INTERVAL_MAX) | scale_idx << 14);
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_LISTEN_INTERVAL,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set li\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(li, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/lnabypass.c
+++ b/feeds/morse/utils/morsectrl/src/lnabypass.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "command.h"
+
+struct PACKED command_lna_bypass
+{
+    /* 0 sets LNA as default, 1 sets LNA in bypass mode */
+    uint8_t lna_bypass;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tlnabypass 1 sets LNA in bypass mode, lnabypass 0 sets LNA in default mode\n");
+}
+
+int lnabypass(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret  = -1;
+    uint8_t lna_bypass;
+    struct command_lna_bypass *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    if (str_to_uint8_range(argv[1], &lna_bypass, 0, 1))
+    {
+        mctrl_err("Invalid LNA bypass value\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_lna_bypass);
+    cmd->lna_bypass = lna_bypass;
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_LNA_BYPASS,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to change LNA status\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(lnabypass, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/long_sleep.c
+++ b/feeds/morse/utils/morsectrl/src/long_sleep.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_long_sleep_config_command
+{
+    uint8_t long_sleep_enabled;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tlong_sleep [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' will enable long sleep (allow sleeping through DTIM)\n");
+    mctrl_print("\t\t\t\t'disable' will disable long sleep\n");
+}
+
+
+int long_sleep(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enabled;
+    struct set_long_sleep_config_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    enabled = expression_to_int(argv[1]);
+
+    if (enabled == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_long_sleep_config_command);
+    cmd->long_sleep_enabled = enabled;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_LONG_SLEEP_CONFIG,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set long sleep mode\n");
+    }
+    else
+    {
+        mctrl_print("\tLong Sleep Mode: %s\n",
+            (cmd->long_sleep_enabled) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(long_sleep, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/macaddr.c
+++ b/feeds/morse/utils/morsectrl/src/macaddr.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_mac_addr_req
+{
+    uint8_t write;
+    uint8_t mac_octet[MAC_ADDR_LEN];
+};
+
+struct PACKED command_mac_addr_cfm
+{
+    uint8_t mac_octet[MAC_ADDR_LEN];
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print(
+        "\tmacaddr [-w <mac_addr>]\treads the MAC address of the chip if -w was not passed\n");
+    mctrl_print(
+        "\t\t-w <mac_addr>\twrites the given 'XX:XX:XX:XX:XX:XX' MAC  address to the chip\n");
+    mctrl_print("\t\t\t\t(this is not reversible)\n");
+}
+
+int macaddr(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1, option;
+    struct command_mac_addr_req *cmd;
+    struct command_mac_addr_cfm *resp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (!argc)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_mac_addr_req);
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct command_mac_addr_cfm);
+    cmd->write = false;
+
+    switch (argc)
+    {
+        case 1:
+        case 3:
+            while ((option = getopt(argc, argv, "w:")) != -1)
+            {
+                uint8_t *mac_octet = cmd->mac_octet;
+
+                switch (option)
+                {
+                    case 'w' :
+                        cmd->write = true;
+                        if (str_to_mac_addr(mac_octet, optarg) < 0)
+                        {
+                            mctrl_err("Invalid MAC address\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                        break;
+                    default :
+                        usage(mors);
+                        goto exit;
+                }
+            }
+            break;
+        default:
+            mctrl_err("Invalid arguments\n");
+            usage(mors);
+            goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_MAC_ADDR,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret)
+        mctrl_err("Command macaddr Failed(%d)\n", ret);
+    else
+    {
+        uint8_t *mac_octet = resp->mac_octet;
+        mctrl_print("Chip MAC address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+               mac_octet[0], mac_octet[1], mac_octet[2], mac_octet[3],
+               mac_octet[4], mac_octet[5]);
+    }
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(macaddr, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/maxampdulen.c
+++ b/feeds/morse/utils/morsectrl/src/maxampdulen.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+
+struct PACKED set_max_ampdu_length_command
+{
+    int32_t n_bytes;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tmaxampdulen <bytes>\n");
+    mctrl_print("\t\t\t\tset the max ampdu length the chip is allowed to aggregate\n");
+    mctrl_print("\t\t\t\tset to (-1) to reset to chip default\n");
+}
+
+int maxampdulen(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct set_max_ampdu_length_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int32_t n_bytes;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_max_ampdu_length_command);
+
+    if (str_to_int32(argv[1], &n_bytes))
+    {
+        mctrl_err("Invalid ampdu length\n");
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->n_bytes = htole32(n_bytes);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_MAX_AMPDU_LENGTH,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set max ampdu length: %d\n", ret);
+    }
+    else
+    {
+        if (cmd->n_bytes == -1)
+            mctrl_print("Reset max ampdu length to chip default\n");
+        else
+            mctrl_print("Set max ampdu length to: %d\n", cmd->n_bytes);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(maxampdulen, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/mbca.c
+++ b/feeds/morse/utils/morsectrl/src/mbca.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+#define MBCA_CONFIG_MIN 1
+#define MBCA_CONFIG_MAX 3
+#define MIN_BEACON_GAP_MIN 5
+#define MIN_BEACON_GAP_MAX 100
+#define TBTT_ADJ_INT_MIN 30
+#define TBTT_ADJ_INT_MAX 65
+#define BEACON_TIMING_REP_INT_MIN 1
+#define BEACON_TIMING_REP_INT_MAX 255
+#define MBSS_SCAN_DURATION_MIN 2048
+#define MBSS_SCAN_DURATION_MAX 10240
+
+struct PACKED command_set_mbca_conf {
+    /** Configuration to enable or disable MBCA TBTT Selection and Adjustment */
+    uint8_t mbca_config;
+
+    /** Beacon Timing Element Report interval */
+    uint8_t beacon_timing_report_interval;
+
+    /** Minimum gap between our beacon and neighbor beacons */
+    uint8_t min_beacon_gap_ms;
+
+     /** Initial scan duration to find neighbor mesh peers in the MBSS */
+    uint16_t mbss_start_scan_duration_ms;
+
+    /** TBTT adjustment timer interval in LMAC firmware */
+    uint16_t tbtt_adj_interval_ms;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print(
+        "\tmbca -m <mbca config> -s <initial scan duration> -r <beacon timing report int> "
+        "-g <min beacon gap> -i <tbtt adj int>\n");
+    mctrl_print("\t\tconfigure Mesh beacon collision avoidance\n");
+    mctrl_print("\t\tdo not use - for internal use by wpa_supplicant\n");
+    mctrl_print("\t\t-m <value>\t1: To enable TBTT selection, 3: To enable TBTT selection and ");
+    mctrl_print("adjustment\n");
+    mctrl_print("\t\t-s <value>\tInitial scan duration in msecs to find peers. min:%u, max:%u\n",
+        MBSS_SCAN_DURATION_MIN, MBSS_SCAN_DURATION_MAX);
+    mctrl_print("\t\t-r <value>\tBeacon Timing Report interval. min:%u, max:%u\n",
+        BEACON_TIMING_REP_INT_MIN, BEACON_TIMING_REP_INT_MAX);
+    mctrl_print("\t\t-g <value>\tMinimum gap in msecs between our and neighbor's beacons. min:%u, ",
+        MIN_BEACON_GAP_MIN);
+    mctrl_print("max:%u\n", MIN_BEACON_GAP_MAX);
+    mctrl_print("\t\t-i <value>\tTBTT adjustment timer interval in secs. min:%u, max:%u\n",
+        TBTT_ADJ_INT_MIN, TBTT_ADJ_INT_MAX);
+}
+
+int mbca(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_set_mbca_conf *mbca_req = NULL;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+    uint8_t temp;
+    uint16_t temp_short;
+    int option;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 11)
+    {
+        mctrl_err("Insufficient command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*mbca_req));
+    if (!cmd_tbuff)
+    {
+        goto exit;
+    }
+
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+    if (!rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    mbca_req = TBUFF_TO_CMD(cmd_tbuff, struct command_set_mbca_conf);
+    memset(mbca_req, 0, sizeof(*mbca_req));
+
+    while ((option = getopt(argc, argv, "m:s:r:g:i:")) != -1)
+    {
+        switch (option) {
+        case 'm':
+            if (str_to_uint8_range(optarg, &temp, MBCA_CONFIG_MIN, MBCA_CONFIG_MAX) < 0)
+            {
+                mctrl_err("MBCA Config not a valid uint8_t value\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            mbca_req->mbca_config = temp;
+            break;
+        case 's':
+            if (str_to_uint16_range(optarg, &temp_short, MBSS_SCAN_DURATION_MIN,
+                MBSS_SCAN_DURATION_MAX) < 0)
+            {
+                mctrl_err("MBSS start scan duration %u must be within the range min %u :"
+                    " max %u \n", temp_short, MBSS_SCAN_DURATION_MIN, MBSS_SCAN_DURATION_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            mbca_req->mbss_start_scan_duration_ms = temp_short;
+            break;
+        case 'r':
+            if (str_to_uint8_range(optarg, &temp, BEACON_TIMING_REP_INT_MIN,
+                BEACON_TIMING_REP_INT_MAX) < 0)
+            {
+                mctrl_err("Beacon Timing Report Interval %u must be within the range min %u : "
+                    "max %u \n", temp, BEACON_TIMING_REP_INT_MIN, BEACON_TIMING_REP_INT_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            mbca_req->beacon_timing_report_interval = temp;
+            break;
+        case 'g':
+            if (str_to_uint8_range(optarg, &temp, MIN_BEACON_GAP_MIN, MIN_BEACON_GAP_MAX) < 0)
+            {
+                mctrl_err("Min Beacon Gap %d must be within the range min %u : max %u \n", temp,
+                    MIN_BEACON_GAP_MIN, MIN_BEACON_GAP_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            mbca_req->min_beacon_gap_ms = temp;
+            break;
+        case 'i':
+            if (str_to_uint8_range(optarg, &temp, TBTT_ADJ_INT_MIN, TBTT_ADJ_INT_MAX) < 0)
+            {
+                mctrl_err("TBTT adjustment interval %d must be within the range min %u : max %u \n"
+                    , temp, TBTT_ADJ_INT_MIN, TBTT_ADJ_INT_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            mbca_req->tbtt_adj_interval_ms = SECS_TO_MSECS(temp);
+            break;
+        case '?' :
+            usage(mors);
+            goto exit;
+        default:
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_MBCA_SET_CONF, cmd_tbuff,
+            rsp_tbuff);
+
+exit:
+    if (cmd_tbuff)
+    {
+        morsectrl_transport_buff_free(cmd_tbuff);
+    }
+
+    if (rsp_tbuff)
+    {
+        morsectrl_transport_buff_free(rsp_tbuff);
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(mbca, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/mbssid.c
+++ b/feeds/morse/utils/morsectrl/src/mbssid.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#ifndef MORSE_WIN_BUILD
+#include <net/if.h>
+#endif
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+#define BSS_MIN 0
+#define BSS_MAX 2
+#define BSS_ID_DEFAULT 0
+
+
+struct PACKED set_mbssid_ie
+{
+    /** Maximum supported BSS to be updated in MBSSID IE */
+    uint8_t max_bssid_indicator;
+
+    /** Beacon or probe reponse transmitting interface name */
+    char transmitter_iface[IFNAMSIZ];
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tmbssid -t <transmitting BSS> -m <max bss id>\n");
+    mctrl_print("\t\t\tAdvertise a BSS from another BSS's beacons\n");
+    mctrl_print("\t\t-t <value>\tTransmitting interface name, eg: wlan0\n");
+    mctrl_print("\t\t-m <value>\tMaximum number of BSSes supported\n");
+}
+
+int mbssid(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    uint8_t max_bssid_indicator = BSS_ID_DEFAULT;
+    char *transmitter_iface = "";
+    struct set_mbssid_ie *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2 || argc > 5)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_mbssid_ie);
+
+    memset(cmd, 0, sizeof(*cmd));
+    while ((option = getopt(argc, argv, "t:m:")) != -1)
+    {
+        switch (option) {
+        case 'm' :
+            if (str_to_uint8_range(optarg, &max_bssid_indicator,
+                BSS_MIN, BSS_MAX) < 0)
+            {
+                mctrl_err("Maximum supported BSS  %u must be within range min %u : max %u\n",
+                        max_bssid_indicator, BSS_MIN, BSS_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->max_bssid_indicator = max_bssid_indicator;
+            break;
+        case 't' :
+            transmitter_iface = optarg;
+            if (transmitter_iface)
+                strncpy(cmd->transmitter_iface, transmitter_iface,
+                    sizeof(cmd->transmitter_iface) - 1);
+            break;
+        case '?' :
+            usage(mors);
+            goto exit;
+        default :
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            goto exit;
+        }
+    }
+
+    if (max_bssid_indicator == BSS_ID_DEFAULT)
+    {
+        mctrl_err("Invalid max_bssid_indicator %d \n", max_bssid_indicator);
+        usage(mors);
+        goto exit;
+    }
+    if (transmitter_iface[0] == '\0')
+    {
+        mctrl_err("Invalid transmitter_iface %d \n", max_bssid_indicator);
+        usage(mors);
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_MBSSID_INFO,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set MBSSID IE info\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(mbssid, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/mcs.c
+++ b/feeds/morse/utils/morsectrl/src/mcs.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_mcs_command
+{
+    /** The flags of this message */
+    uint32_t mcs;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print(
+        "\tmcs <value>\t\tselects mcs mode(0~9) or type (auto) for auto rate control\n");
+}
+
+int mcs(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t mcs;
+    struct set_mcs_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_mcs_command);
+
+    if (!strcmp(argv[1], "auto"))
+    {
+        mcs = 0x7FFFFFFF;
+    }
+    else
+    {
+        if (str_to_uint32_range(argv[1], &mcs, 0, 10))
+        {
+            mctrl_err("Invalid mcs value\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+
+    cmd->mcs = htole32(mcs);
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_MODULATION,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set mcs\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(mcs, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/mesh_config.c
+++ b/feeds/morse/utils/morsectrl/src/mesh_config.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#ifndef MORSE_WIN_BUILD
+#include <net/if.h>
+#endif
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+#define MESH_ID_LEN_MAX 32
+
+#define MESH_BEACONLESS_MODE_DISABLE 0
+#define MESH_BEACONLESS_MODE_ENABLE 1
+#define PEER_LINKS_MIN 0
+#define PEER_LINKS_MAX 10
+
+struct PACKED set_mesh_config
+{
+    /** Mesh ID Len */
+    uint8_t mesh_id_len;
+
+    /** Mesh ID, equivalent to SSID in infra */
+    uint8_t mesh_id[MESH_ID_LEN_MAX];
+
+    /** Mesh beaconless mode enabled/disabled */
+    uint8_t mesh_beaconless_mode;
+
+    /** Maximum number of peer links */
+    uint8_t max_plinks;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tmesh_config -m <mesh id> [-b <beaconless mode>] -p <max_peer_links>\n");
+    mctrl_print("\t\t\tConfigure Mesh\n");
+    mctrl_print("\t\t-m <value>\tMesh ID as a hex string\n");
+    mctrl_print("\t\t-b <value>\tMesh beaconless mode. 1: enable, 0: disable\n");
+    mctrl_print("\t\t-p <value>\tMaximum number of peer links. Min:%u, Max:%u\n",
+        PEER_LINKS_MIN, PEER_LINKS_MAX);
+    mctrl_print("\t\t\t\tdo not use - for internal use by wpa_supplicant\n");
+}
+
+int mesh_config(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    size_t length = 0;
+    struct set_mesh_config *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint8_t temp = 0;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 5 || argc > 7)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_mesh_config);
+
+    memset(cmd, 0, sizeof(*cmd));
+
+    while ((option = getopt(argc, argv, "m:b:p:")) != -1)
+    {
+        switch (option) {
+        case 'b' :
+            if (str_to_uint8_range(optarg, &temp,
+                MESH_BEACONLESS_MODE_DISABLE, MESH_BEACONLESS_MODE_ENABLE) < 0)
+            {
+                mctrl_err("Mesh beaconless mode %d must be either %u or %u\n",
+                        temp,
+                        MESH_BEACONLESS_MODE_DISABLE,
+                        MESH_BEACONLESS_MODE_ENABLE);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->mesh_beaconless_mode = temp;
+            break;
+        case 'm' :
+            length = strlen(optarg);
+
+            if (!length || (length & 1))
+            {
+                mctrl_err("Invalid Mesh ID hex string length\n");
+                ret = -1;
+                goto exit;
+            }
+            length = length / 2;
+
+            if (length > sizeof(cmd->mesh_id))
+            {
+                mctrl_err("Mesh ID invalid length:%zu, max allowed length is:%zu\n",
+                        length, sizeof(cmd->mesh_id));
+                ret = -1;
+                goto exit;
+            }
+
+            if (hexstr2bin(optarg, cmd->mesh_id, length))
+            {
+                mctrl_err("Invalid Mesh ID hex string\n");
+                ret = -1;
+                goto exit;
+            }
+            cmd->mesh_id_len = length;
+            break;
+        case 'p' :
+            if (str_to_uint8_range(optarg, &temp, PEER_LINKS_MIN, PEER_LINKS_MAX) < 0)
+            {
+                mctrl_err("Max peer links %d must be within in the range min %u max %u\n",
+                        temp,
+                        PEER_LINKS_MIN,
+                        PEER_LINKS_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->max_plinks = temp;
+            break;
+        case '?' :
+            usage(mors);
+            goto exit;
+        default :
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_MESH_CONFIG,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set Mesh Config info\n");
+        usage(mors);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(mesh_config, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/mm_argtable3.h
+++ b/feeds/morse/utils/morsectrl/src/mm_argtable3.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+#include "utilities.h"
+#include "argtable3/argtable3.h"
+
+extern char TOOL_NAME[];
+
+struct mm_argtable {
+    int count;
+    const char *desc;
+    struct arg_lit *help;
+    struct arg_end *end;
+    void **argtable;
+};
+
+void mctrl_print(const char* format, ...);
+
+static inline void mm_help_argtable(const char *name, struct mm_argtable *mm_args)
+{
+    mctrl_print("\t%s", name);
+    arg_print_syntax(stdout, mm_args->argtable, "\n");
+    if (mm_args->desc)
+        mctrl_print("\t\t%s\n", mm_args->desc);
+    arg_print_glossary(stdout, mm_args->argtable, "\t\t%-40s %s\n");
+}
+
+static inline int mm_parse_argtable_noerror(const char *name, struct mm_argtable *mm_args,
+                                            int argc, char **argv)
+{
+    int nerrors;
+
+    nerrors = arg_parse(argc, argv, mm_args->argtable);
+
+    if (mm_args->help->count > 0)
+    {
+        mctrl_print("%s %s", TOOL_NAME, name ? name : "");
+        arg_print_syntax(stdout, mm_args->argtable, "\n");
+        if (mm_args->desc)
+            mctrl_print("\t%s\n", mm_args->desc);
+        arg_print_glossary(stdout, mm_args->argtable, "\t%-40s %s\n");
+        return -1;
+    }
+
+    return nerrors;
+}
+
+static inline int mm_parse_argtable(const char *name, struct mm_argtable *mm_args,
+                                    int argc, char **argv)
+{
+    int nerrors = mm_parse_argtable_noerror(name, mm_args, argc, argv);
+
+    if (nerrors > 0)
+    {
+        arg_print_errors(stdout, mm_args->end, name != NULL ? name : TOOL_NAME);
+        mctrl_print("Try %s --help for more information\n", TOOL_NAME);
+    }
+
+    return nerrors;
+}
+
+static inline void mm_free_argtable(struct mm_argtable *mm_args)
+{
+    arg_freetable(mm_args->argtable, mm_args->count);
+    free(mm_args->argtable);
+}
+
+// NOLINT(-whitespace/comma)
+#define MM_INIT_ARGTABLE(_argtable, _desc, ...) \
+    do { \
+        void *tmp_table[] = {                                       \
+            _argtable->help = arg_lit0("h", "help", \
+                                       "display this help and exit"), \
+            __VA_ARGS__ __VA_OPT__(,)                                   \
+            _argtable->end = arg_end(20)                                 \
+    };                                                                  \
+        _argtable->desc = _desc;                                        \
+        _argtable->argtable = malloc(sizeof(tmp_table));                \
+        memcpy(_argtable->argtable, tmp_table, sizeof(tmp_table));      \
+        _argtable->count = sizeof(tmp_table) / sizeof(_argtable->end);  \
+    } while (0)
+// NOLINT(+whitespace/comma)

--- a/feeds/morse/utils/morsectrl/src/morsectrl.c
+++ b/feeds/morse/utils/morsectrl/src/morsectrl.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <getopt.h>
+#include <ctype.h>
+
+#include "morsectrl.h"
+#include "command.h"
+
+#ifndef MORSE_CLIENT
+char TOOL_NAME[] = "morsectrl";
+#else
+char TOOL_NAME[] = "morse_cli";
+#endif
+
+#ifndef MORSECTRL_VERSION_STRING
+#define MORSECTRL_VERSION_STRING "Undefined"
+#endif
+
+static struct
+{
+    struct arg_lit *debug;
+    struct arg_rex *trans_opts;
+    struct arg_str *iface;
+    struct arg_str *cfg_opts;
+    struct arg_str *file_opts;
+    struct arg_lit *version;
+    struct arg_str *command;
+} args;
+
+extern struct command_handler __start_cli_handlers[];
+extern struct command_handler __stop_cli_handlers[];
+
+static void usage(struct morsectrl *mors)
+{
+    struct command_handler *handler;
+
+    morsectrl_transport_list_available();
+
+    mctrl_print("\nInterface Commands:\n");
+
+    for (handler = __start_cli_handlers;
+         handler < __stop_cli_handlers;
+         handler++)
+    {
+        if (handler->is_intf_cmd == MM_INTF_REQUIRED)
+        {
+            if (handler->direct_chip_supported_cmd ||
+                morsectrl_transport_driver_commands_supported())
+            {
+                if (handler->init)
+                {
+                    handler->init(mors, &handler->args);
+                    mm_help_argtable(handler->name, &handler->args);
+                }
+                else
+                {
+                    handler->handler(mors, 0, NULL);
+                }
+            }
+        }
+    }
+
+    mctrl_print("\nGeneral Commands (no interface required):\n");
+    for (handler = __start_cli_handlers;
+         handler < __stop_cli_handlers;
+         handler++)
+    {
+        if (handler->is_intf_cmd == MM_INTF_NOT_REQUIRED)
+        {
+            if (handler->direct_chip_supported_cmd ||
+                morsectrl_transport_driver_commands_supported())
+            {
+                if (handler->init)
+                {
+                    handler->init(mors, &handler->args);
+                    mm_help_argtable(handler->name, &handler->args);
+                }
+                else
+                {
+                    handler->handler(mors, 0, NULL);
+                }
+            }
+        }
+    }
+}
+
+static void print_version(void)
+{
+    /* print Morsectrl Version: ... or Morse_cli Version: ...
+    The leading captial letter is for backwards compatibility
+    */
+    mctrl_print("%c%s Version: %s\n",
+        toupper(TOOL_NAME[0]),
+        TOOL_NAME + 1,
+        MORSECTRL_VERSION_STRING);
+}
+
+int cmdname_cmp(const void * a, const void * b) {
+    return strcmp(((struct command_handler *)a)->name, ((struct command_handler *)b)->name);
+}
+
+
+int main(int argc, char *argv[])
+{
+    struct command_handler *handler = NULL;
+    int ret = MORSE_OK;
+    char *trans_opts = NULL;
+    char *iface_opts = NULL;
+    char *cfg_opts = NULL;
+    char *file_opts = NULL;
+    char *transport_regex;
+    struct mm_argtable main_args = {};
+
+    struct morsectrl mors = {
+        .debug = false,
+    };
+
+    transport_regex = morsectrl_transport_get_regex();
+    if (transport_regex == NULL)
+    {
+        return 1;
+    }
+
+    qsort(__start_cli_handlers, (__stop_cli_handlers - __start_cli_handlers),
+          sizeof(struct command_handler), cmdname_cmp);
+
+    MM_INIT_ARGTABLE((&main_args), NULL,
+                     args.debug = arg_lit0("d", "debug", "show debug messages for given command"),
+                     args.iface = arg_str0("i", "interface", NULL,
+                                           "specify the interface for the transport "
+                                           "(default " DEFAULT_INTERFACE_NAME ")"),
+                     args.file_opts = arg_str0("f", "configfile", NULL,
+                                               "specify config file with transport/interface/config"
+                                               " (command line will override file contents)"),
+                     args.trans_opts = arg_rex0("t", "transport", transport_regex,
+                                                transport_regex, 0,
+                                                "specify the transport to use"),
+                     args.cfg_opts = arg_str0("c", "config", NULL,
+                                              "specify the config for the transport"),
+                     args.version = arg_lit0("v", NULL, "print the version"),
+                     args.command = arg_str1(NULL, NULL, "command", "sub-command to run"));
+
+    args.iface->sval[0] = DEFAULT_INTERFACE_NAME;
+
+    args.command->hdr.flag |= ARG_STOPPARSE;
+
+    ret = mm_parse_argtable_noerror(NULL, &main_args, argc, argv);
+
+    if (args.debug->count)
+    {
+        mors.debug = true;
+    }
+
+    if (args.iface->count)
+    {
+        iface_opts = (char *)args.iface->sval[0];
+    }
+
+    if (args.file_opts->count)
+    {
+        file_opts = (char *)args.file_opts->sval[0];
+    }
+
+    if (args.trans_opts->count)
+    {
+        trans_opts = (char *)args.trans_opts->sval[0];
+    }
+
+    if (args.cfg_opts->count)
+    {
+        cfg_opts = (char *)args.cfg_opts->sval[0];
+    }
+
+    if (ret)
+    {
+        if (main_args.help->count)
+        {
+            morsectrl_transport_parse(&mors.transport, mors.debug,
+                                      trans_opts, iface_opts, cfg_opts);
+            usage(&mors);
+        }
+        else if (args.version->count)
+        {
+            print_version();
+            ret = 0;
+        }
+        else
+        {
+            arg_print_errors(stdout, main_args.end, TOOL_NAME);
+            mctrl_err("Try %s --help for more information\n", TOOL_NAME);
+        }
+        goto exit;
+    }
+
+    if (file_opts)
+    {
+        ret = morsectrl_config_file_parse(file_opts,
+                                          &trans_opts,
+                                          &iface_opts,
+                                          &cfg_opts,
+                                          mors.debug);
+
+        if (ret)
+            goto exit;
+    }
+
+    ret = morsectrl_transport_parse(&mors.transport, mors.debug, trans_opts, iface_opts, cfg_opts);
+    if (ret)
+        goto exit;
+
+    for (handler = __start_cli_handlers;
+         handler < __stop_cli_handlers;
+         handler++)
+    {
+        if (!strcmp(args.command->sval[0], handler->name))
+        {
+            if (mors.debug)
+            {
+                mctrl_print("Calling: %s ", handler->name);
+                for (int j = 1; j < argc; j++)
+                {
+                    mctrl_print("%s ", argv[j]);
+                }
+                mctrl_print("\n");
+            }
+
+            if (handler->init)
+            {
+                if (handler->init(&mors, &handler->args))
+                {
+                    ret = MORSE_ARG_ERR;
+                    goto exit;
+                }
+
+                if ((ret = mm_parse_argtable(handler->name, &handler->args,
+                                             argc - args.command->hdr.idx,
+                                             argv + args.command->hdr.idx)) != 0)
+                {
+                    mm_free_argtable(&handler->args);
+                    if (ret > 0)
+                        ret = MORSE_ARG_ERR;
+                    else
+                        ret = 0;
+
+                    goto exit;
+                }
+            }
+            else
+            {
+                /* Legacy handlers need argc and argv updated, and also optind resset */
+                argc -= args.command->hdr.idx;
+                argv += args.command->hdr.idx;
+                optind = 1;
+            }
+
+            if (handler->direct_chip_supported_cmd != MM_DIRECT_CHIP_SUPPORTED &&
+                !morsectrl_transport_has_driver(mors.transport))
+            {
+                mctrl_err("Command '%s' cannot be used with transport %s\n", handler->name,
+                          trans_opts);
+                mctrl_err("To check valid commands run 'morsectrl -t %s -h'\n", trans_opts);
+                ret = ETRANSFTDISPIERR;
+                goto exit;
+            }
+
+            if (!strcmp(handler->name, "version"))
+                print_version();
+
+            if (handler->is_intf_cmd == MM_INTF_REQUIRED ||
+                (!strncmp(handler->name, "reset", strlen(handler->name)) &&
+                 morsectrl_transport_has_reset(mors.transport)))
+            {
+                ret = morsectrl_transport_init(mors.transport);
+                if (ret)
+                {
+                    mctrl_err("Transport init failed\n");
+                    goto exit;
+                }
+            }
+
+            ret = handler->handler(&mors, argc, argv);
+            goto transport_exit;
+        }
+    }
+
+    ret = MORSE_CMD_ERR;
+    mctrl_err("Invalid command '%s'\n", args.command->sval[0]);
+    mctrl_err("Try %s --help for more information\n", TOOL_NAME);
+
+transport_exit:
+    if (handler != NULL && (handler < __stop_cli_handlers) &&
+        handler->is_intf_cmd == MM_INTF_REQUIRED)
+        morsectrl_transport_deinit(mors.transport);
+exit:
+    /**
+     * For return codes less than 0, or greater than 255 (i.e. the nix return code error range)
+     * remap error to MORSE_CMD_ERR. The return code 255 (-1) is avoided as ssh uses this to
+     * indicate an ssh error.
+     */
+    if ((ret < 0) || (ret > 254))
+    {
+        ret = MORSE_CMD_ERR;
+    }
+    return ret;
+}

--- a/feeds/morse/utils/morsectrl/src/morsectrl.h
+++ b/feeds/morse/utils/morsectrl/src/morsectrl.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "utilities.h"
+#include "transport/transport.h"
+#include "mm_argtable3.h"
+
+#define MORSE_ARRAY_SIZE(array) (sizeof((array)) / sizeof((array[0])))
+
+#define MORSE_OK 0
+#define MORSE_ARG_ERR 1
+#define MORSE_CMD_ERR 2
+
+typedef struct statistics_offchip_data offchip_stats_t; /* typedef reqd for circular definition */
+
+struct morsectrl {
+    bool debug;
+    struct morsectrl_transport *transport;
+    offchip_stats_t *stats;
+    size_t n_stats;
+};
+
+enum mm_intr_requirements {
+    /** Indicates that for this command a network interface is not required */
+    MM_INTF_NOT_REQUIRED = false,
+    /** Indicates that for this command a network interface is required */
+    MM_INTF_REQUIRED = true
+};
+
+enum mm_direct_chip_support {
+    /** Indicates that this command does not support direct to chip communication */
+    MM_DIRECT_CHIP_NOT_SUPPORTED = false,
+    /** Indicates that this command supports direct to chip communication */
+    MM_DIRECT_CHIP_SUPPORTED = true
+};
+
+/**
+ * @brief Parse a config file to obtain transport, interface and other configuration options.
+ *
+ * The parser will allocate the memory for the transport, interface and configuration strings.
+ *
+ * @param file_opts     String containing the filename of the config file
+ * @param trans_opts    Transport string (to be filled by parser)
+ * @param iface_opts    Interface string (to be filled by parser)
+ * @param cfg_opts      Other configuration options (to be filled by parser)
+ * @param debug         Whether or not to print debug information while parsing
+ *
+ * @return              0 if success otherwise -1
+ */
+int morsectrl_config_file_parse(const char *file_opts,
+                                char **trans_opts,
+                                char **iface_opts,
+                                char **cfg_opts,
+                                bool debug);
+
+/* Our command link handlers need to be aligned to 8 byte boundaries (for up to 64-bit platforms) */
+#define MM_CLI_HANDLER_ALIGN __attribute__((aligned(8)))
+
+struct MM_CLI_HANDLER_ALIGN command_handler
+{
+    const char *name;
+    int (*init)(struct morsectrl *, struct mm_argtable *);
+    int (*handler)(struct morsectrl *, int, char **);
+    const enum mm_intr_requirements is_intf_cmd;
+    const enum mm_direct_chip_support direct_chip_supported_cmd;
+    const bool deprecated;
+    struct mm_argtable args;
+};
+
+#define _MM_CLI_HANDLER(command, _is_intf_cmd, _direct_chip_supported_cmd, deprecated) \
+    __attribute__((weak)) int command##_init(struct morsectrl *mors, struct mm_argtable *mmargs); \
+    __attribute__((section("cli_handlers"))) MM_CLI_HANDLER_ALIGN \
+    struct command_handler command##_cli_handler = { \
+        #command, \
+        command##_init, \
+        command, \
+        _is_intf_cmd, \
+        _direct_chip_supported_cmd, \
+        deprecated }
+
+#define MM_CLI_HANDLER(command, _is_intf_cmd, _direct_chip_supported_cmd) \
+     _MM_CLI_HANDLER(command, _is_intf_cmd, _direct_chip_supported_cmd, false)
+
+#define MM_CLI_HANDLER_DEPRECATED(command, _is_intf_cmd, _direct_chip_supported_cmd) \
+    _MM_CLI_HANDLER(command, _is_intf_cmd, _direct_chip_supported_cmd, true)

--- a/feeds/morse/utils/morsectrl/src/morsectrl.mk
+++ b/feeds/morse/utils/morsectrl/src/morsectrl.mk
@@ -1,0 +1,85 @@
+#
+# Copyright 2022-2023 Morse Micro
+#
+
+MORSECTRL_SRCS := $(SRCS)
+
+MORSECTRL_SRCS += fem.c
+MORSECTRL_SRCS += mcs.c
+MORSECTRL_SRCS += bw.c
+MORSECTRL_SRCS += rpg.c
+MORSECTRL_SRCS += ifs.c
+MORSECTRL_SRCS += qos.c
+MORSECTRL_SRCS += responseindication.c
+MORSECTRL_SRCS += transmissionrate.c
+MORSECTRL_SRCS += statype.c
+MORSECTRL_SRCS += encmode.c
+MORSECTRL_SRCS += txop.c
+MORSECTRL_SRCS += controlresponse.c
+MORSECTRL_SRCS += ndpprobes.c
+MORSECTRL_SRCS += turbo.c
+MORSECTRL_SRCS += force_assert.c
+MORSECTRL_SRCS += lnabypass.c
+MORSECTRL_SRCS += txscaler.c
+MORSECTRL_SRCS += transmit_cw.c
+MORSECTRL_SRCS += periodic_cal.c
+MORSECTRL_SRCS += dtim_channel.c
+MORSECTRL_SRCS += bcn_rssi_threshold.c
+MORSECTRL_SRCS += sig_field_error_evt.c
+MORSECTRL_SRCS += antenna.c
+MORSECTRL_SRCS += tdc_pg_disable.c
+MORSECTRL_SRCS += capabilities.c
+MORSECTRL_SRCS += transraw.c
+MORSECTRL_SRCS += hwkeydump.c
+MORSECTRL_SRCS += twt.c
+MORSECTRL_SRCS += tsf.c
+MORSECTRL_SRCS += mpsw.c
+MORSECTRL_SRCS += phy_deaf.c
+MORSECTRL_SRCS += override_pa_on_delay.c
+MORSECTRL_SRCS += fsg.c
+MORSECTRL_SRCS += chan_query.c
+MORSECTRL_SRCS += edconfig.c
+MORSECTRL_SRCS += ocs.c
+MORSECTRL_SRCS += tx_pwr_adj.c
+MORSECTRL_SRCS += agc_gaincode.c
+MORSECTRL_SRCS += gpio.c
+MORSECTRL_SRCS += physm_watchdog.c
+MORSECTRL_SRCS += mesh_config.c
+MORSECTRL_SRCS += mbca.c
+MORSECTRL_SRCS += dynamic_peering.c
+
+MORSECTRL_WIN_SRCS := $(WIN_SRCS)
+
+MORSECTRL_LINUX_SRCS := $(LINUX_SRCS)
+MORSECTRL_LINUX_SRCS += io.c
+MORSECTRL_LINUX_SRCS += serial.c
+MORSECTRL_LINUX_SRCS += jtag.c
+
+# As noted in transport.c, the default transport is the first transport linked. Therefore we
+# put LINUX_SRCS before SRCS so that nl80211 has higher priority.
+MORSECTRL_OBJS = $(patsubst %.c, %_ctrl.o, $(MORSECTRL_LINUX_SRCS) $(MORSECTRL_SRCS))
+MORSECTRL_OBJS_WIN = $(patsubst %.c, %_ctrl_win.o, $(MORSECTRL_SRCS) $(MORSECTRL_WIN_SRCS))
+
+all: morsectrl morse_cli
+
+%_ctrl.o: %.c $(DEPS)
+	@echo Compiling $<
+	$(Q) $(CC) $(MORSECTRL_CFLAGS) $(LINUX_CFLAGS) -c -o $@  $<
+
+morsectrl: $(MORSECTRL_OBJS)
+	@echo Linking $@
+	$(Q) $(CC) $(MORSECTRL_CFLAGS) $(LINUX_CFLAGS) -o $@ $^ \
+		$(MORSECTRL_LDFLAGS) $(LINUX_LDFLAGS)
+
+%_ctrl_win.o: %.c $(DEPS)
+	@echo Compiling $<
+	$(Q) $(WIN_CC) $(MORSECTRL_CFLAGS) $(WIN_CFLAGS) -c -o $@  $<
+
+morsectrl_win: $(MORSECTRL_OBJS_WIN)
+	@echo Linking $@
+	$(Q) $(WIN_CC) $(MORSECTRL_CFLAGS) $(WIN_CFLAGS) -o morsectrl $^ \
+		$(MORSECTRL_LDFLAGS) $(WIN_LDFLAGS)
+
+install:
+	@echo Installing morsectrl to /usr/bin
+	$(Q) cp morsectrl /usr/bin

--- a/feeds/morse/utils/morsectrl/src/mpsw.c
+++ b/feeds/morse/utils/morsectrl/src/mpsw.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+/** No upper bound value for airtime duration */
+#define AIRTIME_UNLIMITED 0
+
+#define NUM_BOUNDS_VALUES 2
+
+#define SET_MPSW_CFG_AIRTIME_BOUNDS  BIT(0)
+#define SET_MPSW_CFG_PKT_SPC_WIN_LEN BIT(1)
+#define SET_MPSW_CFG_ENABLED         BIT(2)
+
+struct PACKED mpsw_configuration
+{
+    /** The maximum allowable packet airtime duration */
+    uint32_t airtime_max_us;
+    /** The minimum packet airtime duration to trigger spacing */
+    uint32_t airtime_min_us;
+    /** The length of time to close the tx window between packets */
+    uint32_t packet_space_window_length_us;
+    /** Whether to enable airtime bounds checking and packet spacing enforcement */
+    uint8_t  enable;
+};
+
+struct PACKED command_mpsw_cfg_req
+{
+    struct mpsw_configuration config;
+    uint8_t set_cfgs;
+};
+
+struct PACKED command_mpsw_cfg_cfm
+{
+    struct mpsw_configuration config;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tmpsw <opts>\t");
+    mctrl_print("configure or query (with no args) the minimum packet spacing window parameters\n");
+    mctrl_print("\t\t-b <lower bound us> <upper bound us>\n");
+    mctrl_print("\t\t-w <packet spacing window length us>\n");
+    mctrl_print("\t\t-e <disable or enable mpsw 0|1>\n");
+}
+
+static void print_mpsw_cfg(struct mpsw_configuration *cfg)
+{
+    mctrl_print("                 MPSW Active: %d\n", cfg->enable);
+    mctrl_print("       Airtime Minimum Bound: %u\n", cfg->airtime_min_us);
+    mctrl_print("       Airtime Maximum Bound: %u\n", cfg->airtime_max_us);
+    mctrl_print("Packet Spacing Window Length: %u\n", cfg->packet_space_window_length_us);
+}
+
+/* Only call this function when parsing arguments in a getopt while loop context */
+static int parse_bounds_flag_args(char *argv[], int argc,
+                                  struct command_mpsw_cfg_req *cmd)
+{
+    int flag_idx = 0;
+    uint32_t tmp;
+
+    optind--;
+    for (; optind < argc && *argv[optind] != '-'; optind++)
+    {
+        if (flag_idx == NUM_BOUNDS_VALUES)
+        {
+            break;
+        }
+        if (!argv[optind] || *argv[optind] == '-')
+        {
+            mctrl_err("Not enough args for -b");
+            return -1;
+        }
+        if (flag_idx == 0)
+        {
+            if (str_to_uint32(argv[optind], &tmp))
+            {
+                return -1;
+            }
+            cmd->config.airtime_min_us = tmp;
+        }
+        if (flag_idx == 1)
+        {
+            if (str_to_uint32(argv[optind], &tmp))
+            {
+                return -1;
+            }
+            cmd->config.airtime_max_us = tmp;
+        }
+        flag_idx++;
+    }
+
+    if (((cmd->config.airtime_min_us > cmd->config.airtime_max_us) &&
+         (cmd->config.airtime_max_us != AIRTIME_UNLIMITED)) ||
+         (cmd->config.airtime_min_us == cmd->config.airtime_max_us))
+    {
+        mctrl_err("airtime_min (%d) must be < airtime max (%d), or airtime max must be 0\n",
+               cmd->config.airtime_min_us,
+               cmd->config.airtime_max_us);
+        return -1;
+    }
+
+    cmd->set_cfgs |= SET_MPSW_CFG_AIRTIME_BOUNDS;
+    cmd->config.airtime_min_us = htole32(cmd->config.airtime_min_us);
+    cmd->config.airtime_max_us = htole32(cmd->config.airtime_max_us);
+    return 0;
+}
+
+
+int mpsw(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    int enable;
+    uint32_t tmp;
+
+    struct command_mpsw_cfg_req *cmd_mpsw;
+    struct command_mpsw_cfg_cfm *rsp_mpsw;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_mpsw));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp_mpsw));
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_mpsw = TBUFF_TO_CMD(cmd_tbuff, struct command_mpsw_cfg_req);
+    rsp_mpsw = TBUFF_TO_RSP(rsp_tbuff, struct command_mpsw_cfg_cfm);
+
+    if (cmd_mpsw == NULL ||
+        rsp_mpsw == NULL)
+    {
+        goto exit;
+    }
+
+    memset(cmd_mpsw, 0, sizeof(*cmd_mpsw));
+
+    while ((option = getopt(argc, argv, "b:w:e:")) != -1)
+    {
+        switch (option)
+        {
+            case 'b':
+                ret = parse_bounds_flag_args(argv, argc, cmd_mpsw);
+                if (ret < 0)
+                {
+                    mctrl_err("Failed to parse values for -b\n");
+                    goto exit;
+                }
+                break;
+            case 'w':
+                if (str_to_uint32(optarg, &tmp))
+                {
+                    mctrl_err("Invalid value for -w\n");
+                    ret = -1;
+                    goto exit;
+                }
+                cmd_mpsw->set_cfgs |= SET_MPSW_CFG_PKT_SPC_WIN_LEN;
+                cmd_mpsw->config.packet_space_window_length_us = htole32(tmp);
+                break;
+            case 'e':
+                enable = expression_to_int(optarg);
+                if (enable == -1)
+                {
+                    mctrl_err("Invalid value (%d) for -e\n", enable);
+                    ret = -1;
+                    goto exit;
+                }
+                cmd_mpsw->set_cfgs |= SET_MPSW_CFG_ENABLED;
+                cmd_mpsw->config.enable = enable;
+                break;
+            default:
+                usage(mors);
+                ret = -1;
+                goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+                                 MORSE_COMMAND_MPSW_CONFIG,
+                                 cmd_tbuff,
+                                 rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Command error (%d)\n", ret);
+    }
+    else
+    {
+        print_mpsw_cfg(&rsp_mpsw->config);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(mpsw, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/ndpprobes.c
+++ b/feeds/morse/utils/morsectrl/src/ndpprobes.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_ndp_probe_support
+{
+    uint8_t enabled;
+    uint8_t requested_response_is_pv1;
+    int8_t tx_bw_mhz;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tndpprobe [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' must always be included when configuring a parameter\n");
+    mctrl_print("\t\t\t\t'disable' will stop sending normal probes as NDPs\n");
+    mctrl_print("\t\t-r <value>\tSet desired probe response replies: 0 for PV0, 1 for PV1\n");
+    mctrl_print("\t\t-b <value>\tTX bandwidth in MHz (1|2) or (-1) to use default from host\n");
+}
+
+int ndpprobe(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    struct set_ndp_probe_support *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int8_t tmp;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_ndp_probe_support);
+
+    cmd->enabled = 0;
+    cmd->tx_bw_mhz = -1;
+    cmd->requested_response_is_pv1 = 0;
+
+    switch (expression_to_int(argv[1]))
+    {
+        case true:
+            argc -= 1;
+            argv += 1;
+            cmd->enabled = 1;
+            while ((option = getopt(argc, argv, "r:b:")) != -1)
+            {
+                switch (option)
+                {
+                    case 'r' :
+                        if (str_to_int8_range(optarg, &tmp, 0, 1))
+                        {
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->requested_response_is_pv1 = tmp;
+                    break;
+
+                    case 'b' :
+                        if (str_to_int8(optarg, &tmp) &&
+                                (cmd->tx_bw_mhz != -1 &&
+                                cmd->tx_bw_mhz != 1 &&
+                                cmd->tx_bw_mhz != 2))
+                        {
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->tx_bw_mhz = tmp;
+                    break;
+
+                    case '?' :
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+
+                    default :
+                        mctrl_err("Invalid argument\n");
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+        break;
+
+        case false:
+            cmd->enabled = 0;
+        break;
+
+        default:
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_NDP_PROBE_SUPPORT,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set ndp probe support\n");
+    }
+    else
+    {
+        mctrl_print("\tNDP Probe support: %s\n", (cmd->enabled) ? "enabled" : "disabled");
+        mctrl_print("\t\tRequested Probe Response type: PV%d\n",
+            (cmd->requested_response_is_pv1) ? 1 : 0);
+        if (cmd->tx_bw_mhz == -1)
+            mctrl_print("\t\tTX BW of NDP Probes: default from host\n");
+        else
+            mctrl_print("\t\tTX BW of NDP Probes: %d MHz\n", cmd->tx_bw_mhz);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(ndpprobe, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/ocs.c
+++ b/feeds/morse/utils/morsectrl/src/ocs.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "channel.h"
+#include "transport/transport.h"
+#include "utilities.h"
+
+enum ocs_subcmd
+{
+    OCS_SUBCMD_CONFIG = 1,
+    OCS_SUBCMD_STATUS,
+};
+
+struct PACKED command_ocs_config_req
+{
+    uint32_t operating_channel_freq_hz;
+    uint8_t operating_channel_bw_mhz;
+    uint8_t primary_channel_bw_mhz;
+    uint8_t primary_1mhz_channel_index;
+};
+
+struct PACKED command_ocs_req
+{
+    uint32_t subcmd;
+    union
+    {
+        uint8_t opaque[0];
+        struct command_ocs_config_req config;
+    };
+};
+
+struct PACKED command_ocs_status_cfm
+{
+    uint8_t running;
+};
+
+struct PACKED command_ocs_cfm
+{
+    uint32_t subcmd;
+    union
+    {
+        uint8_t opaque[0];
+        struct command_ocs_status_cfm status;
+    };
+};
+
+static void usage()
+{
+    mctrl_print("\tocs [config [options] | status]\n");
+    mctrl_print("\t\tconfig: sets OCS config\n");
+    mctrl_print("\t\t\t-c <value>\tsets channel frequency (kHz)\n");
+    mctrl_print("\t\t\t-o <value>\toperating bandwidth (MHz)\n");
+    mctrl_print("\t\t\t-p <value>\tprimary bandwidth (MHz)\n");
+    mctrl_print("\t\t\t-n <value>\tprimary 1 MHz channel index\n");
+    mctrl_print("\t\tstatus: gets OCS status\n");
+}
+
+static int ocs_cmd_config(int argc, char *argv[], struct command_ocs_req *req)
+{
+    int option;
+    uint32_t val;
+
+    if (argc != 9)
+    {
+        return -EINVAL;
+    }
+
+    memset(req, 0, sizeof(*req));
+
+    req->subcmd = OCS_SUBCMD_CONFIG;
+
+    while ((option = getopt(argc, argv, "c:o:p:n:")) != -1)
+    {
+        switch (option)
+        {
+        case 'c':
+            if (str_to_uint32(optarg, &val) < 0)
+            {
+                return -EINVAL;
+            }
+            req->config.operating_channel_freq_hz = htole32(KHZ_TO_HZ(val));
+            break;
+        case 'o':
+            if (str_to_uint32(optarg, &val) < 0)
+            {
+                return -EINVAL;
+            }
+            req->config.operating_channel_bw_mhz = val;
+            break;
+        case 'p':
+            if (str_to_uint32(optarg, &val) < 0)
+            {
+                return -EINVAL;
+            }
+            req->config.primary_channel_bw_mhz = val;
+            break;
+        case 'n':
+            if (str_to_uint32(optarg, &val) < 0)
+            {
+                return -EINVAL;
+            }
+            req->config.primary_1mhz_channel_index = val;
+            break;
+        default:
+            return -EINVAL;
+        }
+    }
+
+    return 0;
+}
+
+static int ocs_cmd_status(int argc, char *argv[], struct command_ocs_req *req)
+{
+    if (argc != 1)
+    {
+        return -EINVAL;
+    }
+
+    req->subcmd = OCS_SUBCMD_STATUS;
+
+    return 0;
+}
+
+static void ocs_cfm_status(struct command_ocs_cfm *cfm)
+{
+    mctrl_print("%s: running %u\n", __func__, cfm->status.running);
+}
+
+int ocs(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = 0;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *resp_tbuff;
+    struct command_ocs_req *req;
+    struct command_ocs_cfm *cfm;
+    uint32_t subcmd;
+
+    if (argc < 2)
+    {
+        usage();
+        return -EINVAL;
+    }
+
+    --argc;
+    ++argv;
+
+    if (!strcmp(argv[0], "config"))
+    {
+        subcmd = htole32(OCS_SUBCMD_CONFIG);
+    }
+    else if (!strcmp(argv[0], "status"))
+    {
+        subcmd = htole32(OCS_SUBCMD_STATUS);
+    }
+    else
+    {
+        usage();
+        return -EINVAL;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*req));
+    resp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*cfm));
+    if (!cmd_tbuff || !resp_tbuff)
+    {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    req = TBUFF_TO_CMD(cmd_tbuff, struct command_ocs_req);
+    cfm = TBUFF_TO_RSP(resp_tbuff, struct command_ocs_cfm);
+
+    switch (subcmd)
+    {
+    case OCS_SUBCMD_CONFIG:
+        ret = ocs_cmd_config(argc, argv, req);
+        break;
+    case OCS_SUBCMD_STATUS:
+        ret = ocs_cmd_status(argc, argv, req);
+        break;
+    }
+
+    if (ret < 0)
+    {
+        usage();
+        goto out;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_OCS_REQ, cmd_tbuff, resp_tbuff);
+    if (ret < 0)
+    {
+        mctrl_err("%s: Error %d in sending %s\n", __func__, ret, STR(MORSE_COMMAND_OCS_REQ));
+        goto out;
+    }
+
+    switch (cfm->subcmd) {
+    case OCS_SUBCMD_CONFIG:
+        /* Nothing to do */
+        break;
+    case OCS_SUBCMD_STATUS:
+        ocs_cfm_status(cfm);
+        break;
+    default:
+        /* Should not be possible */
+        break;
+    }
+
+out:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(resp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(ocs, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/offchip_statistics.c
+++ b/feeds/morse/utils/morsectrl/src/offchip_statistics.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
+#include "offchip_statistics.h"
+#include "command.h"
+
+
+/*
+* Get the offchip data for this tag,
+* or NULL if none can be found.
+*/
+struct statistics_offchip_data *get_stats_offchip(const struct morsectrl *mors, stats_tlv_tag_t tag)
+{
+#ifdef ENABLE_TRANS_NL80211
+    struct statistics_offchip_data *res = NULL;
+    for (int i = 0; i < mors->n_stats; i++)
+    {
+        if (mors->stats[i].tag == tag)
+        {
+            res = mors->stats + i;
+            break;
+        }
+    }
+    return res;
+#else
+    return NULL;
+#endif
+}
+
+
+int64_t get_signed_value_as_int64(const uint8_t *buf, uint32_t size)
+{
+    int64_t n = 0;
+    switch (size)
+    {
+        case 1:
+        {
+            int8_t x;
+            memcpy(&x, buf, size);
+            n = (int64_t)x;
+            break;
+        }
+        case 2:
+        {
+            int16_t x;
+            memcpy(&x, buf, size);
+            n = (int64_t)x;
+            break;
+        }
+        case 4:
+        {
+            int32_t x;
+            memcpy(&x, buf, size);
+            n = (int64_t)x;
+            break;
+        }
+        case 8:
+            memcpy(&n, buf, size);
+            break;
+        default:
+            mctrl_err("get_signed_value_as_int64 can't convert %d-byte quantity\n", size);
+            break;
+    }
+    return n;
+}
+
+uint64_t get_unsigned_value_as_uint64(const uint8_t *buf, uint32_t size)
+{
+    uint64_t n = 0;
+    switch (size)
+    {
+        case 1:
+        {
+            uint8_t x;
+            memcpy(&x, buf, size);
+            n = (uint64_t)x;
+            break;
+        }
+        case 2:
+        {
+            uint16_t x;
+            memcpy(&x, buf, size);
+            n = (uint64_t)x;
+            break;
+        }
+        case 4:
+        {
+            uint32_t x;
+            memcpy(&x, buf, size);
+            n = (uint64_t)x;
+            break;
+        }
+        case 8:
+            memcpy(&n, buf, size);
+            break;
+        default:
+            mctrl_err("get_unsigned_value_as_uint64 can't convert %d-byte quantity\n", size);
+            break;
+    }
+    return n;
+}

--- a/feeds/morse/utils/morsectrl/src/offchip_statistics.h
+++ b/feeds/morse/utils/morsectrl/src/offchip_statistics.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Morse Micro
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "morsectrl.h"
+
+
+typedef uint16_t stats_tlv_tag_t;
+typedef uint16_t stats_tlv_len_t;
+#define STATS_TLV_OVERHEAD (sizeof(stats_tlv_tag_t) + sizeof(stats_tlv_len_t))
+
+/* New format specifiers get added here.
+ * Must be kept in sync with the firmware.
+ */
+enum morse_statistics_format {
+    MORSE_STATS_FMT_DEC = 0,
+    MORSE_STATS_FMT_U_DEC = 1,
+    MORSE_STATS_FMT_HEX = 2,
+    MORSE_STATS_FMT_0_HEX = 3,
+    MORSE_STATS_FMT_AMPDU_AGGREGATES = 4,
+    MORSE_STATS_FMT_AMPDU_BITMAP = 5,
+    MORSE_STATS_FMT_TXOP = 6,
+    MORSE_STATS_FMT_PAGESET = 7,
+    MORSE_STATS_FMT_RETRIES = 8,
+    MORSE_STATS_FMT_RAW = 9,            /* Restricted Access Window */
+    MORSE_STATS_FMT_CALIBRATION = 10,
+    MORSE_STATS_FMT_DUTY_CYCLE = 11,
+    MORSE_STATS_FMT_MAC_STATE = 12,
+
+    MORSE_STATS_FMT_LAST, /* Used as default print, make sure this is last */
+    MORSE_STATS_FMT_END = 0xFFFFFFFF,
+};
+#define STATS_OFFCHIP_STRING_TYPE_MAX 50
+#define STATS_OFFCHIP_STRING_NAME_MAX 50
+#define STATS_OFFCHIP_STRING_KEY_MAX 100
+
+struct __attribute__((packed)) statistics_offchip_data {
+    const char type_str[STATS_OFFCHIP_STRING_TYPE_MAX];
+    const char name[STATS_OFFCHIP_STRING_NAME_MAX];
+    const char key[STATS_OFFCHIP_STRING_KEY_MAX];
+    enum morse_statistics_format format;
+    stats_tlv_tag_t tag;
+};
+
+#define OLD_STATS_COMMAND_MASK 0xDF
+
+struct statistics_offchip_data *get_stats_offchip(const struct morsectrl *mors,
+                                                    stats_tlv_tag_t tag);
+int64_t get_signed_value_as_int64(const uint8_t *buf, uint32_t size);
+uint64_t get_unsigned_value_as_uint64(const uint8_t *buf, uint32_t size);

--- a/feeds/morse/utils/morsectrl/src/opclass.c
+++ b/feeds/morse/utils/morsectrl/src/opclass.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+#define GLOBAL_OP_CLASS_MIN 64
+#define GLOBAL_OP_CLASS_MAX 77
+
+struct PACKED set_opclass_command
+{
+    uint8_t opclass;
+    uint8_t prim_opclass;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\topclass [s1g_operating_class] -l <s1g_prim_chan_global_op_class>\n");
+    mctrl_print("\t\t\t\tSet s1g_operating_class for S1G Operation element in\n");
+    mctrl_print("\t\t\t\tbeacon and global operating class of primary channel\n");
+    mctrl_print("\t\t\t\tfor country ie in probe response\n");
+    mctrl_print("\t\t-l <value>\tGlobal Operating class for primary channel\n");
+}
+
+int opclass(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    uint8_t tmp;
+    struct set_opclass_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2 || argc > 5)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_opclass_command);
+
+    if (str_to_uint8(argv[1], &tmp))
+    {
+        mctrl_err("Invalid op class\n");
+        ret = -1;
+        goto exit;
+    }
+    cmd->opclass = tmp;
+
+    while ((option = getopt(argc-1, argv+1, "l:")) != -1)
+    {
+        switch (option) {
+        case 'l' :
+        {
+            if (str_to_uint8_range(optarg, &tmp,
+                    GLOBAL_OP_CLASS_MIN, GLOBAL_OP_CLASS_MAX) < 0)
+            {
+                mctrl_err("Global operating class %u must be within range min %u : max %u\n",
+                                    tmp, GLOBAL_OP_CLASS_MIN, GLOBAL_OP_CLASS_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->prim_opclass = tmp;
+            break;
+        }
+        case '?' :
+            usage(mors);
+            goto exit;
+        default :
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_S1G_OP_CLASS,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set opclass\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(opclass, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/otp.c
+++ b/feeds/morse/utils/morsectrl/src/otp.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_otp_req
+{
+    /** Bool, 1=enabled, 0=disabled */
+    uint8_t write_otp;
+    uint8_t bank_num;
+    uint32_t bank_val;
+};
+
+struct PACKED command_otp_cfm
+{
+    uint32_t bank_val;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\totp <bank_num> [-w <bank_val>]\n"
+           "\t\t\t\tread/write OTP bank given from chip\n");
+    mctrl_print("\t\tbank_num\tbank number to read/write from/to. eg.: for 610x [0-7]\n");
+#if !defined(MORSE_CLIENT)
+    mctrl_print("\t\t-w <bank_val>\tburns the value to the OTP bank\n");
+#endif
+}
+
+int otp(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t bank_num;
+    int option;
+    uint32_t bank_val;
+
+    struct command_otp_req *cmd;
+    struct command_otp_cfm *resp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+            usage(mors);
+            return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_otp_req);
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct command_otp_cfm);
+    cmd->write_otp = 0;
+
+    switch (argc)
+    {
+        case 2:
+        case 4:
+            if (str_to_uint32(argv[1], &bank_num))
+            {
+                mctrl_err("Invalid OTP bank number\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->bank_num = bank_num;
+            while ((option = getopt(argc-1, argv+1, "w:")) != -1)
+            {
+                switch (option)
+                {
+                    case 'w' :
+                        cmd->write_otp = 1;
+                        if (str_to_uint32(optarg, &bank_val))
+                        {
+                            mctrl_err("Invalid OTP bank value\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->bank_val = htole32(bank_val);
+                        break;
+                    default :
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+            break;
+        default:
+            mctrl_err("Invalid arguments\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_OTP,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+        mctrl_err("Command OTP Failed(%d)\n", ret);
+    else if (!cmd->write_otp)
+        mctrl_print("OTP Bank(%d): 0x%x\n", bank_num, resp->bank_val);
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(otp, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/override_pa_on_delay.c
+++ b/feeds/morse/utils/morsectrl/src/override_pa_on_delay.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED override_pa_on_delay_command
+{
+    /** The flags of this message. Bool, 1=enabled, 0=disabled */
+    uint8_t enable;
+    uint32_t delay_us;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\toverride_pa_on_delay [enable|disable] <delay us>\n");
+    mctrl_print("\t\t\t\tenable overriding pa turn on delay with given value\n");
+    mctrl_print("\t\t\t\tor disable overriding\n");
+}
+
+int override_pa_on_delay(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    bool enable = 0;
+    uint32_t delay_us = 0;
+    struct override_pa_on_delay_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+    switch (expression_to_int(argv[1]))
+    {
+        case true:
+            if (argc == 3)
+            {
+                enable = 1;
+
+                if (check_string_is_int(argv[2]))
+                {
+                    if (str_to_uint32(argv[2], &delay_us))
+                    {
+                        mctrl_err("Invalid delay\n");
+                        return -1;
+                    }
+                }
+            }
+            else
+            {
+                usage(mors);
+                return -1;
+            }
+            break;
+
+        case false:
+            enable = 0;
+            delay_us = 0;
+            break;
+
+        default:
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct override_pa_on_delay_command);
+    cmd->enable = htole32(enable);
+    cmd->delay_us = htole32(delay_us);
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_OVERRIDE_PA_ON_DELAY,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to execute command\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(override_pa_on_delay, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/params.c
+++ b/feeds/morse/utils/morsectrl/src/params.c
@@ -1,0 +1,521 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+enum morse_param_action
+{
+    MORSE_PARAM_ACTION_SET = 0,
+    MORSE_PARAM_ACTION_GET = 1,
+
+    MORSE_PARAM_ACTION_LAST,
+    MORSE_PARAM_ACTION_MAX = UINT32_MAX,
+};
+
+enum morse_param_id
+{
+    MORSE_PARAM_ID_MAX_TRAFFIC_DELIVERY_WAIT_US     = 0,
+    MORSE_PARAM_ID_EXTRA_ACK_TIMEOUT_ADJUST_US      = 1,
+    MORSE_PARAM_ID_TX_STATUS_FLUSH_WATERMARK        = 2,
+    MORSE_PARAM_ID_TX_STATUS_FLUSH_MIN_AMPDU_SIZE   = 3,
+    MORSE_PARAM_ID_POWERSAVE_TYPE                   = 4,
+    MORSE_PARAM_ID_SNOOZE_ADJUST                    = 5,
+    MORSE_PARAM_ID_TX_BLOCK                         = 6,
+    MORSE_PARAM_ID_FORCED_SNOOZE_PERIOD_US          = 7,
+    MORSE_PARAM_ID_WAKE_ACTION_GPIO                 = 8,
+    MORSE_PARAM_ID_WAKE_ACTION_GPIO_PULSE_MS        = 9,
+    MORSE_PARAM_ID_CONNECTION_MONITOR_GPIO          = 10,
+    MORSE_PARAM_ID_INPUT_TRIGGER_GPIO               = 11,
+    MORSE_PARAM_ID_INPUT_TRIGGER_MODE               = 12,
+
+    MORSE_PARAM_ID_LAST,
+    MORSE_PARAM_ID_MAX = UINT32_MAX,
+};
+
+struct PACKED command_param_req
+{
+    /** The parameter to perform the action on [enum morse_param_id] */
+    uint32_t param_id;
+    /** The action to take on the the parameter [get | set] */
+    uint32_t action;
+    /** Any flags to modify the behaviour of the action (for forwards/backwards compatibility) */
+    uint32_t flags;
+    /** The value to set (only applicable for set actions) */
+    uint32_t value;
+};
+
+struct PACKED command_param_cfm
+{
+    /** Any flags to signal change of interpretation of response
+     *  (forwards/backwards compatibility) */
+    uint32_t flags;
+    /** The value returned (only applicable for get actions) */
+    uint32_t value;
+};
+
+struct param_entry;
+
+/**
+ * @brief Callback to process user input for setting a parameter entry.
+ *
+ * @param entry The parameter entry to set.
+ * @param value The value provided by the user on the CLI.
+ * @param req On success of parsing, the value field of the req struct will be filled.
+ *
+ * @return 0 on success, else specific error code.
+ */
+typedef int (*param_process_t)(const struct param_entry* entry,
+    char* value, struct command_param_req* req);
+
+/**
+ * @brief Callback that formats the response of a get operation, printing to stdout.
+ *
+ * @param entry The parameter entry to format.
+ * @param resp Pointer to the response to format.
+ *
+ * @return 0 on success, else specific error code.
+ */
+typedef int (*param_format_t)(const struct param_entry* entry, struct command_param_cfm* resp);
+
+struct param_entry {
+    /** ID of the parameter */
+    enum morse_param_id id;
+    /** Name of the parameter (used to match on user CLI input) */
+    const char *name;
+    /** The help message to display for the parameter */
+    const char *help;
+    /** Minimum allowed value of the parameter (can be of a different int type,
+     * but cast to uint32) */
+    uint32_t min_val;
+    /** Maximum allowed value of the parameter (can be of a different int type,
+     * but cast to uint32) */
+    uint32_t max_val;
+    /** Function that processes user input for the set command */
+    param_process_t set_fn;
+    /** Function that formats response of the get command to stdout */
+    param_format_t get_fn;
+};
+
+static int param_set_uint32(const struct param_entry* entry, char* value,
+    struct command_param_req* req)
+{
+    int ret;
+    uint32_t val;
+
+    ret = str_to_uint32_range(value, &val, entry->min_val, entry->max_val);
+    if (ret)
+    {
+        mctrl_err("Failed to parse value for '%s' [min:%u, max:%u]\n",
+            entry->name, entry->min_val, entry->max_val);
+        return ret;
+    }
+
+    req->value = val;
+    return 0;
+}
+
+static int param_get_uint32(const struct param_entry* entry, struct command_param_cfm* resp)
+{
+    mctrl_print("%u\n", resp->value);
+    return 0;
+}
+
+static int param_set_int32(const struct param_entry* entry, char* value,
+    struct command_param_req* req)
+{
+    int ret;
+    int32_t val;
+
+    ret = str_to_int32_range(value, &val, (int32_t)(entry->min_val), (int32_t)(entry->max_val));
+    if (ret)
+    {
+        mctrl_err("Failed to parse value for '%s' [min:%d, max:%d]\n",
+            entry->name, entry->min_val, entry->max_val);
+        return ret;
+    }
+
+    req->value = (uint32_t)val;
+    return 0;
+}
+
+static int param_get_int32(const struct param_entry* entry, struct command_param_cfm* resp)
+{
+    mctrl_print("%d\n", (int32_t)(resp->value));
+    return 0;
+}
+
+/* Help strings for parameters should not have line control characters (e.g. '\n') embedded
+ * within.
+ */
+struct param_entry params[] = {
+    {
+        .id = MORSE_PARAM_ID_MAX_TRAFFIC_DELIVERY_WAIT_US,
+        .name = "traffic_delivery_wait",
+        .help = "Time to wait for traffic delivery from the AP after the TIM "
+                "is set in a busy BSS (us).",
+        .min_val = 0,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_EXTRA_ACK_TIMEOUT_ADJUST_US,
+        .name = "ack_timeout_adjust",
+        .help = "Extra time to wait for 802.11 control response frames to be "
+                "delivered (us).",
+        .min_val = 0,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_WAKE_ACTION_GPIO,
+        .name = "wake_action_gpio",
+        .help = "Specify GPIO to pulse on reception of a Morse Micro "
+                "wake action frame (-1 to disable).",
+        .min_val = (uint32_t) -1,
+        .max_val = INT32_MAX,
+        .set_fn = param_set_int32,
+        .get_fn = param_get_int32,
+    },
+    {
+        .id = MORSE_PARAM_ID_WAKE_ACTION_GPIO_PULSE_MS,
+        .name = "wake_action_gpio_pulse",
+        .help = "Time to hold wake action GPIO high after reception of "
+                "a morse micro wake action frame (ms).",
+        .min_val = 50,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_CONNECTION_MONITOR_GPIO,
+        .name = "connection_monitor_gpio",
+        .help = "Specify GPIO that monitors and reflects device's "
+                "802.11 connection status (-1 to disable).",
+        .min_val = (uint32_t) -1,
+        .max_val = INT32_MAX,
+        .set_fn = param_set_int32,
+        .get_fn = param_get_int32,
+    },
+    {
+        .id = MORSE_PARAM_ID_INPUT_TRIGGER_GPIO,
+        .name = "input_trigger_gpio",
+        .help = "Specify GPIO that listens for an input signal to "
+                "wake an external host (-1 to disable).",
+        .min_val = (uint32_t) -1,
+        .max_val = INT32_MAX,
+        .set_fn = param_set_int32,
+        .get_fn = param_get_int32,
+    },
+    {
+        .id = MORSE_PARAM_ID_INPUT_TRIGGER_MODE,
+        .name = "input_trigger_mode",
+        .help = "Specify the active mode (high or low) for the trigger GPIO",
+        .min_val = (uint32_t) -1,
+        .max_val = INT32_MAX,
+        .set_fn = param_set_int32,
+        .get_fn = param_get_int32,
+    },
+#if !defined (MORSE_CLIENT)
+    {
+        .id = MORSE_PARAM_ID_TX_STATUS_FLUSH_WATERMARK,
+        .name = "tx_status_flush_watermark",
+        .help = "Number of pending tx statuses in the chip that will trigger a "
+                "flush event back to the host.",
+        .min_val = 1,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_TX_STATUS_FLUSH_MIN_AMPDU_SIZE,
+        .name = "tx_status_flush_min_ampdu_size",
+        .help = "Minimum number of mpdus in an AMPDU that will trigger an "
+                "immediate flush of all pending tx statuses back to the host "
+                "on tx completion.",
+        .min_val = 0,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_POWERSAVE_TYPE,
+        .name = "powersave_type",
+        .help = "The type of powersave normal snooze: 0, "
+                "superb snooze (testmode only): 1, "
+                "super snooze: 2.",
+        .min_val = 0,
+        .max_val = 2,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_SNOOZE_ADJUST,
+        .name = "snooze_adjust",
+        .help = "Adjust the time to snooze for during power save (in usec) "
+                "(+ve => longer snooze, -ve => shorter snooze)",
+        .min_val = (uint32_t)(INT32_MIN),
+        .max_val = (uint32_t)(INT32_MAX),
+        .set_fn = param_set_int32,
+        .get_fn = param_get_int32,
+    },
+    {
+        .id = MORSE_PARAM_ID_TX_BLOCK,
+        .name = "tx_block",
+        .help = "Block the chip from transmitting",
+        .min_val = 0,
+        .max_val = 1,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+    {
+        .id = MORSE_PARAM_ID_FORCED_SNOOZE_PERIOD_US,
+        .name = "forced_snooze_period_us",
+        .help = "Set a sleep period (uS) to force the chip to snooze even when not associated. "
+                "To disable forced snooze test, set to 0.",
+        .min_val = 0,
+        .max_val = UINT32_MAX,
+        .set_fn = param_set_uint32,
+        .get_fn = param_get_uint32,
+    },
+#endif
+};
+
+static int get_line(const char **start, const char *end)
+{
+    const int max_len = 60; /* Max line length after leading tabs */
+    int len = 0;
+    int last_space = max_len + 1;
+    const char *p;
+    char *eol = MIN((char *)end, (char *)(*start) + max_len);
+
+    /* Find first char to print on this line */
+    while ((*start < eol) && ((**start == ' ') || (**start == '\n')))
+    {
+        (*start)++;
+    }
+    p = *start;
+
+    /* Search up to the max characters that can be printed for a line
+     * termination or end-of-text.
+     * Keep track of the last space found, so the text is not split in the
+     * middle of a word.
+     */
+    while (p <= eol)
+    {
+        if (*p == '\0' || *p == '\n')
+        {
+            return len;
+        }
+        if (*p == ' ')
+        {
+            last_space = len;
+        }
+        len++;
+        p++;
+    }
+
+    return MIN(last_space, len);
+}
+
+static void print_param_help(const struct param_entry* param)
+{
+    const char *prefix = "\t\t\t";
+    const char *start = param->help;
+    const char *end = start + strlen(param->help);
+    int len = 0;
+
+    len = get_line(&start, end);
+    while (start < end)
+    {
+        mctrl_print("%s%.*s\n", prefix, len, start);
+        start += len;
+        len = get_line(&start, end);
+    }
+}
+
+static void set_help(struct morsectrl *mors)
+{
+    mctrl_print("\tset <param> <value>\n");
+
+    for (unsigned int entry = 0; entry < MORSE_ARRAY_SIZE(params); entry++)
+    {
+        const struct param_entry* param = &params[entry];
+
+        if (param->set_fn == NULL)
+        {
+            continue;
+        }
+
+        mctrl_print("\t\t%s\n", param->name);
+        print_param_help(param);
+    }
+}
+
+static void get_help(struct morsectrl *mors)
+{
+    mctrl_print("\tget <param>\n");
+
+    for (unsigned int entry = 0; entry < MORSE_ARRAY_SIZE(params); entry++)
+    {
+        const struct param_entry* param = &params[entry];
+
+        if (param->get_fn == NULL)
+        {
+            continue;
+        }
+
+        mctrl_print("\t\t%s\n", param->name);
+        print_param_help(param);
+    }
+}
+
+static const struct param_entry* match_str_to_param(char *str, enum morse_param_action action)
+{
+    for (unsigned int entry = 0; entry < MORSE_ARRAY_SIZE(params); entry++)
+    {
+        const struct param_entry* param = &params[entry];
+
+        if (strncmp(str, param->name, strlen(str)) == 0)
+        {
+            if ((action == MORSE_PARAM_ACTION_SET) && (param->set_fn == NULL))
+            {
+                break;
+            }
+
+            if ((action == MORSE_PARAM_ACTION_GET) && (param->get_fn == NULL))
+            {
+                break;
+            }
+
+            return param;
+        }
+    }
+
+    return NULL;
+}
+
+static void param_help(struct morsectrl *mors, enum morse_param_action action)
+{
+    if (action == MORSE_PARAM_ACTION_SET)
+    {
+        set_help(mors);
+    }
+    else if (action == MORSE_PARAM_ACTION_GET)
+    {
+        get_help(mors);
+    }
+}
+
+static int param_get_set(struct morsectrl *mors,
+    enum morse_param_action action, int argc, char *argv[])
+{
+    int ret = MORSE_ARG_ERR;
+    const struct param_entry *param;
+    struct command_param_req *cmd;
+    struct command_param_cfm *rsp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    param = match_str_to_param(argv[1], action);
+    if (param == NULL)
+    {
+        mctrl_err("Invalid parameter: '%s'\n", argv[1]);
+        param_help(mors, action);
+        return ret;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_param_req);
+    rsp = TBUFF_TO_RSP(rsp_tbuff, struct command_param_cfm);
+
+    cmd->param_id = param->id;
+    cmd->action = action;
+    cmd->flags = 0;
+
+    if (action == MORSE_PARAM_ACTION_SET)
+    {
+        ret = param->set_fn(param, argv[2], cmd);
+        if (ret < 0)
+        {
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+        MORSE_COMMAND_GET_SET_GENERIC_PARAM, cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret == 0)
+    {
+        if (action == MORSE_PARAM_ACTION_GET)
+        {
+            param->get_fn(param, rsp);
+        }
+    }
+    else
+    {
+        mctrl_err("Failed to %s parameter: '%s'\n",
+            (action == MORSE_PARAM_ACTION_SET) ? "set" : "get",
+            param->name);
+        ret = MORSE_CMD_ERR;
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+int get(struct morsectrl *mors, int argc, char *argv[])
+{
+    if (argc == 0)
+    {
+        get_help(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        get_help(mors);
+        return MORSE_ARG_ERR;
+    }
+
+    return param_get_set(mors, MORSE_PARAM_ACTION_GET, argc, argv);
+}
+
+int set(struct morsectrl *mors, int argc, char *argv[])
+{
+    if (argc == 0)
+    {
+        set_help(mors);
+        return 0;
+    }
+
+    if (argc < 3)
+    {
+        mctrl_err("Invalid command parameters\n");
+        set_help(mors);
+        return MORSE_ARG_ERR;
+    }
+
+    return param_get_set(mors, MORSE_PARAM_ACTION_SET, argc, argv);
+}
+
+MM_CLI_HANDLER(get, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);
+MM_CLI_HANDLER(set, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/periodic_cal.c
+++ b/feeds/morse/utils/morsectrl/src/periodic_cal.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+/** Calibration types available in the system, values can be or'ed together to create a mask */
+typedef enum
+{
+    /** Temperature calibration */
+    CALIBRATION_TEMPERATURE = (1 << 0),
+    /** VBAT calibration */
+    CALIBRATION_VBAT = (1 << 1),
+    /** AON clock calibration */
+    CALIBRATION_AON_CLK = (1 << 2),
+    /** DC calibration */
+    CALIBRATION_DC = (1 << 3),
+    /** I/Q calibration */
+    CALIBRATION_IQ = (1 << 4),
+
+    /** Special calibration type for testing purposes */
+    CALIBRATION_SPOOF_TEST = (1 << 30),
+
+    /** Last / MAX */
+    CALIBRATION_LAST = (CALIBRATION_TEMPERATURE | CALIBRATION_VBAT |
+                        CALIBRATION_AON_CLK | CALIBRATION_DC |
+                        CALIBRATION_IQ | CALIBRATION_SPOOF_TEST),
+    CALIBRATION_MAX = UINT32_MAX
+} calibration_type_t;
+
+struct PACKED set_periodic_cal_cmd
+{
+    calibration_type_t periodic_cal_enabled;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tperiodic_cal <enable_mask>\n");
+    mctrl_print("\t\trespective bit position is 1 will enable the respective cal on-chip\n");
+    mctrl_print("\t\trespective bit position is 0 will disable the respective cal on-chip\n");
+    mctrl_print(
+        "\t\tone-shot enable/disable for all cals,careful not to overwrite current config\n");
+    mctrl_print("\t\t0x10 - IQ\n");
+    mctrl_print("\t\t0x08 - DC\n");
+    mctrl_print("\t\t0x04 - AON_CLK\n");
+    mctrl_print("\t\t0x02 - VBAT\n");
+    mctrl_print("\t\t0x01 - TEMP\n");
+}
+
+int periodic_cal(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enable_mask;
+    char *ptr;
+    struct set_periodic_cal_cmd *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    enable_mask = strtol(argv[1] + 2, &ptr, 16);
+
+    if (enable_mask == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_periodic_cal_cmd);
+    cmd->periodic_cal_enabled = enable_mask;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_PERIODIC_CAL,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set periodic cal\n");
+    }
+    else
+    {
+        mctrl_print("\tCalibration type: 0x%x\n", cmd->periodic_cal_enabled);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(periodic_cal, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/phy_deaf.c
+++ b/feeds/morse/utils/morsectrl/src/phy_deaf.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <stdio.h>
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_phy_deaf
+{
+    /* 0 sets PHY into normal operation, 1 sets PHY into deaf/blocked mode */
+    uint8_t enable;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tphy_deaf <command>\n");
+    mctrl_print("\t\t 1: \tput phy in a deaf mode, it will not be able to receive\n");
+    mctrl_print("\t\t 2: \tput phy in a blocked mode, it will not be able to transmit\n");
+    mctrl_print("\t\t 3: \tput phy in a deaf and blocked mode, "
+                "it will not be able to receive or transmit\n");
+    mctrl_print("\t\t 0: \treturn to normal operation\n");
+}
+
+int phy_deaf(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret  = -1;
+    int8_t phy_deaf;
+    struct command_phy_deaf *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    int error = str_to_int8_range(argv[1], &phy_deaf, 0, 3);
+    if (error)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_phy_deaf);
+    cmd->enable = phy_deaf;
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_PHY_DEAF,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set phy_deaf mode\n");
+    }
+
+    if (cmd_tbuff)
+        morsectrl_transport_buff_free(cmd_tbuff);
+    if (rsp_tbuff)
+        morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(phy_deaf, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/physm_watchdog.c
+++ b/feeds/morse/utils/morsectrl/src/physm_watchdog.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "command.h"
+
+struct PACKED command_set_physm_watchdog
+{
+    /* physm watchdog */
+    uint8_t physm_watchdog_en;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tphysm_watchdog_en [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' will enable PHYSM watchdog with a timeout of 60ms\n");
+    mctrl_print("\t\t\t\t'disable' will disable PHYPRM watchdog.\n");
+}
+
+int physm_watchdog_en(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret  = -1;
+    uint8_t physm_watchdog_en;
+    struct command_set_physm_watchdog *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    physm_watchdog_en = expression_to_int(argv[1]);
+    if ((physm_watchdog_en != 0) && (physm_watchdog_en != 1))
+    {
+        mctrl_err("Valid values are 0 and 1\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_physm_watchdog);
+    cmd->physm_watchdog_en = physm_watchdog_en;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_PHYSM_WATCHDOG,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set physm watchdog\n");
+    }
+    else
+    {
+        mctrl_print("\tPHYSM watchdog: %s\n",
+            (cmd->physm_watchdog_en) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(physm_watchdog_en, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/portable_endian.h
+++ b/feeds/morse/utils/morsectrl/src/portable_endian.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+typedef uint16_t be16_t;
+typedef uint32_t be32_t;
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#include <endian.h>
+
+#elif defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#include <endian.h>
+
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#include <sys/endian.h>
+
+#define be16toh(x) betoh16(x)
+#define le16toh(x) letoh16(x)
+
+#define be32toh(x) betoh32(x)
+#define le32toh(x) letoh32(x)
+
+#define be64toh(x) betoh64(x)
+#define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#include <winsock2.h>
+#ifdef __GNUC__
+#include <sys/param.h>
+#endif
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+
+#elif BYTE_ORDER == BIG_ENDIAN
+
+/* that would be xbox 360 */
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+
+#else
+
+#error byte order not supported
+
+#endif
+
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__QNXNTO__)
+
+#include <gulliver.h>
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN    4321
+#define __PDP_ENDIAN    3412
+
+#if defined(__BIGENDIAN__)
+
+#define __BYTE_ORDER __BIG_ENDIAN
+
+#define htobe16(x) (x)
+#define htobe32(x) (x)
+#define htobe64(x) (x)
+
+#define htole16(x) ENDIAN_SWAP16(x)
+#define htole32(x) ENDIAN_SWAP32(x)
+#define htole64(x) ENDIAN_SWAP64(x)
+
+#elif defined(__LITTLEENDIAN__)
+
+#define __BYTE_ORDER __LITTLE_ENDIAN
+
+#define htole16(x) (x)
+#define htole32(x) (x)
+#define htole64(x) (x)
+
+#define htobe16(x) ENDIAN_SWAP16(x)
+#define htobe32(x) ENDIAN_SWAP32(x)
+#define htobe64(x) ENDIAN_SWAP64(x)
+
+#else
+
+#error byte order not supported
+
+#endif
+
+#define be16toh(x) ENDIAN_BE16(x)
+#define be32toh(x) ENDIAN_BE32(x)
+#define be64toh(x) ENDIAN_BE64(x)
+#define le16toh(x) ENDIAN_LE16(x)
+#define le32toh(x) ENDIAN_LE32(x)
+#define le64toh(x) ENDIAN_LE64(x)
+
+#else
+
+#error platform not supported
+
+#endif

--- a/feeds/morse/utils/morsectrl/src/qos.c
+++ b/feeds/morse/utils/morsectrl/src/qos.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED command_qos_params_req
+{
+    /** index of the QoS queue whose values will be changed */
+    uint8_t queue_idx;
+
+    /** How many slots to wait for AIFS */
+    uint8_t aifs_slot_count;
+
+    /** Contention window min/max values */
+    uint16_t contention_window_min;
+    uint16_t contention_window_max;
+
+    /** Maximum possible TX OP in us */
+    uint32_t max_txop_us;
+};
+
+struct PACKED command_qos_params_cfm
+{
+    /** How many slots to wait for AIFS */
+    uint8_t aifs_slot_count;
+
+    /** Contention window min/max values */
+    uint16_t contention_window_min;
+    uint16_t contention_window_max;
+
+    /** Maximum possible TX OP in us */
+    uint32_t max_txop_us;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tqos [options] <queue_ID>\n");
+    mctrl_print("\t\t\t\tsets/reads QOS parameters for given queue ID\n");
+    mctrl_print("\t\t-c  <value>\tnumber of AIFS slots to wait for\n");
+    mctrl_print("\t\t-t  <value>\tmaximum possible TX OP in us\n");
+    mctrl_print("\t\t-m  <min> <max>\tcontention window MIN,MAX values\n");
+}
+
+int qos(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    struct command_qos_params_req *cmd;
+    struct command_qos_params_cfm *resp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint8_t set = 0;
+    uint8_t aifs_slot_count;
+    uint16_t tmp;
+    uint32_t max_txop_us;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2)
+    {
+        mctrl_err("Too few arguments\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_qos_params_req);
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct command_qos_params_cfm);
+
+    cmd->queue_idx = -1;
+    cmd->aifs_slot_count = -1;
+    cmd->contention_window_min = -1;
+    cmd->contention_window_max = -1;
+    cmd->max_txop_us = -1;
+
+    while ((option = getopt(argc, argv, "c:t:m:")) != -1)
+    {
+        switch (option)
+        {
+            case 'c' :
+                if (str_to_uint8(optarg, &aifs_slot_count))
+                {
+                    mctrl_err("Invalid aif slot count\n");
+                    ret = -1;
+                    goto exit;
+                }
+                cmd->aifs_slot_count = aifs_slot_count;
+                set = 1;
+                break;
+            case 't' :
+                if (str_to_uint32(optarg, &max_txop_us))
+                {
+                    mctrl_err("Invalid max txop (us)\n");
+                    ret = -1;
+                    goto exit;
+                }
+                cmd->max_txop_us = htole32(max_txop_us);
+                set = 1;
+                break;
+            case 'm' :
+                if (str_to_uint16(optarg, &tmp))
+                {
+                    mctrl_err("Invalid minimum value\n");
+                    ret = -1;
+                    goto exit;
+                }
+                cmd->contention_window_min = tmp;
+
+                if (argv[optind])
+                {
+                    if (str_to_uint16(argv[optind], &tmp))
+                    {
+                        mctrl_err("Invalid maximum value\n");
+                        ret = -1;
+                        goto exit;
+                    }
+                    cmd->contention_window_max = tmp;
+                }
+
+                if (((cmd->contention_window_max == 0) && (argv[optind][0] != '0'))
+                                                || (cmd->contention_window_max == (uint16_t)(-1)))
+                {
+                    mctrl_err("Invalid maximum value\n");
+                    usage(mors);
+                    ret = -1;
+                    goto exit;
+                }
+                optind++;
+                if (cmd->contention_window_min > cmd->contention_window_max)
+                {
+                    mctrl_err("Min should never exceed Max\n");
+                    ret = -1;
+                    goto exit;
+                }
+                set = 1;
+                break;
+            case '?' :
+                usage(mors);
+                ret = -1;
+                goto exit;
+            default :
+                mctrl_err("Invalid argument\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+        }
+    }
+    if (optind + 1 != argc)
+    {
+        mctrl_err("Invalid arguments\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    if (argv[optind])
+    {
+        if (str_to_uint16(argv[optind], &tmp))
+        {
+            mctrl_err("Invalid queue ID\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+
+        cmd->queue_idx = tmp;
+    }
+
+    if (((cmd->queue_idx == 0) && (argv[optind][0] != '0')) || (cmd->queue_idx == (uint8_t)(-1)))
+    {
+        mctrl_err("Invalid queue ID\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    if (set)
+    {
+        cmd->contention_window_max = htole16(cmd->contention_window_max);
+        cmd->contention_window_min = htole16(cmd->contention_window_min);
+
+        ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_QOS_PARAMS,
+                                     cmd_tbuff, rsp_tbuff);
+
+        if (ret < 0)
+        {
+            mctrl_err("Command set qos error (%d)\n", ret);
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_QOS_PARAMS,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (!ret)
+    {
+        mctrl_print("QoS (min): %d\t(max): %d\n",
+               (uint16_t)resp->contention_window_min, (uint16_t)resp->contention_window_max);
+        mctrl_print("AIFS count: %d\n", (uint8_t)resp->aifs_slot_count);
+        mctrl_print("Max TX OP (us): %d\n", (uint32_t)resp->max_txop_us);
+    }
+    else
+    {
+        mctrl_err("Command get qos error (%d)\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(qos, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/raw.c
+++ b/feeds/morse/utils/morsectrl/src/raw.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "stats_format.h"
+#include "transport/transport.h"
+#include "utilities.h"
+#define RAW_CMD_MAX_3BIT_SLOTS          (0b111)
+#define RAW_CMD_MIN_SLOT_DUR_US         (500)
+#define RAW_CMD_MAX_SLOT_DUR_US         (RAW_CMD_MIN_SLOT_DUR_US + (200 * (1 << 11) - 1))
+#define RAW_CMD_MAX_START_TIME_US       (UINT8_MAX * 2 * 1024)
+#define RAW_CMD_MAX_AID                 (2007) /* set by linux */
+
+enum morse_cmd_raw_tlv_tag {
+    MORSE_RAW_CMD_TAG_SLOT_DEF = 0,
+    MORSE_RAW_CMD_TAG_GROUP = 1,
+    MORSE_RAW_CMD_TAG_START_TIME = 2,
+    MORSE_RAW_CMD_TAG_PRAW = 3,
+    MORSE_RAW_CMD_TAG_BCN_SPREAD = 4,
+
+    NUM_MORSE_RAW_CMD_TAGS
+};
+
+/* slot definition is required for new raw configs */
+struct PACKED morse_cmd_raw_tlv_slot_def {
+    uint8_t tag;
+    /** Total length of the RAW window. This / num_slots = slot_duration */
+    uint32_t raw_duration_us;
+    /** Number of individual "slots" within the RAW window */
+    uint8_t num_slots;
+    /** Allow STAs to transmit into the next slot */
+    uint8_t cross_slot_bleed;
+};
+
+struct PACKED morse_cmd_raw_tlv_group {
+    uint8_t tag;
+
+    /** Start AID for this raw config */
+    uint16_t aid_start;
+
+    /** End AID for this config (inclusive) */
+    uint16_t aid_end;
+};
+
+struct PACKED morse_cmd_raw_tlv_start_time {
+    uint8_t tag;
+    /** Time the RAW window starts, measured from the end of the frame carrying RPS IE.*/
+    uint32_t start_time_us;
+};
+
+struct PACKED morse_cmd_raw_tlv_praw {
+    uint8_t tag;
+    uint8_t periodicity;
+    uint8_t validity;
+    uint8_t start_offset;
+    uint8_t refresh_on_expiry;
+};
+
+struct PACKED morse_cmd_raw_tlv_bcn_spread {
+    uint8_t tag;
+    /** Maximum number of beacons to spread across*/
+    uint16_t max_spread;
+    /** Nominal stations per beacon */
+    uint16_t nominal_sta_per_bcn;
+};
+
+union PACKED morse_cmd_raw_tlvs {
+    uint8_t tag;
+    struct morse_cmd_raw_tlv_slot_def slot_def;
+    struct morse_cmd_raw_tlv_group group;
+    struct morse_cmd_raw_tlv_start_time start_time;
+    struct morse_cmd_raw_tlv_praw praw;
+    struct morse_cmd_raw_tlv_bcn_spread bcn_spread;
+};
+
+enum morse_cmd_raw_config_flags {
+    /** Set bit to enable RAW */
+    RAW_CMD_FLAG_ENABLE = BIT(0),
+    /** Set bit to delete RAW at this index */
+    RAW_CMD_FLAG_DELETE = BIT(1),
+    /** Set bit to update RAW config state */
+    RAW_CMD_FLAG_UPDATE = BIT(2),
+};
+
+struct PACKED morse_cmd_raw_cfg {
+    /** Flags for this RAW config */
+    uint32_t flags;
+
+    /** ID to reference this RAW config.
+     * If ID already exists, existing config will be overwritten
+     */
+    uint16_t id;
+
+    uint8_t variable[];
+};
+
+static struct {
+    struct arg_csi *slot_def;
+    struct arg_lit *cross_slot;
+    struct arg_csi *aid_group;
+    struct arg_int *start_time;
+    struct arg_csi *bcn_spread;
+    struct arg_csi *praw;
+    struct arg_rex *enable;
+    struct arg_int *id;
+} args;
+
+int raw_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Configure Restricted Access Window parameters",
+        args.slot_def = arg_csi0("s", "slot_def", "<RAW duration (usec)>,<number of slots>", 2,
+            "Slot definition of RAW assignment. Required for new configs."),
+        args.cross_slot = arg_lit0("x", "cross_slot",
+            "Enable cross slot bleed (requires --slot_def)"),
+        args.aid_group = arg_csi0("a", "aid_group", "<start AID>,<end AID>", 2,
+            "AID range for the config"),
+        args.start_time = arg_int0("t", "start_time", "<start time (usec)>",
+            "Start time for the RAW window from the end of the frame"),
+        args.bcn_spread = arg_csi0("b", "bcn_spread",
+            "<max beacons to spread over>,<nominal STAs per beacon>", 2, "Use beacon spreading"),
+        args.praw = arg_csi0("p", "praw", "<periodicity>,<validity (-1 for persistent)>,<offset>",
+            3, "Use Periodic RAW"),
+        args.enable = arg_rex1(NULL, NULL, "(enable|disable|delete)", "{enable|disable|delete}", 0,
+            "enable/disable or delete RAW configs. If <id> is 0, globally enable/disable/delete"),
+        args.id = arg_int1(NULL, NULL, "<id>", "ID for the RAW config. 0 is reserved as 'global'"));
+    return 0;
+}
+
+
+int raw(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morse_cmd_raw_cfg *cmd;
+    union morse_cmd_raw_tlvs *tlv;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    static const size_t cmd_max_size = sizeof(*cmd) + (sizeof(*tlv) * NUM_MORSE_RAW_CMD_TAGS);
+
+    /* allocate for largest possible size */
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, cmd_max_size);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct morse_cmd_raw_cfg);
+    tlv = (union morse_cmd_raw_tlvs *) &cmd->variable[0];
+
+    memset(cmd, 0 , cmd_max_size);
+
+    if (args.id->count != 0)
+    {
+        if (args.id->ival[0] > UINT16_MAX)
+        {
+            mctrl_err("Invalid RAW ID, must be 1 - %u (or 0 for global)\n", UINT16_MAX);
+            ret = -1;
+            goto exit;
+        }
+        cmd->id = args.id->ival[0];
+    }
+
+    if (args.enable->count)
+    {
+        if (strcmp("enable", args.enable->sval[0]) == 0)
+        {
+            cmd->flags |= RAW_CMD_FLAG_ENABLE;
+        }
+        if (strcmp("delete", args.enable->sval[0]) == 0)
+        {
+            cmd->flags |= RAW_CMD_FLAG_DELETE;
+            goto done;
+        }
+        /* else, disable */
+    }
+
+    if (args.slot_def->count)
+    {
+        uint8_t num_slots = args.slot_def->ival[0][1];
+
+        tlv->slot_def.tag = MORSE_RAW_CMD_TAG_SLOT_DEF;
+        tlv->slot_def.raw_duration_us = args.slot_def->ival[0][0];
+        tlv->slot_def.num_slots = num_slots;
+        tlv->slot_def.cross_slot_bleed = (args.cross_slot->count != 0);
+
+        if (num_slots < 1 || num_slots > 63)
+        {
+            mctrl_err("Invalid number of slots, must be 1-63\n");
+            ret = -1;
+            goto exit;
+        }
+
+
+        if (tlv->slot_def.raw_duration_us < (num_slots * RAW_CMD_MIN_SLOT_DUR_US) ||
+                tlv->slot_def.raw_duration_us > (num_slots * RAW_CMD_MAX_SLOT_DUR_US))
+        {
+            mctrl_err("Invalid RAW duration. min: %u, max: %u\n"
+                    "Try reducing the number of slots\n",
+                    num_slots * RAW_CMD_MIN_SLOT_DUR_US,
+                    num_slots * RAW_CMD_MAX_SLOT_DUR_US);
+            ret = -1;
+            goto exit;
+        }
+
+        tlv = (union morse_cmd_raw_tlvs *)(((uint8_t*)tlv) + sizeof(tlv->slot_def));
+    }
+    else
+    {
+        if (args.cross_slot->count)
+        {
+            mctrl_err("Cross slot is ignored without a slot_def\n");
+            /* dont need to exit here. Warning the user is enough */
+        }
+    }
+
+    if (args.aid_group->count)
+    {
+        tlv->group.tag = MORSE_RAW_CMD_TAG_GROUP;
+        tlv->group.aid_start = args.aid_group->ival[0][0];
+        tlv->group.aid_end = args.aid_group->ival[0][1];
+
+        if (tlv->group.aid_start > tlv->group.aid_end)
+        {
+            mctrl_err("AID start (%u) should be less than AID end (%u)\n",
+                    tlv->group.aid_start, tlv->group.aid_end);
+            ret = -1;
+            goto exit;
+        }
+
+        if (tlv->group.aid_start < 1 || tlv->group.aid_end > RAW_CMD_MAX_AID)
+        {
+            mctrl_err("AID range is invalid (min: 1, max: %u)\n", RAW_CMD_MAX_AID);
+            ret = -1;
+            goto exit;
+        }
+
+        tlv = (union morse_cmd_raw_tlvs *)(((uint8_t*)tlv) + sizeof(tlv->group));
+    }
+
+    if (args.start_time->count)
+    {
+        tlv->start_time.tag = MORSE_RAW_CMD_TAG_START_TIME;
+        tlv->start_time.start_time_us = args.start_time->ival[0];
+
+        if (tlv->start_time.start_time_us > RAW_CMD_MAX_START_TIME_US) {
+            mctrl_err("Invalid start time, must be 0-%u\n", RAW_CMD_MAX_START_TIME_US);
+            ret = -1;
+            goto exit;
+        }
+
+        tlv = (union morse_cmd_raw_tlvs *)(((uint8_t*)tlv) + sizeof(tlv->start_time));
+    }
+
+    if (args.praw->count && args.bcn_spread->count)
+    {
+        mctrl_err("Beacon spreading and PRAW are not supported together\n");
+        ret = -1;
+        goto exit;
+    }
+
+    if (args.praw->count)
+    {
+        tlv->praw.tag = MORSE_RAW_CMD_TAG_PRAW;
+
+        if (args.praw->ival[0][0] > UINT8_MAX || args.praw->ival[0][0] < 1) {
+            mctrl_err("Invalid periodicity, must be 1-%u\n", UINT8_MAX);
+            ret = -1;
+            goto exit;
+        }
+        tlv->praw.periodicity = args.praw->ival[0][0];
+
+        if (args.praw->ival[0][1] != -1 &&
+                (args.praw->ival[0][1] > UINT8_MAX || args.praw->ival[0][0] < 1)) {
+            mctrl_err("Invalid validity, must be 1-%u, or -1 for persistent\n", UINT8_MAX);
+            ret = -1;
+            goto exit;
+        }
+        if (args.praw->ival[0][1] == -1) {
+            tlv->praw.validity = 255;
+            tlv->praw.refresh_on_expiry = 1;
+        } else {
+            tlv->praw.validity = args.praw->ival[0][1];
+        }
+
+        if (args.praw->ival[0][2] > UINT8_MAX || args.praw->ival[0][2] < 0) {
+            mctrl_err("Invalid start offset, must be 0-%u\n", UINT8_MAX);
+            ret = -1;
+            goto exit;
+        }
+        tlv->praw.start_offset = args.praw->ival[0][2];
+
+        if (tlv->praw.start_offset >= tlv->praw.periodicity) {
+            mctrl_err("Start offset (%u) must be less than periodicity (%u)\n",
+                    tlv->praw.start_offset, tlv->praw.periodicity);
+            ret = -1;
+            goto exit;
+        }
+
+        tlv = (union morse_cmd_raw_tlvs *)(((uint8_t*)tlv) + sizeof(tlv->praw));
+    }
+
+    if (args.bcn_spread->count)
+    {
+        tlv->bcn_spread.tag = MORSE_RAW_CMD_TAG_BCN_SPREAD;
+        tlv->bcn_spread.max_spread = args.bcn_spread->ival[0][0];
+        tlv->bcn_spread.nominal_sta_per_bcn = args.bcn_spread->ival[0][1];
+
+        if (tlv->bcn_spread.max_spread > UINT16_MAX)
+        {
+            mctrl_err("Invalid max beacon spread (max: %u)\n", UINT16_MAX);
+            ret = -1;
+            goto exit;
+        }
+
+        if (tlv->bcn_spread.nominal_sta_per_bcn > UINT16_MAX)
+        {
+            mctrl_err("Invalid nominal STAs per beacon (max: %u)\n", UINT16_MAX);
+            ret = -1;
+            goto exit;
+        }
+
+        tlv = (union morse_cmd_raw_tlvs *)(((uint8_t*)tlv) + sizeof(tlv->bcn_spread));
+    }
+
+    if ((uint8_t*)tlv > cmd->variable)
+    {
+        if (cmd->id == 0) {
+            mctrl_err("Can't set options when configuring global RAW\n");
+            ret = -1;
+            goto exit;
+        }
+        cmd->flags |= RAW_CMD_FLAG_UPDATE;
+    }
+
+    morsectrl_transport_set_cmd_data_length(cmd_tbuff, (uint8_t*)tlv - (uint8_t*)cmd);
+
+done:
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_CONFIG_RAW,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set RAW config\n");
+    }
+    else
+    {
+        mctrl_print("RAW config sent for ID:%u (%s)\n", cmd->id,
+            cmd->flags & RAW_CMD_FLAG_ENABLE ? "enable" : "disable");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(raw, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/reset.c
+++ b/feeds/morse/utils/morsectrl/src/reset.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#ifdef MORSE_WIN_BUILD
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
+#include "transport/transport.h"
+#include "utilities.h"
+#include "command.h"
+#ifndef MORSE_WIN_BUILD
+#include "gpioctrl.h"
+#endif
+
+#define MM610X_CPU_SOFT_RESET_ADDR      (0x10054094)
+#define MM610X_CPU_SOFT_RESET_VAL       (0xF)
+#define MM610X_CPU_SOFT_UNRESET_VAL     (0xE)
+#define MM610X_HOST_INTERRUPT_ADDR      (0x02000000)
+#define MM610X_HOST_INTERRUPT_VAL       (0x1)
+
+#define MM610X_REG_MAC_BOOT_ADDR        (0x10054024)
+#define MM610X_REG_MAC_BOOT_VALUE       (0x00100000)
+#define MM610X_REG_CLK_CTRL_ADDR        (0x1005406C)
+#define MM610X_REG_CLK_CTRL_VALUE       (0xEF)
+#define MM610X_REG_AON_COUNT            (2)
+#define MM610X_REG_AON_ADDR             (0x10058094)
+#define MM610X_REG_AON_LATCH_MASK       BIT(0)
+#define MM610X_REG_AON_LATCH_ADDR       (0x1005807C)
+
+#define RESET_TIME_MS                   (50)
+#define AON_DELAY_MS                    (5)
+
+static struct
+{
+    struct arg_lit *softreset;
+    struct arg_int *gpio;
+} args;
+
+int morsectrl_reset(struct morsectrl_transport *transport, int reset_gpio)
+{
+    int ret = 0;
+
+#ifndef MORSE_WIN_BUILD
+    ret = gpio_export(reset_gpio);
+    if (ret)
+    {
+        goto exit;
+    }
+
+    ret = gpio_set_dir(reset_gpio, "out");
+    if (ret)
+    {
+        goto exit;
+    }
+
+    ret = gpio_set_val(reset_gpio, 0);
+    if (ret)
+    {
+        goto exit;
+    }
+
+    sleep_ms(RESET_TIME_MS);
+    ret = gpio_set_dir(reset_gpio, "in");
+    if (ret)
+    {
+        goto exit;
+    }
+    sleep_ms(RESET_TIME_MS);
+
+    /* Reverses the exporting gpio */
+    ret = gpio_unexport(reset_gpio);
+exit:
+#endif
+
+    return ret;
+}
+
+/*
+ * 'Magic' sequence to reboot chip after performing a reset. Only applies to transports that don't
+ *  use the driver.
+ */
+static int soft_reset(struct morsectrl *mors)
+{
+    struct morsectrl_transport *transport = mors->transport;
+    int ret;
+    int idx;
+    uint32_t address = MM610X_REG_AON_ADDR;
+    uint32_t latch;
+
+    /* Clear AON. */
+    for (idx = 0; idx < MM610X_REG_AON_COUNT; idx++, address += 4)
+    {
+        /* clear AON in case there is any latched sleeps */
+        ret = morsectrl_transport_reg_write(transport, address, 0);
+        if (ret == -ETRANSNOTSUP)
+        {
+            morsectrl_transport_err("Soft Reset", -ETRANSERR,
+                                    "Transport doesn't support soft reset (rebooting)\n");
+            return ret;
+        }
+        else if (ret)
+        {
+            morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write clk ctrl reg\n");
+            return ret;
+        }
+    }
+
+    /* invoke AON latch procedure */
+    ret = morsectrl_transport_reg_read(transport, MM610X_REG_AON_LATCH_ADDR, &latch);
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to read aon latch reg\n");
+        return ret;
+    }
+
+    ret = morsectrl_transport_reg_write(transport, MM610X_REG_AON_LATCH_ADDR,
+                                        latch & ~(MM610X_REG_AON_LATCH_MASK));
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write aon latch reg\n");
+        return ret;
+    }
+    sleep_ms(AON_DELAY_MS);
+
+    ret = morsectrl_transport_reg_write(transport, MM610X_REG_AON_LATCH_ADDR,
+                                        latch | MM610X_REG_AON_LATCH_MASK);
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write aon latch reg\n");
+        return ret;
+    }
+    sleep_ms(AON_DELAY_MS);
+
+    ret = morsectrl_transport_reg_write(transport, MM610X_REG_AON_LATCH_ADDR,
+                                        latch & ~(MM610X_REG_AON_LATCH_MASK));
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write aon latch reg\n");
+        return ret;
+    }
+    sleep_ms(AON_DELAY_MS);
+
+    /* Boot chip. */
+    ret = morsectrl_transport_reg_write(transport, MM610X_REG_MAC_BOOT_ADDR,
+                                        MM610X_REG_MAC_BOOT_VALUE);
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write MAC boot reg\n");
+        return ret;
+    }
+
+    ret = morsectrl_transport_reg_write(transport, MM610X_REG_CLK_CTRL_ADDR,
+                                        MM610X_REG_CLK_CTRL_VALUE);
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write clk ctrl reg\n");
+        return ret;
+    }
+
+    ret = morsectrl_transport_reg_write(transport, MM610X_HOST_INTERRUPT_ADDR,
+                                        MM610X_HOST_INTERRUPT_VAL);
+    if (ret)
+    {
+        morsectrl_transport_err("Soft Reset", -ETRANSERR, "Failed to write host interrupt reg\n");
+        return ret;
+    }
+
+    return ret;
+}
+
+int reset_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    args.softreset = arg_lit0("s", "softreset", "do a soft reset"),
+    args.gpio = arg_int0(NULL, NULL, "gpio", "RPi GPIO number");
+
+    /* Only use GPIO-based reset if transport does not include reset and this is not a
+     * Windows build. */
+#ifndef MORSE_WIN_BUILD
+    if (!morsectrl_transport_has_reset(mors->transport))
+    {
+        MM_INIT_ARGTABLE(mm_args, "Send reset signal over RPi GPIO pin", args.softreset, args.gpio
+        ); /* NOLINT (whitespace/parens) */
+    }
+    else
+    {
+        MM_INIT_ARGTABLE(mm_args, "Send reset signal over libmpsse GPIO pin", args.softreset
+        ); /* NOLINT (whitespace/parens) */
+    }
+#endif
+
+    return 0;
+}
+
+int reset(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret;
+    int reset_gpio = 0;
+    bool do_soft_reset = (args.softreset->count > 0);
+
+#ifndef MORSE_WIN_BUILD
+#endif
+
+    if (do_soft_reset)
+    {
+        ret = soft_reset(mors);
+    }
+    else
+    {
+        if (args.gpio->count == 0)
+        {
+            if (morsectrl_transport_has_reset(mors->transport))
+            {
+                ret = morsectrl_transport_reset_device(mors->transport);
+                goto exit;
+            }
+            else
+            {
+#ifndef MORSE_WIN_BUILD
+                reset_gpio = gpio_get_env(RESET_GPIO);
+
+                if (reset_gpio == -1)
+                {
+                    mctrl_err("Couldn't identify GPIO\n"
+                              "Try entering GPIO manually or export %s to your env var\n",
+                              RESET_GPIO);
+
+                    return -1;
+                }
+#endif
+            }
+        }
+        else
+        {
+            reset_gpio = args.gpio->ival[0];
+        }
+
+        ret = morsectrl_reset(mors->transport, reset_gpio);
+    }
+
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to reset chip\n");
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(reset, MM_INTF_NOT_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/responseindication.c
+++ b/feeds/morse/utils/morsectrl/src/responseindication.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_response_indication_command
+{
+    int8_t response_indication;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\tri <enable|disable> <value>\n");
+    mctrl_print("\t\t\t\tforces specificed response indication if 'enable'\n");
+    mctrl_print("\t\t\t\totherwise 'disable' force\n");
+}
+
+int ri(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int8_t ri;
+    struct set_response_indication_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_response_indication_command);
+
+    switch (expression_to_int(argv[1]))
+    {
+        case true:
+            if (argc != 3)
+            {
+                mctrl_err("Invalid command parameters\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            if (str_to_int8_range(argv[2], &ri, 0, 3))
+            {
+                mctrl_err("Invalid value response indication must be between 0 and 3\n");
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+        break;
+
+        case false:
+            ri = -1;
+        break;
+
+        default:
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+    }
+
+    cmd->response_indication = ri;
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_RESPONSE_INDICATION,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set ri\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(ri, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/rpg.c
+++ b/feeds/morse/utils/morsectrl/src/rpg.c
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+enum morse_rpg_commands_id
+{
+    /* RPG Commands */
+    MORSE_CMD_RPG_START_TX          = 0x100,
+    MORSE_CMD_RPG_STOP_TX           = 0x101,
+    MORSE_CMD_RPG_GET_STATS         = 0x102,
+    MORSE_CMD_RPG_RESET_STATS       = 0x103,
+    MORSE_CMD_RPG_SET_SOURCE_ADDR   = 0x104,
+    MORSE_CMD_RPG_SET_DEST_ADDR     = 0x105,
+    MORSE_CMD_RPG_FORCE_AMPDU       = 0x106
+};
+
+struct PACKED memcmd_rpg_start_tx
+{
+    int32_t  size;
+    int32_t  count;
+    uint8_t  random;
+};
+
+struct PACKED memcmd_rpg_get_statistics
+{
+    uint32_t total_rx_packets;
+    uint32_t total_rx_packets_w_correct_fcs;
+    uint32_t total_tx_packets;
+    uint32_t rx_signal_field_errors;
+};
+
+struct PACKED morse_rpg_cmd_set_source_addr
+{
+    uint8_t source[6];
+};
+
+struct PACKED morse_rpg_cmd_set_destination_addr
+{
+    uint8_t destination[6];
+};
+
+struct PACKED morse_rpg_cmd_force_ampdu
+{
+    uint32_t number;
+};
+
+struct PACKED morse_rpg_cmd
+{
+    uint16_t id;
+    union {
+        uint8_t opaque[0];
+        struct memcmd_rpg_start_tx start;
+        struct morse_rpg_cmd_set_source_addr set_source;
+        struct morse_rpg_cmd_set_destination_addr set_destination;
+        struct morse_rpg_cmd_force_ampdu force_ampdu;
+    };
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\trpg <command>\n");
+    mctrl_print("\t\tstart [options] starts rpg\n");
+    mctrl_print("\t\t    -l\t\tlistening mode (other options are overlooked)\n");
+    mctrl_print("\t\t    -c <value>\tnumber of packets to send (default unlimited)\n"
+           "\t\t    -s <value>\tspecifies the size of the packets to be sent (min: 24).\n"
+           "\t\t              \tRandom if not specified.\n");
+    mctrl_print("\t\t    -d\t\tdisables random packet contents (for casim)\n");
+    mctrl_print("\t\tstop\t\tterminates rpg (if started)\n");
+    mctrl_print("\t\tstats [options]\treads rpg stats collected (if started)\n");
+    mctrl_print("\t\t    -r\t\treset the rpg stats (if started)\n");
+    mctrl_print("\t\tsrcaddr [mac address]\n");
+    mctrl_print("\t\t\t\tsets source mac address of rpg packets\n");
+    mctrl_print("\t\tdstaddr [mac address]\n");
+    mctrl_print("\t\t\t\tsets destination mac address of rpg packets\n");
+    mctrl_print("\t\tampdu [number]\n");
+    mctrl_print("\t\t\t\tforce using ampdu with [number] mpdu\n");
+}
+
+int rpg_get_cmd(char str[])
+{
+    if (strcmp("start", str) == 0) return MORSE_CMD_RPG_START_TX;
+    else if (strcmp("stop", str) == 0) return MORSE_CMD_RPG_STOP_TX;
+    else if (strcmp("stats", str) == 0) return MORSE_CMD_RPG_GET_STATS;
+    else if (strcmp("reset", str) == 0) return MORSE_CMD_RPG_RESET_STATS;
+    else if (strcmp("srcaddr", str) == 0) return MORSE_CMD_RPG_SET_SOURCE_ADDR;
+    else if (strcmp("dstaddr", str) == 0) return MORSE_CMD_RPG_SET_DEST_ADDR;
+    else if (strcmp("ampdu", str) == 0) return MORSE_CMD_RPG_FORCE_AMPDU;
+    else
+    {
+        return -1;
+    }
+}
+
+int rpg(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morse_rpg_cmd *cmd;
+    struct memcmd_rpg_get_statistics *stats;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int option;
+    int32_t start_count, start_size;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    ret = rpg_get_cmd(argv[1]);
+    if ( ret < 0 )
+    {
+        mctrl_err("Invalid rpg command '%s'\n", argv[1]);
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*stats));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct morse_rpg_cmd);
+    stats = TBUFF_TO_RSP(rsp_tbuff, struct memcmd_rpg_get_statistics);
+    cmd->id = ret;
+    switch (cmd->id)
+    {
+        case MORSE_CMD_RPG_START_TX:
+        {
+            cmd->start.random = 1;
+            argc -= 1;
+            argv += 1;
+
+            cmd->start.count = -1;
+            cmd->start.size = -1;
+            while ((option = getopt(argc, argv, "c:s:dl")) != -1)
+            {
+                switch (option)
+                {
+                    case 'c' :
+                        if (cmd->start.count != -1) {
+                            mctrl_err("Conflicting options\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+
+                        if (str_to_int32(optarg, &start_count))
+                        {
+                            mctrl_err("Invalid argument\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->start.count = start_count;
+                        break;
+                    case 's' :
+                        if (cmd->start.size != -1) {
+                            mctrl_err("Conflicting options\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+
+                        if (str_to_int32(optarg, &start_size))
+                        {
+                            mctrl_err("Invalid argument\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->start.size = start_size;
+                        break;
+                    case 'l' :
+                        if (cmd->start.size != -1 || cmd->start.count != -1) {
+                            mctrl_err("Conflicting options\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->start.size = 0;
+                        cmd->start.count = 0;
+                        break;
+                    case 'd' :
+                        cmd->start.random = 0;
+                        break;
+                    case '?' :
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                    default :
+                        mctrl_err("Invalid argument\n");
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+        }
+        break;
+        case MORSE_CMD_RPG_SET_SOURCE_ADDR:
+        {
+            uint8_t* mac = cmd->set_source.source;
+
+            if (argc < 3)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            if (str_to_mac_addr(mac, argv[2]) < 0)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+        }
+        break;
+        case MORSE_CMD_RPG_SET_DEST_ADDR:
+        {
+            uint8_t* mac = cmd->set_destination.destination;
+
+            if (argc < 3)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            if (str_to_mac_addr(mac, argv[2]) < 0)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+        }
+        break;
+        case MORSE_CMD_RPG_FORCE_AMPDU:
+        {
+            if (argc < 3)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+
+            ret = sscanf(argv[2], "%uld", &(cmd->force_ampdu.number));
+
+            if (ret != 1)
+            {
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+        }
+        break;
+        case MORSE_CMD_RPG_GET_STATS:
+        {
+            argc -= 1;
+            argv += 1;
+
+            while ((option = getopt(argc, argv, "r")) != -1)
+            {
+                switch (option)
+                {
+                    case 'r' :
+                        cmd->id = MORSE_CMD_RPG_RESET_STATS;
+                        break;
+                    case '?' :
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                    default :
+                        mctrl_err("Invalid argument\n");
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+        }
+        break;
+        case MORSE_CMD_RPG_RESET_STATS:
+            mctrl_err("rpg reset is deprecated and replaced with rpg stats -r\n");
+            /* fall through */
+        default:
+        {
+            /* remaining commands take no argument or options */
+            if (argc != 2)
+            {
+                mctrl_err("Error: rpg command '%s' takes no arguments\n", argv[1]);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+        }
+    }
+
+    cmd->start.size = htole32(cmd->start.size);
+    cmd->start.count = htole32(cmd->start.count);
+    cmd->id = htole16(cmd->id);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_RPG,
+                                 cmd_tbuff, rsp_tbuff);
+
+    if ((!ret) && (cmd->id == MORSE_CMD_RPG_GET_STATS))
+    {
+        mctrl_print("total Rx = %d, RX FCS pass = %d, RX sig field fail = %d, total TX = %d\n",
+               (int)stats->total_rx_packets,
+               (int)stats->total_rx_packets_w_correct_fcs,
+               (int)stats->rx_signal_field_errors,
+               (int)stats->total_tx_packets);
+    }
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Command rpg error (%d)\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(rpg, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/serial.c
+++ b/feeds/morse/utils/morsectrl/src/serial.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "command.h"
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tserial\n");
+    mctrl_print("\t\t\t\treads the chip serial number from OTP (zeroes if none blown)\n");
+}
+
+/**
+ * This address should be the same for all boards but some boards will
+ * have the bits not blown which will always show zeroes in that case,
+ * please update the address if necessary
+ */
+#define SERIAL_OTP_ADDR "0x1005412c"
+
+int io(struct morsectrl *mors, int argc, char **argv);
+
+int serial(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret;
+
+    char io_cmd_name[] = "io";
+    char io_read_arg[] = "-r";
+    char otp_addr[] = SERIAL_OTP_ADDR;
+
+    char *io_argv[] = {io_cmd_name, io_read_arg, otp_addr};
+    int io_argc = MORSE_ARRAY_SIZE(io_argv);
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 1)
+    {
+        mctrl_err("This command doesn't expect arguments\n");
+        usage(mors);
+        return -1;
+    }
+    else
+    {
+        ret = io(mors, io_argc, io_argv);
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(serial, MM_INTF_NOT_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/sig_field_error_evt.c
+++ b/feeds/morse/utils/morsectrl/src/sig_field_error_evt.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "command.h"
+#include "utilities.h"
+
+#define SIG_FIELD_ERROR_EVENT_DISABLED              (0)
+#define SIG_FIELD_ERROR_EVENT_ENABLED_MONITOR_ONLY  (1)
+#define SIG_FIELD_ERROR_EVENT_ENABLED_ANY_MODE      (2)
+
+struct PACKED command_set_sig_field_error_event_config_req
+{
+    uint8_t config;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tsig_field_error_evt [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' will sig field error events when monitor mode is enabled.\n");
+    mctrl_print("\t\t\t\t         These events will show up in sniffer traces as radiotap\n");
+    mctrl_print("\t\t\t\t         headers with no payload.\n");
+    mctrl_print("\t\t\t\t'disable' will disable sig field error events (default state).\n");
+}
+
+
+int sig_field_error_evt(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enabled;
+    struct command_set_sig_field_error_event_config_req *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    enabled = expression_to_int(argv[1]);
+
+    if (enabled == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_sig_field_error_event_config_req);
+
+    if (enabled)
+    {
+        /*
+         * As noted in the usage documentation, the "enable" option means enabled in monitor
+         * mode. The firmware supports enabling this event in any mode (i.e.,
+         * SIG_FIELD_ERROR_EVENT_ENABLED_ANY_MODE), but there is currently no use case for it.
+         */
+        cmd->config = SIG_FIELD_ERROR_EVENT_ENABLED_MONITOR_ONLY;
+    }
+    else
+    {
+        cmd->config = SIG_FIELD_ERROR_EVENT_DISABLED;
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+                                 MORSE_TEST_COMMAND_SET_SIG_FIELD_ERROR_EVENT_CONFIG,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set sig field error event config\n");
+    }
+    else
+    {
+        mctrl_print("\tSig field error event config: %s\n",
+            (enabled) ? "enabled in monitor mode" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(sig_field_error_evt, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/standby.c
+++ b/feeds/morse/utils/morsectrl/src/standby.c
@@ -1,0 +1,913 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <ctype.h>
+
+#include "command.h"
+#include "utilities.h"
+#include "transport/transport.h"
+#include "channel.h"
+
+/** The maximum allowed length of a user specified payload (bytes) in the status frames */
+#define STANDBY_STATUS_FRAME_USER_PAYLOAD_MAX_LEN  (64)
+/** The maximum allowed length of a user filter to apply to wake frames */
+#define STANDBY_WAKE_FRAME_USER_FILTER_MAX_LEN     (64)
+
+/** Max line length for a config file line */
+#define MAX_LINE_LENGTH     (255)
+
+typedef enum
+{
+    /** The external host is indicating that it's now awake */
+    STANDBY_MODE_CMD_EXIT = 0x0,
+    /** The external host is indicating that it's going into standby mode */
+    STANDBY_MODE_CMD_ENTER,
+    /** This version of the config command has since been deprecated */
+    STANDBY_MODE_CMD_SET_CONFIG_V1_DEPRECATED,
+    /** The external host provides a payload that gets appended to status frames */
+    STANDBY_MODE_CMD_SET_STATUS_PAYLOAD,
+    /** The external host provides a filter to be applied to incoming standby wake frames */
+    STANDBY_MODE_CMD_SET_WAKE_FILTER,
+    /** The external host sets a number of configuration options for standby mode */
+    STANDBY_MODE_CMD_SET_CONFIG_V2,
+
+    /** Force enum to UINT32 */
+    STANDBY_MODE_CMD_MAX = UINT32_MAX,
+} standby_mode_commands_t;
+
+struct PACKED command_standby_set_config
+{
+    /** Interval for transmitting Standby status packets */
+    uint32_t notify_period_s;
+    /** Time for firmware to wait during beacon loss before entering deep sleep in seconds */
+    uint32_t bss_inactivity_before_deep_sleep_s;
+    /** Time for firmware to remain in deep sleep in seconds */
+    uint32_t deep_sleep_period_s;
+    /** Source IP address */
+    ipv4_addr_t src_ip;
+    /** Destination IP address */
+    ipv4_addr_t dst_ip;
+    /** Destination UDP Port */
+    uint16_t dst_port;
+    /** pad to word boundary */
+    uint8_t pad[2];
+    /** Time in seconds to increment each successive deep sleep */
+    uint32_t deep_sleep_increment_s;
+    /** Max time to deep sleep for */
+    uint32_t deep_sleep_max_s;
+};
+
+struct PACKED command_standby_set_wake_filter
+{
+    /** The length of the wake filter */
+    uint32_t len;
+    /** The offset at which to apply the wake filter */
+    uint32_t offset;
+    /** The user-defined filter */
+    uint8_t filter[STANDBY_WAKE_FRAME_USER_FILTER_MAX_LEN];
+};
+
+struct PACKED command_standby_set_status_payload
+{
+    /** The length of the payload */
+    uint32_t len;
+    /** The payload */
+    uint8_t payload[STANDBY_STATUS_FRAME_USER_PAYLOAD_MAX_LEN];
+};
+
+struct PACKED command_standby_enter
+{
+    /** The BSSID to monitor for activity (or lack thereof) before entering deep sleep */
+    uint8_t bssid[MAC_ADDR_LEN];
+};
+
+/**
+ * Structure for Configuring MM standby mode
+ */
+struct PACKED command_standby_mode_req
+{
+    /** Standby Mode subcommands, see @ref standby_mode_commands_t */
+    uint32_t cmd;
+    union {
+        uint8_t opaque[0];
+        /** Valid for STANDBY_MODE_CMD_SET_CONFIG cmd */
+        struct command_standby_set_config config;
+        /** Valid for STANDBY_MODE_CMD_SET_STATUS_PAYLOAD cmd */
+        struct command_standby_set_status_payload set_payload;
+        /** Valid for STANDBY_MODE_CMD_ENTER cmd*/
+        struct command_standby_enter enter;
+        /** Valid for STANDBY_MODE_CMD_SET_WAKE_FILTER cmd */
+        struct command_standby_set_wake_filter set_filter;
+    };
+};
+
+typedef enum
+{
+    /** No specific reason for exiting standby mode */
+    STANDBY_MODE_EXIT_REASON_NONE,
+    /** The STA has received the wakeup frame */
+    STANDBY_MODE_EXIT_REASON_WAKEUP_FRAME,
+    /** The STA needs to associate */
+    STANDBY_MODE_EXIT_REASON_ASSOCIATE,
+
+    /** Force to UINT8_MAX */
+    STANDBY_MODE_EXIT_REASON_MAX = UINT8_MAX,
+} standby_mode_exit_reason_t;
+
+/**
+ * Response structure for MM standby mode command
+ */
+struct PACKED command_standby_mode_cfm
+{
+    union {
+        uint8_t opaque[0];
+        /** Valid for a response to STANDBY_MODE_CMD_EXIT, see @ref standby_mode_exit_reason_t */
+        uint8_t reason;
+    };
+};
+
+struct standby_config_parse_context
+{
+    struct command_standby_set_config *set_cfg;
+    struct command_standby_set_wake_filter *filter_cfg;
+};
+
+struct standby_session_parse_context
+{
+    uint8_t *bssid;
+    struct command_set_channel_req *req;
+};
+
+static int standby_get_cmd(char str[])
+{
+    if (strcmp("enter", str) == 0) return STANDBY_MODE_CMD_ENTER;
+    else if (strcmp("exit", str) == 0) return STANDBY_MODE_CMD_EXIT;
+    else if (strcmp("config", str) == 0) return STANDBY_MODE_CMD_SET_CONFIG_V2;
+    else if (strcmp("payload", str) == 0) return STANDBY_MODE_CMD_SET_STATUS_PAYLOAD;
+    else
+    {
+        return -1;
+    }
+}
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tstandby <command> [options]\n");
+    mctrl_print("\t\tenter [<session dir>]\n"
+                "\t\t\tPut the STA FW into standby mode.\n");
+    mctrl_print(
+           "\t\t<session dir>\tThe full directory path for storing persistent sessions,\n"
+           "\t\t\twhich should be obtained from the wpa_supplicant standby_config_dir\n"
+           "\t\t\tconfiguration parameter. This parameter is no longer required\n"
+           "\t\t\tand is retained for backwards compatibility.\n");
+    mctrl_print("\t\texit \tTell the STA FW that the external host is awake.\n");
+    mctrl_print("\t\tpayload\t<hex string of user data to append to standby status frames>\n");
+    mctrl_print("\t\tconfig\t <config file>\t Configure standby mode\n"
+            "\t\t\t <config file> Path to file containing Standby mode configuration parameters\n");
+    if (mors->debug)
+    {
+        mctrl_print("\t\tstore -b <bssid> -d <dir>\t"
+                   "Store session information when associated (internal use only)\n"
+               "\t\t\t-b <bssid>\t\tthe association BSSID\n"
+               "\t\t\t-d <dir>\t\tthe full directory path for storing persistent sessions\n");
+    }
+}
+
+static int parse_standby_config_keyval(struct morsectrl *mors, void *context, const char *key,
+                                    const char *val)
+{
+    struct standby_config_parse_context *config = context;
+    uint32_t temp;
+    ipv4_addr_t temp_ip;
+
+    if (mors->debug)
+    {
+        mctrl_print("standby_config: %s - %s\n", key, val);
+    }
+
+    if (strcmp("notify_period_s", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->notify_period_s = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("bss_inactivity_before_deep_sleep_s", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->bss_inactivity_before_deep_sleep_s = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("deep_sleep_period_s", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->deep_sleep_period_s = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("src_ip", key) == 0)
+    {
+        if (str_to_ip(val, &temp_ip) < 0)
+        {
+            goto error;
+        }
+        memcpy(&config->set_cfg->src_ip, &temp_ip, sizeof(config->set_cfg->src_ip));
+        return 0;
+    }
+    else if (strcmp("dest_ip", key) == 0)
+    {
+        if (str_to_ip(val, &temp_ip) < 0)
+        {
+            goto error;
+        }
+        memcpy(&config->set_cfg->dst_ip, &temp_ip, sizeof(config->set_cfg->dst_ip));
+        return 0;
+    }
+    else if (strcmp("dest_port", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->dst_port = htole16((uint16_t) temp);
+        return 0;
+    }
+    else if (strcmp("deep_sleep_increment_s", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->deep_sleep_increment_s = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("deep_sleep_max_s", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->set_cfg->deep_sleep_max_s = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("wake_packet_filter", key) == 0)
+    {
+        uint32_t len = MIN(strlen(val) / 2, MORSE_ARRAY_SIZE(config->filter_cfg->filter));
+        hexstr2bin(val, config->filter_cfg->filter, len);
+        config->filter_cfg->len = htole32(len);
+        return 0;
+    }
+    else if (strcmp("wake_packet_filter_offset", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        config->filter_cfg->offset = htole32(temp);
+        return 0;
+    }
+    mctrl_err("Key is not a recognised parameter: %s\n", key);
+    return 0;
+
+error:
+    mctrl_err("Failed to parse value for %s (val: %s)\n", key, val);
+    return -1;
+}
+
+static int parse_standby_session_keyval(struct morsectrl *mors, void *context, const char *key,
+                                            const char *val)
+{
+    struct standby_session_parse_context *ctx = context;
+    uint32_t temp;
+
+    if (mors->debug)
+    {
+        mctrl_print("standby_session: %s - %s\n", key, val);
+    }
+
+    if (strcmp("bssid", key) == 0)
+    {
+        if (str_to_mac_addr(ctx->bssid, val) < 0)
+        {
+            goto error;
+        }
+        return 0;
+    }
+    else if (strcmp("op_chan_freq", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        ctx->req->operating_channel_freq_hz = htole32(temp);
+        return 0;
+    }
+    else if (strcmp("op_chan_bw", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        ctx->req->operating_channel_bw_mhz = (uint8_t) temp;
+        return 0;
+    }
+    else if (strcmp("pri_chan_bw", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        ctx->req->primary_channel_bw_mhz = (uint8_t) temp;
+        return 0;
+    }
+    else if (strcmp("pri_1mhz_chan", key) == 0)
+    {
+        if (str_to_uint32(val, &temp) < 0)
+        {
+            goto error;
+        }
+        ctx->req->primary_1mhz_channel_index = (uint8_t) temp;
+        return 0;
+    }
+
+    mctrl_err("Key is not a recognised parameter: %s\n", key);
+    return 0;
+
+error:
+    mctrl_err("Failed to parse value for %s (val: %s)\n", key, val);
+    return -1;
+}
+
+/**
+ * @brief Generic config file parser.
+ * Scans lines and calls a handler function for each `key=value` it finds.
+ * Lines starting with a `#` will be interpreted as a comment and ignored.
+ *
+ * @param mors Morsectrl object
+ * @param conf_file File to parse
+ * @param keyval_process Callback function called for each key value
+ * @param context Context pointer for callback function
+ * @return int 0 if successfully parsed, otherwise negative value
+ */
+static int config_parse(struct morsectrl *mors, const char *conf_file,
+                        int (*keyval_process)(
+                                    struct morsectrl *mors,
+                                    void *context,
+                                    const char *key,
+                                    const char *val),
+                        void *context)
+{
+    int ret;
+    FILE *cfg_file;
+    char line[MAX_LINE_LENGTH];
+    uint16_t line_num = 0;
+
+    if (!conf_file || !keyval_process || is_dir(conf_file))
+        return -1;
+
+    cfg_file = fopen(conf_file, "r");
+
+    if (cfg_file == NULL)
+        return -1;
+
+    while (fgets(line, MAX_LINE_LENGTH, cfg_file))
+    {
+        char *key, *val;
+
+        line_num++;
+
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+            continue;
+
+        key = strip(line);
+        val = strchr(line, '=');
+
+        if (val)
+            *val++ = '\0';
+
+        if (key && key[0] && val && val[0])
+        {
+            ret = keyval_process(mors, context, key, val);
+            if (ret)
+            {
+                fclose(cfg_file);
+                return ret;
+            }
+        }
+        else
+        {
+            mctrl_err("No key=value on line %d\n", line_num);
+            fclose(cfg_file);
+            return -1;
+        }
+    }
+
+    fclose(cfg_file);
+    return 0;
+}
+
+static int standby_session_store(struct morsectrl *mors, const char *ifname, const uint8_t *bssid,
+    const char *standby_session_dir, struct command_get_channel_cfm *rsp)
+{
+    FILE *f;
+    char dir[MORSE_FILENAME_LEN_MAX];
+    char fname[MORSE_FILENAME_LEN_MAX];
+    struct stat buf;
+
+    if (snprintf(dir, sizeof(dir), "%s", standby_session_dir) < 0)
+    {
+        mctrl_err("%s: Failed to set dir name (%d)\n",
+                dir, errno);
+        return -1;
+    }
+
+    if (stat(dir, &buf) != 0) {
+        if (mkdir_path(dir) < 0)
+        {
+            mctrl_err("%s: Failed to create %s (%d)\n",
+                    ifname, dir, errno);
+            return -1;
+        }
+    }
+
+    if (snprintf(fname, sizeof(fname), "%s/%s", dir, ifname) < 0) {
+        mctrl_err("%s: Failed to set file name (%d)\n",
+                ifname, errno);
+        return -1;
+    }
+
+    f = fopen(fname, "w");
+    if (!f) {
+        mctrl_err("%s: Failed to open %s\n",
+                ifname, fname);
+        return -1;
+    }
+
+    fprintf(f, "bssid=" MACSTR "\n", MAC2STR(bssid));
+    fprintf(f, "op_chan_freq=%u\n", rsp->operating_channel_freq_hz);
+    fprintf(f, "op_chan_bw=%u\n", rsp->operating_channel_bw_mhz);
+    fprintf(f, "pri_chan_bw=%u\n", rsp->primary_channel_bw_mhz);
+    fprintf(f, "pri_1mhz_chan=%u\n", rsp->primary_1mhz_channel_index);
+
+    fclose(f);
+
+    if (mors->debug)
+    {
+        mctrl_print("%s: Created %s\n", ifname, fname);
+    }
+
+    return 0;
+}
+
+static int standby_session_load(struct morsectrl *mors, const char *standby_session_dir,
+        uint8_t *bssid, struct command_set_channel_req *req)
+{
+    const char *ifname = morsectrl_transport_get_ifname(mors->transport);
+    struct standby_session_parse_context context = {
+        .bssid = bssid,
+        .req = req
+    };
+
+    char session_path[MORSE_FILENAME_LEN_MAX];
+
+    if (snprintf(session_path, sizeof(session_path),
+                "%s/%s", standby_session_dir, ifname) < 0)
+    {
+        mctrl_err("%s: Failed to set session path name (%d)\n",
+                ifname, errno);
+        return -1;
+    }
+
+    if (config_parse(mors, session_path, parse_standby_session_keyval, &context))
+    {
+        goto err_parse;
+    }
+
+    return 0;
+
+err_parse:
+    mctrl_err("%s: Failed to parse %s\n", ifname, standby_session_dir);
+    return -1;
+}
+
+static int process_standby_enter(struct morsectrl *mors,
+                                    struct command_standby_mode_req *standby_cmd,
+                                    int argc, char *argv[])
+{
+    const char *standby_session_dir = NULL;
+    int ret;
+    struct command_set_channel_req *ch_cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc < 2 || argc > 3)
+    {
+        mctrl_err("Invalid number of arguments\n");
+        return -1;
+    }
+
+    if (argc == 2)
+    {
+        return 0;
+    }
+
+    standby_session_dir = argv[2];
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*ch_cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        mctrl_err("Alloc failure\n");
+        ret = -1;
+        goto exit;
+    }
+
+    ch_cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_channel_req);
+
+    /* load the saved standby parameters */
+    ret = standby_session_load(mors, standby_session_dir, standby_cmd->enter.bssid, ch_cmd);
+    if (ret < 0)
+    {
+        mctrl_err("Failed to load session info\n");
+        goto exit;
+    }
+
+    if (mors->debug)
+    {
+        mctrl_print("Loaded session info:\n");
+        mctrl_print("bssid " MACSTR "\n", MAC2STR(standby_cmd->enter.bssid));
+        mctrl_print("op ch freq %d\n", ch_cmd->operating_channel_freq_hz);
+        mctrl_print("op ch bw %d\n", ch_cmd->operating_channel_bw_mhz);
+        mctrl_print("pri ch bw %d\n", ch_cmd->primary_channel_bw_mhz);
+        mctrl_print("pri 1mhz idx %d\n", ch_cmd->primary_1mhz_channel_index);
+    }
+
+    /* Set the channel before we go to sleep */
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_CHANNEL,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        mctrl_err("failed to set channel info %d\n", ret);
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+/* Standby store commands are invoked from wpa_supplicant, so provide some context for error
+ * messages.
+ */
+static void standby_store_print_msg(const char *msg)
+{
+    mctrl_err("morsectrl standby store failed - %s\n", msg);
+}
+
+static int standby_store_session_cmd(struct morsectrl *mors, int argc, char *argv[])
+{
+    int option;
+    uint8_t bssid[MAC_ADDR_LEN] = { 0 };
+    bool have_bssid = false;
+    char *standby_session_dir = NULL;
+    int ret;
+    const char *ifname = morsectrl_transport_get_ifname(mors->transport);
+    struct command_set_channel_req *cmd;
+    struct command_get_channel_cfm *rsp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (ifname == NULL)
+    {
+        standby_store_print_msg("no interface - transport not supported");
+        ret = -1;
+        goto exit;
+    }
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        standby_store_print_msg("alloc failure");
+        ret = -1;
+        goto exit;
+    }
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_set_channel_req);
+    rsp = TBUFF_TO_RSP(rsp_tbuff, struct command_get_channel_cfm);
+
+    if (argc < 1)
+    {
+        standby_store_print_msg("not enough arguments to store command");
+        ret = -1;
+        goto exit;
+    }
+
+    while ((option = getopt(argc, argv, "b:d:")) != -1)
+    {
+        switch (option)
+        {
+            case 'b':
+            {
+                if (str_to_mac_addr(bssid, optarg) < 0)
+                {
+                    standby_store_print_msg("invalid BSSID");
+                    ret = -1;
+                    goto exit;
+                }
+                have_bssid = true;
+                break;
+            }
+            case 'd':
+            {
+                standby_session_dir = optarg;
+                break;
+            }
+            default:
+                standby_store_print_msg("invalid argument");
+                ret = -1;
+                goto exit;
+        }
+    }
+
+    if (!have_bssid || !standby_session_dir)
+    {
+        standby_store_print_msg("BSSID or session directory not supplied");
+        ret = -1;
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_FULL_CHANNEL,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        standby_store_print_msg("failed to get channel info");
+        ret = -1;
+        goto exit;
+    }
+
+    ret = standby_session_store(mors, ifname, bssid, standby_session_dir, rsp);
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+static int send_wake_filter_cmd(struct morsectrl *mors,
+                                    struct command_standby_set_wake_filter *wake_cmd)
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    struct command_standby_mode_req *cmd;
+    struct command_standby_mode_cfm *rsp = NULL;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_standby_mode_req);
+    rsp = TBUFF_TO_RSP(rsp_tbuff, struct command_standby_mode_cfm);
+
+    cmd->cmd = STANDBY_MODE_CMD_SET_WAKE_FILTER;
+
+    memcpy(&cmd->set_filter, wake_cmd, sizeof(*wake_cmd));
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_STANDBY_MODE,
+        cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to send standby command %d\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+static int process_set_config_cmd(struct morsectrl *mors, struct command_standby_mode_req* cmd,
+                                    int argc, char *argv[])
+{
+    if (argc != 3)
+    {
+        mctrl_err("Invalid number of arguments %d\n", argc);
+        return -1;
+    }
+
+    struct command_standby_set_wake_filter wake_filter = {0};
+    static const struct command_standby_set_config config_default = {
+        .bss_inactivity_before_deep_sleep_s = 60,
+        .deep_sleep_period_s = 120,
+        .notify_period_s = 15,
+        .dst_ip.as_u32 = 0,
+        .dst_port = 22000,
+        .src_ip.as_u32 = 0,
+        .deep_sleep_increment_s = 0, /* Default no increment */
+        .deep_sleep_max_s = UINT32_MAX, /* Default max int / no max */
+    };
+
+    memcpy(&cmd->config, &config_default, sizeof(config_default));
+
+    struct standby_config_parse_context context = {
+        .filter_cfg = &wake_filter,
+        .set_cfg = &cmd->config
+    };
+
+    if (config_parse(mors, argv[2], parse_standby_config_keyval, &context))
+    {
+        mctrl_err("Failed to parse config file\n");
+        return -1;
+    }
+
+    /* If the wake filter has been configured, send the command to set it here. */
+    if (wake_filter.len != 0)
+    {
+        return send_wake_filter_cmd(mors, &wake_filter);
+    }
+
+    return 0;
+}
+
+static int process_set_status_payload(struct command_standby_mode_req* cmd, int argc, char *argv[])
+{
+    uint32_t payload_len;
+
+    if (argc != 3)
+    {
+        mctrl_err("Invalid number of arguments\n");
+        return -1;
+    }
+
+    argc -= 1;
+    argv += 1;
+
+    payload_len = strlen(argv[1]);
+    if ((payload_len % 2) != 0)
+    {
+        mctrl_err("Invalid hex string, length must be a multiple of 2\n");
+        return -1;
+    }
+
+    payload_len = (payload_len / 2);
+    if (payload_len > STANDBY_STATUS_FRAME_USER_PAYLOAD_MAX_LEN)
+    {
+        mctrl_err("Supplied payload is too large: %d > %d\n", payload_len,
+            STANDBY_STATUS_FRAME_USER_PAYLOAD_MAX_LEN);
+        return -1;
+    }
+
+    cmd->set_payload.len = payload_len;
+    for (int i = 0; i < payload_len; i++)
+    {
+        int ret = sscanf(&(argv[1][i * 2]), "%2hhx", &cmd->set_payload.payload[i]);
+        if (ret != 1)
+        {
+            mctrl_err("Invalid hex string\n");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int standby(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    struct command_standby_mode_req *cmd;
+    struct command_standby_mode_cfm *rsp = NULL;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    /* Local-only command - not sent to firmware */
+    if (strcmp("store", argv[1]) == 0)
+    {
+        return standby_store_session_cmd(mors, argc - 1, &argv[1]);
+    }
+
+    ret = standby_get_cmd(argv[1]);
+    if (ret < 0)
+    {
+        mctrl_err("Invalid standby command '%s'\n", argv[1]);
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_standby_mode_req);
+    rsp = TBUFF_TO_RSP(rsp_tbuff, struct command_standby_mode_cfm);
+
+    cmd->cmd = standby_get_cmd(argv[1]);
+
+    switch (cmd->cmd)
+    {
+        case STANDBY_MODE_CMD_SET_CONFIG_V2:
+        {
+            if (process_set_config_cmd(mors, cmd, argc, argv))
+            {
+                ret = -1;
+                usage(mors);
+                goto exit;
+            }
+
+            if (mors->debug)
+            {
+                mctrl_print("Setting standby configuration:\n");
+                mctrl_print("deep sleep inactivity period: %d\n",
+                        cmd->config.bss_inactivity_before_deep_sleep_s);
+                mctrl_print("deep_sleep period: %d\n", cmd->config.deep_sleep_period_s);
+                mctrl_print("notify period : %d\n", cmd->config.notify_period_s);
+                mctrl_print("dst port: %d\n", cmd->config.dst_port);
+                mctrl_print("dst ip: " IPSTR "\n", IP2STR(cmd->config.dst_ip.octet));
+                mctrl_print("src ip: " IPSTR "\n", IP2STR(cmd->config.src_ip.octet));
+            }
+
+            break;
+        }
+        case STANDBY_MODE_CMD_SET_STATUS_PAYLOAD:
+        {
+            if (process_set_status_payload(cmd, argc, argv))
+            {
+                ret = -1;
+                usage(mors);
+                goto exit;
+            }
+
+            break;
+        }
+        case STANDBY_MODE_CMD_ENTER:
+        {
+            if (process_standby_enter(mors, cmd, argc, argv))
+            {
+                ret = -1;
+                usage(mors);
+                goto exit;
+            }
+            mctrl_print("Enter standby\n");
+            break;
+        }
+        case STANDBY_MODE_CMD_EXIT:
+        default:
+            break;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_STANDBY_MODE,
+        cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to send standby command %d\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(standby, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/stats.c
+++ b/feeds/morse/utils/morsectrl/src/stats.c
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+#ifndef MORSE_WIN_BUILD
+#include <regex.h>
+#endif
+
+#include "portable_endian.h"
+#include "command.h"
+#include "elf_file.h"
+#include "offchip_statistics.h"
+#include "stats_format.h"
+#include "utilities.h"
+#include "transport/transport.h"
+#include "mm_argtable3.h"
+
+#ifndef MAX_PATH
+#define MAX_PATH 1024
+#endif
+
+static struct
+{
+    struct arg_lit *apps_core;
+    struct arg_lit *mac_core;
+    struct arg_lit *phy_core;
+    struct arg_lit *reset;
+    struct arg_lit *json_format;
+    struct arg_lit *pprint_format;
+    struct arg_str *filter_str;
+    struct arg_str *firmware_path;
+} args;
+
+/* Read and return a single word from a file.
+ * The result is always null terminated.
+ */
+static char *get_word_from_file(const char *path, char *word, size_t n)
+{
+    FILE *infile = fopen(path, "r");
+    if (infile)
+    {
+        fgets(word, n, infile); /* fgets always null terminates */
+        fclose(infile);
+        return strip(word);
+    }
+    return NULL;
+}
+
+/* Get the firmware path from the driver debugfs file
+ * ...using phy name from sysfs file
+ * ...using wlan name from morsectrl struct
+ * The append it to the firmware path.
+ *
+ * If any of these steps fail, nothing is written to the firmware path.
+ */
+static void get_override_firmware_path(struct morsectrl *mors, char *firmware_full_path, size_t n)
+{
+    char path_buf[MAX_PATH];
+    char content_buf[MAX_PATH];
+    const char *sysfs_path_fmt = "/sys/class/net/%s/phy80211/name";
+    const char *debugfs_path_fmt = "/sys/kernel/debug/ieee80211/%s/morse/firmware_path";
+    const char *firmware_path_fmt = "/lib/firmware/%s";
+
+    char *phy_name;
+    char *firmware_path;
+
+#ifdef CONFIG_TRANS_NL80211
+    if (mors->transport.type == MORSECTRL_TRANSPORT_NL80211)
+    {
+        snprintf(path_buf, sizeof(path_buf), sysfs_path_fmt,
+                mors->transport.config.nl80211.interface_name);
+    }
+    else
+    {
+#else
+    {
+#endif
+        snprintf(path_buf, sizeof(path_buf), sysfs_path_fmt, DEFAULT_INTERFACE_NAME);
+    }
+
+    phy_name = get_word_from_file(path_buf, content_buf, sizeof(content_buf));
+    if (phy_name)
+    {
+        snprintf(path_buf, sizeof(path_buf), debugfs_path_fmt, phy_name);
+        firmware_path = get_word_from_file(path_buf, content_buf, sizeof(content_buf));
+        if (firmware_path)
+        {
+            snprintf(firmware_full_path, n, firmware_path_fmt, firmware_path);
+        }
+    }
+}
+
+static int load_offchip_statistics(struct morsectrl *mors, const char *filename)
+{
+    FILE *infile;
+    char firmware_path[MAX_PATH] = "/lib/firmware/morse/mm6108.bin";
+
+    if (!filename)
+    {
+        filename = firmware_path;
+        get_override_firmware_path(mors, firmware_path, sizeof(firmware_path));
+    }
+
+    infile = fopen(filename, "rb");
+    if (infile)
+    {
+        uint8_t *buf = NULL;
+
+        load_file(infile, &buf);
+        if (buf)
+        {
+            morse_stats_load(&mors->stats, &mors->n_stats, buf);
+            free(buf);
+        }
+        fclose(infile);
+    }
+    else
+    {
+        mctrl_err("Error - could not open %s to read stats metadata\n", filename);
+        return -1;
+    }
+    return 0;
+}
+
+
+#ifndef MORSE_WIN_BUILD
+static regex_t *filter_re = NULL;
+
+static int filter_init(const char *filter_string)
+{
+    int ret = 0;
+
+    filter_re = malloc(sizeof(*filter_re));
+    ret = regcomp(filter_re, filter_string, 0);
+
+    if (ret)
+    {
+        size_t len = regerror(ret, filter_re, NULL, 0);
+        char *re_err_buf = malloc(len);
+        regerror(ret, filter_re, re_err_buf, len);
+        mctrl_err("Invalid filter string: %s\n", re_err_buf);
+        free(re_err_buf);
+        free(filter_re);
+        filter_re = NULL;
+    }
+
+    return ret;
+}
+
+static int filter_stat(const char *key)
+{
+    return regexec(filter_re, key, 0, NULL, 0);
+}
+
+static void filter_deinit(void)
+{
+    if (filter_re)
+    {
+        regfree(filter_re);
+        free(filter_re);
+    }
+    filter_re = NULL;
+}
+
+static const char *filter_help(void)
+{
+    return "uses a regular expression";
+}
+#else
+static const char *filter_str = NULL;
+
+static int filter_init(const char *filter_string)
+{
+    filter_str = filter_string;
+
+    return 0;
+}
+
+static int filter_stat(const char *key)
+{
+    return strcmp(key, filter_str);
+}
+
+static void filter_deinit(void)
+{
+    filter_str = NULL;
+}
+
+static const char *filter_help(void)
+{
+    return "case sensitive, match from start of key";
+}
+#endif
+
+int morsectrl_stats_cmd(struct morsectrl *mors, int cmd, int reset,
+                            const char *filter_string, enum format_type format_val)
+{
+    int ret = -1;
+    int resp_sz;
+    const struct format_table *table;
+    struct stats_response *resp;
+    struct morsectrl_transport_buff *cmd_tbuff =
+        morsectrl_transport_cmd_alloc(mors->transport, 0);
+    struct morsectrl_transport_buff *rsp_tbuff =
+        morsectrl_transport_resp_alloc(mors->transport, sizeof(*resp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    if (filter_string)
+    {
+        ret = filter_init(filter_string);
+
+        if (ret)
+            goto exit;
+    }
+
+    resp = TBUFF_TO_RSP(rsp_tbuff, struct stats_response);
+
+    if (reset)
+        cmd += 1;
+
+    ret = morsectrl_send_command(mors->transport, cmd, cmd_tbuff, rsp_tbuff);
+    resp_sz = rsp_tbuff->data_len - sizeof(struct response);
+
+    if (ret)
+    {
+        /* Try the deprecated command */
+        ret = morsectrl_send_command(mors->transport, OLD_STATS_COMMAND_MASK & cmd,
+                                     cmd_tbuff, rsp_tbuff);
+        resp_sz = rsp_tbuff->data_len - sizeof(struct response);
+        if (!reset && !ret)
+        {
+            mctrl_print("%s", resp->stats);
+        }
+        goto exit;
+    }
+
+    if (!reset && !ret)
+    {
+        uint8_t *buf = (uint8_t *)resp->stats;
+
+        switch (format_val)
+        {
+            case FORMAT_REGULAR:
+            {
+                table = stats_format_regular_get_formatter_table();
+                break;
+            }
+            case FORMAT_JSON_PPRINT:
+            {
+                stats_format_json_set_pprint(true);
+                /* fall through */
+            }
+            case FORMAT_JSON:
+            {
+                table = stats_format_json_get_formatter_table();
+                break;
+            }
+            default:
+                ret = -1;
+                goto exit;
+        }
+
+        while (resp_sz > STATS_TLV_OVERHEAD )
+        {
+            stats_tlv_tag_t tag =  *((stats_tlv_tag_t *)buf);
+            buf += sizeof(stats_tlv_tag_t);
+
+            stats_tlv_len_t len =  *((stats_tlv_len_t *)buf);
+            buf += sizeof(stats_tlv_len_t);
+
+            if ((len > resp_sz) || (len == 0))
+            {
+                mctrl_err("error: malformed TLV (tag %d/0x%x, len %u/0x%x, size %u)\n",
+                        tag, tag, len, len, resp_sz);
+                break;
+            }
+
+            struct statistics_offchip_data *offchip = get_stats_offchip(mors, tag);
+            if (offchip)
+            {
+                if ((offchip->format == MORSE_STATS_FMT_DEC) &&
+                        !strncmp(offchip->type_str, "uint", 4))
+                {
+                    offchip->format = MORSE_STATS_FMT_U_DEC;
+                }
+
+                if (!filter_string || !filter_stat(offchip->key))
+                {
+                    if (format_val == FORMAT_JSON || format_val == FORMAT_JSON_PPRINT)
+                    {
+                        stats_format_json_init();
+                    }
+
+                    if (offchip->format > MORSE_STATS_FMT_LAST)
+                    {
+                        offchip->format = MORSE_STATS_FMT_LAST;
+                    }
+
+                    table->format_func[offchip->format]((const char *) offchip->key,
+                                                                (const uint8_t *)buf, len);
+                }
+            }
+            else
+            {
+                mctrl_err("UNKOWN KEY for tag %d: ", tag);
+                hexdump(buf, len);
+                mctrl_err("\n");
+            }
+            buf += len;
+
+            resp_sz -= (STATS_TLV_OVERHEAD + len);
+        }
+    }
+exit:
+    filter_deinit();
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+static void dump_stats_types(struct morsectrl *mors)
+{
+    int ii;
+
+    mctrl_print("Stats types\n");
+    for (ii = 0; ii < mors->n_stats; ii++)
+    {
+        mctrl_print("Type: %s\n", mors->stats[ii].type_str);
+        mctrl_print("Name: %s\n", mors->stats[ii].name);
+        mctrl_print("Key: %s\n\n", mors->stats[ii].key);
+    }
+}
+
+int stats_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Read statistics from the chip",
+                     args.apps_core = arg_lit0("a", NULL, "read statistics from the Apps core"),
+                     args.mac_core = arg_lit0("m", NULL, "read statistics from the MAC core"),
+                     args.phy_core = arg_lit0("u", NULL, "read statistics from the PHY core"),
+                     args.reset = arg_lit0("r", NULL, "reset the statistics"),
+                     args.json_format = arg_lit0("j", "json", "Format the statistics in JSON"),
+                     args.pprint_format = arg_lit0("p", NULL, "Format the statistics in pprint"),
+                     args.filter_str = arg_str0("f", "filter", "<filter>", filter_help()),
+                     args.firmware_path =
+                         arg_str0("s", "firmware",
+                                  "<firmware>",
+                                  "Path to the firmware used to process the statistics"));
+    return 0;
+}
+
+int stats(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = 0;
+    bool reset = false, app_c = false, mac_c = false, uph_c = false;
+    enum format_type format = FORMAT_REGULAR;
+
+    ret = load_offchip_statistics(mors, args.firmware_path->count >
+                                  0 ? args.firmware_path->sval[0] : NULL);
+
+    if (ret)
+    {
+        goto exit_stats;
+    }
+
+    if (mors->debug)
+        dump_stats_types(mors);
+
+    app_c = (bool)(args.apps_core->count > 0);
+    mac_c = (bool)(args.mac_core->count > 0);
+    uph_c = (bool)(args.phy_core->count > 0);
+
+    /* If no core selected then enable all. */
+    if ((!app_c) && (!mac_c) && (!uph_c))
+    {
+        app_c = true;
+        mac_c = true;
+        uph_c = true;
+    }
+
+    if (args.json_format->count > 0)
+        format = FORMAT_JSON;
+    else if (args.pprint_format->count > 0)
+        format = FORMAT_JSON_PPRINT;
+
+    if (format == FORMAT_JSON)
+    {
+        mctrl_print("{");
+    }
+    else if (format == FORMAT_JSON_PPRINT)
+    {
+        mctrl_print("{\n");
+    }
+
+    reset = !!(args.reset->count);
+
+    if (app_c)
+    {
+        ret = morsectrl_stats_cmd(mors, MORSE_COMMAND_APP_STATS_LOG, reset,
+            args.filter_str->sval[0], format);
+        if (ret) goto exit_stats;
+    }
+    if (mac_c)
+    {
+        ret = morsectrl_stats_cmd(mors, MORSE_COMMAND_MAC_STATS_LOG, reset,
+            args.filter_str->sval[0], format);
+        if (ret) goto exit_stats;
+    }
+    if (uph_c)
+    {
+        ret = morsectrl_stats_cmd(mors, MORSE_COMMAND_UPHY_STATS_LOG, reset,
+            args.filter_str->sval[0], format);
+        if (ret) goto exit_stats;
+    }
+
+    if (format == FORMAT_JSON)
+    {
+        mctrl_print("}\n");
+    }
+    else if (format == FORMAT_JSON_PPRINT)
+    {
+        mctrl_print("\n}\n");
+    }
+
+exit_stats:
+    if (ret < 0)
+    {
+        mctrl_err("Command stats error (%d)\n", ret);
+    }
+
+    return ret;
+}
+
+MM_CLI_HANDLER(stats, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/stats_format.h
+++ b/feeds/morse/utils/morsectrl/src/stats_format.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 Morse Micro
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "offchip_statistics.h"
+
+/**
+ * Bit field definitions for mac_state statistic
+ **/
+#define ENCODE_MAC_STATE_RX_STATE           (0x000000000000000F)
+#define ENCODE_MAC_STATE_TX_STATE           (0x00000000000000F0)
+#define ENCODE_MAC_STATE_CHANNEL_CONFIG     (0x0000000000000F00)
+#define ENCODE_MAC_STATE_MGD_CALIB_STATE    (0x0000000000007000)
+#define ENCODE_MAC_STATE_STA_PS_STATE       (0x0000000000038000)
+#define ENCODE_MAC_STATE_TX_BLOCKED         (0x0000000000080000)
+#define ENCODE_MAC_STATE_WAITING_MED_SYNC   (0x0000000000100000)
+#define ENCODE_MAC_STATE_PS_EN              (0x0000000000200000)
+#define ENCODE_MAC_STATE_DYN_PS_OFFLOAD_EN  (0x0000000000400000)
+#define ENCODE_MAC_STATE_WAITING_ON_DYN_PS  (0x0000000000800000)
+#define ENCODE_MAC_STATE_N_PKTS_IN_QUEUES   (0x00000000FF000000)
+
+/* The maximum number of bits in the NDP bitmap */
+#define DOT11AH_NDP_MAX_BITMAP_BIT          (16)
+
+/**
+ * A counter of the number of times an MPDU is received successfully for each position in the AMPDU
+ **/
+typedef struct __attribute__((packed)) {
+    uint32_t bitmap[DOT11AH_NDP_MAX_BITMAP_BIT];
+} ampdu_bitmap_t;
+
+/**
+ * A counter of the number of aggregates
+ */
+typedef struct __attribute__((packed)) {
+    /* This count starts at zero and goes to 16, so it's 17 elements */
+    uint32_t count[17];
+} ampdu_count_t;
+
+#define MAC_MAX_RETRY_COUNT 10
+ /* Account for 0 retry, for more than
+  * MAC_MAX_RETRY_COUNT, and fail */
+#define APP_STATS_COUNT (MAC_MAX_RETRY_COUNT + 3)
+
+struct __attribute__((packed)) retry_stats {
+    uint64_t start, stop;
+    uint64_t sum[APP_STATS_COUNT];
+    uint32_t count[APP_STATS_COUNT];
+};
+
+
+#define NUM_PAGESETS 2
+struct __attribute__((packed)) pageset_stats {
+    uint32_t pages_allocated[NUM_PAGESETS];
+    uint32_t pages_to_allocate[NUM_PAGESETS];
+};
+
+
+
+/** TX OP statistics, Note: Changes made to this struct must be reflected in statistics.py parser */
+struct __attribute__((packed)) txop_statistics {
+    uint64_t    duration;
+    uint32_t    count;
+    uint32_t    pkts;
+    uint32_t    max_pkts_in_txop;
+    uint32_t    lost_beacons;
+    uint8_t     beacon_lost;
+};
+
+
+/**
+ * RAW (Restricted Access Window) statistics
+ */
+typedef struct PACKED {
+    /** Currently only supporting up to 8 assignments */
+    uint32_t assignments[8];
+    /** A counter of assignments that get truncated due to the next tbtt */
+    uint32_t assignments_truncated_from_tbtt;
+    /** Number of invalid assignments (/unsupported) observed */
+    uint32_t invalid_assignments;
+    /** Number of assignments that are valid but system time has already passed */
+    uint32_t already_past_assignment;
+    /** ACI delayed frames due to RAW */
+    uint32_t aci_frames_delayed;
+    /** Broadcast / Multicast delayed frames due to RAW */
+    uint32_t bc_mc_frames_delayed;
+    /** Absolute time frames delayed due to RAW */
+    uint32_t abs_frames_delayed;
+    /** Frames that could've been sent in the RAW but were too long for slot */
+    uint32_t frame_crosses_slot_delayed;
+} raw_stats_t;
+
+typedef struct {
+    /** A quiet calibration was granted */
+    uint32_t quiet_calibration_granted;
+    /** A non-quiet calibration was granted */
+    uint32_t non_quiet_calibration_granted;
+    /** A quiet calibration was in progress, but then cancelled */
+    uint32_t quiet_calibration_cancelled;
+    /** A quiet calibration was rejected */
+    uint32_t quiet_calibration_rejected;
+    /** A quiet/non-quiet calibration completed */
+    uint32_t calibration_complete;
+} managed_calibration_stats_t;
+
+typedef struct
+{
+    /** Total transmitter 'on air' (Tair) time in us */
+    uint64_t total_t_air;
+    /** Total transmitter 'blocked' (Toff) time in us */
+    uint64_t total_t_off;
+    /** Configured duty cycle restriction (100th of a percent). 10000 is no restriction. */
+    uint32_t target_duty_cycle;
+    /** Number of packets ignoring duty cycle restrictions. */
+    uint32_t num_early;
+    /** Maximum time the t_off timer is started for */
+    uint64_t max_t_off;
+} duty_cycle_stats_t;
+
+
+struct PACKED stats_response
+{
+    /** The contents of the response */
+    uint8_t stats[2048];
+};
+
+
+/** Enum type for printing format  */
+enum format_type
+{
+    FORMAT_REGULAR,
+    FORMAT_JSON,
+    FORMAT_JSON_PPRINT,
+    /* Add additional formats here  */
+};
+
+
+typedef void (*format_func_t)(const char *key, const uint8_t *buf, uint32_t len);
+
+struct format_table {
+    format_func_t format_func[MORSE_STATS_FMT_LAST + 1];
+};
+
+/** Regular format function  */
+const struct format_table* stats_format_regular_get_formatter_table();
+void hexdump(const uint8_t *buf, uint32_t len);
+
+/** JSON format functions  */
+const struct format_table* stats_format_json_get_formatter_table();
+void stats_format_json_init();
+void stats_format_json_set_pprint(bool pprint);

--- a/feeds/morse/utils/morsectrl/src/stats_format_json.c
+++ b/feeds/morse/utils/morsectrl/src/stats_format_json.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <stdarg.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "offchip_statistics.h"
+#include "stats_format.h"
+#include "utilities.h"
+
+#define SPACES_PER_INDENT 4
+#define INDENT_FIRST_LEVEL 1
+
+static int indent_level;
+static bool pretty;
+
+/** Print wrapper function to prepend additional indentation*/
+static void printf_indent(char* format, ...)
+{
+    if (pretty)
+    {
+        mctrl_print("%*s", indent_level * SPACES_PER_INDENT, "");
+    }
+
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+};
+
+
+/** JSON formatting functions for morsectrl statistics */
+static void print_dec(const char *key, const uint8_t *buf, uint32_t len)
+{
+    int64_t n = get_signed_value_as_int64(buf, len);
+    printf_indent("\"%s\": %lld", key, n);
+}
+
+
+static void print_udec(const char *key, const uint8_t *buf, uint32_t len)
+{
+    uint64_t n = get_unsigned_value_as_uint64(buf, len);
+    printf_indent("\"%s\": %llu", key, n);
+}
+
+
+static void print_ampdu_aggregates(const char *key, const uint8_t *buf, uint32_t len)
+{
+    ampdu_count_t *count = (ampdu_count_t *)buf;
+    printf_indent("\"%s\": ", key);
+    mctrl_print("\"");
+    for (int i = 0; i < MORSE_ARRAY_SIZE(count->count); i++)
+    {
+        mctrl_print("%d ", count->count[i]);
+    }
+    mctrl_print("\"");
+}
+
+
+static void print_ampdu_bitmap(const char *key, const uint8_t *buf, uint32_t len)
+{
+    ampdu_bitmap_t *bitmap = (ampdu_bitmap_t *)buf;
+    printf_indent("\"%s\": ", key);
+    mctrl_print("\"");
+    for (int i = 0; i < MORSE_ARRAY_SIZE(bitmap->bitmap); i++)
+    {
+        mctrl_print("%u ", bitmap->bitmap[i]);
+    }
+    mctrl_print("\"");
+}
+
+
+static void print_txop(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct txop_statistics *txop_stats = (struct txop_statistics *)buf;
+    uint32_t duration_avg = 0, packets_avg = 0;
+
+    if (txop_stats->count)
+    {
+        packets_avg = (uint32_t)(txop_stats->pkts / txop_stats->count);
+        duration_avg = (uint32_t)(txop_stats->duration / txop_stats->count);
+    }
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"TXOP count\": %lu,%s", txop_stats->count, terminator);
+    printf_indent("\"Total TXOP time\": %llu,%s", txop_stats->duration, terminator);
+    printf_indent("\"Average TXOP time\": %lu,%s", duration_avg, terminator);
+    printf_indent("\"Total TXOP Tx packets\": %lu,%s", txop_stats->pkts, terminator);
+    printf_indent("\"Average TXOP Tx packets\": %lu%s", packets_avg, terminator);
+
+    mctrl_print("%s", terminator);
+    indent_level--;
+    printf_indent("}");
+}
+
+
+static void print_pageset(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct pageset_stats *pageset = (struct pageset_stats *)buf;
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("[%s", terminator);
+    indent_level++;
+
+    for (int i = 0; i < NUM_PAGESETS; i++)
+    {
+        if (i) mctrl_print(",%s", terminator);
+
+        printf_indent("{%s", terminator);
+        indent_level++;
+
+        printf_indent("\"Pageset\": %d,%s", i, terminator);
+        printf_indent("\"allocated\": %d,%s", pageset->pages_allocated[i], terminator);
+        printf_indent("\"total\": %d%s", pageset->pages_to_allocate[i], terminator);
+
+        indent_level--;
+        printf_indent("}");
+    }
+
+    indent_level--;
+    mctrl_print("%s", terminator);
+    printf_indent("]");
+}
+
+
+static void print_retries(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct retry_stats *retries = (struct retry_stats *)buf;
+    char *terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("[%s", terminator);
+    indent_level++;
+
+    for (int i = 0; i < APP_STATS_COUNT; i++)
+    {
+        if (i) mctrl_print(",%s", terminator);
+        printf_indent("{%s", terminator);
+        indent_level++;
+        uint32_t count = retries->count[i];
+        uint32_t avg_time = retries->count[i] ?
+            (uint32_t)(retries->sum[i]/retries->count[i]) : 0;
+
+        printf_indent("\"Retry\": %d,%s", i, terminator);
+        printf_indent("\"Count\": %lu,%s", count, terminator);
+        printf_indent("\"Avg Time\": %lu%s", avg_time, terminator);
+        indent_level--;
+        printf_indent("}");
+    }
+    indent_level--;
+    mctrl_print("%s", terminator);
+    printf_indent("]");
+}
+
+
+static void print_raw(const char *key, const uint8_t *buf, uint32_t len)
+{
+    raw_stats_t *raw_stats = (raw_stats_t *)buf;
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"RAW Assignments\": %s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"Valid\": \"");
+
+    for (uint8_t i = 0; i < MORSE_ARRAY_SIZE(raw_stats->assignments); i++)
+    {
+        mctrl_print(" %d", raw_stats->assignments[i]);
+    }
+    mctrl_print("\",%s", terminator);
+
+    printf_indent("\"Truncated by tbtt\": %ld,%s",
+        raw_stats->assignments_truncated_from_tbtt, terminator);
+    printf_indent("\"Invalid\": %ld,%s", raw_stats->invalid_assignments, terminator);
+    printf_indent("\"Already past\": %ld%s", raw_stats->already_past_assignment, terminator);
+
+    indent_level--;
+    printf_indent("},%s", terminator);
+    printf_indent("\"Delayed due to RAW\": %s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"From aci queue\": %ld,%s", raw_stats->aci_frames_delayed, terminator);
+    printf_indent("\"From bc/mc queue\": %ld,%s", raw_stats->bc_mc_frames_delayed, terminator);
+    printf_indent("\"From abs time queue\": %ld,%s",
+        raw_stats->abs_frames_delayed, terminator);
+    printf_indent("\"Frame crosses slot\": %ld%s",
+        raw_stats->frame_crosses_slot_delayed, terminator);
+
+    indent_level--;
+    printf_indent("}%s", terminator);
+
+    indent_level--;
+    printf_indent("}");
+}
+
+
+static void print_calibration(const char *key, const uint8_t *buf, uint32_t len)
+{
+    managed_calibration_stats_t *calib_stats = (managed_calibration_stats_t *)buf;
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"Manged Calibration\": %s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"Quiet calibration granted\": %ld,%s",
+            calib_stats->quiet_calibration_granted, terminator);
+    printf_indent("\"Quiet calibration rejected\": %ld,%s",
+            calib_stats->quiet_calibration_rejected, terminator);
+    printf_indent("\"Quiet calibration cancelled\": %ld,%s",
+            calib_stats->quiet_calibration_cancelled, terminator);
+    printf_indent("\"Non-Quiet calibration granted\": %ld,%s",
+            calib_stats->non_quiet_calibration_granted, terminator);
+    printf_indent("\"Calibration complete\": %ld%s", calib_stats->calibration_complete,
+            terminator);
+
+    indent_level--;
+    printf_indent("}%s", terminator);
+    indent_level--;
+    printf_indent("}");
+}
+
+
+static void print_duty_cycle(const char *key, const uint8_t *buf, uint32_t len)
+{
+    duty_cycle_stats_t *duty_cycle_stats = (duty_cycle_stats_t*)buf;
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    /* Duty Cycle Body*/
+    printf_indent("\"Duty Cycle Target (%%)\": %d.%02d,%s",
+                  duty_cycle_stats->target_duty_cycle / 100,
+                  duty_cycle_stats->target_duty_cycle % 100,
+                  terminator);
+    printf_indent("\"Duty Cycle TX On (us)\": %llu,%s",
+                  duty_cycle_stats->total_t_air,
+                  terminator);
+    printf_indent("\"Duty Cycle TX Off (Blocked) (us)\": %llu,%s",
+                  duty_cycle_stats->total_t_off,
+                  terminator);
+    printf_indent("\"Duty Cycle Max toff (us)\": %llu,%s",
+                  duty_cycle_stats->max_t_off,
+                  terminator);
+    printf_indent("\"Duty Cycle Early Frames\": %u%s",
+                  duty_cycle_stats->num_early,
+                  terminator);
+
+    indent_level--;
+    printf_indent("}");
+}
+
+
+static void print_mac_state(const char *key, const uint8_t *buf, uint32_t len)
+{
+    uint64_t mac_state;
+    memcpy(&mac_state, buf, sizeof(mac_state));
+    char* terminator = pretty ? "\n" : "";
+
+    printf_indent("\"%s\": ", key);
+    mctrl_print("%s", terminator);
+    printf_indent("{%s", terminator);
+    indent_level++;
+
+    printf_indent("\"%s\": %lld,%s", "RX state",
+        BMGET(mac_state, ENCODE_MAC_STATE_RX_STATE), terminator);
+    printf_indent("\"%s\": %lld,%s", "TX state",
+        BMGET(mac_state, ENCODE_MAC_STATE_TX_STATE), terminator);
+    printf_indent("\"%s\": %lld,%s", "Channel config",
+        BMGET(mac_state, ENCODE_MAC_STATE_CHANNEL_CONFIG), terminator);
+    printf_indent("\"%s\": %lld,%s", "Managed calibration state",
+        BMGET(mac_state, ENCODE_MAC_STATE_MGD_CALIB_STATE), terminator);
+    printf_indent("\"%s\": %lld,%s", "Powersave enabled",
+        BMGET(mac_state, ENCODE_MAC_STATE_PS_EN), terminator);
+    printf_indent("\"%s\": %lld,%s", "Dynamic powersave offload enabled",
+        BMGET(mac_state, ENCODE_MAC_STATE_DYN_PS_OFFLOAD_EN), terminator);
+    printf_indent("\"%s\": %lld,%s", "STA PS state",
+        BMGET(mac_state, ENCODE_MAC_STATE_STA_PS_STATE), terminator);
+    printf_indent("\"%s\": %lld,%s", "Is waiting on dynamic powersave timeout",
+        BMGET(mac_state, ENCODE_MAC_STATE_WAITING_ON_DYN_PS), terminator);
+    printf_indent("\"%s\": %lld,%s", "TX blocked by host cmd",
+        BMGET(mac_state, ENCODE_MAC_STATE_TX_BLOCKED), terminator);
+    printf_indent("\"%s\": %lld,%s", "Is waiting for medium sync",
+        BMGET(mac_state, ENCODE_MAC_STATE_WAITING_MED_SYNC), terminator);
+    printf_indent("\"%s\": %lld%s", "N packets in QoS queues",
+        BMGET(mac_state, ENCODE_MAC_STATE_N_PKTS_IN_QUEUES), terminator);
+
+    indent_level--;
+    printf_indent("}");
+}
+
+
+
+
+static void print_default(const char *key, const uint8_t *buf, uint32_t len)
+{
+    printf_indent("\"%s\": ", key);
+    mctrl_print("\"");
+    for (int i = 0; i < len; i++)
+    {
+        mctrl_print("%02X ", buf[i]);
+    }
+    mctrl_print("\"");
+}
+
+
+/**
+ * Array of function pointers indexed by the TLV format key.
+ *
+ * JSON doesn't support hex numbers, so
+ * so use unsigned decimal instead.
+ */
+static const struct format_table table = {
+    .format_func = {
+        [MORSE_STATS_FMT_DEC] = print_dec,
+        [MORSE_STATS_FMT_U_DEC] = print_udec,
+        [MORSE_STATS_FMT_HEX] = print_udec,
+        [MORSE_STATS_FMT_0_HEX] = print_udec,
+        [MORSE_STATS_FMT_AMPDU_AGGREGATES] = print_ampdu_aggregates,
+        [MORSE_STATS_FMT_AMPDU_BITMAP] = print_ampdu_bitmap,
+        [MORSE_STATS_FMT_TXOP] =  print_txop,
+        [MORSE_STATS_FMT_PAGESET] = print_pageset,
+        [MORSE_STATS_FMT_RETRIES] = print_retries,
+        [MORSE_STATS_FMT_RAW] = print_raw,
+        [MORSE_STATS_FMT_CALIBRATION] = print_calibration,
+        [MORSE_STATS_FMT_DUTY_CYCLE] = print_duty_cycle,
+        [MORSE_STATS_FMT_MAC_STATE] = print_mac_state,
+        /* Add new function pointers here */
+        /* [MORSE_STATS_NEW_TLV_FORMAT] = print_new_format */
+
+        [MORSE_STATS_FMT_LAST] = print_default,
+    }
+};
+
+
+const struct format_table* stats_format_json_get_formatter_table()
+{
+    return &table;
+}
+
+
+void stats_format_json_init()
+{
+    indent_level = INDENT_FIRST_LEVEL;
+
+    static bool first = true;
+    if (first)
+    {
+        first = false;
+    }
+    else
+    {
+        pretty ? mctrl_print(",\n") : mctrl_print(",");
+    }
+}
+
+
+void stats_format_json_set_pprint(bool pprint)
+{
+    pretty = pprint;
+}

--- a/feeds/morse/utils/morsectrl/src/stats_format_regular.c
+++ b/feeds/morse/utils/morsectrl/src/stats_format_regular.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "offchip_statistics.h"
+#include "stats_format.h"
+#include "utilities.h"
+
+
+/** Regular formatting functions for morsectrl statistics */
+
+static void print_dec(const char *key, const uint8_t *buf, uint32_t len)
+{
+    mctrl_print("%s:%" PRId64 "\n", key, get_signed_value_as_int64(buf, len));
+}
+
+
+static void print_udec(const char *key, const uint8_t *buf, uint32_t len)
+{
+    mctrl_print("%s: %" PRIu64 "\n", key, get_unsigned_value_as_uint64(buf, len));
+}
+
+
+static void print_hex(const char *key, const uint8_t *buf, uint32_t len)
+{
+    mctrl_print("%s: 0x%" PRIx64 "\n", key, get_unsigned_value_as_uint64(buf, len));
+}
+
+
+static void print_0hex(const char *key, const uint8_t *buf, uint32_t len)
+{
+    mctrl_print("%s: 0x%0*" PRIx64 "\n", key, len * 2, get_unsigned_value_as_uint64(buf, len));
+}
+
+
+static void print_ampdu_aggregates(const char *key, const uint8_t *buf, uint32_t len)
+{
+    ampdu_count_t *count = (ampdu_count_t *)buf;
+    mctrl_print("%s: ", key);
+    for (int i = 0; i < MORSE_ARRAY_SIZE(count->count); i++)
+    {
+        mctrl_print("%u ", count->count[i]);
+    }
+    mctrl_print("\n");
+}
+
+
+static void print_ampdu_bitmap(const char *key, const uint8_t *buf, uint32_t len)
+{
+    ampdu_bitmap_t *bitmap = (ampdu_bitmap_t *)buf;
+    mctrl_print("%s: ", key);
+    for (int i = 0; i < MORSE_ARRAY_SIZE(bitmap->bitmap); i++)
+    {
+        mctrl_print("%u ", bitmap->bitmap[i]);
+    }
+    mctrl_print("\n");
+}
+
+
+static void print_txop(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct txop_statistics *txop_stats = (struct txop_statistics *)buf;
+    uint32_t duration_avg = 0, packets_avg = 0;
+
+    if (txop_stats->count)
+    {
+        packets_avg = (uint32_t)(txop_stats->pkts / txop_stats->count);
+        duration_avg = (uint32_t)(txop_stats->duration / txop_stats->count);
+    }
+
+    mctrl_print("%s: ", key);
+    mctrl_print("TXOP count: %u\n", txop_stats->count);
+    mctrl_print("Total TXOP time: %" PRIu64 "\n", txop_stats->duration);
+    mctrl_print("Average TXOP time: %u\n", duration_avg);
+    mctrl_print("Total TXOP Tx packets: %u\n", txop_stats->pkts);
+    mctrl_print("Average TXOP Tx packets: %u\n", packets_avg);
+}
+
+
+static void print_pageset(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct pageset_stats *pageset = (struct pageset_stats *)buf;
+
+    mctrl_print("%s: \n", key);
+    for (int i = 0; i < NUM_PAGESETS; i++)
+    {
+        mctrl_print("Pageset %d\n", i);
+        mctrl_print("\tallocated: %d\n", pageset->pages_allocated[i]);
+        mctrl_print("\ttotal: %d\n", pageset->pages_to_allocate[i]);
+    }
+}
+
+
+static void print_retries(const char *key, const uint8_t *buf, uint32_t len)
+{
+    struct retry_stats *retries = (struct retry_stats *)buf;
+    mctrl_print("%s: \n", key);
+    mctrl_print("Retry\tCount\tAvg Time\n");
+    mctrl_print("=====\t=====\t========\n");
+
+    for (int i = 0; i < APP_STATS_COUNT; i++)
+    {
+        mctrl_print("%d\t%u\t%u\n", i, retries->count[i],
+        retries->count[i] ? (uint32_t)(retries->sum[i]/retries->count[i]) : 0);
+    }
+}
+
+
+static void print_raw(const char *key, const uint8_t *buf, uint32_t len)
+{
+    raw_stats_t *raw_stats = (raw_stats_t *)buf;
+    mctrl_print("%s: \n", key);
+    mctrl_print("RAW Assignments\n\tValid:");
+
+    for (uint8_t i = 0; i < MORSE_ARRAY_SIZE(raw_stats->assignments); i++)
+    {
+        mctrl_print(" %d", raw_stats->assignments[i]);
+    }
+    mctrl_print("\n");
+    mctrl_print("\tTruncated by tbtt: %d\n", raw_stats->assignments_truncated_from_tbtt);
+    mctrl_print("\tInvalid: %d\n", raw_stats->invalid_assignments);
+    mctrl_print("\tAlready past: %d\n", raw_stats->already_past_assignment);
+    mctrl_print("Delayed due to RAW\n");
+    mctrl_print("\tFrom aci queue: %d\n", raw_stats->aci_frames_delayed);
+    mctrl_print("\tFrom bc/mc queue: %d\n", raw_stats->bc_mc_frames_delayed);
+    mctrl_print("\tFrom abs time queue: %d\n", raw_stats->abs_frames_delayed);
+    mctrl_print("\tFrame crosses slot: %d\n", raw_stats->frame_crosses_slot_delayed);
+}
+
+
+static void print_calibration(const char *key, const uint8_t *buf, uint32_t len)
+{
+    managed_calibration_stats_t *calib_stats = (managed_calibration_stats_t *)buf;
+    mctrl_print("%s: \n", key);
+    mctrl_print("Manged Calibration\n");
+    mctrl_print("\tQuiet calibration granted: %d\n",
+            calib_stats->quiet_calibration_granted);
+    mctrl_print("\tQuiet calibration rejected: %d\n",
+            calib_stats->quiet_calibration_rejected);
+    mctrl_print("\tQuiet calibration cancelled: %d\n",
+            calib_stats->quiet_calibration_cancelled);
+    mctrl_print("\tNon-Quiet calibration granted: %d\n",
+            calib_stats->non_quiet_calibration_granted);
+    mctrl_print("\tCalibration complete: %d\n", calib_stats->calibration_complete);
+}
+
+
+static void print_duty_cycle(const char *key, const uint8_t *buf, uint32_t len)
+{
+    duty_cycle_stats_t *duty_cycle_stats = (duty_cycle_stats_t *)buf;
+    mctrl_print("%s: \n", key);
+    mctrl_print("Duty Cycle Target (%%): %d.%02d\n",
+            duty_cycle_stats->target_duty_cycle / 100,
+            duty_cycle_stats->target_duty_cycle % 100);
+    mctrl_print("Duty Cycle TX On (us): %" PRIu64 "\n", duty_cycle_stats->total_t_air);
+    mctrl_print("Duty Cycle TX Off (Blocked) (us): %" PRIu64 "\n", duty_cycle_stats->total_t_off);
+    mctrl_print("Duty Cycle Max toff (us): %" PRIu64 "\n", duty_cycle_stats->max_t_off);
+    mctrl_print("Duty Cycle Early Frames: %u\n", duty_cycle_stats->num_early);
+}
+
+
+static void print_mac_state(const char *key, const uint8_t *buf, uint32_t len)
+{
+    uint64_t mac_state;
+    const uint8_t desc_len = 39;
+    memcpy(&mac_state, buf, sizeof(mac_state));
+    mctrl_print("%s: \n", key);
+    mctrl_print("\n    %-*s :%" PRId64 "\n", desc_len, "RX state",
+        BMGET(mac_state, ENCODE_MAC_STATE_RX_STATE));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "TX state",
+        BMGET(mac_state, ENCODE_MAC_STATE_TX_STATE));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Channel config",
+        BMGET(mac_state, ENCODE_MAC_STATE_CHANNEL_CONFIG));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Managed calibration state",
+        BMGET(mac_state, ENCODE_MAC_STATE_MGD_CALIB_STATE));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Powersave enabled",
+        BMGET(mac_state, ENCODE_MAC_STATE_PS_EN));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Dynamic powersave offload enabled",
+        BMGET(mac_state, ENCODE_MAC_STATE_DYN_PS_OFFLOAD_EN));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "STA PS state",
+        BMGET(mac_state, ENCODE_MAC_STATE_STA_PS_STATE));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Is waiting on dynamic powersave timeout",
+        BMGET(mac_state, ENCODE_MAC_STATE_WAITING_ON_DYN_PS));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "TX blocked by host cmd",
+        BMGET(mac_state, ENCODE_MAC_STATE_TX_BLOCKED));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "Is waiting for medium sync",
+        BMGET(mac_state, ENCODE_MAC_STATE_WAITING_MED_SYNC));
+    mctrl_print("    %-*s :%" PRId64 "\n", desc_len, "N packets in QoS queues",
+        BMGET(mac_state, ENCODE_MAC_STATE_N_PKTS_IN_QUEUES));
+}
+
+
+
+
+static void print_default(const char *key, const uint8_t *buf, uint32_t len)
+{
+    /* Not implemented prior, use default hexdump in previous switch statement */
+    mctrl_print("%s :", key);
+    hexdump(buf, len);
+    mctrl_print("\n");
+}
+
+void hexdump(const uint8_t *buf, uint32_t len)
+{
+    for (int i = 0; i < len; i++)
+    {
+        mctrl_print("%02X ", buf[i]);
+    }
+}
+
+/**
+ * Array of function pointers indexed by the TLV format key
+ */
+static const struct format_table table = {
+    .format_func = {
+        [MORSE_STATS_FMT_DEC] = print_dec,
+        [MORSE_STATS_FMT_U_DEC] = print_udec,
+        [MORSE_STATS_FMT_HEX] = print_hex,
+        [MORSE_STATS_FMT_0_HEX] = print_0hex,
+        [MORSE_STATS_FMT_AMPDU_AGGREGATES] = print_ampdu_aggregates,
+        [MORSE_STATS_FMT_AMPDU_BITMAP] = print_ampdu_bitmap,
+        [MORSE_STATS_FMT_TXOP] =  print_txop,
+        [MORSE_STATS_FMT_PAGESET] = print_pageset,
+        [MORSE_STATS_FMT_RETRIES] = print_retries,
+        [MORSE_STATS_FMT_RAW] = print_raw,
+        [MORSE_STATS_FMT_CALIBRATION] = print_calibration,
+        [MORSE_STATS_FMT_DUTY_CYCLE] = print_duty_cycle,
+        [MORSE_STATS_FMT_MAC_STATE] = print_mac_state,
+        /* Add new function pointers here */
+        /* [MORSE_STATS_NEW_TLV_FORMAT] = print_new_format */
+
+        [MORSE_STATS_FMT_LAST] = print_default,
+    }
+};
+
+
+const struct format_table* stats_format_regular_get_formatter_table()
+{
+    return &table;
+}

--- a/feeds/morse/utils/morsectrl/src/statype.c
+++ b/feeds/morse/utils/morsectrl/src/statype.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_sta_type_command
+{
+    /* data of this message */
+    uint8_t sta_type;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tsta_type <value>\tsets set sta_type for S1G cap to driver\n");
+}
+
+int sta_type(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct set_sta_type_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint8_t sta_type;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_sta_type_command);
+
+    if (str_to_uint8(argv[1], &sta_type))
+    {
+        mctrl_err("Invalid sta_type\n");
+        ret = -1;
+        goto exit;
+    }
+    cmd->sta_type = sta_type;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_STA_TYPE,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set sta_type\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(sta_type, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/tcp_keepalive.c
+++ b/feeds/morse/utils/morsectrl/src/tcp_keepalive.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+#if defined(__WINDOWS__)
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "command.h"
+#include "utilities.h"
+
+#define TCP_KEEPALIVE_SET_CFG_PERIOD         BIT(0)
+#define TCP_KEEPALIVE_SET_CFG_RETRY_COUNT    BIT(1)
+#define TCP_KEEPALIVE_SET_CFG_RETRY_INTERVAL BIT(2)
+#define TCP_KEEPALIVE_SET_CFG_SRC_IP_ADDR    BIT(3)
+#define TCP_KEEPALIVE_SET_CFG_DEST_IP_ADDR   BIT(4)
+#define TCP_KEEPALIVE_SET_CFG_SRC_PORT       BIT(5)
+#define TCP_KEEPALIVE_SET_CFG_DEST_PORT      BIT(6)
+
+#define TCP_KEEPALIVE_PARAM_PORT_MAX           (65535)
+#define TCP_KEEPALIVE_PARAM_PERIOD_MAX         (65535)
+#define TCP_KEEPALIVE_PARAM_RETRY_COUNT_MAX    (255)
+#define TCP_KEEPALIVE_PARAM_RETRY_INTERVAL_MAX (255)
+
+struct PACKED tcp_keepalive_command
+{
+    uint8_t enabled;
+    uint8_t retry_count;
+    uint8_t retry_interval_s;
+    uint8_t set_cfgs;
+    be32_t src_ip;
+    be32_t dest_ip;
+    be16_t src_port;
+    be16_t dest_port;
+    be16_t period_s;
+};
+
+static struct
+{
+    struct arg_rex *enable;
+    struct arg_int *period_s;
+    struct arg_int *retry_count;
+    struct arg_int *retry_interval_s;
+    struct arg_str *src_ip;
+    struct arg_str *dest_ip;
+    struct arg_int *src_port;
+    struct arg_int *dest_port;
+} args;
+
+int tcp_keepalive_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Configure TCP keepalive offload parameters",
+        args.period_s = arg_int0("p", NULL, "<period>",
+            "Period in seconds - range 1-65535"),
+        args.retry_count = arg_int0("c", NULL, "<retry count>",
+            "Number of retries - range 0-255"),
+        args.retry_interval_s = arg_int0("i", NULL, "<retry interval>",
+            "Seconds between retries - range 1-255"),
+        args.src_ip = arg_str0("s", NULL, "<src IP>",
+            "Source IP address in dotted decimal notation"),
+        args.dest_ip = arg_str0("d", NULL, "<dest IP>",
+            "Destination IP address in dotted decimal notation"),
+        args.src_port = arg_int0("S", NULL, "<src port>",
+            "TCP source port - range 1-65535"),
+        args.dest_port = arg_int0("D", NULL, "<dest port>",
+            "TCP destination port - range 1-65535"),
+        args.enable = arg_rex1(NULL, NULL, "(enable|disable)", "{enable|disable}", 0,
+            "enable/disable TCP keepalive offload"));
+    return 0;
+}
+
+int tcp_keepalive(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    struct tcp_keepalive_command *cmd;
+    int add_arg_count = 0;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct tcp_keepalive_command);
+    memset(cmd, 0, sizeof(*cmd));
+
+    add_arg_count =
+            args.enable->count +
+            args.period_s->count +
+            args.retry_count->count +
+            args.retry_interval_s->count +
+            args.src_ip->count +
+            args.dest_ip->count +
+            args.src_port->count +
+            args.dest_port->count;
+
+    if (add_arg_count == 0)
+    {
+        mctrl_err("No parameters specified\n");
+        goto exit;
+    }
+
+    if (args.enable->count)
+    {
+        if (strcmp("enable", args.enable->sval[0]) == 0)
+        {
+            cmd->enabled = 1;
+        }
+        else if (strcmp("disable", args.enable->sval[0]) == 0)
+        {
+            cmd->enabled = 0;
+        }
+    }
+
+    if (args.period_s->count)
+    {
+        if (args.period_s->ival[0] < 1 || args.period_s->ival[0] > TCP_KEEPALIVE_PARAM_PERIOD_MAX)
+        {
+            mctrl_err("Invalid period %d\n", args.period_s->ival[0]);
+            goto exit;
+        }
+        cmd->period_s = htole16(args.period_s->ival[0]);
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_PERIOD;
+    }
+
+    if (args.retry_count->count)
+    {
+        if (args.retry_count->ival[0] < 0 ||
+                        args.retry_count->ival[0] > TCP_KEEPALIVE_PARAM_RETRY_COUNT_MAX)
+        {
+            mctrl_err("Invalid retry count %d\n", args.retry_count->ival[0]);
+            goto exit;
+        }
+        cmd->retry_count = args.retry_count->ival[0];
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_RETRY_COUNT;
+    }
+
+    if (args.retry_interval_s->count)
+    {
+        if (args.retry_interval_s->ival[0] < 1 ||
+                        args.retry_interval_s->ival[0] > TCP_KEEPALIVE_PARAM_RETRY_INTERVAL_MAX)
+        {
+            mctrl_err("Invalid retry interval %d\n", args.retry_interval_s->ival[0]);
+            goto exit;
+        }
+        cmd->retry_interval_s = args.retry_interval_s->ival[0];
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_RETRY_INTERVAL;
+    }
+
+    if (args.src_ip->count)
+    {
+        if (inet_pton(AF_INET, args.src_ip->sval[0], &cmd->src_ip) != 1)
+        {
+            mctrl_err("Invalid source IP address %s\n", args.src_ip->sval[0]);
+            goto exit;
+        }
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_SRC_IP_ADDR;
+    }
+
+    if (args.dest_ip->count)
+    {
+        if (inet_pton(AF_INET, args.dest_ip->sval[0], &cmd->dest_ip) != 1)
+        {
+            mctrl_err("Invalid destination IP address %s\n", args.dest_ip->sval[0]);
+            goto exit;
+        }
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_DEST_IP_ADDR;
+    }
+
+    if (args.src_port->count)
+    {
+        if (args.src_port->ival[0] > TCP_KEEPALIVE_PARAM_PORT_MAX)
+        {
+            mctrl_err("Invalid source port %d\n", args.src_port->ival[0]);
+            goto exit;
+        }
+        cmd->src_port = htobe16(args.src_port->ival[0]);
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_SRC_PORT;
+    }
+
+    if (args.dest_port->count)
+    {
+        if (args.dest_port->ival[0] > TCP_KEEPALIVE_PARAM_PORT_MAX)
+        {
+            mctrl_err("Invalid destination port %d\n", args.dest_port->ival[0]);
+            goto exit;
+        }
+        cmd->dest_port = htobe16(args.dest_port->ival[0]);
+        cmd->set_cfgs |= TCP_KEEPALIVE_SET_CFG_DEST_PORT;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_TCP_KEEPALIVE,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        mctrl_err("TCP keepalive command failed - error(%d)\n", ret);
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(tcp_keepalive, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/tdc_pg_disable.c
+++ b/feeds/morse/utils/morsectrl/src/tdc_pg_disable.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_tdc_pg_disable
+{
+    /* 0 sets LNA as default, 1 sets LNA in bypass mode */
+    uint8_t tdc_pg_disable;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\ttdc_pg_disable [0|1]\n");
+    mctrl_print("\t\t\t\t'1' will disable TDC clock gating\n");
+    mctrl_print("\t\t\t\t'0' will keep the default configuration\n");
+}
+
+int tdc_pg_disable(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int8_t tdc_pg_disable;
+    struct command_tdc_pg_disable *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+
+    tdc_pg_disable = expression_to_int(argv[1]);
+    if (tdc_pg_disable == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_tdc_pg_disable);
+    cmd->tdc_pg_disable = tdc_pg_disable;
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_TDC_PG_DISABLE,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("failed to change the status of energy-based AGC \n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(tdc_pg_disable, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/transmissionrate.c
+++ b/feeds/morse/utils/morsectrl/src/transmissionrate.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+#define MAX_NSS (4)
+
+struct PACKED set_transmission_rate
+{
+    int32_t mcs_index;
+    int32_t bandwidth_mhz;
+    int32_t tx_80211ah_format;
+    int8_t use_traveling_pilots;
+    int8_t use_sgi;
+    uint8_t enabled;
+    int8_t nss_idx;
+    int8_t use_ldpc;
+    int8_t use_stbc;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\ttxrate [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' must always be included when configuring a parameter to force\n");
+    mctrl_print("\t\t\t\t'disable' will reset all forced rate parameters\n");
+    mctrl_print("\t\t-m <value>\tMCS index (0-10) or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-b <value>\ttx bandwidth in MHz or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-f <value>\tduplicate format (0, 1, 2) or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-t <value>\ttraveling pilots (0, 1) or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-s <value>\tshort guard interval (0, 1) or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-n <value>\tSpatial streams (1-%d) or (-1) to use default in firmware\n",
+                MAX_NSS);
+    mctrl_print("\t\t-l <value>\tLDPC (0, 1) or (-1) to use default in firmware\n");
+    mctrl_print("\t\t-c <value>\tSTBC (0, 1) or (-1) to use default in firmware\n");
+}
+
+int txrate(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    struct set_transmission_rate *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int32_t tmp;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_transmission_rate);
+    cmd->mcs_index = -1;
+    cmd->bandwidth_mhz = -1;
+    cmd->tx_80211ah_format = -1;
+    cmd->use_traveling_pilots = -1;
+    cmd->use_sgi = -1;
+    cmd->nss_idx = -1;
+    cmd->use_ldpc = -1;
+    cmd->use_stbc = -1;
+    cmd->enabled = 0;
+
+    switch (expression_to_int(argv[1]))
+    {
+        case true:
+            argc -= 1;
+            argv += 1;
+            cmd->enabled = 1;
+            while ((option = getopt(argc, argv, "m:b:f:t:s:n:l:c:")) != -1)
+            {
+                switch (option)
+                {
+                    case 'm' :
+                        if (str_to_int32(optarg, &tmp))
+                        {
+                            mctrl_err("Invalid MCS index\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->mcs_index = htole32(tmp);
+                    break;
+
+                    case 'b' :
+                        if (str_to_int32(optarg, &tmp))
+                        {
+                            mctrl_err("Invalid bandwidth\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->bandwidth_mhz = htole32(tmp);
+                    break;
+
+                    case 'f' :
+                        if (str_to_int32(optarg, &tmp))
+                        {
+                            mctrl_err("Invalid duplicate format\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->tx_80211ah_format = htole32(tmp);
+                    break;
+
+                    case 't' :
+                        if (str_to_int8(optarg, &cmd->use_traveling_pilots))
+                        {
+                            mctrl_err("Invalid travelling pilots arg\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                    break;
+
+                    case 's' :
+                        if (str_to_int8(optarg, &cmd->use_sgi))
+                        {
+                            mctrl_err("Invalid duplicate format\n");
+                            ret = -1;
+                            goto exit;
+                        }
+                    break;
+
+                    case 'n' :
+                    {
+                        /* Support default (-1) or 1 to MAX_NSS spatial streams. */
+                        int8_t nss;
+
+                        if (str_to_int8_range(optarg, &nss, -1, MAX_NSS) || nss == 0)
+                        {
+                            mctrl_err("Invalid spatial streams parameter: %d\n", nss);
+                            ret = -1;
+                            goto exit;
+                        }
+                        cmd->nss_idx = (nss == -1) ? -1 : NSS_TO_NSS_IDX(nss);
+                    }
+                    break;
+
+                    case 'l' :
+                        if (str_to_int8_range(optarg, &cmd->use_ldpc, -1, 1))
+                        {
+                            mctrl_err("Invalid LDPC parameter: %d\n", cmd->use_ldpc);
+                            ret = -1;
+                            goto exit;
+                        }
+                    break;
+
+                    case 'c' :
+                        if (str_to_int8_range(optarg, &cmd->use_stbc, -1, 1))
+                        {
+                            mctrl_err("Invalid STBC parameter: %d\n", cmd->use_stbc);
+                            ret = -1;
+                            goto exit;
+                        }
+                    break;
+
+                    case '?' :
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+
+                    default :
+                        mctrl_err("Invalid argument\n");
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+        break;
+
+        case false:
+            cmd->enabled = 0;
+        break;
+
+        default:
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            ret = -1;
+            goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_TRANSMISSION_RATE,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set transmission rate\n");
+    }
+    else if (cmd->enabled)
+    {
+        mctrl_print("Set the following transmission rate parameters:\n");
+
+        if (cmd->mcs_index != -1)
+            mctrl_print("\tMCS index: %d\n", cmd->mcs_index);
+        if (cmd->bandwidth_mhz != -1)
+            mctrl_print("\tTx Channel BW: %d (MHz)\n", cmd->bandwidth_mhz);
+        if (cmd->tx_80211ah_format != -1)
+            mctrl_print("\tTX format: %d\n", cmd->tx_80211ah_format);
+        if (cmd->use_traveling_pilots != -1)
+            mctrl_print("\tUse Traveling pilots: %d\n", cmd->use_traveling_pilots);
+        if (cmd->use_sgi != -1)
+            mctrl_print("\tUse Short Guard Interval: %d\n", cmd->use_sgi);
+        if (cmd->nss_idx != -1)
+            mctrl_print("\tSpatial Streams: %d\n", NSS_IDX_TO_NSS(cmd->nss_idx));
+        if (cmd->use_ldpc != -1)
+            mctrl_print("\tUse LDPC: %d\n", cmd->use_ldpc);
+        if (cmd->use_stbc != -1)
+            mctrl_print("\tUse STBC: %d\n", cmd->use_stbc);
+    }
+    else
+    {
+        mctrl_print("Disabled forced transmission rate\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(txrate, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/transmit_cw.c
+++ b/feeds/morse/utils/morsectrl/src/transmit_cw.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED transmit_cw_command
+{
+    /** The flags of this message */
+    int32_t start;
+    int32_t tone_frequency_hz;
+    int32_t power_dbm;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\ttransmit_cw [start|stop] <tone_frequency_hz> <power_dbm>\n");
+    mctrl_print(
+        "\t\t\t\tstart continuous wave transmission for given frequency and at given power\n");
+    mctrl_print("\t\t\t\tor stop the continuous wave transmission\n");
+    mctrl_print("\t\t\t\tPossible frequencies:\n");
+    mctrl_print(
+        "\t\t\t\t\tOFDM tones, other frequencies that are an integer multiple of (BW / 4000)\n");
+}
+
+int transmit_cw(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int32_t tone_frequency_hz;
+    int32_t power_dbm;
+    int32_t start;
+    struct transmit_cw_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    switch (argc)
+    {
+        case 0:
+            usage(mors);
+            return 0;
+        case 2:
+            if (strncmp(argv[1], "stop", 4) == 0)
+            {
+                start = 0;
+                tone_frequency_hz = 0;
+                power_dbm = 0;
+            }
+            else
+            {
+                usage(mors);
+                return -1;
+            }
+            break;
+        case 4:
+            if (strncmp(argv[1], "start", 5) == 0)
+            {
+                start = 1;
+            }
+            else
+            {
+                usage(mors);
+                return -1;
+            }
+
+            if (str_to_int32(argv[2], &tone_frequency_hz)) {
+                mctrl_err("Invalid tone frequency\n");
+                usage(mors);
+                return -1;
+            }
+
+            if (str_to_int32(argv[3], &power_dbm)) {
+                mctrl_err("Invalid power value\n");
+                usage(mors);
+                return -1;
+            }
+            break;
+        default:
+            mctrl_err("Invalid command parameters\n");
+            usage(mors);
+            return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct transmit_cw_command);
+    cmd->start = htole32(start);
+    cmd->tone_frequency_hz = htole32(tone_frequency_hz);
+    cmd->power_dbm = htole32(power_dbm);
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_TRANSMIT_CW,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to execute command\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(transmit_cw, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/transport/ftdi_spi.c
+++ b/feeds/morse/utils/morsectrl/src/transport/ftdi_spi.c
@@ -1,0 +1,1182 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ftd2xx.h"
+#include "libmpsse_spi.h"
+#include "transport.h"
+#include "transport_private.h"
+#include "sdio_over_spi.h"
+
+/* We need this to trim the response to the correct length */
+#include "../command.h"
+
+#if MORSE_WIN_BUILD
+#include "../win/strsep.h"
+#endif
+
+
+#define MM_OCTETS_OF_INIT_CLK           (18)
+
+#define MMDEBUG_CS_PIN_DEFAULT          SPI_CONFIG_OPTION_CS_DBUS3
+#define MMDEBUG_CS_ACTIVE_LOW_DEFAULT   true
+#define MMDEBUG_JTAGRST_PIN_DEFAULT     (0)
+#define MMDEBUG_RST_PIN_DEFAULT         (1)
+#define MMDEBUG_RESET_MS_DEFAULT        (100)
+#define MMDEBUG_CPOL_DEFAULT            false
+#define MMDEBUG_CPHA_DEFAULT            false
+#define MMDEBUG_LATENCY_DEFAULT         (0)
+#define MMDEBUG_MAX_CHANNELS            (4UL)
+
+#define FTDI_SPI_MIN_FREQ_KHZ           (1)
+#define FTDI_SPI_MAX_FREQ_KHZ           (30000)
+
+#define MMDEBUG_FREQ_KHZ_DEFAULT        FTDI_SPI_MAX_FREQ_KHZ
+
+#define FTDI_SPI_OPTS_BITS              BIT(0)
+#define FTDI_SPI_OPTS_CS_START          BIT(1)
+#define FTDI_SPI_OPTS_CS_FINISH         BIT(2)
+
+/* GPIO are from 0-7, 4 on each channel. */
+#define FTDI_SPI_MAX_GPIO               (3)
+#define FTDI_SPI_GPIO_OFFSET            (4)
+#define FTDI_SPI_GPIOL_MASK             (0xFF)
+
+#define FTDI_SPI_JUNK_OCTET             (0xFF)
+
+#define FTDI_SPI_STR_CPOL               "cpol"
+#define FTDI_SPI_STR_CPHA               "cpha"
+#define FTDI_SPI_STR_FREQ               "freq_khz"
+#define FTDI_SPI_STR_LAG                "latency"
+#define FTDI_SPI_STR_CS_POL             "cs_pol"
+#define FTDI_SPI_STR_CS_PIN             "cs_pin"
+#define FTDI_SPI_STR_RST_PIN            "reset_pin_num"
+#define FTDI_SPI_STR_JTAGRST_PIN        "jtag_reset_pin_num"
+#define FTDI_SPI_STR_RESET_MS           "reset_ms"
+#define FTDI_SPI_STR_SERIAL_NUM         "serial_num"
+#define FTDI_SPI_STR_HELP               "help"
+
+#define RESP_TIMEOUT_MS                 (3000)
+#define RESP_POLL_INTERVAL_MS           (100)
+
+#define FTDI_SPI_PINSTATE_TO_VAL(x)     (((x) >> 8) & 0xFF)
+#define FTDI_SPI_PINSTATE_TO_DIR(x)     ((x) & 0xFF)
+
+#define MM_MANIFEST_ADDR                (0x10054d40)
+#define MM_TRIGGER_ADDR                 (0x100A6010)
+#define MM_STATUS_ADDR                  (0x100A6060)
+#define MM_STATUS_CLR_ADDR              (0x100A6068)
+#define MM_CMD_MASK                     BIT(1)
+#define MM_CMD_ADDR_OFFSET              (16)
+#define MM_RESP_ADDR_OFFSET             (20)
+
+#define FTDI_SPI_FREQ_KHZ_TO_HZ(freq_khz)  ((freq_khz) * 1000)
+
+
+static const struct morsectrl_transport_ops ftdi_spi_ops;
+
+struct morsectrl_ftdi_spi_chan_info
+{
+    DWORD spi_loc_id;
+    DWORD spi_loc_id_ch;
+    DWORD reset_loc_id;
+    DWORD reset_loc_id_ch;
+};
+
+/** @brief Configuration for the FTDI SPI interface. */
+struct morsectrl_ftdi_spi_cfg
+{
+    ChannelConfig channel;
+    UCHAR reset_pin_num;
+    UCHAR jtag_reset_pin_num;
+    uint32_t reset_ms;
+    /** Size taken from FT_DEVICE_LIST_INFO_NODE structure in libmpsse library. */
+    char serial_num[MAX_SERIAL_NUMBER_LEN];
+};
+
+/** @brief State information for the FTDI SPI interface. */
+struct morsectrl_ftdi_spi_state
+{
+    FT_HANDLE handle;
+    FT_HANDLE reset_handle;
+};
+
+/** @brief Data structure used to represent an instance of this transport. */
+struct morsectrl_ftdi_spi_transport
+{
+    struct morsectrl_transport common;
+    struct morsectrl_ftdi_spi_cfg config;
+    struct morsectrl_ftdi_spi_state state;
+};
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *        config field.
+ */
+static struct morsectrl_ftdi_spi_cfg *ftdi_spi_cfg(struct morsectrl_transport *transport)
+{
+    struct morsectrl_ftdi_spi_transport *ftdi_spi_transport =
+        (struct morsectrl_ftdi_spi_transport *)transport;
+    return &ftdi_spi_transport->config;
+}
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *        state field.
+ */
+static struct morsectrl_ftdi_spi_state *ftdi_spi_state(struct morsectrl_transport *transport)
+{
+    struct morsectrl_ftdi_spi_transport *ftdi_spi_transport =
+        (struct morsectrl_ftdi_spi_transport *)transport;
+    return &ftdi_spi_transport->state;
+}
+
+/**
+ * @brief Prints an error message if possible.
+ *
+ * @param transport     Transport to print the error message from.
+ * @param error_code    Error code.
+ * @param error_msg     Error message.
+ */
+static void ftdi_spi_error(int error_code, char *error_msg)
+{
+    morsectrl_transport_err("FTDI_SPI", error_code, error_msg);
+}
+
+/**
+ * @brief Checks to see if a string contains the key and fills the boolean value.
+ *
+ * @param str   String that may contain the key.
+ * @param key   Key to search for.
+ * @param value Value to fill with key value, otherwise unchanged if key absent.
+ * @return      true if key was found, otherwise false.
+ */
+static bool ftdi_spi_get_bool(const char *str, const char *key, bool *value)
+{
+    if (!strncmp(str, key, strlen(key)))
+    {
+        int temp = expression_to_int(&str[strlen(key) + 1]);
+
+        *value = !!temp;
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @brief Checks to see if a string contains the key and fills the uint32_t value.
+ *
+ * @param str   String that may contain the key.
+ * @param key   Key to search for.
+ * @param value Value to fill with key value, otherwise unchanged if key absent.
+ * @return      true if key was found, otherwise false.
+ */
+static bool ftdi_spi_get_uint32(const char *str, const char *key, uint32_t *value)
+{
+    if (!strncmp(str, key, strlen(key)))
+    {
+        int ret;
+        uint32_t temp;
+        ret = str_to_uint32(&str[strlen(key) + 1], &temp);
+        if (!ret)
+        {
+            *value = temp;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Checks to see if a string contains the key and fills the uint8_t value.
+ *
+ * @param str   String that may contain the key.
+ * @param key   Key to search for.
+ * @param value Value to fill with key value, otherwise unchanged if key absent.
+ * @return      true if key was found, otherwise false.
+ */
+static bool ftdi_spi_get_uint8(const char *str, const char *key, uint8_t *value)
+{
+    uint32_t temp;
+    bool ret;
+
+    ret = ftdi_spi_get_uint32(str, key, &temp);
+
+    if (ret)
+    {
+        *value = (uint8_t)temp;
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * @brief Checks to see if a string contains the key and fills the string value.
+ *
+ * @param str   String that may contain the key.
+ * @param key   Key to search for.
+ * @param value Value to fill with key value, otherwise unchanged if key absent.
+ * @return      true if key was found, otherwise false.
+ */
+static bool ftdi_spi_get_string(const char *str, const char *key, char *val, int len_max)
+{
+    uint8_t key_len = strlen(key);
+
+    if ((strlen(str) > (key_len + 1)) && (!strncmp(str, key, key_len)) && (str[key_len] == '='))
+    {
+        if (snprintf(val, len_max, "%s", (str + key_len + 1)) >= len_max)
+        {
+            mctrl_err("Length of %s exceeds max (max len=%d)\n", key, len_max);
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+static bool ftdi_spi_print_config_usage(const char *str, const char *key)
+{
+    if (strncmp(str, key, strlen(key)))
+    {
+        return false;
+    }
+    mctrl_print("<config string> is a comma-separated list of <keyword>=<value>, "
+                "where <keyword> is one of the following\n");
+    mctrl_print("\t%s - Clock polarity (default %d)\n", FTDI_SPI_STR_CPOL,
+                    MMDEBUG_CPOL_DEFAULT);
+    mctrl_print("\t%s - Clock phase (default %d)\n", FTDI_SPI_STR_CPHA, MMDEBUG_CPHA_DEFAULT);
+    mctrl_print("\t%s - Frequency to use (default %d)\n", FTDI_SPI_STR_FREQ,
+                    MMDEBUG_FREQ_KHZ_DEFAULT);
+    mctrl_print("\t%s - Latency (default %d)\n", FTDI_SPI_STR_LAG, MMDEBUG_LATENCY_DEFAULT);
+    mctrl_print("\t%s - CS Polarity (default %d)\n", FTDI_SPI_STR_CS_POL,
+                    MMDEBUG_CS_ACTIVE_LOW_DEFAULT);
+    mctrl_print("\t%s - CS pin number (default %d)\n", FTDI_SPI_STR_CS_PIN,
+                    MMDEBUG_CS_PIN_DEFAULT);
+    mctrl_print("\t%s - Reset pin number (default %d)\n", FTDI_SPI_STR_RST_PIN,
+                    MMDEBUG_RST_PIN_DEFAULT);
+    mctrl_print("\t%s - JTAG reset pin number (default %d)\n", FTDI_SPI_STR_JTAGRST_PIN,
+                    MMDEBUG_JTAGRST_PIN_DEFAULT);
+    mctrl_print("\t%s - Reset time (default %d)\n", FTDI_SPI_STR_RESET_MS,
+                    MMDEBUG_RESET_MS_DEFAULT);
+    mctrl_print("\t%s - Serial number to use\n", FTDI_SPI_STR_SERIAL_NUM);
+    mctrl_print("\t%s - Prints this message\n", FTDI_SPI_STR_HELP);
+
+    return true;
+}
+
+/**
+ * @brief Parse the configuration for the FTDI SPI interface.
+ *
+ * @param transport     The transport structure.
+ * @param debug         Indicates whether debug print statements are enabled.
+ * @param iface_opts    String containing the interface to use. May be NULL.
+ * @param cfg_opts      Comma separated string with FTDI SPI configuration options.
+ * @return              0 on success otherwise relevant error.
+ */
+static int ftdi_spi_parse(struct morsectrl_transport **transport,
+                          bool debug,
+                          const char *iface_opts,
+                          const char *cfg_opts)
+{
+    struct morsectrl_ftdi_spi_cfg *config;
+    ChannelConfig *chan_config;
+    char *cpy;
+    char *ptr;
+    /* Use some sane defaults. */
+    bool cpol = MMDEBUG_CPOL_DEFAULT;
+    bool cpha = MMDEBUG_CPHA_DEFAULT;
+    bool cs_active_low = MMDEBUG_CS_ACTIVE_LOW_DEFAULT;
+    uint32_t cs_pin = MMDEBUG_CS_PIN_DEFAULT;
+    uint32_t freq_khz = MMDEBUG_FREQ_KHZ_DEFAULT;
+    uint8_t reset_pin_num = MMDEBUG_RST_PIN_DEFAULT;
+    uint8_t jtag_reset_pin_num = MMDEBUG_JTAGRST_PIN_DEFAULT;
+    int config_error = 0;
+
+    struct morsectrl_ftdi_spi_transport *ftdi_spi_transport =
+        calloc(1, sizeof(*ftdi_spi_transport));
+    if (!ftdi_spi_transport)
+    {
+        mctrl_err("Transport memory allocation failure\n");
+        return -ETRANSNOMEM;
+    }
+
+    ftdi_spi_transport->common.tops = &ftdi_spi_ops;
+    ftdi_spi_transport->common.debug = debug;
+    *transport = &ftdi_spi_transport->common;
+    config = ftdi_spi_cfg(*transport);
+
+    chan_config = &config->channel;
+
+    chan_config->LatencyTimer = MMDEBUG_LATENCY_DEFAULT;
+    chan_config->Pin = 0xFFFFFFFF;
+    chan_config->configOptions = 0;
+    config->reset_ms = MMDEBUG_RESET_MS_DEFAULT;
+
+    if (cfg_opts)
+    {
+        cpy = strdup(cfg_opts);
+
+        while ((ptr = strsep(&cpy, ",")) != NULL)
+        {
+            if (ftdi_spi_get_bool(ptr, FTDI_SPI_STR_CPOL, &cpol))
+                continue;
+            if (ftdi_spi_get_bool(ptr, FTDI_SPI_STR_CPHA, &cpha))
+                continue;
+            if (ftdi_spi_get_uint32(ptr, FTDI_SPI_STR_FREQ, &freq_khz))
+                continue;
+            if (ftdi_spi_get_uint8(ptr, FTDI_SPI_STR_LAG, &chan_config->LatencyTimer))
+                continue;
+            if (ftdi_spi_get_bool(ptr, FTDI_SPI_STR_CS_POL, &cs_active_low))
+                continue;
+            if (ftdi_spi_get_uint32(ptr, FTDI_SPI_STR_CS_PIN, &cs_pin))
+                continue;
+            if (ftdi_spi_get_uint8(ptr, FTDI_SPI_STR_RST_PIN, &reset_pin_num))
+                continue;
+            if (ftdi_spi_get_uint8(ptr, FTDI_SPI_STR_JTAGRST_PIN, &jtag_reset_pin_num))
+                continue;
+            if (ftdi_spi_get_uint32(ptr, FTDI_SPI_STR_RESET_MS, &config->reset_ms))
+                continue;
+            if (ftdi_spi_get_string(ptr, FTDI_SPI_STR_SERIAL_NUM, config->serial_num,
+                                    sizeof(config->serial_num)))
+                continue;
+            if (ftdi_spi_print_config_usage(ptr, FTDI_SPI_STR_HELP))
+                exit(ETRANSSUCC);
+
+            config_error++;
+        }
+    }
+
+    if (config_error)
+    {
+        mctrl_err("FTDI SPI configuration error\n");
+        ftdi_spi_print_config_usage("help", FTDI_SPI_STR_HELP);
+        return ETRANSERR;
+    }
+
+    if (!cpol)
+    {
+        if (!cpha)
+            chan_config->configOptions |= SPI_CONFIG_OPTION_MODE0;
+        else
+            chan_config->configOptions |= SPI_CONFIG_OPTION_MODE1;
+    }
+    else
+    {
+        if (!cpha)
+            chan_config->configOptions |= SPI_CONFIG_OPTION_MODE2;
+        else
+            chan_config->configOptions |= SPI_CONFIG_OPTION_MODE3;
+    }
+
+    if (freq_khz > FTDI_SPI_MAX_FREQ_KHZ)
+        chan_config->ClockRate = FTDI_SPI_FREQ_KHZ_TO_HZ(FTDI_SPI_MAX_FREQ_KHZ);
+    else if (freq_khz < FTDI_SPI_MIN_FREQ_KHZ)
+        chan_config->ClockRate = FTDI_SPI_FREQ_KHZ_TO_HZ(FTDI_SPI_MIN_FREQ_KHZ);
+    else
+        chan_config->ClockRate = FTDI_SPI_FREQ_KHZ_TO_HZ(freq_khz);
+
+    if (cs_active_low)
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_ACTIVELOW;
+    else
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_ACTIVEHIGH;
+
+    switch (cs_pin)
+    {
+    case 3:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS3;
+        break;
+
+    case 4:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS4;
+        break;
+
+    case 5:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS5;
+        break;
+
+    case 6:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS6;
+        break;
+
+    case 7:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS7;
+        break;
+
+    default:
+        chan_config->configOptions |= SPI_CONFIG_OPTION_CS_DBUS3;
+        cs_pin = MMDEBUG_CS_PIN_DEFAULT;
+    }
+
+    config->jtag_reset_pin_num = BIT(jtag_reset_pin_num + FTDI_SPI_GPIO_OFFSET);
+    config->reset_pin_num = BIT(reset_pin_num + FTDI_SPI_GPIO_OFFSET);
+
+    if (ftdi_spi_transport->common.debug)
+    {
+        mctrl_print("Frequency       = %u Hz\n", chan_config->ClockRate);
+        mctrl_print("Latency         = %d Cycles\n", chan_config->LatencyTimer);
+        mctrl_print("CPOL            = %d\n", cpol ? 1 : 0);
+        mctrl_print("CPHA            = %d\n", cpha ? 1 : 0);
+        mctrl_print("CS Polarity     = Active %s\n", cs_active_low ? "low" : "high");
+        mctrl_print("CS Pin          = DBUS%d\n", cs_pin);
+        mctrl_print("Reset Pin       = %d\n", reset_pin_num);
+        mctrl_print("JTAG Reset Pin  = %d\n", jtag_reset_pin_num);
+        mctrl_print("Reset time (ms) = %u\n", config->reset_ms);
+        mctrl_print("Serial Number   = %s\n", strlen(config->serial_num) ?
+                                              config->serial_num : "N/A");
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Sets the spi and reset channel info to use
+ *
+ * @param loc_id         Location id of the port.
+ * @param channel_num    Channel number on which the port is present.
+ * @param spi_chan_info  Structure to contain the SPI and reset port channel number and id
+ */
+static void ftdi_spi_set_spi_and_reset_chan(DWORD loc_id,
+                                            unsigned int channel_num,
+                                            struct morsectrl_ftdi_spi_chan_info *spi_chan_info)
+{
+    /* The lowest location ID will be the SPI port and the second will be the reset port. */
+    if (loc_id < spi_chan_info->spi_loc_id)
+    {
+        spi_chan_info->reset_loc_id = spi_chan_info->spi_loc_id;
+        spi_chan_info->reset_loc_id_ch = spi_chan_info->spi_loc_id_ch;
+        spi_chan_info->spi_loc_id = loc_id;
+        spi_chan_info->spi_loc_id_ch = channel_num;
+    }
+    else if (loc_id < spi_chan_info->reset_loc_id)
+    {
+        spi_chan_info->reset_loc_id = loc_id;
+        spi_chan_info->reset_loc_id_ch = channel_num;
+    }
+}
+
+/**
+ * @brief Initalise an FTDI SPI interface.
+ *
+ * @note This should be done after parsing the configuration.
+ *
+ * @param transport Transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_init(struct morsectrl_transport *transport)
+{
+    struct morsectrl_ftdi_spi_state *state = ftdi_spi_state(transport);
+    struct morsectrl_ftdi_spi_cfg *config = ftdi_spi_cfg(transport);
+    struct morsectrl_ftdi_spi_chan_info spi_chan_info = {
+        .spi_loc_id = UINT32_MAX,
+        .spi_loc_id_ch = UINT32_MAX,
+        .reset_loc_id = UINT32_MAX,
+        .reset_loc_id_ch = UINT32_MAX
+    };
+    FT_DEVICE_LIST_INFO_NODE device_node;
+    FT_STATUS status;
+    DWORD num_chan;
+    DWORD verMPSSE = 0;
+    DWORD verD2XX = 0;
+    unsigned int ii;
+    char serial_num_list[MMDEBUG_MAX_CHANNELS][MAX_SERIAL_NUMBER_LEN] = {"\0"};
+
+    Init_libMPSSE();
+
+    if (transport->debug)
+    {
+        Ver_libMPSSE(&verMPSSE, &verD2XX);
+        mctrl_print("libmpsse version:  0x%08x\n", verMPSSE);
+        mctrl_print("libftd2xx version: 0x%08x\n", verD2XX);
+    }
+
+    status = SPI_GetNumChannels(&num_chan);
+
+    if (status != FT_OK)
+        return -ETRANSFTDISPIERR;
+
+    if (transport->debug)
+    {
+        mctrl_print("Number of available SPI channels %u\n", num_chan);
+    }
+
+    if (num_chan > MMDEBUG_MAX_CHANNELS)
+    {
+        ftdi_spi_error(num_chan, "Too many SPI channels");
+        return -ETRANSFTDISPIERR;
+    }
+
+    for (ii = 0; ii < num_chan; ii ++)
+    {
+        status = SPI_GetChannelInfo(ii, &device_node);
+        if (status != FT_OK)
+        {
+            mctrl_err("FTDI_SPI, code %d: Failed to get SPI channel %d information\n", status, ii);
+            continue;
+        }
+        strncpy(serial_num_list[ii], device_node.SerialNumber, MAX_SERIAL_NUMBER_LEN);
+
+        if (config->serial_num[0])
+        {
+            if (!strncmp(config->serial_num, device_node.SerialNumber, strlen(config->serial_num)))
+                ftdi_spi_set_spi_and_reset_chan(device_node.LocId, ii, &spi_chan_info);
+        }
+        else
+        {
+            ftdi_spi_set_spi_and_reset_chan(device_node.LocId, ii, &spi_chan_info);
+        }
+
+        if (transport->debug)
+        {
+            mctrl_print("Information on channel number %d:\n", ii + 1);
+            /* print the dev info */
+            mctrl_print("  Flags        = 0x%08x\n", device_node.Flags);
+            mctrl_print("  Type         = 0x%08x\n", device_node.Type);
+            mctrl_print("  ID           = 0x%08x\n", device_node.ID);
+            mctrl_print("  LocId        = 0x%08x\n", device_node.LocId);
+            mctrl_print("  SerialNumber = %s\n", device_node.SerialNumber);
+            mctrl_print("  Description  = %s\n", device_node.Description);
+            mctrl_print("  ftHandle     = %p\n", device_node.ftHandle);
+        }
+    }
+
+    if (transport->debug)
+    {
+        mctrl_print("SPI, reset on channels: %u, %u\n", spi_chan_info.spi_loc_id_ch,
+                                                        spi_chan_info.reset_loc_id_ch);
+    }
+
+    if (spi_chan_info.spi_loc_id_ch == UINT32_MAX || (spi_chan_info.reset_loc_id_ch == UINT32_MAX))
+    {
+        if ((config->serial_num[0]))
+        {
+            mctrl_print("Serial number %s not valid. Avalable serial numbers:\n",
+                        config->serial_num);
+            for (int i = 0; i < MORSE_ARRAY_SIZE(serial_num_list); i++)
+            {
+                if (serial_num_list[i][0])
+                    mctrl_print("\tchannel %d - %s\n", i, serial_num_list[i]);
+            }
+        }
+        return -ETRANSFTDISPIERR;
+    }
+
+    status = SPI_OpenChannel(spi_chan_info.spi_loc_id_ch, &state->handle);
+    if (status != FT_OK)
+    {
+        ftdi_spi_error(status, "Failed to open MPSSE SPI channel");
+        return -ETRANSFTDISPIERR;
+    }
+
+    status = SPI_InitChannel(state->handle, &config->channel);
+    if (status != FT_OK)
+    {
+        ftdi_spi_error(status, "Failed to init MPSSE SPI channel");
+        return -ETRANSFTDISPIERR;
+    }
+
+    status = SPI_OpenChannel(spi_chan_info.reset_loc_id_ch, &state->reset_handle);
+    if (status != FT_OK)
+    {
+        ftdi_spi_error(status, "Failed to open MPSSE reset channel");
+        return -ETRANSFTDISPIERR;
+    }
+
+    status = SPI_InitChannel(state->reset_handle, &config->channel);
+    if (status != FT_OK)
+    {
+        ftdi_spi_error(status, "Failed to init MPSSE reset channel");
+        return -ETRANSFTDISPIERR;
+    }
+
+    /* Set all GPIO as High Inputs except for reset pins (High Outputs). */
+    FT_WriteGPIOL(state->reset_handle,
+                  config->jtag_reset_pin_num | config->reset_pin_num,
+                  FTDI_SPI_GPIOL_MASK);
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief De-initalise an FTDI Transport.
+ *
+ * @param transport The transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_deinit(struct morsectrl_transport *transport)
+{
+    struct morsectrl_ftdi_spi_state *state = ftdi_spi_state(transport);
+    int ret = ETRANSSUCC;
+
+    SPI_CloseChannel(state->handle);
+    SPI_CloseChannel(state->reset_handle);
+    Cleanup_libMPSSE();
+
+    return ret;
+}
+
+/**
+ * @brief Allocate @ref morsectrl_transport_buff.
+ *
+ * @param transport Transport structure.
+ * @param size      Size of command and morse headers or raw data.
+ * @return          Allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+static struct morsectrl_transport_buff *ftdi_spi_alloc(struct morsectrl_transport *transport,
+                                                       size_t size)
+{
+    struct morsectrl_transport_buff *buff;
+    size_t aligned_size;
+
+    if (!transport)
+        return NULL;
+
+    if (size <= 0)
+        return NULL;
+
+    /* Alignment to word boundaries. */
+    aligned_size = align_size(size, sizeof(uint32_t));
+
+    buff = malloc(sizeof(*buff));
+    if (!buff)
+        return NULL;
+
+    buff->capacity = aligned_size;
+    buff->memblock = (uint8_t *)malloc(buff->capacity);
+    if (!buff->memblock)
+    {
+        free(buff);
+        return NULL;
+    }
+    buff->data = buff->memblock;
+    buff->data_len = size;
+    memset(&buff->data[size], FTDI_SPI_JUNK_OCTET, aligned_size - size);
+
+    return buff;
+}
+
+/**
+ * @brief Allocate @ref morsectrl_transport_buff that is used for writing data over the transport.
+ *
+ * @param transport
+ * @param size
+ * @return struct morsectrl_transport_buff*
+ */
+static struct morsectrl_transport_buff *ftdi_spi_write_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    return ftdi_spi_alloc(transport, size);
+}
+
+static struct morsectrl_transport_buff *ftdi_spi_read_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    return ftdi_spi_alloc(transport, size);
+}
+
+/**
+ * @brief Read a 32bit register.
+ *
+ * @note It can also be a word aligned 32bit memory value.
+ *
+ * @param transport The transport structure.
+ * @param addr      The address to read from. Must be word aligned.
+ * @param value     Pointer to memory to store the result.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_reg_read(struct morsectrl_transport *transport,
+                             uint32_t addr, uint32_t *value)
+{
+    return sdio_over_spi_read_reg_32bit(transport, addr, value);
+}
+
+/**
+ * @brief Write a 32bit register.
+ *
+ * @note It can also be a word aligned 32bit memory value.
+ *
+ * @param transport The transport structure.
+ * @param addr      The address to write to. Must be word aligned.
+ * @param value     Value to write.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_reg_write(struct morsectrl_transport *transport,
+                              uint32_t addr, uint32_t value)
+{
+    return sdio_over_spi_write_reg_32bit(transport, addr, value);
+}
+
+/**
+ * @brief Read a block of memory.
+ *
+ * @note Memory must be word aligned.
+ *
+ * @param transport The transport structure.
+ * @param read      Buffer to read data into.
+ * @param addr      The address to read from. Must be word aligned.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_mem_read(struct morsectrl_transport *transport,
+                             struct morsectrl_transport_buff *read,
+                             uint32_t addr)
+{
+    return sdio_over_spi_read_memblock(transport, read, addr);
+}
+
+/**
+ * @brief Write a block of memory.
+ *
+ * @note Memory must be word aligned.
+ *
+ * @param transport The transport structure.
+ * @param write     Buffer to write data from.
+ * @param addr      The address to write to. Must be word aligned.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_mem_write(struct morsectrl_transport *transport,
+                              struct morsectrl_transport_buff *write,
+                              uint32_t addr)
+{
+    return sdio_over_spi_write_memblock(transport, write, addr);
+}
+
+/**
+ * @brief Set the state of the chip select line.
+ *
+ * @param transport The transport structure.
+ * @param assert    If true assert CS, otherwise de-assert.
+ * @return          0 on success otherwise relevant error.
+ */
+static int ftdi_spi_set_cs(struct morsectrl_transport *transport, bool assert)
+{
+    FT_HANDLE handle =  ftdi_spi_state(transport)->handle;
+    FT_STATUS status;
+
+    /* There's no delay so apply final state. */
+    if (assert)
+        status = SPI_ToggleCS(handle, true);
+    else
+        status = SPI_ToggleCS(handle, false);
+
+    if (status)
+    {
+        ftdi_spi_error(status, "Failed to set CS");
+        return -ETRANSFTDISPIERR;
+    }
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief Read data from the FTDI SPI device.
+ *
+ * @param transport The transport structure.
+ * @param read      Buffer to read data into.
+ * @param start     Whether to assert CS before data transmission.
+ * @param finish    Whether to de-assert CS after data transmission.
+ * @return          0 on success or relevant error.
+ */
+static int ftdi_spi_raw_read(struct morsectrl_transport *transport,
+                             struct morsectrl_transport_buff *read,
+                             bool start,
+                             bool finish)
+{
+    DWORD options = 0;
+    FT_STATUS status;
+    DWORD size_transferred;
+
+    if (read == NULL)
+    {
+        if (finish)
+            return ftdi_spi_set_cs(transport, false);
+        else if (start)
+            return ftdi_spi_set_cs(transport, true);
+
+        ftdi_spi_error(-ETRANSFTDISPIERR, "Empty SPI read");
+        return -ETRANSFTDISPIERR;
+    }
+
+    if (start)
+        options |= FTDI_SPI_OPTS_CS_START;
+    if (finish)
+        options |= FTDI_SPI_OPTS_CS_FINISH;
+
+    status = SPI_Read(ftdi_spi_state(transport)->handle,
+                      read->data, read->data_len,
+                      &size_transferred, options);
+
+    if (status)
+    {
+        ftdi_spi_error(status, "Failed to raw read");
+        return -ETRANSFTDISPIERR;
+    }
+
+    if (size_transferred != read->data_len)
+    {
+        ftdi_spi_error(status, "Raw read size mismatch");
+        return -ETRANSFTDISPIERR;
+    }
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief Write data to the FTDI SPI device.
+ *
+ * @param transport The transport structure.
+ * @param write     Buffer to write data from.
+ * @param start     Whether to assert CS before data transmission.
+ * @param finish    Whether to de-assert CS after data transmission.
+ * @return          0 on success or relevant error.
+ */
+int ftdi_spi_raw_write(struct morsectrl_transport *transport,
+                       struct morsectrl_transport_buff *write,
+                       bool start,
+                       bool finish)
+{
+    DWORD options = 0;
+    FT_STATUS status;
+    DWORD size_transferred;
+
+    if (write == NULL)
+    {
+        if (finish)
+            return ftdi_spi_set_cs(transport, false);
+        else if (start)
+            return ftdi_spi_set_cs(transport, true);
+
+        ftdi_spi_error(-ETRANSFTDISPIERR, "Empty SPI read");
+        return -ETRANSFTDISPIERR;
+    }
+
+    if (start)
+        options |= FTDI_SPI_OPTS_CS_START;
+    if (finish)
+        options |= FTDI_SPI_OPTS_CS_FINISH;
+
+    status = SPI_Write(ftdi_spi_state(transport)->handle,
+                       write->data, write->data_len,
+                       &size_transferred, options);
+
+    if (status)
+    {
+        ftdi_spi_error(status, "Failed to raw write");
+        return -ETRANSFTDISPIERR;
+    }
+
+    if (size_transferred != write->data_len)
+    {
+        ftdi_spi_error(status, "Raw write size mismatch");
+        return -ETRANSFTDISPIERR;
+    }
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief Write data to the FTDI SPI device and read at the same time.
+ *
+ * @param transport The transport structure.
+ * @param read      Buffer to read data into.
+ * @param write     Buffer to write data from.
+ * @param start     Whether to assert CS before data transmission.
+ * @param finish    Whether to de-assert CS after data transmission.
+ * @return          0 on success or relevant error.
+ */
+int ftdi_spi_raw_read_write(struct morsectrl_transport *transport,
+                            struct morsectrl_transport_buff *read,
+                            struct morsectrl_transport_buff *write,
+                            bool start,
+                            bool finish)
+{
+    DWORD options = 0;
+    FT_STATUS status;
+    DWORD size_transferred;
+    /* If we want to do an asymmetric read set finish to false and use another raw function. */
+    DWORD transfer_size;
+
+    if (!read || !write)
+    {
+        ftdi_spi_error(0, "Raw read/write missing buffer");
+        return -ETRANSFTDISPIERR;
+    }
+
+    transfer_size = MIN(read->data_len, write->data_len);
+
+    if (start)
+        options |= FTDI_SPI_OPTS_CS_START;
+    if (finish)
+        options |= FTDI_SPI_OPTS_CS_FINISH;
+
+    status = SPI_ReadWrite(ftdi_spi_state(transport)->handle,
+                           read->data, write->data, transfer_size,
+                           &size_transferred, options);
+
+    if (status)
+    {
+        ftdi_spi_error(status, "Failed to raw read/write");
+        return -ETRANSFTDISPIERR;
+    }
+
+    if (size_transferred != transfer_size)
+    {
+        ftdi_spi_error(status, "Raw read/write size mismatch");
+        return -ETRANSFTDISPIERR;
+    }
+
+    return ETRANSSUCC;
+} /* NOLINT */
+
+static int ftdi_spi_send(struct morsectrl_transport *transport,
+                         struct morsectrl_transport_buff *cmd,
+                         struct morsectrl_transport_buff *resp)
+{
+    const struct morsectrl_transport_ops *tops;
+    struct response *response;
+    uint32_t host_table_ptr;
+    uint32_t cmd_addr;
+    uint32_t resp_addr;
+    uint32_t status;
+    int ii;
+    int ret;
+
+    if (!transport || !transport->tops ||
+        !transport->tops->reg_read || !transport->tops->reg_write ||
+        !transport->tops->mem_read || !transport->tops->mem_write ||
+        !cmd || !resp)
+    {
+        return -ETRANSFTDISPIERR;
+    }
+
+    tops = transport->tops;
+
+    /* Locate command and response memory locations. */
+    ret = tops->reg_read(transport, MM_MANIFEST_ADDR, &host_table_ptr);
+    if (ret)
+        goto fail;
+    if (transport->debug)
+        mctrl_print("\nHost table ptr: 0x%08x\n\n", host_table_ptr);
+
+    ret = tops->reg_read(transport, host_table_ptr + MM_CMD_ADDR_OFFSET, &cmd_addr);
+    /* For production firmware which doesn't support memcmd, the address supplied to write commands
+     * is 0.
+     */
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nCommand addr: 0x%08x\n\n", cmd_addr);
+    }
+    if (!cmd_addr)
+    {
+        ftdi_spi_error(cmd_addr, "This transport is not supported for production firmware");
+        return -ETRANSFTDISPIERR;
+    }
+
+    ret = tops->reg_read(transport, host_table_ptr + MM_RESP_ADDR_OFFSET, &resp_addr);
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nResponse addr: 0x%08x\n\n", resp_addr);
+    }
+
+    ret = tops->reg_write(transport, MM_STATUS_CLR_ADDR, MM_CMD_MASK);
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nCleared status\n\n");
+    }
+
+    ret = tops->mem_write(transport, cmd, cmd_addr);
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nWrote command\n\n");
+    }
+
+    ret = tops->reg_write(transport, MM_TRIGGER_ADDR, MM_CMD_MASK);
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nTriggered command\n\n");
+    }
+
+    /* Poll for reponse. */
+    for (ii = 0; ii < RESP_TIMEOUT_MS; ii += RESP_POLL_INTERVAL_MS)
+    {
+        ret = tops->reg_read(transport, MM_STATUS_ADDR, &status);
+        if (ret)
+            goto fail;
+
+        if (transport->debug)
+            mctrl_print("\nStatus: 0x%08x\n\n", status);
+
+        if (status & MM_CMD_MASK)
+        {
+            break;
+        }
+        sleep_ms(RESP_POLL_INTERVAL_MS);
+    }
+
+    if (ii >= RESP_TIMEOUT_MS)
+    {
+        goto fail;
+    }
+
+    /* Read in response. */
+    ret = tops->mem_read(transport, resp, resp_addr);
+    if (ret)
+    {
+        goto fail;
+    }
+    if (transport->debug)
+    {
+        mctrl_print("\nRead response\n\n");
+    }
+
+    /* Clear status. */
+    tops->reg_write(transport, MM_STATUS_CLR_ADDR, MM_CMD_MASK);
+    if (transport->debug)
+    {
+        mctrl_print("\nCleared status\n\n");
+    }
+
+    /* Trim response length (required for variable length responses). */
+    response = (struct response *)resp->data;
+    /* Size the response buffer to the size of the data, status rc, and cmd hdr */
+    resp->data_len = response->hdr.len + sizeof(response->hdr);
+
+    return ETRANSSUCC;
+
+fail:
+    ftdi_spi_error(ret, "Failed to send command");
+    return ret;
+}
+
+
+static int ftdi_spi_reset(struct morsectrl_transport *transport)
+{
+    struct morsectrl_transport_buff *buff =
+        morsectrl_transport_raw_write_alloc(transport, MM_OCTETS_OF_INIT_CLK);
+    struct morsectrl_ftdi_spi_state *state = ftdi_spi_state(transport);
+    struct morsectrl_ftdi_spi_cfg *config = ftdi_spi_cfg(transport);
+    ChannelConfig *channel_cfg = NULL;
+    FT_STATUS status;
+    UCHAR value;
+    UCHAR dir;
+    int ret;
+
+    if (!buff)
+    {
+        return -ETRANSFTDISPIERR;
+    }
+
+    status = SPI_GetChannelConfig(state->reset_handle, &channel_cfg);
+    if (status != FT_OK)
+    {
+        morsectrl_transport_buff_free(buff);
+        ftdi_spi_error(status, "Failed to get channel config during GPIO reset");
+        return -ETRANSFTDISPIERR;
+    }
+
+    value = FTDI_SPI_PINSTATE_TO_VAL(channel_cfg->currentPinState);
+    dir = FTDI_SPI_PINSTATE_TO_DIR(channel_cfg->currentPinState);
+    value &= ~(config->reset_pin_num | config->jtag_reset_pin_num);
+    dir |= (config->reset_pin_num | config->jtag_reset_pin_num);
+    status = FT_WriteGPIOL(state->reset_handle, dir, value);
+    if (status != FT_OK)
+    {
+        morsectrl_transport_buff_free(buff);
+        ftdi_spi_error(status, "Failed to write GPIO reset line");
+        return -ETRANSFTDISPIERR;
+    }
+    status = ftdi_spi_set_cs(transport, false);
+    if (status != FT_OK)
+    {
+        morsectrl_transport_buff_free(buff);
+        return -ETRANSFTDISPIERR;
+    }
+
+    sleep_ms(config->reset_ms);
+    value |= config->reset_pin_num;
+    status = FT_WriteGPIOL(state->reset_handle, dir, value);
+    if (status != FT_OK)
+    {
+        morsectrl_transport_buff_free(buff);
+        ftdi_spi_error(status, "Failed to write GPIO reset line");
+        return -ETRANSFTDISPIERR;
+    }
+
+    /* De-assert JTAG-reset after reset. */
+    sleep_ms(config->reset_ms);
+    value |= config->jtag_reset_pin_num;
+    status = FT_WriteGPIOL(state->reset_handle, dir, value);
+    if (status != FT_OK)
+    {
+        morsectrl_transport_buff_free(buff);
+        ftdi_spi_error(status, "Failed to write GPIO JTAG reset line");
+        return -ETRANSFTDISPIERR;
+    }
+
+    /* Writing of GPIO doesn't seem to block and reset does some weird stuff. */
+    sleep_ms(config->reset_ms);
+
+    /* Put CS into correct state (deasserted). */
+    ftdi_spi_set_cs(transport, false);
+
+    /* Put some clock cycles into the SPI port. (Data can be garbage). */
+    memset(buff->data, 0xFF, buff->data_len);
+    transport->tops->raw_write(transport, buff, false, false);
+
+    morsectrl_transport_buff_free(buff);
+
+    /* Use this to send the CMD63 to enter SPI mode. */
+    ret = sdio_over_spi_post_hard_reset(transport);
+
+    return ret;
+}
+
+static const struct morsectrl_transport_ops ftdi_spi_ops = {
+    .name = "ftdi_spi",
+    .description = "FTDI SPI interface direct to transceiver",
+    .has_reset = true,
+    .has_driver = false,
+    .parse = ftdi_spi_parse,
+    .init = ftdi_spi_init,
+    .deinit = ftdi_spi_deinit,
+    .write_alloc = ftdi_spi_write_alloc,
+    .read_alloc = ftdi_spi_read_alloc,
+    .send = ftdi_spi_send,
+    .reg_read = ftdi_spi_reg_read,
+    .reg_write = ftdi_spi_reg_write,
+    .mem_read = ftdi_spi_mem_read,
+    .mem_write = ftdi_spi_mem_write,
+    .raw_read = ftdi_spi_raw_read,
+    .raw_write = ftdi_spi_raw_write,
+    .raw_read_write = ftdi_spi_raw_read_write,
+    .reset_device = ftdi_spi_reset,
+    .get_ifname = NULL,
+};
+
+REGISTER_TRANSPORT(ftdi_spi_ops);

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/include/libmpsse_i2c.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/include/libmpsse_i2c.h
@@ -1,0 +1,414 @@
+/*!
+ * \file libmpsse_i2c.h
+ *
+ * \author FTDI
+ * \date 20110127
+ *
+ * Copyright � 2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: I2C
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - added macro I2C_DISABLE_3PHASE_CLOCKING
+ * 0.3 - 20200428 - removed unnecessary files and directory structure
+ *                  type of bool changed to unsigned int match WinTypes.h
+ */
+
+#ifndef FTDI_I2C_H
+#define FTDI_I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef FTDIMPSSE_API
+#ifdef _WIN32
+// The following ifdef block is the standard way of creating macros
+// which make exporting from a DLL simpler.  All files within this DLL
+// are compiled with the FTDIMPSSE_EXPORTS symbol defined on the command line.
+// This symbol should not be defined on any project that uses this DLL.
+// This way any other project whose source files include this file see
+// FTDIMPSSE_API functions as being imported from a DLL, whereas this DLL
+// sees symbols defined with this macro as being exported.
+
+#ifdef FTDIMPSSE_EXPORTS
+#define FTDIMPSSE_API __declspec(dllexport)
+#elif defined(FTDIMPSSE_STATIC)
+// Avoid decorations when linking statically.
+#define FTDIMPSSE_API
+#else // FTDIMPSSE_EXPORTS
+#define FTDIMPSSE_API __declspec(dllimport)
+#endif // FTDIMPSSE_EXPORTS
+
+#else // _WIN32
+
+// Compiling on non-Windows platform.
+#include "WinTypes.h"
+// No decorations needed.
+#define FTDIMPSSE_API
+
+#endif // _WIN32
+#endif // FTDIMPSSE_API
+
+/******************************************************************************/
+/*								Macro defines								  */
+/******************************************************************************/
+
+/** Options to I2C_DeviceWrite & I2C_DeviceRead */
+/*Generate start condition before transmitting. */
+#define	I2C_TRANSFER_OPTIONS_START_BIT		0x00000001
+
+/*Generate stop condition before transmitting. */
+#define I2C_TRANSFER_OPTIONS_STOP_BIT		0x00000002
+
+/*Continue transmitting data in bulk without caring about Ack or nAck from device if this bit
+is not set. If this bit is set then stop transferring the data in the buffer when the device
+nACKs. */
+#define I2C_TRANSFER_OPTIONS_BREAK_ON_NACK	0x00000004
+
+/* libMPSSE-I2C generates an ACKs for every byte read. Some I2C slaves require the I2C
+master to generate a nACK for the last data byte read. Setting this bit enables working with
+such I2C slaves. */
+#define I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE	0x00000008
+
+/*Fast transfers prepare a buffer containing commands to generate START/STOP/ADDRESS
+   conditions and commands to read/write data. This buffer is sent to the MPSSE in one shot,
+   hence delays between different phases of the I2C transfer are eliminated. Fast transfers
+   can have data length in terms of bits or bytes. The user application should call
+   I2C_DeviceWrite or I2C_DeviceRead with either
+   I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES or
+   I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS bit set to perform a fast transfer.
+   I2C_TRANSFER_OPTIONS_START_BIT and I2C_TRANSFER_OPTIONS_STOP_BIT have
+   their usual meanings when used in fast transfers, however
+   I2C_TRANSFER_OPTIONS_BREAK_ON_NACK and
+   I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE are not applicable in fast transfers. */
+#define I2C_TRANSFER_OPTIONS_FAST_TRANSFER		0x00000030/*not visible to user*/
+
+/* When the user calls I2C_DeviceWrite or I2C_DeviceRead with this bit set then libMPSSE
+	 packs commands to transfer sizeToTransfer number of bytes, and to read/write
+	 sizeToTransfer number of ack bits. If data is written then the read ack bits are ignored, if
+	 data is being read then an acknowledgement bit(SDA=LOW) is given to the I2C slave
+	 after each byte read. */
+#define I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES	0x00000010
+
+/* When the user calls I2C_DeviceWrite or I2C_DeviceRead with this bit set then libMPSSE
+	 packs commands to transfer sizeToTransfer number of bits. There is no ACK phase when
+	 this bit is set. */
+#define I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS	0x00000020
+
+/* The address parameter is ignored in transfers if this bit is set. This would mean that
+	 the address is either a part of the data or this is a special I2C frame that doesn't require
+	 an address. However if this bit is not set then 7bit address and 1bit direction will be
+	 written to the I2C bus each time I2C_DeviceWrite or I2C_DeviceRead is called and a
+	 1bit acknowledgement will be read after that. */
+#define I2C_TRANSFER_OPTIONS_NO_ADDRESS		0x00000040
+
+#define I2C_CMD_GETDEVICEID_RD	0xF9
+#define I2C_CMD_GETDEVICEID_WR	0xF8
+
+#define I2C_GIVE_ACK	1
+#define I2C_GIVE_NACK	0
+
+/* 3-phase clocking is enabled by default. Setting this bit in ConfigOptions will disable it */
+#define I2C_DISABLE_3PHASE_CLOCKING	0x0001
+
+/******************************************************************************/
+/*								Type defines								  */
+/******************************************************************************/
+
+/**
+Valid range for clock divisor is 0 to 65535
+Highest clock freq is 6MHz represented by 0
+The next highest is   3MHz represented by 1
+Lowest is            91Hz  represented by 65535
+
+User can pass either pass I2C_DataRate_100K, I2C_DataRate_400K or
+I2C_DataRate_3_4M for the standard clock rates
+or a clock divisor value may be passed
+*/
+typedef enum I2C_ClockRate_t{
+	I2C_CLOCK_STANDARD_MODE = 100000,		/* 100kb/sec */
+	I2C_CLOCK_FAST_MODE = 400000,			/* 400kb/sec */
+	I2C_CLOCK_FAST_MODE_PLUS = 1000000,		/* 1000kb/sec */
+	I2C_CLOCK_HIGH_SPEED_MODE = 3400000		/* 3.4Mb/sec */
+} I2C_CLOCKRATE;
+
+/**/
+typedef struct ChannelConfig_t
+{
+	I2C_CLOCKRATE	ClockRate; 
+	/** There were 2 functions I2C_TurnOn/OffDivideByFive
+	ClockinghiSpeedDevice (FTC_HANDLE fthandle) in the old DLL. This function turns on the
+	divide by five for the MPSSE clock to allow the hi-speed devices FT2232H and FT4232H to
+	clock at the same rate as the FT2232D device. This allows for backward compatibility
+	NOTE: This feature is probably a per chip feature and not per device*/
+
+	UCHAR			LatencyTimer; 
+	/** Required value, in milliseconds, of latency timer.
+	Valid range is 2 � 255
+	In the FT8U232AM and FT8U245AM devices, the receive buffer timeout that is used to flush
+	remaining data from the receive buffer was fixed at 16 ms. In all other FTDI devices, this
+	timeout is programmable and can be set at 1 ms intervals between 2ms and 255 ms.  This
+	allows the device to be better optimized for protocols requiring faster response times from
+	short data packets
+	NOTE: This feature is probably a per chip feature and not per device*/
+
+	DWORD			Options;	
+	/** This member provides a way to enable/disable features
+	specific to the protocol that are implemented in the chip
+	BIT0		: 3PhaseDataClocking - Setting this bit will turn on 3 phase data clocking for a
+			FT2232H dual hi-speed device or FT4232H quad hi-speed device. Three phase
+			data clocking, ensures the data is valid on both edges of a clock
+	BIT1		: Loopback
+	BIT2		: Clock stretching
+	BIT3 -BIT31		: Reserved
+	*/
+} ChannelConfig;
+
+/******************************************************************************/
+/*								External variables							  */
+/******************************************************************************/
+
+/******************************************************************************/
+/*								Function declarations						  */
+/******************************************************************************/
+
+/*!
+ * \brief This function initializes libMPSSE
+ *
+ * This function is called once when the library is loaded. It initializes all the modules in the
+ * library. This function initializes all the variables and data structures that are required to be
+ * initialized once only during loading.
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note May individually call Ftdi_I2C_Module_Init, Ftdi_SPI_Module_Init, Ftdi_Mid_Module_Init,
+ * Ftdi_Common_Module_Init, etc if required. This function should be called by the OS specific
+ * function(eg: DllMain for windows) that is called by the OS automatically during startup.
+ * \warning
+ */
+FTDIMPSSE_API void Init_libMPSSE(void);
+
+/*!
+ * \brief Cleans up the module before unloading
+ *
+ * This function frees all the resources that were allocated during initialization. It should be called
+ * by the OS to ensure that the module exits gracefully
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API void Cleanup_libMPSSE(void);
+
+/*!
+ * \brief Gets the number of I2C channels connected to the host
+ *
+ * This function gets the number of I2C channels that are connected to the host system
+ * The number of ports available in each of these chips are different.
+ *
+ * \param[out] *numChannels Pointer to variable in which the no of channels will be returned
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note This function doesn't return the number of FTDI chips connected to the host system
+ * \note FT2232D has 1 MPSSE port
+ * \note FT2232H has 2 MPSSE ports
+ * \note FT4232H has 4 ports but only 2 of them have MPSSEs
+ * so call to this function will return 2 if a FT4232 is connected to it.
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_GetNumChannels(DWORD *numChannels);
+
+/*!
+ * \brief Provides information about channel
+ *
+ * This function takes a channel index (valid values are from 1 to the value returned by
+ * I2C_GetNumChannels) and provides information about the channel in the form of a populated
+ * ChannelInfo structure.
+ *
+ * \param[in] index Index of the channel
+ * \param[out] chanInfo Pointer to FT_DEVICE_LIST_INFO_NODE structure(see D2XX \
+ *			  Programmer's Guide)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \note  The channel ID can be determined by the user from the last digit of the location ID
+ * \sa
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_GetChannelInfo(DWORD index,
+	FT_DEVICE_LIST_INFO_NODE *chanInfo);
+
+/*!
+ * \brief Opens a channel and returns a handle to it
+ *
+ * This function opens the indexed channel and returns a handle to it
+ *
+ * \param[in] index Index of the channel
+ * \param[out] handle Pointer to the handle of the opened channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note Trying to open an already open channel will return an error code
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_OpenChannel(DWORD index, FT_HANDLE *handle);
+
+/*!
+ * \brief Initializes a channel
+ *
+ * This function initializes the channel and the communication parameters associated with it
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] config Pointer to ChannelConfig structure(memory to be allocated by caller)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_InitChannel(FT_HANDLE handle, ChannelConfig *config);
+
+/*!
+ * \brief Closes a channel
+ *
+ * Closes a channel and frees all resources that were used by it
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] none
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_CloseChannel(FT_HANDLE handle);
+
+/*!
+ * \brief Reads data from I2C slave
+ *
+ * This function reads the specified number of bytes from an addressed I2C slave
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C slave
+ * \param[in] sizeToTransfer Number of bytes to be read
+ * \param[out] buffer Pointer to the buffer where data is to be read
+ * \param[out] sizeTransferred Pointer to variable containing the number of bytes read
+ * \param[in] options This parameter specifies data transfer options. Namely, if a start/stop bits
+ *			are required, if the transfer should continue or stop if device nAcks, etc
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa	Definitions of macros I2C_TRANSFER_OPTIONS_START_BIT,
+ *		I2C_TRANSFER_OPTIONS_STOP_BIT, I2C_TRANSFER_OPTIONS_BREAK_ON_NACK,
+ *		I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES,
+ *		I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS &
+ *		I2C_TRANSFER_OPTIONS_NO_ADDRESS
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_DeviceRead(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, LPDWORD sizeTransfered, DWORD options);
+
+/*!
+ * \brief Writes data from I2C slave
+ *
+ * This function writes the specified number of bytes from an addressed I2C slave
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C slave
+ * \param[in] sizeToTransfer Number of bytes to be written
+ * \param[out] buffer Pointer to the buffer from where data is to be written
+ * \param[out] sizeTransferred Pointer to variable containing the number of bytes written
+ * \param[in] options This parameter specifies data transfer options. Namely if a start/stop bits
+ *			are required, if the transfer should continue or stop if device nAcks, etc
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa	Definitions of macros I2C_TRANSFER_OPTIONS_START_BIT,
+ *		I2C_TRANSFER_OPTIONS_STOP_BIT, I2C_TRANSFER_OPTIONS_BREAK_ON_NACK,
+ *		I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES,
+ *		I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS &
+ *		I2C_TRANSFER_OPTIONS_NO_ADDRESS
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_DeviceWrite(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, LPDWORD sizeTransfered, DWORD options);
+
+/*!
+ * \brief Get the I2C device ID
+ *
+ * This function retrieves the I2C device ID. It may not be enabled in the library
+ * depending on build configuration. If it is not enabled then it will return
+ * FT_NOT_SUPPORTED.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C slave
+ * \param[out] deviceID Address of memory where the 3byte I2C device ID will be stored
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS I2C_GetDeviceID(FT_HANDLE handle, UCHAR deviceAddress,
+	UCHAR *deviceID);
+
+/*!
+ * \brief Writes to the 8 GPIO lines
+ *
+ * Writes to the 8 GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] dir The direction of the 8 lines. 0 for in and 1 for out
+ * \param[in] value Output state of the 8 GPIO lines
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_WriteGPIO(FT_HANDLE handle, UCHAR dir, UCHAR value);
+
+/*!
+ * \brief Reads from the 8 GPIO lines
+ *
+ * This function reads the GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] *value Input state of the 8 GPIO lines(1 = high)
+ * \return status
+ * \sa
+ * \note The directions of the GPIO pins have to be first set to input mode using FT_WriteGPIO
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_ReadGPIO(FT_HANDLE handle, UCHAR *value);
+
+/******************************************************************************/
+
+/*!
+ * \brief Version Number Function
+ *
+ * Returns libMPSSE and libFTD2XX version number
+ *
+ * \param[out]  *libmpsse	MPSSE version number is returned
+ * \param[out]  *libftd2xx	D2XX version number is returned
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS Ver_libMPSSE(LPDWORD libmpsse, LPDWORD libftd2xx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/*FTDI_I2C_H*/
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/include/libmpsse_spi.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/include/libmpsse_spi.h
@@ -1,0 +1,452 @@
+/*!
+ * \file libmpsse_spi.h
+ *
+ * \author FTDI
+ * \date 20110523
+ *
+ * Copyright © 2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: SPI
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - added function SPI_ChangeCS, moved SPI_Read/WriteGPIO to middle layer
+ * 0.3 - 20111103 - added SPI_ReadWrite
+ * 0.4 - 20200428 - removed unnecessary files and directory structure
+ *                  type of bool changed to unsigned int match WinTypes.h
+ */
+
+#ifndef FTDI_SPI_H
+#define FTDI_SPI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef FTDIMPSSE_API
+#ifdef _WIN32
+	// The following ifdef block is the standard way of creating macros
+	// which make exporting from a DLL simpler.  All files within this DLL
+	// are compiled with the FTDIMPSSE_EXPORTS symbol defined on the command line.
+	// This symbol should not be defined on any project that uses this DLL.
+	// This way any other project whose source files include this file see
+	// FTDIMPSSE_API functions as being imported from a DLL, whereas this DLL
+	// sees symbols defined with this macro as being exported.
+
+#ifdef FTDIMPSSE_EXPORTS
+#define FTDIMPSSE_API __declspec(dllexport)
+#elif defined(FTDIMPSSE_STATIC)
+	// Avoid decorations when linking statically.
+#define FTDIMPSSE_API
+#else // FTDIMPSSE_EXPORTS
+#define FTDIMPSSE_API __declspec(dllimport)
+#endif // FTDIMPSSE_EXPORTS
+
+#else // _WIN32
+
+	// Compiling on non-Windows platform.
+#include "WinTypes.h"
+	// No decorations needed.
+#define FTDIMPSSE_API
+
+#endif // _WIN32
+#endif // FTDIMPSSE_API
+
+/******************************************************************************/
+/*								Macro defines								  */
+/******************************************************************************/
+/* Bit definition of the transferOptions parameter in SPI_Read, SPI_Write & SPI_Transfer  */
+
+/* transferOptions-Bit0: If this bit is 0 then it means that the transfer size provided is in bytes */
+#define	SPI_TRANSFER_OPTIONS_SIZE_IN_BYTES			0x00000000
+/* transferOptions-Bit0: If this bit is 1 then it means that the transfer size provided is in bytes */
+#define	SPI_TRANSFER_OPTIONS_SIZE_IN_BITS			0x00000001
+/* transferOptions-Bit1: if BIT1 is 1 then CHIP_SELECT line will be enabled at start of transfer */
+#define	SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE		0x00000002
+/* transferOptions-Bit2: if BIT2 is 1 then CHIP_SELECT line will be disabled at end of transfer */
+#define SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE		0x00000004
+/* transferOptions-Bit3: if BIT3 is 1 then LSB will be processed first */
+#define SPI_TRANSFER_OPTIONS_LSB_FIRST				0x00000008
+
+
+/* Bit definition of the Options member of configOptions structure */
+#define SPI_CONFIG_OPTION_MODE_MASK		0x00000003
+#define SPI_CONFIG_OPTION_MODE0			0x00000000
+#define SPI_CONFIG_OPTION_MODE1			0x00000001
+#define SPI_CONFIG_OPTION_MODE2			0x00000002
+#define SPI_CONFIG_OPTION_MODE3			0x00000003
+
+#define SPI_CONFIG_OPTION_CS_MASK		0x0000001C		/* 111 00 */
+#define SPI_CONFIG_OPTION_CS_DBUS3		0x00000000		/* 000 00 */
+#define SPI_CONFIG_OPTION_CS_DBUS4		0x00000004		/* 001 00 */
+#define SPI_CONFIG_OPTION_CS_DBUS5		0x00000008		/* 010 00 */
+#define SPI_CONFIG_OPTION_CS_DBUS6		0x0000000C		/* 011 00 */
+#define SPI_CONFIG_OPTION_CS_DBUS7		0x00000010		/* 100 00 */
+
+#define SPI_CONFIG_OPTION_CS_ACTIVEHIGH	0x00000000
+#define SPI_CONFIG_OPTION_CS_ACTIVELOW	0x00000020
+
+
+/******************************************************************************/
+/*								Type defines								  */
+/******************************************************************************/
+
+/* Structure contains configuration information of the SPI channel. It is populated by the user
+application during initialization of the channel and then it is saved in a linked-list and used
+internally by other SPI functions during operation. The structure is removed from the list when
+the user application calls SPI_CloseChannel */
+typedef struct ChannelConfig_t
+{
+	DWORD	ClockRate; /* SPI clock rate, value should be <= 30000000 */
+	UCHAR	LatencyTimer; /* value in milliseconds, maximum value should be <= 255 */
+	DWORD	configOptions;	/* This member provides a way to enable/disable features
+	specific to the protocol that are implemented in the chip
+	BIT1-0=CPOL-CPHA:	00 - MODE0 - data captured on rising edge, propagated on falling
+ 						01 - MODE1 - data captured on falling edge, propagated on rising
+ 						10 - MODE2 - data captured on falling edge, propagated on rising
+ 						11 - MODE3 - data captured on rising edge, propagated on falling
+	BIT4-BIT2: 000 - A/B/C/D_DBUS3=ChipSelect
+			 : 001 - A/B/C/D_DBUS4=ChipSelect
+ 			 : 010 - A/B/C/D_DBUS5=ChipSelect
+ 			 : 011 - A/B/C/D_DBUS6=ChipSelect
+ 			 : 100 - A/B/C/D_DBUS7=ChipSelect
+ 	BIT5: ChipSelect is active high if this bit is 0
+	BIT6 -BIT31		: Reserved
+	*/
+	DWORD		Pin;/* BIT7   -BIT0:   Initial direction of the pins	*/
+					/* BIT15 -BIT8:   Initial values of the pins		*/
+					/* BIT23 -BIT16: Final direction of the pins		*/
+					/* BIT31 -BIT24: Final values of the pins		*/
+	USHORT		currentPinState;/* BIT7   -BIT0:   Current direction of the pins	*/
+								/* BIT15 -BIT8:   Current values of the pins	*/
+}ChannelConfig;
+
+/* This structure associates the channel configuration information to a handle stores them in the
+form of a linked list */
+typedef struct ChannelContext_t
+{
+	FT_HANDLE 		handle;
+	ChannelConfig	config;
+	struct ChannelContext_t *next;
+}ChannelContext;
+
+
+/******************************************************************************/
+/*								External variables							  */
+/******************************************************************************/
+
+
+
+
+
+/******************************************************************************/
+/*								Function declarations						  */
+/******************************************************************************/
+
+/*!
+ * \brief This function initializes libMPSSE
+ *
+ * This function is called once when the library is loaded. It initializes all the modules in the
+ * library. This function initializes all the variables and data structures that are required to be
+ * initialized once only during loading.
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note May individually call Ftdi_I2C_Module_Init, Ftdi_SPI_Module_Init, Ftdi_Mid_Module_Init,
+ * Ftdi_Common_Module_Init, etc if required. This function should be called by the OS specific
+ * function(eg: DllMain for windows) that is called by the OS automatically during startup.
+ * \warning
+ */
+FTDIMPSSE_API void Init_libMPSSE(void);
+
+/*!
+ * \brief Cleans up the module before unloading
+ *
+ * This function frees all the resources that were allocated during initialization. It should be called
+ * by the OS to ensure that the module exits gracefully
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API void Cleanup_libMPSSE(void);
+
+/*!
+ * \brief Gets the number of SPI channels connected to the host
+ *
+ * This function gets the number of SPI channels that are connected to the host system
+ *
+ * \param[out] *numChannels Pointer to variable in which the no of channels will be returned
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note This function doesn't return the number of FTDI chips connected to the host system
+ * \note FT2232D has 1 MPSSE port
+ * \note FT2232H has 2 MPSSE ports
+ * \note FT4232H has 4 ports but only 2 of them have MPSSEs
+ * so call to this function will return 2 if a FT4232 is connected to it.
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_GetNumChannels(DWORD *numChannels);
+
+/*!
+ * \brief Provides information about channel
+ *
+ * This function takes a channel index (valid values are from 0 to the value returned by
+ * SPI_GetChannelInfo -1) and provides information about the channel in the form of a
+ * populated ChannelInfo structure.
+ *
+ * \param[in] index Index of the channel
+ * \param[out] chanInfo Pointer to FT_DEVICE_LIST_INFO_NODE structure(see D2XX \
+Programmer's Guide)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \note  The channel ID can be determined by the user from the last digit of the location ID
+ * \sa
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_GetChannelInfo(DWORD index,
+	FT_DEVICE_LIST_INFO_NODE *chanInfo);
+
+/*!
+ * \brief Opens a channel and returns a handle to it
+ *
+ * This function opens the indexed channel and returns a handle to it
+ *
+ * \param[in] index Index of the channel
+ * \param[out] handle Pointer to the handle of the opened channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note Trying to open an already open channel will return an error code
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_OpenChannel(DWORD index, FT_HANDLE *handle);
+
+/*!
+ * \brief Initializes a channel
+ *
+ * This function initializes the channel and the communication parameters associated with it
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] config Pointer to ChannelConfig structure(memory to be allocated by caller)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_InitChannel(FT_HANDLE handle, ChannelConfig *config);
+
+/*!
+ * \brief Closes a channel
+ *
+ * Closes a channel and frees all resources that were used by it
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] none
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_CloseChannel(FT_HANDLE handle);
+
+/*!
+ * \brief Reads data from a SPI slave device
+ *
+ * This function reads the specified number of bits or bytes from the SPI device
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] *buffer Pointer to buffer to where data will be read to
+ * \param[in] sizeToTransfer Size of data to be transfered
+ * \param[out] sizeTransfered Pointer to variable containing the size of data
+ *			that got transferred
+ * \param[in] transferOptions This parameter specifies data transfer options
+ *				if BIT0 is 0 then size is in bytes, otherwise in bits
+ *				if BIT1 is 1 then CHIP_SELECT line will be enables at start of transfer
+ *				if BIT2 is 1 then CHIP_SELECT line will be disabled at end of transfer
+ *
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_Read(FT_HANDLE handle, UCHAR *buffer,
+	DWORD sizeToTransfer, LPDWORD sizeTransfered, DWORD options);
+
+/*!
+ * \brief Writes data to a SPI slave device
+ *
+ * This function writes the specified number of bits or bytes to the SPI device
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] *buffer Pointer to buffer from containing the data
+ * \param[in] sizeToTransfer Size of data to be transfered
+ * \param[out] sizeTransfered Pointer to variable containing the size of data
+ *			that got transferred
+ * \param[in] transferOptions This parameter specifies data transfer options
+ *				if BIT0 is 0 then size is in bytes, otherwise in bits
+ *				if BIT1 is 1 then CHIP_SELECT line will be enables at start of transfer
+ *				if BIT2 is 1 then CHIP_SELECT line will be disabled at end of transfer
+ *
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_Write(FT_HANDLE handle, UCHAR *buffer,
+	DWORD sizeToTransfer, LPDWORD sizeTransfered, DWORD options);
+
+/*!
+ * \brief Reads and writes data from/to a SPI slave device
+ *
+ * This function transfers data in both directions between a SPI master and a slave. One bit is
+ * clocked out and one bit is clocked in during every clock.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] *inBuffer Pointer to buffer to which data read will be stored
+ * \param[in] *outBuffer Pointer to buffer that contains data to be transferred to the slave
+ * \param[in] sizeToTransfer Size of data to be transferred
+ * \param[out] sizeTransfered Pointer to variable containing the size of data
+ *			that got transferred
+ * \param[in] transferOptions This parameter specifies data transfer options
+ *				if BIT0 is 0 then size is in bytes, otherwise in bits
+ *				if BIT1 is 1 then CHIP_SELECT line will be enables at start of transfer
+ *				if BIT2 is 1 then CHIP_SELECT line will be disabled at end of transfer
+ *
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_ReadWrite(FT_HANDLE handle, UCHAR *inBuffer,
+	UCHAR *outBuffer, DWORD sizeToTransfer, LPDWORD sizeTransferred,
+	DWORD transferOptions);
+
+/*!
+ * \brief Read the state of SPI MISO line
+ *
+ * Reads the logic state of the SPI MISO line without clocking the bus
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] *state State of the line
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note This function may be used for applications that needs to poll the state of
+ *		the MISO line to check if the device is busy
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_IsBusy(FT_HANDLE handle, BOOL *state);
+
+/*!
+ * \brief Changes the chip select line
+ *
+ * This function changes the chip select line that is to be used to communicate to the SPI slave
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] configOptions Provides a way to select the chip select line & SPI mode
+ *	BIT1-0=CPOL-CPHA:	00 - MODE0 - data captured on rising edge, propagated on falling
+ *						01 - MODE1 - data captured on falling edge, propagated on rising
+ *						10 - MODE2 - data captured on falling edge, propagated on rising
+ *						11 - MODE3 - data captured on rising edge, propagated on falling
+ *	BIT4-BIT2: 000 - A/B/C/D_DBUS3=ChipSelect
+ *			 : 001 - A/B/C/D_DBUS4=ChipSelect
+ * 			 : 010 - A/B/C/D_DBUS5=ChipSelect
+ *			 : 011 - A/B/C/D_DBUS6=ChipSelect
+ *			 : 100 - A/B/C/D_DBUS7=ChipSelect
+ *	BIT5: ChipSelect is active high if this bit is 0
+ *	BIT6 -BIT31		: Reserved
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note This function should only be called after SPI_Init has been called
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_ChangeCS(FT_HANDLE handle, DWORD configOptions);
+
+/*!
+ * \brief Toggles the state of the CS line
+ *
+ * This function turns ON/OFF the chip select line associated with the channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] state TRUE if CS needs to be set, false otherwise
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_ToggleCS(FT_HANDLE handle, BOOL state);
+
+/*!
+ * \brief Writes to the 8 GPIO lines
+ *
+ * Writes to the 8 GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] dir The direction of the 8 lines. 0 for in and 1 for out
+ * \param[in] value Output state of the 8 GPIO lines
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_WriteGPIO(FT_HANDLE handle, UCHAR dir, UCHAR value);
+
+/* Also need this to get the pin state. */
+FTDIMPSSE_API FT_STATUS SPI_GetChannelConfig(FT_HANDLE handle, ChannelConfig **config);
+
+/* Lower GPIO byte. */
+FTDIMPSSE_API FT_STATUS FT_WriteGPIOL(FT_HANDLE handle, UCHAR dir, UCHAR value);
+
+/* Lower GPIO byte. */
+FTDIMPSSE_API FT_STATUS FT_ReadGPIOL(FT_HANDLE handle, UCHAR dir, UCHAR value);
+
+/*!
+ * \brief Reads from the 8 GPIO lines
+ *
+ * This function reads the GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] *value Input state of the 8 GPIO lines(1 = high)
+ * \return status
+ * \sa
+ * \note The directions of the GPIO pins have to be first set to input mode using FT_WriteGPIO
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_ReadGPIO(FT_HANDLE handle, UCHAR *value);
+
+/******************************************************************************/
+
+/*!
+ * \brief Version Number Function
+ *
+ * Returns libMPSSE and libFTD2XX version number
+ *
+ * \param[out]  *libmpsse	MPSSE version number is returned
+ * \param[out]  *libftd2xx	D2XX version number is returned
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS Ver_libMPSSE(LPDWORD libmpsse, LPDWORD libftd2xx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/*FTDI_SPI_H*/
+
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/libftd2xx/WinTypes.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/libftd2xx/WinTypes.h
@@ -1,0 +1,154 @@
+#ifndef __WINDOWS_TYPES__
+#define __WINDOWS_TYPES__
+
+#define WINAPI
+
+typedef unsigned int            DWORD;
+typedef unsigned int            ULONG;
+typedef unsigned short            USHORT;
+typedef unsigned short            SHORT;
+typedef unsigned char            UCHAR;
+typedef unsigned short            WORD;
+typedef unsigned short            WCHAR;
+typedef unsigned char            BYTE;
+typedef BYTE                    *LPBYTE;
+typedef unsigned int            BOOL;
+typedef unsigned char            BOOLEAN;
+typedef unsigned char            CHAR;
+typedef BOOL                    *LPBOOL;
+typedef UCHAR                    *PUCHAR;
+typedef const char                *LPCSTR;
+typedef char                    *PCHAR;
+typedef void                    *PVOID;
+typedef void                    *HANDLE;
+typedef unsigned int            LONG;
+typedef int                        INT;
+typedef unsigned int            UINT;
+typedef char                    *LPSTR;
+typedef char                    *LPTSTR;
+typedef const char                *LPCTSTR;
+typedef DWORD                    *LPDWORD;
+typedef WORD                    *LPWORD;
+typedef ULONG                    *PULONG;
+typedef LONG                    *LPLONG;
+typedef PVOID                    LPVOID;
+typedef void                    VOID;
+typedef USHORT                  *PUSHORT;
+typedef unsigned long long int    ULONGLONG;
+
+typedef struct _OVERLAPPED {
+    DWORD Internal;
+    DWORD InternalHigh;
+    union {
+        struct{
+            DWORD Offset;
+            DWORD OffsetHigh;
+        };
+        PVOID  Pointer;
+    };
+    HANDLE hEvent;
+} OVERLAPPED, *LPOVERLAPPED;
+
+typedef struct _SECURITY_ATTRIBUTES {
+    DWORD nLength;
+    LPVOID lpSecurityDescriptor;
+    BOOL bInheritHandle;
+} SECURITY_ATTRIBUTES , *LPSECURITY_ATTRIBUTES;
+
+#include <pthread.h>
+// Substitute for HANDLE returned by Windows CreateEvent API.
+// FT_SetEventNotification expects parameter 3 to be the address
+// of one of these structures.
+typedef struct _EVENT_HANDLE
+{
+    pthread_cond_t  eCondVar;
+    pthread_mutex_t eMutex;
+    int             iVar;
+} EVENT_HANDLE;
+
+typedef struct timeval SYSTEMTIME;
+typedef struct timeval FILETIME;
+
+// WaitForSingleObject return values.
+#define WAIT_ABANDONED      0x00000080L
+#define WAIT_OBJECT_0       0x00000000L
+#define WAIT_TIMEOUT        0x00000102L
+#define WAIT_FAILED         0xFFFFFFFF
+// Special value for WaitForSingleObject dwMilliseconds parameter
+#define INFINITE            0xFFFFFFFF  // Infinite timeout
+
+#ifndef TRUE
+#define TRUE    1
+#endif
+#ifndef FALSE
+#define FALSE    0
+#endif
+#ifndef CONST
+#define CONST const
+#endif
+//
+// Modem Status Flags
+//
+#define MS_CTS_ON           ((DWORD)0x0010)
+#define MS_DSR_ON           ((DWORD)0x0020)
+#define MS_RING_ON          ((DWORD)0x0040)
+#define MS_RLSD_ON          ((DWORD)0x0080)
+
+//
+// Error Flags
+//
+#define CE_RXOVER           0x0001  // Receive Queue overflow
+#define CE_OVERRUN          0x0002  // Receive Overrun Error
+#define CE_RXPARITY         0x0004  // Receive Parity Error
+#define CE_FRAME            0x0008  // Receive Framing error
+#define CE_BREAK            0x0010  // Break Detected
+#define CE_TXFULL           0x0100  // TX Queue is full
+#define CE_PTO              0x0200  // LPTx Timeout
+#define CE_IOE              0x0400  // LPTx I/O Error
+#define CE_DNS              0x0800  // LPTx Device not selected
+#define CE_OOP              0x1000  // LPTx Out-Of-Paper
+#define CE_MODE             0x8000  // Requested mode unsupported
+
+//
+// Events
+//
+#define EV_RXCHAR           0x0001  // Any Character received
+#define EV_RXFLAG           0x0002  // Received certain character
+#define EV_TXEMPTY          0x0004  // Transmit Queue Empty
+#define EV_CTS              0x0008  // CTS changed state
+#define EV_DSR              0x0010  // DSR changed state
+#define EV_RLSD             0x0020  // RLSD changed state
+#define EV_BREAK            0x0040  // BREAK received
+#define EV_ERR              0x0080  // Line status error occurred
+#define EV_RING             0x0100  // Ring signal detected
+#define EV_PERR             0x0200  // Printer error occured
+#define EV_RX80FULL         0x0400  // Receive buffer is 80 percent full
+#define EV_EVENT1           0x0800  // Provider specific event 1
+#define EV_EVENT2           0x1000  // Provider specific event 2
+
+//
+// Escape Functions
+//
+#define SETXOFF             1       // Simulate XOFF received
+#define SETXON              2       // Simulate XON received
+#define SETRTS              3       // Set RTS high
+#define CLRRTS              4       // Set RTS low
+#define SETDTR              5       // Set DTR high
+#define CLRDTR              6       // Set DTR low
+#define RESETDEV            7       // Reset device if possible
+#define SETBREAK            8       // Set the device break line.
+#define CLRBREAK            9       // Clear the device break line.
+
+//
+// PURGE function flags.
+//
+#define PURGE_TXABORT       0x0001  // Kill the pending/current writes to the comm port.
+#define PURGE_RXABORT       0x0002  // Kill the pending/current reads to the comm port.
+#define PURGE_TXCLEAR       0x0004  // Kill the transmit queue if there.
+#define PURGE_RXCLEAR       0x0008  // Kill the typeahead buffer if there.
+
+#ifndef INVALID_HANDLE_VALUE
+#define INVALID_HANDLE_VALUE 0xFFFFFFFF
+#endif
+
+#endif /* __WINDOWS_TYPES__ */

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/libftd2xx/ftd2xx.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/libftd2xx/ftd2xx.h
@@ -1,0 +1,3393 @@
+/*++
+
+Copyright (c) 2001-2021 Future Technology Devices International Limited
+
+THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FTDI DRIVERS MAY BE USED ONLY IN CONJUNCTION WITH PRODUCTS BASED ON FTDI PARTS.
+
+FTDI DRIVERS MAY BE DISTRIBUTED IN ANY FORM AS LONG AS LICENSE INFORMATION IS NOT MODIFIED.
+
+IF A CUSTOM VENDOR ID AND/OR PRODUCT ID OR DESCRIPTION STRING ARE USED, IT IS THE
+RESPONSIBILITY OF THE PRODUCT MANUFACTURER TO MAINTAIN ANY CHANGES AND SUBSEQUENT WHQL
+RE-CERTIFICATION AS A RESULT OF MAKING THESE CHANGES.
+
+
+Module Name:
+
+ftd2xx.h
+
+Abstract:
+
+Native USB device driver for FTDI FT232x, FT245x, FT2232x, FT4232x, FT2233H and FT4233H devices
+FTD2XX library definitions
+
+Environment:
+
+kernel & user mode
+
+
+--*/
+
+/** @file ftd2xx.h
+ */
+
+#ifndef FTD2XX_H
+#define FTD2XX_H
+
+#ifdef _WIN32
+// Compiling on Windows
+#include <winsock2.h>
+#include <windows.h>
+
+// The following ifdef block is the standard way of creating macros
+// which make exporting from a DLL simpler.  All files within this DLL
+// are compiled with the FTD2XX_EXPORTS symbol defined on the command line.
+// This symbol should not be defined on any project that uses this DLL.
+// This way any other project whose source files include this file see
+// FTD2XX_API functions as being imported from a DLL, whereas this DLL
+// sees symbols defined with this macro as being exported.
+
+#ifdef FTD2XX_EXPORTS
+#define FTD2XX_API __declspec(dllexport)
+#elif defined(FTD2XX_STATIC)
+// Avoid decorations when linking statically to D2XX.
+#define FTD2XX_API
+// Static D2XX depends on these Windows libs:
+#pragma comment(lib, "setupapi.lib")
+#pragma comment(lib, "advapi32.lib")
+#pragma comment(lib, "user32.lib")
+#else
+#define FTD2XX_API __declspec(dllimport)
+#endif
+
+#else // _WIN32
+// Compiling on non-Windows platform.
+#include "WinTypes.h"
+// No decorations needed.
+#define FTD2XX_API
+
+#endif // _WIN32
+
+/** @name FT_HANDLE 
+ * An opaque value used as a handle to an opened FT device.
+ */
+typedef PVOID	FT_HANDLE;
+
+/** @{
+ * @name FT_STATUS 
+ * @details Return status values for API calls. 
+ */
+typedef ULONG	FT_STATUS;
+
+enum {
+	FT_OK,
+	FT_INVALID_HANDLE,
+	FT_DEVICE_NOT_FOUND,
+	FT_DEVICE_NOT_OPENED,
+	FT_IO_ERROR,
+	FT_INSUFFICIENT_RESOURCES,
+	FT_INVALID_PARAMETER,
+	FT_INVALID_BAUD_RATE,
+
+	FT_DEVICE_NOT_OPENED_FOR_ERASE,
+	FT_DEVICE_NOT_OPENED_FOR_WRITE,
+	FT_FAILED_TO_WRITE_DEVICE,
+	FT_EEPROM_READ_FAILED,
+	FT_EEPROM_WRITE_FAILED,
+	FT_EEPROM_ERASE_FAILED,
+	FT_EEPROM_NOT_PRESENT,
+	FT_EEPROM_NOT_PROGRAMMED,
+	FT_INVALID_ARGS,
+	FT_NOT_SUPPORTED,
+	FT_OTHER_ERROR,
+	FT_DEVICE_LIST_NOT_READY,
+};
+/** @} */
+
+/** @name FT_SUCCESS Macro 
+ * Macro to determine success of an API call.
+ * @returns Non-zero for successful call.
+ */
+#define FT_SUCCESS(status) ((status) == FT_OK)
+
+/** @{
+ * @name FT_OpenEx Flags
+ * @see FT_OpenEx
+ */
+#define FT_OPEN_BY_SERIAL_NUMBER	1
+#define FT_OPEN_BY_DESCRIPTION		2
+#define FT_OPEN_BY_LOCATION			4
+
+#define FT_OPEN_MASK (FT_OPEN_BY_SERIAL_NUMBER | \
+					  FT_OPEN_BY_DESCRIPTION | \
+					  FT_OPEN_BY_LOCATION)
+/** @} */
+
+/** @{
+ * @name FT_ListDevices Flags
+ * @remarks Used in conjunction with FT_OpenEx Flags
+ * @see FT_ListDevices
+ * @see FT_OpenEx
+ */
+#define FT_LIST_NUMBER_ONLY			0x80000000
+#define FT_LIST_BY_INDEX			0x40000000
+#define FT_LIST_ALL					0x20000000
+
+#define FT_LIST_MASK (FT_LIST_NUMBER_ONLY|FT_LIST_BY_INDEX|FT_LIST_ALL)
+/** @} */
+
+/** @{ 
+ * @name Baud Rates
+ * Standard baud rates supported by many implementations and applications.
+ * @see FT_SetBaudRate
+ */
+#define FT_BAUD_300			300
+#define FT_BAUD_600			600
+#define FT_BAUD_1200		1200
+#define FT_BAUD_2400		2400
+#define FT_BAUD_4800		4800
+#define FT_BAUD_9600		9600
+#define FT_BAUD_14400		14400
+#define FT_BAUD_19200		19200
+#define FT_BAUD_38400		38400
+#define FT_BAUD_57600		57600
+#define FT_BAUD_115200		115200
+#define FT_BAUD_230400		230400
+#define FT_BAUD_460800		460800
+#define FT_BAUD_921600		921600
+/** @} */
+
+/** @{ 
+ * @name Word Lengths
+ * @see FT_SetDataCharacteristics
+ */
+#define FT_BITS_8			(UCHAR) 8
+#define FT_BITS_7			(UCHAR) 7
+/** @} */
+
+/** @{ 
+ * @name Stop Bits
+ * @see FT_SetDataCharacteristics
+ */
+#define FT_STOP_BITS_1		(UCHAR) 0
+#define FT_STOP_BITS_2		(UCHAR) 2
+/** @} */
+
+/* * @name Parity
+ * @see FT_SetDataCharacteristics
+ * @{ 
+ */
+#define FT_PARITY_NONE		(UCHAR) 0
+#define FT_PARITY_ODD		(UCHAR) 1
+#define FT_PARITY_EVEN		(UCHAR) 2
+#define FT_PARITY_MARK		(UCHAR) 3
+#define FT_PARITY_SPACE		(UCHAR) 4
+/** @} */
+
+/** @{ 
+ * @name Flow Control
+ * @see FT_SetFlowControl
+ */
+#define FT_FLOW_NONE		0x0000
+#define FT_FLOW_RTS_CTS		0x0100
+#define FT_FLOW_DTR_DSR		0x0200
+#define FT_FLOW_XON_XOFF	0x0400
+/** @} */
+
+/** @{ 
+ * @name Purge rx and tx buffers
+ * @see FT_Purge
+ */
+#define FT_PURGE_RX			1
+#define FT_PURGE_TX			2
+/** @} */
+
+/** @{ 
+ * @name Events
+ * @see FT_SetEventNotification
+ */
+typedef void(*PFT_EVENT_HANDLER)(DWORD, DWORD);
+
+#define FT_EVENT_RXCHAR			1
+#define FT_EVENT_MODEM_STATUS	2
+#define FT_EVENT_LINE_STATUS	4
+/** @} */
+
+/** @{ 
+ * @name Timeouts
+ * @see FT_SetTimeouts
+ */
+#define FT_DEFAULT_RX_TIMEOUT	300
+#define FT_DEFAULT_TX_TIMEOUT	300
+/** @} */
+
+/** @{ 
+ * @name Device Types
+ * @details Known supported FTDI device types supported by this library.
+ */
+typedef ULONG	FT_DEVICE;
+
+enum {
+	FT_DEVICE_BM,
+	FT_DEVICE_AM,
+	FT_DEVICE_100AX,
+	FT_DEVICE_UNKNOWN,
+	FT_DEVICE_2232C,
+	FT_DEVICE_232R,
+	FT_DEVICE_2232H,
+	FT_DEVICE_4232H,
+	FT_DEVICE_232H,
+	FT_DEVICE_X_SERIES,
+	FT_DEVICE_4222H_0,
+	FT_DEVICE_4222H_1_2,
+	FT_DEVICE_4222H_3,
+	FT_DEVICE_4222_PROG,
+	FT_DEVICE_900,
+	FT_DEVICE_930,
+	FT_DEVICE_UMFTPD3A,
+	FT_DEVICE_2233HP,
+	FT_DEVICE_4233HP,
+	FT_DEVICE_2232HP,
+	FT_DEVICE_4232HP,
+	FT_DEVICE_233HP,
+	FT_DEVICE_232HP,
+	FT_DEVICE_2232HA,
+	FT_DEVICE_4232HA,
+};
+/** @} */
+
+/** @{ 
+ * @name Bit Modes
+ * @see FT_SetBitMode FT_GetBitMode
+ */
+#define FT_BITMODE_RESET					0x00
+#define FT_BITMODE_ASYNC_BITBANG			0x01
+#define FT_BITMODE_MPSSE					0x02
+#define FT_BITMODE_SYNC_BITBANG				0x04
+#define FT_BITMODE_MCU_HOST					0x08
+#define FT_BITMODE_FAST_SERIAL				0x10
+#define FT_BITMODE_CBUS_BITBANG				0x20
+#define FT_BITMODE_SYNC_FIFO				0x40
+/** @} */
+
+/** @{ 
+ * @name FT232R CBUS Options EEPROM values
+ */
+#define FT_232R_CBUS_TXDEN					0x00	//	Tx Data Enable
+#define FT_232R_CBUS_PWRON					0x01	//	Power On
+#define FT_232R_CBUS_RXLED					0x02	//	Rx LED
+#define FT_232R_CBUS_TXLED					0x03	//	Tx LED
+#define FT_232R_CBUS_TXRXLED				0x04	//	Tx and Rx LED
+#define FT_232R_CBUS_SLEEP					0x05	//	Sleep
+#define FT_232R_CBUS_CLK48					0x06	//	48MHz clock
+#define FT_232R_CBUS_CLK24					0x07	//	24MHz clock
+#define FT_232R_CBUS_CLK12					0x08	//	12MHz clock
+#define FT_232R_CBUS_CLK6					0x09	//	6MHz clock
+#define FT_232R_CBUS_IOMODE					0x0A	//	IO Mode for CBUS bit-bang
+#define FT_232R_CBUS_BITBANG_WR				0x0B	//	Bit-bang write strobe
+#define FT_232R_CBUS_BITBANG_RD				0x0C	//	Bit-bang read strobe
+#define FT_232R_CBUS0_RXF					0x0D	//	CBUS0 RXF#
+#define FT_232R_CBUS1_TXE					0x0D	//	CBUS1 TXE#
+#define FT_232R_CBUS2_RD					0x0D	//	CBUS2 RD#
+#define FT_232R_CBUS3_WR					0x0D	//	CBUS3 WR#
+/** @} */
+
+/** @{ 
+ * @name FT232H CBUS Options EEPROM values
+ */
+#define FT_232H_CBUS_TRISTATE				0x00	//	Tristate
+#define FT_232H_CBUS_TXLED					0x01	//	Tx LED
+#define FT_232H_CBUS_RXLED					0x02	//	Rx LED
+#define FT_232H_CBUS_TXRXLED				0x03	//	Tx and Rx LED
+#define FT_232H_CBUS_PWREN					0x04	//	Power Enable
+#define FT_232H_CBUS_SLEEP					0x05	//	Sleep
+#define FT_232H_CBUS_DRIVE_0				0x06	//	Drive pin to logic 0
+#define FT_232H_CBUS_DRIVE_1				0x07	//	Drive pin to logic 1
+#define FT_232H_CBUS_IOMODE					0x08	//	IO Mode for CBUS bit-bang
+#define FT_232H_CBUS_TXDEN					0x09	//	Tx Data Enable
+#define FT_232H_CBUS_CLK30					0x0A	//	30MHz clock
+#define FT_232H_CBUS_CLK15					0x0B	//	15MHz clock
+#define FT_232H_CBUS_CLK7_5					0x0C	//	7.5MHz clock
+/** @} */
+
+/** @{ 
+ * @name FT X Series CBUS Options EEPROM values
+ */
+#define FT_X_SERIES_CBUS_TRISTATE			0x00	//	Tristate
+#define FT_X_SERIES_CBUS_TXLED				0x01	//	Tx LED
+#define FT_X_SERIES_CBUS_RXLED				0x02	//	Rx LED
+#define FT_X_SERIES_CBUS_TXRXLED			0x03	//	Tx and Rx LED
+#define FT_X_SERIES_CBUS_PWREN				0x04	//	Power Enable
+#define FT_X_SERIES_CBUS_SLEEP				0x05	//	Sleep
+#define FT_X_SERIES_CBUS_DRIVE_0			0x06	//	Drive pin to logic 0
+#define FT_X_SERIES_CBUS_DRIVE_1			0x07	//	Drive pin to logic 1
+#define FT_X_SERIES_CBUS_IOMODE				0x08	//	IO Mode for CBUS bit-bang
+#define FT_X_SERIES_CBUS_TXDEN				0x09	//	Tx Data Enable
+#define FT_X_SERIES_CBUS_CLK24				0x0A	//	24MHz clock
+#define FT_X_SERIES_CBUS_CLK12				0x0B	//	12MHz clock
+#define FT_X_SERIES_CBUS_CLK6				0x0C	//	6MHz clock
+#define FT_X_SERIES_CBUS_BCD_CHARGER		0x0D	//	Battery charger detected
+#define FT_X_SERIES_CBUS_BCD_CHARGER_N		0x0E	//	Battery charger detected inverted
+#define FT_X_SERIES_CBUS_I2C_TXE			0x0F	//	I2C Tx empty
+#define FT_X_SERIES_CBUS_I2C_RXF			0x10	//	I2C Rx full
+#define FT_X_SERIES_CBUS_VBUS_SENSE			0x11	//	Detect VBUS
+#define FT_X_SERIES_CBUS_BITBANG_WR			0x12	//	Bit-bang write strobe
+#define FT_X_SERIES_CBUS_BITBANG_RD			0x13	//	Bit-bang read strobe
+#define FT_X_SERIES_CBUS_TIMESTAMP			0x14	//	Toggle output when a USB SOF token is received
+#define FT_X_SERIES_CBUS_KEEP_AWAKE			0x15	//	
+/** @} */
+
+/** @{ 
+ * @name Driver Types
+ */
+#define FT_DRIVER_TYPE_D2XX		0
+#define FT_DRIVER_TYPE_VCP		1
+/** @} */
+
+/** @{
+ * @name FT_DEVICE_LIST_INFO_NODE Device Information Flags
+ * @par Summary
+ * These flags are used in the Flags member of FT_DEVICE_LIST_INFO_NODE to indicated the state of 
+ * the device and speed of the device.
+*/
+enum {
+	FT_FLAGS_OPENED = 1,
+	FT_FLAGS_HISPEED = 2
+};
+/** @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef FTD2XX_STATIC
+	FTD2XX_API FT_STATUS WINAPI FT_Initialise(
+		void
+		);
+
+	FTD2XX_API void WINAPI FT_Finalise(
+		void
+		);
+#endif // FTD2XX_STATIC
+
+/**	 * @name D2XX Classic Functions 
+ 	The functions listed in this section are compatible with all FTDI devices.
+ */
+/** @{ */
+#ifndef _WIN32
+
+	/** @noop FT_SetVIDPID
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * @par Summary
+	 * A command to include a custom VID and PID combination within the internal device list table. 
+	 * This will allow the driver to load for the specified VID and PID combination.
+	 * @param dwVID Device Vendor ID (VID)
+	 * @param dwPID Device Product ID (PID)
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * By default, the driver will support a limited set of VID and PID matched devices (VID 0x0403 
+	 * with PIDs for standard FTDI devices only).
+	 * @n In order to use the driver with other VID and PID combinations the FT_SetVIDPID function 
+	 * must be used prior to calling FT_ListDevices, FT_Open, FT_OpenEx or FT_CreateDeviceInfoList.
+	 * @note Extra function for non-Windows platforms to compensate for lack of .INF file to specify 
+	 * Vendor and Product IDs.
+	 */
+	FTD2XX_API FT_STATUS FT_SetVIDPID(
+		DWORD dwVID,
+		DWORD dwPID
+		);
+
+	/** @noop FT_GetVIDPID
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * @par Summary
+	 * A command to retrieve the current VID and PID combination from within the internal device list table.
+	 * @param pdwVID Pointer to DWORD that will contain the internal VID
+	 * @param pdwPID Pointer to DWORD that will contain the internal PID
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * @note Extra function for non-Windows platforms to compensate for lack of .INF file to specify Vendor and Product IDs.
+	 * @see FT_SetVIDPID.
+	 */
+	FTD2XX_API FT_STATUS FT_GetVIDPID(
+		DWORD * pdwVID,
+		DWORD * pdwPID
+		);
+
+#endif // _WIN32        
+
+	/** @noop FT_CreateDeviceInfoList
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later) 
+	 * @par Summary
+	 * This function builds a device information list and returns the number of D2XX devices connected to the
+	 * system. The list contains information about both unopen and open devices.
+	 * @param lpdwNumDevs Pointer to unsigned long to store the number of devices connected.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * An application can use this function to get the number of devices attached to the system. It can then
+	 * allocate space for the device information list and retrieve the list using FT_GetDeviceInfoList or
+	 * FT_GetDeviceInfoDetail.
+	 * @n If the devices connected to the system change, the device info list will not be updated until
+	 * FT_CreateDeviceInfoList is called again. 
+	 * @see FT_GetDeviceInfoList
+	 * @see FT_GetDeviceInfoDetail
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_CreateDeviceInfoList(
+		LPDWORD lpdwNumDevs
+		);
+
+	/**  @noop FT_DEVICE_LIST_INFO_NODE
+	 * @par Summary
+	 * This structure is used for passing information about a device back from the FT_GetDeviceInfoList function.
+	 * @see FT_GetDeviceInfoList
+	 */
+	typedef struct _ft_device_list_info_node {
+		ULONG Flags;
+		ULONG Type;
+		ULONG ID;
+		DWORD LocId;
+		char SerialNumber[16];
+		char Description[64];
+		FT_HANDLE ftHandle;
+	} FT_DEVICE_LIST_INFO_NODE;
+
+	/** @noop FT_GetDeviceInfoList
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later) 
+	 * @par Summary
+	 * This function returns a device information list and the number of D2XX devices in the list.
+	 * @param *pDest Pointer to an array of FT_DEVICE_LIST_INFO_NODE structures.
+	 * @param lpdwNumDevs Pointer to the number of elements in the array.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function should only be called after calling FT_CreateDeviceInfoList. If the devices connected to the
+	 * system change, the device info list will not be updated until FT_CreateDeviceInfoList is called again.
+	 * Location ID information is not returned for devices that are open when FT_CreateDeviceInfoList is called.
+	 * Information is not available for devices which are open in other processes. In this case, the Flags
+	 * parameter of the FT_DEVICE_LIST_INFO_NODE will indicate that the device is open, but other fields will
+	 * be unpopulated.
+	 * @n The flag value is a 4-byte bit map containing miscellaneous data as defined Appendix A - Type
+	 * Definitions. Bit 0 (least significant bit) of this number indicates if the port is open (1) or closed (0). Bit 1
+	 * indicates if the device is enumerated as a high-speed USB device (2) or a full-speed USB device (0). The
+	 * remaining bits (2 - 31) are reserved.
+	 * @n The array of FT_DEVICE_LIST_INFO_NODES contains all available data on each device. The structure of
+	 * FT_DEVICE_LIST_INFO_NODES is given in the Appendix. The storage for the list must be allocated by
+	 * the application. The number of devices returned by FT_CreateDeviceInfoList can be used to do this.
+	 * When programming in Visual Basic, LabVIEW or similar languages, FT_GetDeviceInfoDetail may be
+	 * required instead of this function.
+	 * @note Please note that Windows CE does not support location IDs. As such, the Location ID parameter in the 
+	 * structure will be empty.
+	 * @see FT_CreateDeviceInfoList
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetDeviceInfoList(
+		FT_DEVICE_LIST_INFO_NODE *pDest,
+		LPDWORD lpdwNumDevs
+		);
+
+	/** @noop FT_GetDeviceInfoDetail
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later) 
+	 * @par Summary
+	 * This function returns an entry from the device information list.
+	 * @param dwIndex Index of the entry in the device info list.
+	 * @param lpdwFlags Pointer to unsigned long to store the flag value.
+	 * @param lpdwType Pointer to unsigned long to store device type.
+	 * @param lpdwID Pointer to unsigned long to store device ID.
+	 * @param lpdwLocId Pointer to unsigned long to store the device location ID.
+	 * @param lpSerialNumber Pointer to buffer to store device serial number as a nullterminated string.
+	 * @param lpDescription Pointer to buffer to store device description as a null-terminated string.
+	 * @param *pftHandle Pointer to a variable of type FT_HANDLE where the handle will be stored.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function should only be called after calling FT_CreateDeviceInfoList. If the devices connected to the
+	 * system change, the device info list will not be updated until FT_CreateDeviceInfoList is called again.
+	 * @n The index value is zero-based.
+	 * @n The flag value is a 4-byte bit map containing miscellaneous data as defined Appendix A - Type
+	 * Definitions. Bit 0 (least significant bit) of this number indicates if the port is open (1) or closed (0). Bit 1
+	 * indicates if the device is enumerated as a high-speed USB device (2) or a full-speed USB device (0). The
+	 * remaining bits (2 - 31) are reserved.
+	 * @n Location ID information is not returned for devices that are open when FT_CreateDeviceInfoList is called.
+	 * Information is not available for devices which are open in other processes. In this case, the lpdwFlags
+	 * parameter will indicate that the device is open, but other fields will be unpopulated.
+	 * To return the whole device info list as an array of FT_DEVICE_LIST_INFO_NODE structures, use
+	 * FT_CreateDeviceInfoList.
+	 * @note Please note that Windows CE does not support location IDs. As such, the Location ID parameter in the 
+	 * structure will be empty.
+	 * @see FT_CreateDeviceInfoList
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetDeviceInfoDetail(
+		DWORD dwIndex,
+		LPDWORD lpdwFlags,
+		LPDWORD lpdwType,
+		LPDWORD lpdwID,
+		LPDWORD lpdwLocId,
+		LPVOID lpSerialNumber,
+		LPVOID lpDescription,
+		FT_HANDLE *pftHandle
+		);
+
+	/** @noop FT_ListDevices
+	 * @par Summary
+	 * Gets information concerning the devices currently connected. This function can return information such
+	 * as the number of devices connected, the device serial number and device description strings, and the
+	 * location IDs of connected devices.
+	 * @param pvArg1 Meaning depends on dwFlags.
+	 * @param pvArg2 Meaning depends on dwFlags.
+	 * @param dwFlags Determines format of returned information.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function can be used in a number of ways to return different types of information. A more powerful
+	 * way to get device information is to use the FT_CreateDeviceInfoList, FT_GetDeviceInfoList and
+	 * FT_GetDeviceInfoDetail functions as they return all the available information on devices.
+	 * In its simplest form, it can be used to return the number of devices currently connected. If
+	 * FT_LIST_NUMBER_ONLY bit is set in dwFlags, the parameter pvArg1 is interpreted as a pointer to a
+	 * DWORD location to store the number of devices currently connected.
+	 * @n It can be used to return device information: if FT_OPEN_BY_SERIAL_NUMBER bit is set in dwFlags, the
+	 * serial number string will be returned; if FT_OPEN_BY_DESCRIPTION bit is set in dwFlags, the product 
+	 * description string will be returned; if FT_OPEN_BY_LOCATION bit is set in dwFlags, the Location ID will 
+	 * be returned; if none of these bits is set, the serial number string will be returned by default.
+	 * @n It can be used to return device string information for a single device. If FT_LIST_BY_INDEX and
+	 * FT_OPEN_BY_SERIAL_NUMBER or FT_OPEN_BY_DESCRIPTION bits are set in dwFlags, the parameter
+	 * pvArg1 is interpreted as the index of the device, and the parameter pvArg2 is interpreted as a pointer to
+	 * a buffer to contain the appropriate string. Indexes are zero-based, and the error code
+	 * FT_DEVICE_NOT_FOUND is returned for an invalid index.
+	 * @n It can be used to return device string information for all connected devices. If FT_LIST_ALL and
+	 * FT_OPEN_BY_SERIAL_NUMBER or FT_OPEN_BY_DESCRIPTION bits are set in dwFlags, the parameter
+	 * pvArg1 is interpreted as a pointer to an array of pointers to buffers to contain the appropriate strings and
+	 * the parameter pvArg2 is interpreted as a pointer to a DWORD location to store the number of devices
+	 * currently connected. Note that, for pvArg1, the last entry in the array of pointers to buffers should be a
+	 * NULL pointer so the array will contain one more location than the number of devices connected.
+	 * @n The location ID of a device is returned if FT_LIST_BY_INDEX and FT_OPEN_BY_LOCATION bits are set in
+	 * dwFlags. In this case the parameter pvArg1 is interpreted as the index of the device, and the parameter
+	 * pvArg2 is interpreted as a pointer to a variable of type long to contain the location ID. Indexes are 
+	 * zerobased, and the error code FT_DEVICE_NOT_FOUND is returned for an invalid index. Please note that
+	 * Windows CE and Linux do not support location IDs.
+	 * @n The location IDs of all connected devices are returned if FT_LIST_ALL and FT_OPEN_BY_LOCATION bits
+	 * are set in dwFlags. In this case, the parameter pvArg1 is interpreted as a pointer to an array of variables
+	 * of type long to contain the location IDs, and the parameter pvArg2 is interpreted as a pointer to a
+	 * DWORD location to store the number of devices currently connected.
+	 * @see FT_CreateDeviceInfoList
+	 * @see FT_GetDeviceInfoList
+	 * @see FT_GetDeviceInfoDetail
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ListDevices(
+		PVOID pvArg1,
+		PVOID pvArg2,
+		DWORD dwFlags
+		);
+
+	/** @noop FT_Open
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Open the device and return a handle which will be used for subsequent accesses.
+	 * @param deviceNumber Index of the device to open. Indices are 0 based.
+	 * @param pHandle Pointer to a variable of type FT_HANDLE where the handle will be stored. This handle must 
+	 * be used to access the device.
+	 * @return
+	 * FT_OK if successful, otherwise the return value is an FT error code. 
+	 * @remarks
+	 * Although this function can be used to open multiple devices by setting iDevice to 0, 1, 2 etc. there is no
+	 * ability to open a specific device. To open named devices, use the function FT_OpenEx.
+	 * @see FT_OpenEx.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Open(
+		int deviceNumber,
+		FT_HANDLE *pHandle
+		);
+
+	/** @noop FT_OpenEx
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Open the specified device and return a handle that will be used for subsequent accesses. The device can
+	 * be specified by its serial number, device description or location.
+	 * @n This function can also be used to open multiple devices simultaneously. Multiple devices can be specified
+	 * by serial number, device description or location ID (location information derived from the physical
+	 * location of a device on USB). Location IDs for specific USB ports can be obtained using the utility
+	 * USBView and are given in hexadecimal format. Location IDs for devices connected to a system can be
+	 * obtained by calling FT_GetDeviceInfoList or FT_ListDevices with the appropriate flags.
+	 * @param pvArg1 Pointer to an argument whose type depends on the value of dwFlags. 
+	 * It is normally be interpreted as a pointer to a null terminated string.
+	 * @param dwFlags FT_OPEN_BY_SERIAL_NUMBER, FT_OPEN_BY_DESCRIPTION or FT_OPEN_BY_LOCATION.
+	 * @param pHandle Pointer to a variable of type FT_HANDLE where the handle will be
+	 * stored. This handle must be used to access the device.
+	 * @returns 
+	 * FT_OK if successful, otherwise the return value is an FT error code. 
+	 * @remarks 
+	 * The parameter specified in pvArg1 depends on dwFlags: if dwFlags is FT_OPEN_BY_SERIAL_NUMBER,
+	 * pvArg1 is interpreted as a pointer to a null-terminated string that represents the serial number of the
+	 * device; if dwFlags is FT_OPEN_BY_DESCRIPTION, pvArg1 is interpreted as a pointer to a nullterminated 
+	 * string that represents the device description; if dwFlags is FT_OPEN_BY_LOCATION, pvArg1
+	 * is interpreted as a long value that contains the location ID of the device. Please note that Windows CE
+	 * and Linux do not support location IDs.
+	 * @n ftHandle is a pointer to a variable of type FT_HANDLE where the handle is to be stored. This handle must
+	 * be used to access the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_OpenEx(
+		PVOID pvArg1,
+		DWORD dwFlags,
+		FT_HANDLE *pHandle
+		);
+
+	/** @noop FT_Close
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Close an open device.
+	 * @param ftHandle Handle of the device.
+	 * @returns 
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Close(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_Read
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read data from the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpBuffer Pointer to the buffer that receives the data from the device.
+	 * @param dwBytesToRead Number of bytes to be read from the device.
+	 * @param lpdwBytesReturned Pointer to a variable of type DWORD which receives the number of
+	 * bytes read from the device.
+	 * @returns
+	 * FT_OK if successful, FT_IO_ERROR otherwise. $see FT_STATUS
+	 * @remarks
+	 * FT_Read always returns the number of bytes read in lpdwBytesReturned.
+	 * @n This function does not return until dwBytesToRead bytes have been read into the buffer. The number of
+	 * bytes in the receive queue can be determined by calling FT_GetStatus or FT_GetQueueStatus, and
+	 * passed to FT_Read as dwBytesToRead so that the function reads the device and returns immediately.
+	 * When a read timeout value has been specified in a previous call to FT_SetTimeouts, FT_Read returns
+	 * when the timer expires or dwBytesToRead have been read, whichever occurs first. If the timeout
+	 * occurred, FT_Read reads available data into the buffer and returns FT_OK.
+	 * @n An application should use the function return value and lpdwBytesReturned when processing the buffer.
+	 * If the return value is FT_OK, and lpdwBytesReturned is equal to dwBytesToRead then FT_Read has
+	 * completed normally. If the return value is FT_OK, and lpdwBytesReturned is less then dwBytesToRead
+	 * then a timeout has occurred and the read has been partially completed. Note that if a timeout occurred
+	 * and no data was read, the return value is still FT_OK.
+	 * @n A return value of FT_IO_ERROR suggests an error in the parameters of the function, or a fatal error like a
+	 * USB disconnect has occurred.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Read(
+		FT_HANDLE ftHandle,
+		LPVOID lpBuffer,
+		DWORD dwBytesToRead,
+		LPDWORD lpdwBytesReturned
+		);
+
+	/** @noop FT_Write
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Write data to the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpBuffer Pointer to the buffer that contains the data to be written to the device.
+	 * @param dwBytesToWrite Number of bytes to write to the device.
+	 * @param lpdwBytesWritten Pointer to a variable of type DWORD which receives the number of
+	 * bytes written to the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Write(
+		FT_HANDLE ftHandle,
+		LPVOID lpBuffer,
+		DWORD dwBytesToWrite,
+		LPDWORD lpdwBytesWritten
+		);
+
+	/** @noop FT_SetBaudRate
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the baud rate for the device.
+	 * @param ftHandle Handle of the device.
+	 * @param dwBaudRate Baud rate.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code
+	 */ 
+	FTD2XX_API FT_STATUS WINAPI FT_SetBaudRate(
+		FT_HANDLE ftHandle,
+		ULONG dwBaudRate
+		);
+
+	/** @noop FT_SetDivisor
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the baud rate for the device. It is used to set non-standard baud rates.
+	 * @param ftHandle Handle of the device.
+	 * @param usDivisor Divisor.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is no longer required as FT_SetBaudRate will now automatically calculate the required
+	 * divisor for a requested baud rate. The application note "Setting baud rates for the FT8U232AM" is
+	 * available from the Application Notes section of the FTDI website describes how to calculate the divisor for
+	 * a non-standard baud rate.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetDivisor(
+		FT_HANDLE ftHandle,
+		USHORT usDivisor
+		);
+
+	/** @noop FT_SetDataCharacteristics
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the data characteristics for the device.
+	 * @param ftHandle Handle of the device.
+	 * @param uWordLength Number of bits per word - must be FT_BITS_8 or FT_BITS_7.
+	 * @param uStopBits Number of stop bits - must be FT_STOP_BITS_1 or FT_STOP_BITS_2.
+	 * @param uParity Parity - must be FT_PARITY_NONE, FT_PARITY_ODD, FT_PARITY_EVEN, 
+	 * FT_PARITY_MARK or FT_PARITY SPACE.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetDataCharacteristics(
+		FT_HANDLE ftHandle,
+		UCHAR uWordLength,
+		UCHAR uStopBits,
+		UCHAR uParity
+		);
+
+	/** @noop FT_SetTimeouts
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the read and write timeouts for the device.
+	 * @param ftHandle Handle of the device.
+	 * @param dwReadTimeout Read timeout in milliseconds.
+	 * @param dwWriteTimeout Write timeout in milliseconds.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetTimeouts(
+		FT_HANDLE ftHandle,
+		ULONG dwReadTimeout,
+		ULONG dwWriteTimeout
+		);
+
+	/** @noop FT_SetFlowControl
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the flow control for the device.
+	 * @param ftHandle Handle of the device.
+	 * @param usFlowControl Must be one of FT_FLOW_NONE, FT_FLOW_RTS_CTS, FT_FLOW_DTR_DSR or 
+	 * FT_FLOW_XON_XOFF.
+	 * @param uXonChar Character used to signal Xon. Only used if flow control is FT_FLOW_XON_XOFF.
+	 * @param uXoffChar Character used to signal Xoff. Only used if flow control is	FT_FLOW_XON_XOFF.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetFlowControl(
+		FT_HANDLE ftHandle,
+		USHORT usFlowControl,
+		UCHAR uXonChar,
+		UCHAR uXoffChar
+		);
+
+	/** @noop FT_SetDtr
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the Data Terminal Ready (DTR) control signal.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function asserts the Data Terminal Ready (DTR) line of the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetDtr(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_ClrDtr
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function clears the Data Terminal Ready (DTR) control signal.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function de-asserts the Data Terminal Ready (DTR) line of the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ClrDtr(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_SetRts
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the Request To Send (RTS) control signal.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function asserts the Request To Send (RTS) line of the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetRts(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_ClrRts
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function clears the Request To Send (RTS) control signal.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function de-asserts the Request To Send (RTS) line of the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ClrRts(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_GetModemStatus
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the modem status and line status from the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwModemStatus Pointer to a variable of type DWORD which receives the modem
+	 * status and line status from the device.
+	 * @returns 
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * The least significant byte of the lpdwModemStatus value holds the modem status. On Windows and
+	 * Windows CE, the line status is held in the second least significant byte of the lpdwModemStatus value.
+	 * @n The modem status is bit-mapped as follows: Clear To Send (CTS) = 0x10, Data Set Ready (DSR) = 0x20,
+	 * Ring Indicator (RI) = 0x40, Data Carrier Detect (DCD) = 0x80.
+	 * @n The line status is bit-mapped as follows: Overrun Error (OE) = 0x02, Parity Error (PE) = 0x04, Framing
+	 * Error (FE) = 0x08, Break Interrupt (BI) = 0x10.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetModemStatus(
+		FT_HANDLE ftHandle,
+		ULONG *lpdwModemStatus
+		);
+
+	/** @noop FT_GetQueueStatus
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the number of bytes in the receive queue.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwAmountInRxQueue Pointer to a variable of type DWORD which receives the number of
+	 * bytes in the receive queue.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetQueueStatus(
+		FT_HANDLE ftHandle,
+		DWORD *lpdwAmountInRxQueue
+		);
+
+	/** @noop FT_GetDeviceInfo
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Get device information for an open device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpftDevice Pointer to unsigned long to store device type.
+	 * @param lpdwID Pointer to unsigned long to store device ID.
+	 * @param pcSerialNumber Pointer to buffer to store device serial number as a nullterminated string.
+	 * @param pcDescription Pointer to buffer to store device description as a null-terminated string.
+	 * @param pvDummy Reserved for future use - should be set to NULL.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is used to return the device type, device ID, device description and serial number.
+	 * The device ID is encoded in a DWORD - the most significant word contains the vendor ID, and the least
+	 * significant word contains the product ID. So the returned ID 0x04036001 corresponds to the device ID
+	 * VID_0403&PID_6001.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetDeviceInfo(
+		FT_HANDLE ftHandle,
+		FT_DEVICE *lpftDevice,
+		LPDWORD lpdwID,
+		PCHAR pcSerialNumber,
+		PCHAR pcDescription,
+		LPVOID pvDummy
+		);
+
+#ifndef _WIN32
+	/**
+	 * @note Extra function for non-Windows platforms to compensate for lack of .INF file to specify Vendor and Product IDs.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetDeviceLocId(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwLocId
+		);
+#endif // _WIN32        
+
+	/** @noop FT_GetDriverVersion
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function returns the D2XX driver version number.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwDriverVersion Pointer to the driver version number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * A version number consists of major, minor and build version numbers contained in a 4-byte field
+	 * (unsigned long). Byte0 (least significant) holds the build version, Byte1 holds the minor version, and
+	 * Byte2 holds the major version. Byte3 is currently set to zero.
+	 * @n For example, driver version "2.04.06" is represented as 0x00020406. Note that a device has to be
+	 * opened before this function can be called.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetDriverVersion(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwDriverVersion
+		);
+
+	/** @noop FT_GetLibraryVersion
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @n
+	 * This function returns D2XX DLL or library version number.
+	 * @param lpdwDLLVersion Pointer to the DLL or library version number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * A version number consists of major, minor and build version numbers contained in a 4-byte field
+	 * (unsigned long). Byte0 (least significant) holds the build version, Byte1 holds the minor version, and
+	 * Byte2 holds the major version. Byte3 is currently set to zero.
+	 * @n For example, D2XX DLL version "3.01.15" is represented as 0x00030115. Note that this function does
+	 * not take a handle, and so it can be called without opening a device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetLibraryVersion(
+		LPDWORD lpdwDLLVersion
+		);
+
+	/** @noop FT_GetComPortNumber
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * Retrieves the COM port associated with a device.
+	 * @param ftHandle Handle of the device.
+	 * @param lplComPortNumber Pointer to a variable of type LONG which receives the COM port number
+	 * associated with the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is only available when using the Windows CDM driver as both the D2XX and VCP drivers can
+	 * be installed at the same time.
+	 * @n If no COM port is associated with the device, lplComPortNumber will have a value of -1
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetComPortNumber(
+		FT_HANDLE ftHandle,
+		LPLONG	lplComPortNumber
+		);
+
+	/** @noop FT_GetStatus
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the device status including number of characters in the receive queue, number of characters in the
+	 * transmit queue, and the current event status.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwAmountInRxQueue Pointer to a variable of type DWORD which receives the number of characters in
+	 * the receive queue.
+	 * @param lpdwAmountInTxQueue Pointer to a variable of type DWORD which receives the number of characters in
+	 * the transmit queue.
+	 * @param lpdwEventStatus Pointer to a variable of type DWORD which receives the current state of
+	 * the event status.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * For an example of how to use this function, see the sample code in FT_SetEventNotification.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetStatus(
+		FT_HANDLE ftHandle,
+		DWORD *lpdwAmountInRxQueue,
+		DWORD *lpdwAmountInTxQueue,
+		DWORD *lpdwEventStatus
+		);
+
+	/** @noop FT_SetEventNotification
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Sets conditions for event notification.
+	 * @param ftHandle Handle of the device.
+	 * @param dwEventMask Conditions that cause the event to be set.
+	 * @param pvArg Interpreted as the handle of an event.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * An application can use this function to setup conditions which allow a thread to block until one of the
+	 * conditions is met. Typically, an application will create an event, call this function, then block on the
+	 * event. When the conditions are met, the event is set, and the application thread unblocked.
+	 * dwEventMask is a bit-map that describes the events the application is interested in. pvArg is interpreted
+	 * as the handle of an event which has been created by the application. If one of the event conditions is
+	 * met, the event is set.
+	 * @n If FT_EVENT_RXCHAR is set in dwEventMask, the event will be set when a character has been received
+	 * by the device.
+	 * @n If FT_EVENT_MODEM_STATUS is set in dwEventMask, the event will be set when a change in the modem
+	 * signals has been detected by the device.
+	 * @n If FT_EVENT_LINE_STATUS is set in dwEventMask, the event will be set when a change in the line status
+	 * has been detected by the device.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetEventNotification(
+		FT_HANDLE ftHandle,
+		DWORD dwEventMask,
+		PVOID pvArg
+		);
+
+	/** @noop FT_SetChars
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the special characters for the device.
+	 * @param ftHandle Handle of the device.
+	 * @param uEventChar Event character.
+	 * @param uEventCharEnabled 0 if event character disabled, non-zero otherwise.
+	 * @param uErrorChar Error character.
+	 * @param uErrorCharEnabled 0 if error character disabled, non-zero otherwise.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function allows for inserting specified characters in the data stream to represent events firing or
+	 * errors occurring.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetChars(
+		FT_HANDLE ftHandle,
+		UCHAR uEventChar,
+		UCHAR uEventCharEnabled,
+		UCHAR uErrorChar,
+		UCHAR uErrorCharEnabled
+		);
+
+	/** @noop FT_SetBreakOn
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Sets the BREAK condition for the device.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code	
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetBreakOn(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_SetBreakOff
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Resets the BREAK condition for the device.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetBreakOff(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_Purge
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function purges receive and transmit buffers in the device.
+	 * @param ftHandle Handle of the device.
+	 * @param ulMask Combination of FT_PURGE_RX and FT_PURGE_TX.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Purge(
+		FT_HANDLE ftHandle,
+		ULONG ulMask
+		);
+
+	/** @noop FT_ResetDevice
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later) 
+	 * @par Summary
+	 * This function sends a reset command to the device.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ResetDevice(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_ResetPort
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * Send a reset command to the port.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is used to attempt to recover the port after a failure. It is not equivalent 
+	 * to an unplug-replug event. For the equivalent of an unplug-replug event, use FT_CyclePort.
+	 * @see FT_CyclePort
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ResetPort(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_CyclePort
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * Send a cycle command to the USB port.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * The effect of this function is the same as disconnecting then reconnecting the device from 
+	 * USB. Possible use of this function is situations where a fatal error has occurred and it is 
+	 * difficult, or not possible, to recover without unplugging and replugging the USB cable. 
+	 * This function can also be used after reprogramming the EEPROM to force the FTDI device to 
+	 * read the new EEPROM contents which would	otherwise require a physical disconnect-reconnect.
+	 * @n As the current session is not restored when the driver is reloaded, the application must 
+	 * be able to recover after calling this function. It is ithe responisbility of the application 
+	 * to close the handle after successfully calling FT_CyclePort.
+	 * @n For FT4232H, FT2232H and FT2232 devices, FT_CyclePort will only work under Windows XP and later.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_CyclePort(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_Rescan
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * This function can be of use when trying to recover devices programatically.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * Calling FT_Rescan is equivalent to clicking the "Scan for hardware changes" button in the Device
+	 * Manager. Only USB hardware is checked for new devices. All USB devices are scanned, not just FTDI
+	 * devices.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Rescan(
+		void
+		);
+
+	/** @noop FT_Reload
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * This function forces a reload of the driver for devices with a specific VID and PID combination.
+	 * @param wVID Vendor ID of the devices to reload the driver for.
+	 * @param wPID Product ID of the devices to reload the driver for.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * Calling FT_Reload forces the operating system to unload and reload the driver for the specified device
+	 * IDs. If the VID and PID parameters are null, the drivers for USB root hubs will be reloaded, causing all
+	 * USB devices connected to reload their drivers. Please note that this function will not work correctly on
+	 * 64-bit Windows when called from a 32-bit application.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_Reload(
+		WORD wVID,
+		WORD wPID
+		);
+
+	/** @noop FT_SetResetPipeRetryCount
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Set the ResetPipeRetryCount value.
+	 * @param ftHandle Handle of the device.
+	 * @param dwCount Unsigned long containing required ResetPipeRetryCount.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is used to set the ResetPipeRetryCount. ResetPipeRetryCount controls the maximum
+	 * number of times that the driver tries to reset a pipe on which an error has occurred.
+	 * ResetPipeRequestRetryCount defaults to 50. It may be necessary to increase this value in noisy
+	 * environments where a lot of USB errors occur.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetResetPipeRetryCount(
+		FT_HANDLE ftHandle,
+		DWORD dwCount
+		);
+
+	/** @noop FT_StopInTask
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Stops the driver's IN task.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is used to put the driver's IN task (read) into a wait state. It can be used in situations
+	 * where data is being received continuously, so that the device can be purged without more data being
+	 * received. It is used together with FT_RestartInTask which sets the IN task running again.
+	 * @see FT_RestartInTask
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_StopInTask(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_RestartInTask
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Restart the driver's IN task.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function is used to restart the driver's IN task (read) after it has been stopped by a call to
+	 * FT_StopInTask.
+	 * @see FT_StopInTask
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_RestartInTask(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_SetDeadmanTimeout
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function allows the maximum time in milliseconds that a USB request can remain outstanding to 
+	 * be set.
+	 * @param ftHandle Handle of the device.
+	 * @param ulDeadmanTimeout Deadman timeout value in milliseconds. Default value is 5000.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * The deadman timeout is referred to in application note AN232B-10 Advanced Driver Options from the
+	 * FTDI web site as the USB timeout. It is unlikely that this function will be required by most users.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetDeadmanTimeout(
+		FT_HANDLE ftHandle,
+		ULONG ulDeadmanTimeout
+		);
+
+	/** @noop FT_IoCtl
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_IoCtl(
+		FT_HANDLE ftHandle,
+		DWORD dwIoControlCode,
+		LPVOID lpInBuf,
+		DWORD nInBufSize,
+		LPVOID lpOutBuf,
+		DWORD nOutBufSize,
+		LPDWORD lpBytesReturned,
+		LPOVERLAPPED lpOverlapped
+		);
+
+	/** @noop FT_SetWaitMask
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetWaitMask(
+		FT_HANDLE ftHandle,
+		DWORD Mask
+		);
+
+	/** @noop FT_WaitOnMask
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_WaitOnMask(
+		FT_HANDLE ftHandle,
+		DWORD *Mask
+		);
+
+	/** @noop FT_GetEventStatus
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetEventStatus(
+		FT_HANDLE ftHandle,
+		DWORD *dwEventDWord
+		);
+
+/** @} */
+
+/** @name EEPROM Programming Interface Functions
+ * FTDI device EEPROMs can be both read and programmed using the functions listed in this section.
+ * @n Please note the following information:
+ * @li The Maximum length of the Manufacturer, ManufacturerId, Description and SerialNumber strings
+ * is 48 words (1 word = 2 bytes).
+ * @li The first two characters of the serial number are the manufacturer ID.
+ * @li The Manufacturer string length plus the Description string length is less than or equal to 40
+ * characters with the following functions: FT_EE_Read, FT_EE_Program, FT_EE_ProgramEx, 
+ * FT_EEPROM_Read, FT_EEPROM_Program.
+ * @li The serial number should be maximum 15 characters long on single port devices (eg FT232R, FT-X) 
+ * and 14 characters on multi port devices (eg FT2232H, FT4232H). If it is longer then it may be
+ * truncated and will not have a null terminator.
+
+ * For instance a serial number which is 15 characters long on a multi-port device will have an 
+ * effective serial number which is 16 characters long since the serial number is appended with the 
+ * channel identifier (A,B,etc). The buffer used to return the string from the API is only 16 
+ * characters in size so the NULL termination will be lost.
+ * @n If the serial number or description are too long in the EEPROM or configuration of a device then the
+ * strings returned by FT_GetDeviceInfo and FT_ListDevices may not be NULL terminated
+ */
+/** @{ */
+
+	/** @noop FT_ReadEE
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read a value from an EEPROM location.
+	 * @param ftHandle Handle of the device.
+	 * @param dwWordOffset EEPROM location to read from.
+	 * @param lpwValue Pointer to the WORD value read from the EEPROM.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * EEPROMs for FTDI devices are organised by WORD, so each value returned is 16-bits wide.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ReadEE(
+		FT_HANDLE ftHandle,
+		DWORD dwWordOffset,
+		LPWORD lpwValue
+		);
+
+	/** @noop FT_WriteEE
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Write a value to an EEPROM location.
+	 * @param ftHandle Handle of the device.
+	 * @param dwWordOffset EEPROM location to read from.
+	 * @param wValue The WORD value write to the EEPROM.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * EEPROMs for FTDI devices are organised by WORD, so each value written to the EEPROM is 
+	 * 16-bits wide.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_WriteEE(
+		FT_HANDLE ftHandle,
+		DWORD dwWordOffset,
+		WORD wValue
+		);
+
+	/** @noop FT_EraseEE
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Erases the device EEPROM.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function will erase the entire contents of an EEPROM, including the user area.
+	 * Note that the FT232R	and FT245R devices have an internal EEPROM that cannot be erased.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EraseEE(
+		FT_HANDLE ftHandle
+		);
+
+	/**
+	 * Structure to hold program data for FT_EE_Program, FT_EE_ProgramEx, FT_EE_Read 
+	 * and FT_EE_ReadEx functions.
+	 * @see FT_EE_Read
+	 * @see FT_EE_ReadEx
+	 * @see FT_EE_Program
+	 * @see FT_EE_ProgramEx
+	 */
+	typedef struct ft_program_data {
+
+		DWORD Signature1;			/// Header - must be 0x00000000 
+		DWORD Signature2;			/// Header - must be 0xffffffff
+		DWORD Version;				/// Header - FT_PROGRAM_DATA version
+		//			0 = original
+		//			1 = FT2232 extensions
+		//			2 = FT232R extensions
+		//			3 = FT2232H extensions
+		//			4 = FT4232H extensions
+		//			5 = FT232H extensions
+
+		WORD VendorId;				/// 0x0403
+		WORD ProductId;				/// 0x6001
+		char *Manufacturer;			/// "FTDI"
+		char *ManufacturerId;		/// "FT"
+		char *Description;			/// "USB HS Serial Converter"
+		char *SerialNumber;			/// "FT000001" if fixed, or NULL
+		WORD MaxPower;				/// 0 < MaxPower <= 500
+		WORD PnP;					/// 0 = disabled, 1 = enabled
+		WORD SelfPowered;			/// 0 = bus powered, 1 = self powered
+		WORD RemoteWakeup;			/// 0 = not capable, 1 = capable
+		/// Rev4 (FT232B) extensions
+		UCHAR Rev4;					/// non-zero if Rev4 chip, zero otherwise
+		UCHAR IsoIn;				/// non-zero if in endpoint is isochronous
+		UCHAR IsoOut;				/// non-zero if out endpoint is isochronous
+		UCHAR PullDownEnable;		/// non-zero if pull down enabled
+		UCHAR SerNumEnable;			/// non-zero if serial number to be used
+		UCHAR USBVersionEnable;		/// non-zero if chip uses USBVersion
+		WORD USBVersion;			/// BCD (0x0200 => USB2)
+		/// Rev 5 (FT2232) extensions
+		UCHAR Rev5;					/// non-zero if Rev5 chip, zero otherwise
+		UCHAR IsoInA;				/// non-zero if in endpoint is isochronous
+		UCHAR IsoInB;				/// non-zero if in endpoint is isochronous
+		UCHAR IsoOutA;				/// non-zero if out endpoint is isochronous
+		UCHAR IsoOutB;				/// non-zero if out endpoint is isochronous
+		UCHAR PullDownEnable5;		/// non-zero if pull down enabled
+		UCHAR SerNumEnable5;		/// non-zero if serial number to be used
+		UCHAR USBVersionEnable5;	/// non-zero if chip uses USBVersion
+		WORD USBVersion5;			/// BCD (0x0200 => USB2)
+		UCHAR AIsHighCurrent;		/// non-zero if interface is high current
+		UCHAR BIsHighCurrent;		/// non-zero if interface is high current
+		UCHAR IFAIsFifo;			/// non-zero if interface is 245 FIFO
+		UCHAR IFAIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IFAIsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR AIsVCP;				/// non-zero if interface is to use VCP drivers
+		UCHAR IFBIsFifo;			/// non-zero if interface is 245 FIFO
+		UCHAR IFBIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IFBIsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR BIsVCP;				/// non-zero if interface is to use VCP drivers
+		/// Rev 6 (FT232R) extensions
+		UCHAR UseExtOsc;			/// Use External Oscillator
+		UCHAR HighDriveIOs;			/// High Drive I/Os
+		UCHAR EndpointSize;			/// Endpoint size
+		UCHAR PullDownEnableR;		/// non-zero if pull down enabled
+		UCHAR SerNumEnableR;		/// non-zero if serial number to be used
+		UCHAR InvertTXD;			/// non-zero if invert TXD
+		UCHAR InvertRXD;			/// non-zero if invert RXD
+		UCHAR InvertRTS;			/// non-zero if invert RTS
+		UCHAR InvertCTS;			/// non-zero if invert CTS
+		UCHAR InvertDTR;			/// non-zero if invert DTR
+		UCHAR InvertDSR;			/// non-zero if invert DSR
+		UCHAR InvertDCD;			/// non-zero if invert DCD
+		UCHAR InvertRI;				/// non-zero if invert RI
+		UCHAR Cbus0;				/// Cbus Mux control
+		UCHAR Cbus1;				/// Cbus Mux control
+		UCHAR Cbus2;				/// Cbus Mux control
+		UCHAR Cbus3;				/// Cbus Mux control
+		UCHAR Cbus4;				/// Cbus Mux control
+		UCHAR RIsD2XX;				/// non-zero if using D2XX driver
+		/// Rev 7 (FT2232H) Extensions
+		UCHAR PullDownEnable7;		/// non-zero if pull down enabled
+		UCHAR SerNumEnable7;		/// non-zero if serial number to be used
+		UCHAR ALSlowSlew;			/// non-zero if AL pins have slow slew
+		UCHAR ALSchmittInput;		/// non-zero if AL pins are Schmitt input
+		UCHAR ALDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR AHSlowSlew;			/// non-zero if AH pins have slow slew
+		UCHAR AHSchmittInput;		/// non-zero if AH pins are Schmitt input
+		UCHAR AHDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BLSlowSlew;			/// non-zero if BL pins have slow slew
+		UCHAR BLSchmittInput;		/// non-zero if BL pins are Schmitt input
+		UCHAR BLDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BHSlowSlew;			/// non-zero if BH pins have slow slew
+		UCHAR BHSchmittInput;		/// non-zero if BH pins are Schmitt input
+		UCHAR BHDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR IFAIsFifo7;			/// non-zero if interface is 245 FIFO
+		UCHAR IFAIsFifoTar7;		/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IFAIsFastSer7;		/// non-zero if interface is Fast serial
+		UCHAR AIsVCP7;				/// non-zero if interface is to use VCP drivers
+		UCHAR IFBIsFifo7;			/// non-zero if interface is 245 FIFO
+		UCHAR IFBIsFifoTar7;		/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IFBIsFastSer7;		/// non-zero if interface is Fast serial
+		UCHAR BIsVCP7;				/// non-zero if interface is to use VCP drivers
+		UCHAR PowerSaveEnable;		/// non-zero if using BCBUS7 to save power for self-powered designs
+		/// Rev 8 (FT4232H) Extensions
+		UCHAR PullDownEnable8;		/// non-zero if pull down enabled
+		UCHAR SerNumEnable8;		/// non-zero if serial number to be used
+		UCHAR ASlowSlew;			/// non-zero if A pins have slow slew
+		UCHAR ASchmittInput;		/// non-zero if A pins are Schmitt input
+		UCHAR ADriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BSlowSlew;			/// non-zero if B pins have slow slew
+		UCHAR BSchmittInput;		/// non-zero if B pins are Schmitt input
+		UCHAR BDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR CSlowSlew;			/// non-zero if C pins have slow slew
+		UCHAR CSchmittInput;		/// non-zero if C pins are Schmitt input
+		UCHAR CDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR DSlowSlew;			/// non-zero if D pins have slow slew
+		UCHAR DSchmittInput;		/// non-zero if D pins are Schmitt input
+		UCHAR DDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR ARIIsTXDEN;			/// non-zero if port A uses RI as RS485 TXDEN
+		UCHAR BRIIsTXDEN;			/// non-zero if port B uses RI as RS485 TXDEN
+		UCHAR CRIIsTXDEN;			/// non-zero if port C uses RI as RS485 TXDEN
+		UCHAR DRIIsTXDEN;			/// non-zero if port D uses RI as RS485 TXDEN
+		UCHAR AIsVCP8;				/// non-zero if interface is to use VCP drivers
+		UCHAR BIsVCP8;				/// non-zero if interface is to use VCP drivers
+		UCHAR CIsVCP8;				/// non-zero if interface is to use VCP drivers
+		UCHAR DIsVCP8;				/// non-zero if interface is to use VCP drivers
+		/// Rev 9 (FT232H) Extensions
+		UCHAR PullDownEnableH;		/// non-zero if pull down enabled
+		UCHAR SerNumEnableH;		/// non-zero if serial number to be used
+		UCHAR ACSlowSlewH;			/// non-zero if AC pins have slow slew
+		UCHAR ACSchmittInputH;		/// non-zero if AC pins are Schmitt input
+		UCHAR ACDriveCurrentH;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR ADSlowSlewH;			/// non-zero if AD pins have slow slew
+		UCHAR ADSchmittInputH;		/// non-zero if AD pins are Schmitt input
+		UCHAR ADDriveCurrentH;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR Cbus0H;				/// Cbus Mux control
+		UCHAR Cbus1H;				/// Cbus Mux control
+		UCHAR Cbus2H;				/// Cbus Mux control
+		UCHAR Cbus3H;				/// Cbus Mux control
+		UCHAR Cbus4H;				/// Cbus Mux control
+		UCHAR Cbus5H;				/// Cbus Mux control
+		UCHAR Cbus6H;				/// Cbus Mux control
+		UCHAR Cbus7H;				/// Cbus Mux control
+		UCHAR Cbus8H;				/// Cbus Mux control
+		UCHAR Cbus9H;				/// Cbus Mux control
+		UCHAR IsFifoH;				/// non-zero if interface is 245 FIFO
+		UCHAR IsFifoTarH;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IsFastSerH;			/// non-zero if interface is Fast serial
+		UCHAR IsFT1248H;			/// non-zero if interface is FT1248
+		UCHAR FT1248CpolH;			/// FT1248 clock polarity - clock idle high (1) or clock idle low (0)
+		UCHAR FT1248LsbH;			/// FT1248 data is LSB (1) or MSB (0)
+		UCHAR FT1248FlowControlH;	/// FT1248 flow control enable
+		UCHAR IsVCPH;				/// non-zero if interface is to use VCP drivers
+		UCHAR PowerSaveEnableH;		/// non-zero if using ACBUS7 to save power for self-powered designs
+
+	} FT_PROGRAM_DATA, *PFT_PROGRAM_DATA;
+
+	/** @noop FT_EE_Read
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read the contents of the EEPROM.
+	 * @param ftHandle Handle of the device.
+	 * @param pData Pointer to structure of type FT_PROGRAM_DATA.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter pData as a pointer to a structure of type FT_PROGRAM_DATA 
+	 * that contains storage for the data to be read from the EEPROM.
+	 * @n The function does not perform any checks on buffer sizes, so the buffers passed in the
+	 * FT_PROGRAM_DATA structure must be big enough to accommodate their respective strings (including
+	 * null terminators). The sizes shown in the following example are more than adequate and can be rounded
+	 * down if necessary. The restriction is that the Manufacturer string length plus the Description string
+	 * length is less than or equal to 40 characters.
+	 * @note Note that the DLL must be informed which version of the FT_PROGRAM_DATA structure is being used.
+	 * This is done through the Signature1, Signature2 and Version elements of the structure. Signature1
+	 * should always be 0x00000000, Signature2 should always be 0xFFFFFFFF and Version can be set to use
+	 * whichever version is required. For compatibility with all current devices Version should be set to the
+	 * latest version of the FT_PROGRAM_DATA structure which is defined in FTD2XX.h. 
+	 * @see FT_PROGRAM_DATA
+	 * */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_Read(
+		FT_HANDLE ftHandle,
+		PFT_PROGRAM_DATA pData
+		);
+
+	/** @noop FT_EE_ReadEx
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read the contents of the EEPROM and pass strings separately.
+	 * @param ftHandle Handle of the device.
+	 * @param pData Pointer to structure of type FT_PROGRAM_DATA.
+	 * @param *Manufacturer Pointer to a null-terminated string containing the manufacturer name.
+	 * @param *ManufacturerId Pointer to a null-terminated string containing the manufacturer ID.
+	 * @param *Description Pointer to a null-terminated string containing the device description.
+	 * @param *SerialNumber Pointer to a null-terminated string containing the device serial number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This variation of the standard FT_EE_Read function was included to provide support for languages such
+	 * as LabVIEW where problems can occur when string pointers are contained in a structure.
+	 * @n This function interprets the parameter pData as a pointer to a structure of type FT_PROGRAM_DATA that
+	 * contains storage for the data to be read from the EEPROM.
+	 * @n The function does not perform any checks on buffer sizes, so the buffers passed in the
+	 * FT_PROGRAM_DATA structure must be big enough to accommodate their respective strings (including
+	 * null terminators).
+	 * @note Note that the DLL must be informed which version of the FT_PROGRAM_DATA structure is being used.
+	 * This is done through the Signature1, Signature2 and Version elements of the structure. Signature1
+	 * should always be 0x00000000, Signature2 should always be 0xFFFFFFFF and Version can be set to use
+	 * whichever version is required. For compatibility with all current devices Version should be set to the
+	 * latest version of the FT_PROGRAM_DATA structure which is defined in FTD2XX.h.
+	 * @n The string parameters in the FT_PROGRAM_DATA structure should be passed as DWORDs to avoid
+	 * overlapping of parameters. All string pointers are passed out separately from the FT_PROGRAM_DATA
+	 * structure.
+	 * @see FT_PROGRAM_DATA
+	 * */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_ReadEx(
+		FT_HANDLE ftHandle,
+		PFT_PROGRAM_DATA pData,
+		char *Manufacturer,
+		char *ManufacturerId,
+		char *Description,
+		char *SerialNumber
+		);
+
+	/** @noop FT_EE_Program
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Program the EEPROM.
+	 * @param ftHandle Handle of the device.
+	 * @param pData Pointer to structure of type FT_PROGRAM_DATA.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter pData as a pointer to a structure of type FT_PROGRAM_DATA 
+	 * that	contains the data to write to the EEPROM. The data is written to EEPROM, then read back and 
+	 * verified.
+	 * @n If the SerialNumber field in FT_PROGRAM_DATA is NULL, or SerialNumber points to a NULL string, 
+	 * a serial number based on the ManufacturerId and the current date and time will be generated. The
+	 * Manufacturer string length plus the Description string length must be less than or equal to 40 
+	 * characters.
+	 * @note Note that the DLL must be informed which version of the FT_PROGRAM_DATA structure is being 
+	 * used. This is done through the Signature1, Signature2 and Version elements of the structure. 
+	 * Signature1 should always be 0x00000000, Signature2 should always be 0xFFFFFFFF and Version can be 
+	 * set to use whichever version is required. For compatibility with all current devices Version 
+	 * should be set to the latest version of the FT_PROGRAM_DATA structure which is defined in FTD2XX.h.
+	 * If pData is NULL, the structure version will default to 0 (original BM series) and the device will 
+	 * be programmed with the default data.
+	 * @see FT_PROGRAM_DATA
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_Program(
+		FT_HANDLE ftHandle,
+		PFT_PROGRAM_DATA pData
+		);
+
+	/** @noop FT_EE_ProgramEx
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Program the EEPROM and pass strings separately.
+	 * @param ftHandle Handle of the device.
+	 * @param pData Pointer to structure of type FT_PROGRAM_DATA.
+	 * @param *Manufacturer Pointer to a null-terminated string containing the manufacturer name.
+	 * @param *ManufacturerId Pointer to a null-terminated string containing the manufacturer ID.
+	 * @param *Description Pointer to a null-terminated string containing the device description.
+	 * @param *SerialNumber Pointer to a null-terminated string containing the device serial number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This variation of the FT_EE_Program function was included to provide support for languages such 
+	 * as LabVIEW where problems can occur when string pointers are contained in a structure.
+	 * @n This function interprets the parameter pData as a pointer to a structure of type FT_PROGRAM_DATA 
+	 * that contains the data to write to the EEPROM. The data is written to EEPROM, then read back and 
+	 * verified. The string pointer parameters in the FT_PROGRAM_DATA structure should be allocated as 
+	 * DWORDs to avoid overlapping of parameters. The string parameters are then passed in separately.
+	 * @n If the SerialNumber field is NULL, or SerialNumber points to a NULL string, a serial number based 
+	 * on the ManufacturerId and the current date and time will be generated. The Manufacturer string 
+	 * length plus the Description string length must be less than or equal to 40 characters.
+	 * @note Note that the DLL must be informed which version of the FT_PROGRAM_DATA structure is being used.
+	 * This is done through the Signature1, Signature2 and Version elements of the structure. Signature1
+	 * should always be 0x00000000, Signature2 should always be 0xFFFFFFFF and Version can be set to use
+	 * whichever version is required. For compatibility with all current devices Version should be set to the
+	 * latest version of the FT_PROGRAM_DATA structure which is defined in FTD2XX.h.
+	 * If pData is NULL, the structure version will default to 0 (original BM series) and the device will be
+	 * programmed with the default data.
+	 * @see FT_PROGRAM_DATA
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_ProgramEx(
+		FT_HANDLE ftHandle,
+		PFT_PROGRAM_DATA pData,
+		char *Manufacturer,
+		char *ManufacturerId,
+		char *Description,
+		char *SerialNumber
+		);
+
+	/** @noop FT_EE_UASize
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Get the available size of the EEPROM user area.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwSize Pointer to a DWORD that receives the available size, in bytes, of the EEPROM 
+	 * user area.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * The user area of an FTDI device EEPROM is the total area of the EEPROM that is unused by device
+	 * configuration information and descriptors. This area is available to the user to store information 
+	 * specific	to their application. The size of the user area depends on the length of the Manufacturer,
+	 * ManufacturerId, Description and SerialNumber strings programmed into the EEPROM.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_UASize(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwSize
+		);
+
+	/** @noop FT_EE_UARead
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read the contents of the EEPROM user area.
+	 * @param ftHandle Handle of the device.
+	 * @param pucData Pointer to a buffer that contains storage for data to be read.
+	 * @param dwDataLen Size, in bytes, of buffer that contains storage for the data to be read.
+	 * @param lpdwBytesRead Pointer to a DWORD that receives the number of bytes read.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter pucData as a pointer to an array of bytes of size 
+	 * dwDataLen that contains storage for the data to be read from the EEPROM user area. The actual 
+	 * number of bytes read is stored in the DWORD referenced by lpdwBytesRead.
+	 * @n If dwDataLen is less than the size of the EEPROM user area, then dwDataLen bytes are read 
+	 * into the buffer. Otherwise, the whole of the EEPROM user area is read into the buffer. The 
+	 * available user area size can be determined by calling FT_EE_UASize.
+	 * @n An application should check the function return value and lpdwBytesRead when FT_EE_UARead 
+	 * returns.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_UARead(
+		FT_HANDLE ftHandle,
+		PUCHAR pucData,
+		DWORD dwDataLen,
+		LPDWORD lpdwBytesRead
+		);
+
+	/** @noop FT_EE_UAWrite
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Write data into the EEPROM user area.
+	 * @param ftHandle Handle of the device.
+	 * @param pucData Pointer to a buffer that contains the data to be written.
+	 * @param dwDataLen Size, in bytes, of buffer that contains storage for the data to be read.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter pucData as a pointer to an array of bytes of size 
+	 * dwDataLen that contains the data to be written to the EEPROM user area. It is a programming 
+	 * error for dwDataLen to be greater than the size of the EEPROM user area. The available user 
+	 * area size can be determined by calling FT_EE_UASize.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_UAWrite(
+		FT_HANDLE ftHandle,
+		PUCHAR pucData,
+		DWORD dwDataLen
+		);
+
+	/**  @noop FT_EEPROM_HEADER
+	 * @par Summary
+	 * Structure to hold data for FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * The structure for the command includes one FT_EEPROM_HEADER with a device-specific
+	 * structure appended.
+	 * @see FT_EEPROM_Read
+	 * @see FT_EEPROM_Program
+	 */
+	typedef struct ft_eeprom_header {
+		FT_DEVICE deviceType;		/// FTxxxx device type to be programmed
+		/// Device descriptor options
+		WORD VendorId;				/// 0x0403
+		WORD ProductId;				/// 0x6001
+		UCHAR SerNumEnable;			/// non-zero if serial number to be used
+		/// Config descriptor options
+		WORD MaxPower;				/// 0 < MaxPower <= 500
+		UCHAR SelfPowered;			/// 0 = bus powered, 1 = self powered
+		UCHAR RemoteWakeup;			/// 0 = not capable, 1 = capable
+		/// Hardware options
+		UCHAR PullDownEnable;		/// non-zero if pull down in suspend enabled
+	} FT_EEPROM_HEADER, *PFT_EEPROM_HEADER;
+
+	/**  @noop FT_EEPROM_232B
+	 * @par Summary
+	 * Structure to hold data for the FT232B data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_232b {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+	} FT_EEPROM_232B, *PFT_EEPROM_232B;
+
+	/**  @noop FT_EEPROM_2232
+	 * @par Summary
+	 * Structure to hold data for the FT2232C, FT2232D and FT2232L data in the FT_EEPROM_Program 
+	 * and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_2232 {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR AIsHighCurrent;		/// non-zero if interface is high current
+		UCHAR BIsHighCurrent;		/// non-zero if interface is high current
+		/// Hardware options
+		UCHAR AIsFifo;				/// non-zero if interface is 245 FIFO
+		UCHAR AIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR AIsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR BIsFifo;				/// non-zero if interface is 245 FIFO
+		UCHAR BIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR BIsFastSer;			/// non-zero if interface is Fast serial
+		/// Driver option
+		UCHAR ADriverType;			/// non-zero if interface is to use VCP drivers
+		UCHAR BDriverType;			/// non-zero if interface is to use VCP drivers
+	} FT_EEPROM_2232, *PFT_EEPROM_2232;
+
+	/**  @noop FT_EEPROM_232R
+	 * @par Summary
+	 * Structure to hold data for the FT232R data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_232r {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR IsHighCurrent;		/// non-zero if interface is high current
+		/// Hardware options
+		UCHAR UseExtOsc;			/// Use External Oscillator
+		UCHAR InvertTXD;			/// non-zero if invert TXD
+		UCHAR InvertRXD;			/// non-zero if invert RXD
+		UCHAR InvertRTS;			/// non-zero if invert RTS
+		UCHAR InvertCTS;			/// non-zero if invert CTS
+		UCHAR InvertDTR;			/// non-zero if invert DTR
+		UCHAR InvertDSR;			/// non-zero if invert DSR
+		UCHAR InvertDCD;			/// non-zero if invert DCD
+		UCHAR InvertRI;				/// non-zero if invert RI
+		UCHAR Cbus0;				/// Cbus Mux control
+		UCHAR Cbus1;				/// Cbus Mux control
+		UCHAR Cbus2;				/// Cbus Mux control
+		UCHAR Cbus3;				/// Cbus Mux control
+		UCHAR Cbus4;				/// Cbus Mux control
+		/// Driver option
+		UCHAR DriverType;			/// non-zero if using D2XX driver
+	} FT_EEPROM_232R, *PFT_EEPROM_232R;
+
+	/**  @noop FT_EEPROM_2232H
+	 * @par Summary
+	 * Structure to hold data for the FT2232H data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_2232h {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR ALSlowSlew;			/// non-zero if AL pins have slow slew
+		UCHAR ALSchmittInput;		/// non-zero if AL pins are Schmitt input
+		UCHAR ALDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR AHSlowSlew;			/// non-zero if AH pins have slow slew
+		UCHAR AHSchmittInput;		/// non-zero if AH pins are Schmitt input
+		UCHAR AHDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BLSlowSlew;			/// non-zero if BL pins have slow slew
+		UCHAR BLSchmittInput;		/// non-zero if BL pins are Schmitt input
+		UCHAR BLDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BHSlowSlew;			/// non-zero if BH pins have slow slew
+		UCHAR BHSchmittInput;		/// non-zero if BH pins are Schmitt input
+		UCHAR BHDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		/// Hardware options
+		UCHAR AIsFifo;				/// non-zero if interface is 245 FIFO
+		UCHAR AIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR AIsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR BIsFifo;				/// non-zero if interface is 245 FIFO
+		UCHAR BIsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR BIsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR PowerSaveEnable;		/// non-zero if using BCBUS7 to save power for self-powered designs
+		/// Driver option
+		UCHAR ADriverType;			/// non-zero if interface is to use VCP drivers
+		UCHAR BDriverType;			/// non-zero if interface is to use VCP drivers
+	} FT_EEPROM_2232H, *PFT_EEPROM_2232H;
+
+	/**  @noop FT_EEPROM_4232H
+	 * @par Summary
+	 * Structure to hold data for the FT4232H data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_4232h {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR ASlowSlew;			/// non-zero if A pins have slow slew
+		UCHAR ASchmittInput;		/// non-zero if A pins are Schmitt input
+		UCHAR ADriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR BSlowSlew;			/// non-zero if B pins have slow slew
+		UCHAR BSchmittInput;		/// non-zero if B pins are Schmitt input
+		UCHAR BDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR CSlowSlew;			/// non-zero if C pins have slow slew
+		UCHAR CSchmittInput;		/// non-zero if C pins are Schmitt input
+		UCHAR CDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR DSlowSlew;			/// non-zero if D pins have slow slew
+		UCHAR DSchmittInput;		/// non-zero if D pins are Schmitt input
+		UCHAR DDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		/// Hardware options
+		UCHAR ARIIsTXDEN;			/// non-zero if port A uses RI as RS485 TXDEN
+		UCHAR BRIIsTXDEN;			/// non-zero if port B uses RI as RS485 TXDEN
+		UCHAR CRIIsTXDEN;			/// non-zero if port C uses RI as RS485 TXDEN
+		UCHAR DRIIsTXDEN;			/// non-zero if port D uses RI as RS485 TXDEN
+		/// Driver option
+		UCHAR ADriverType;			/// non-zero if interface is to use VCP drivers
+		UCHAR BDriverType;			/// non-zero if interface is to use VCP drivers
+		UCHAR CDriverType;			/// non-zero if interface is to use VCP drivers
+		UCHAR DDriverType;			/// non-zero if interface is to use VCP drivers
+	} FT_EEPROM_4232H, *PFT_EEPROM_4232H;
+
+	/**  @noop FT_EEPROM_232H
+	 * @par Summary
+	 * Structure to hold data for the FT232H data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_232h {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR ACSlowSlew;			/// non-zero if AC bus pins have slow slew
+		UCHAR ACSchmittInput;		/// non-zero if AC bus pins are Schmitt input
+		UCHAR ACDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR ADSlowSlew;			/// non-zero if AD bus pins have slow slew
+		UCHAR ADSchmittInput;		/// non-zero if AD bus pins are Schmitt input
+		UCHAR ADDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		/// CBUS options
+		UCHAR Cbus0;				/// Cbus Mux control
+		UCHAR Cbus1;				/// Cbus Mux control
+		UCHAR Cbus2;				/// Cbus Mux control
+		UCHAR Cbus3;				/// Cbus Mux control
+		UCHAR Cbus4;				/// Cbus Mux control
+		UCHAR Cbus5;				/// Cbus Mux control
+		UCHAR Cbus6;				/// Cbus Mux control
+		UCHAR Cbus7;				/// Cbus Mux control
+		UCHAR Cbus8;				/// Cbus Mux control
+		UCHAR Cbus9;				/// Cbus Mux control
+		/// FT1248 options
+		UCHAR FT1248Cpol;			/// FT1248 clock polarity - clock idle high (1) or clock idle low (0)
+		UCHAR FT1248Lsb;			/// FT1248 data is LSB (1) or MSB (0)
+		UCHAR FT1248FlowControl;	/// FT1248 flow control enable
+		/// Hardware options
+		UCHAR IsFifo;				/// non-zero if interface is 245 FIFO
+		UCHAR IsFifoTar;			/// non-zero if interface is 245 FIFO CPU target
+		UCHAR IsFastSer;			/// non-zero if interface is Fast serial
+		UCHAR IsFT1248;			/// non-zero if interface is FT1248
+		UCHAR PowerSaveEnable;		/// 
+		/// Driver option
+		UCHAR DriverType;			/// non-zero if interface is to use VCP drivers
+	} FT_EEPROM_232H, *PFT_EEPROM_232H;
+
+	/**  @noop FT_EEPROM_X_SERIES
+	 * @par Summary
+	 * Structure to hold data for the FT-X series data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_x_series {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		/// Drive options
+		UCHAR ACSlowSlew;			/// non-zero if AC bus pins have slow slew
+		UCHAR ACSchmittInput;		/// non-zero if AC bus pins are Schmitt input
+		UCHAR ACDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR ADSlowSlew;			/// non-zero if AD bus pins have slow slew
+		UCHAR ADSchmittInput;		/// non-zero if AD bus pins are Schmitt input
+		UCHAR ADDriveCurrent;		/// valid values are 4mA, 8mA, 12mA, 16mA
+		/// CBUS options
+		UCHAR Cbus0;				/// Cbus Mux control
+		UCHAR Cbus1;				/// Cbus Mux control
+		UCHAR Cbus2;				/// Cbus Mux control
+		UCHAR Cbus3;				/// Cbus Mux control
+		UCHAR Cbus4;				/// Cbus Mux control
+		UCHAR Cbus5;				/// Cbus Mux control
+		UCHAR Cbus6;				/// Cbus Mux control
+		/// UART signal options
+		UCHAR InvertTXD;			/// non-zero if invert TXD
+		UCHAR InvertRXD;			/// non-zero if invert RXD
+		UCHAR InvertRTS;			/// non-zero if invert RTS
+		UCHAR InvertCTS;			/// non-zero if invert CTS
+		UCHAR InvertDTR;			/// non-zero if invert DTR
+		UCHAR InvertDSR;			/// non-zero if invert DSR
+		UCHAR InvertDCD;			/// non-zero if invert DCD
+		UCHAR InvertRI;				/// non-zero if invert RI
+		/// Battery Charge Detect options
+		UCHAR BCDEnable;			/// Enable Battery Charger Detection
+		UCHAR BCDForceCbusPWREN;	/// asserts the power enable signal on CBUS when charging port detected
+		UCHAR BCDDisableSleep;		/// forces the device never to go into sleep mode
+		/// I2C options
+		WORD I2CSlaveAddress;		/// I2C slave device address
+		DWORD I2CDeviceId;			/// I2C device ID
+		UCHAR I2CDisableSchmitt;	/// Disable I2C Schmitt trigger
+		/// FT1248 options
+		UCHAR FT1248Cpol;			/// FT1248 clock polarity - clock idle high (1) or clock idle low (0)
+		UCHAR FT1248Lsb;			/// FT1248 data is LSB (1) or MSB (0)
+		UCHAR FT1248FlowControl;	/// FT1248 flow control enable
+		/// Hardware options
+		UCHAR RS485EchoSuppress;	/// 
+		UCHAR PowerSaveEnable;		/// 
+		/// Driver option
+		UCHAR DriverType;			/// non-zero if interface is to use VCP drivers
+	} FT_EEPROM_X_SERIES, *PFT_EEPROM_X_SERIES;
+
+	/**  @noop FT_EEPROM_4222H
+	 * @par Summary
+	 * Structure to hold data for the FT4222H data in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER structure.
+	 * @see FT_EEPROM_HEADER
+	 */
+	typedef struct ft_eeprom_4222h {
+		/// Common header
+		FT_EEPROM_HEADER common;	/// common elements for all device EEPROMs
+		CHAR Revision;				/// 'A', 'B', 'C', or 'D'.
+		UCHAR I2C_Slave_Address;
+		/// Suspend
+		UCHAR SPISuspend;			/// 0 for "Disable SPI, tristate pins", 2 for "Keep SPI pin status", 3 for "Enable SPI pin control"
+		UCHAR SuspendOutPol;		/// 0 for negative, 1 for positive (not implemented on Rev A)
+		UCHAR EnableSuspendOut;		/// non-zero to enable (not implemented on Rev A)
+		/// QSPI
+		UCHAR Clock_SlowSlew;		/// non-zero if clock pin has slow slew
+		UCHAR Clock_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR IO0_SlowSlew;			/// non-zero if IO0 pin has slow slew
+		UCHAR IO1_SlowSlew;			/// non-zero if IO1 pin has slow slew
+		UCHAR IO2_SlowSlew;			/// non-zero if IO2 pin has slow slew
+		UCHAR IO3_SlowSlew;			/// non-zero if IO3 pin has slow slew
+		UCHAR IO_Drive; 			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR SlaveSelect_PullUp;	/// non-zero to enable pull up
+		UCHAR SlaveSelect_PullDown;	/// non-zero to enable pull down
+		UCHAR SlaveSelect_Drive;	/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR SlaveSelect_SlowSlew;	/// non-zero if slave select pin has slow slew
+		UCHAR MISO_Suspend;			/// 2 for push-low, 3 for push high, 0 and 1 reserved
+		UCHAR SIMO_Suspend;			/// 2 for push-low, 3 for push high, 0 and 1 reserved
+		UCHAR IO2_IO3_Suspend;		/// 2 for push-low, 3 for push high, 0 and 1 reserved
+		UCHAR SlaveSelect_Suspend;	/// 0 for no-change (not implemented on Rev A), 2 for push-low, 3 for push high, 1 reserved
+		/// GPIO
+		UCHAR GPIO0_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR GPIO1_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR GPIO2_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR GPIO3_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+		UCHAR GPIO0_SlowSlew;		/// non-zero if IO0 pin has slow slew
+		UCHAR GPIO1_SlowSlew;		/// non-zero if IO0 pin has slow slew
+		UCHAR GPIO2_SlowSlew;		/// non-zero if IO0 pin has slow slew
+		UCHAR GPIO3_SlowSlew;		/// non-zero if IO0 pin has slow slew
+		UCHAR GPIO0_PullDown;		/// non-zero to enable pull down
+		UCHAR GPIO1_PullDown;		/// non-zero to enable pull down
+		UCHAR GPIO2_PullDown;		/// non-zero to enable pull down
+		UCHAR GPIO3_PullDown;		/// non-zero to enable pull down
+		UCHAR GPIO0_PullUp;			/// non-zero to enable pull up
+		UCHAR GPIO1_PullUp;			/// non-zero to enable pull up
+		UCHAR GPIO2_PullUp;			/// non-zero to enable pull up
+		UCHAR GPIO3_PullUp;			/// non-zero to enable pull up
+		UCHAR GPIO0_OpenDrain;		/// non-zero to enable open drain
+		UCHAR GPIO1_OpenDrain;		/// non-zero to enable open drain
+		UCHAR GPIO2_OpenDrain;		/// non-zero to enable open drain
+		UCHAR GPIO3_OpenDrain;		/// non-zero to enable open drain
+		UCHAR GPIO0_Suspend;		/// 0 for no-change, 1 for input (not implemented on Rev A), 2 for push-low, 3 for push high
+		UCHAR GPIO1_Suspend;		/// 0 for no-change, 1 for input (not implemented on Rev A), 2 for push-low, 3 for push high
+		UCHAR GPIO2_Suspend;		/// 0 for no-change, 1 for input (not implemented on Rev A), 2 for push-low, 3 for push high
+		UCHAR GPIO3_Suspend;		/// 0 for no-change, 1 for input (not implemented on Rev A), 2 for push-low, 3 for push high
+		UCHAR FallingEdge;			/// non-zero to change GPIO on falling edge
+		/// BCD
+		UCHAR BCD_Disable;			/// non-zero to disable BCD
+		UCHAR BCD_OutputActiveLow;	/// non-zero to set BCD output active low
+		UCHAR BCD_Drive;			/// valid values are 4mA, 8mA, 12mA, 16mA
+	} FT_EEPROM_4222H, *PFT_EEPROM_4222H;
+
+	/**  @noop FT_EEPROM_PD_PDO_mv_ma
+	 * @par Summary
+	 * Structure to hold PDO Configuration structure, mA supported values 0 to 10230mA, mV supported 
+	 * values 0 to 51100mV. This is part of the FT_EEPROM_PD structure.
+	 * @see FT_EEPROM_PD
+	 */
+	typedef struct ft_eeprom_PD_PDO_mv_ma {
+		USHORT PDO1ma;	/// PDO1 mA
+		USHORT PDO1mv;	/// PDO1 mV
+		USHORT PDO2ma;	/// PDO2 mA
+		USHORT PDO2mv;	/// PDO2 mV
+		USHORT PDO3ma;	/// PDO3 mA
+		USHORT PDO3mv;	/// PDO3 mV
+		USHORT PDO4ma;	/// PDO4 mA
+		USHORT PDO4mv;	/// PDO4 mV
+		USHORT PDO5ma;	/// PDO5 mA (FTx233HP only)
+		USHORT PDO5mv;	/// PDO5 mV (FTx233HP only)
+		USHORT PDO6ma;	/// PDO6 mA (FTx233HP only)
+		USHORT PDO6mv;	/// PDO6 mV (FTx233HP only)
+		USHORT PDO7ma;	/// PDO7 mA (FTx233HP only)
+		USHORT PDO7mv;	/// PDO7 mV (FTx233HP only)
+	} FT_EEPROM_PD_PDO_mv_ma;
+
+	/**  @noop FT_EEPROM_PD
+	 * @par Summary
+	 * Structure to hold power delivery configuration data for the FT4233PD, FT2233PD, FT4232PD, 
+	 * FT2232PD, FT233PD and FT232PD in the FT_EEPROM_Program and FT_EEPROM_Read functions.
+	 * This is appended to an FT_EEPROM_HEADER and a base device structure.
+	 * e_g. @verbatim
+	 *		struct {
+	 *			FT_EEPROM_xxx base;
+	 *			FT_EEPROM_PD pd;
+	 *		};
+	 * @endverbatim
+	 * @remarks
+ 	 * Device GPIO values are:
+	 * @li	FTx233HP - 0 to 7, 15 for N/A
+	 * @li FTx232HP - 0 to 3, 15 for N/A
+	 * @see FT_EEPROM_HEADER
+	 * @see FT_EEPROM_PD_PDO_mv_ma
+	 */
+	typedef struct ft_eeprom_pd {
+		/// Configuration
+		UCHAR srprs;		/// non-zero to enable Sink Request Power Role Swap
+		UCHAR sraprs;		/// non-zero to enable Sink Accept PR Swap
+		UCHAR srrprs;		/// non-zero to enable Source Request PR SWAP
+		UCHAR saprs;		/// non-zero to enable Source Accept PR SWAP
+		UCHAR vconns;		/// non-zero to enable vConn Swap
+		UCHAR passthru;		/// non-zero to enable Pass Through (FTx233HP only)
+		UCHAR extmcu;		/// non-zero to enable External MCU
+		UCHAR pd2en;		/// non-zero to enable PD2 (FTx233HP only)
+		UCHAR pd1autoclk;	/// non-zero to enable PD1 Auto Clock
+		UCHAR pd2autoclk;	/// non-zero to enable PD2 Auto Clock (FTx233HP only)
+		UCHAR useefuse;		/// non-zero to Use EFUSE
+		UCHAR extvconn;		/// non-zero to enable External vConn
+
+		/// GPIO Configuration
+		UCHAR count;		/// GPIO Count, supported values are 0 to 7 
+		UCHAR gpio1;		/// GPIO Number 1, supports device GPIO values
+		UCHAR gpio2;		/// GPIO Number 2, supports device GPIO values
+		UCHAR gpio3;		/// GPIO Number 3, supports device GPIO values
+		UCHAR gpio4;		/// GPIO Number 4, supports device GPIO values
+		UCHAR gpio5;		/// GPIO Number 5, supports device GPIO values (FTx233HP only)
+		UCHAR gpio6;		/// GPIO Number 6, supports device GPIO values (FTx233HP only)
+		UCHAR gpio7;		/// GPIO Number 7, supports device GPIO values (FTx233HP only)
+		UCHAR pd1lden;		/// PD1 Load Enable, supports device GPIO values
+		UCHAR pd2lden;		/// PD2 Load Enable, supports device GPIO values (FTx233HP only)
+		UCHAR dispin;		/// Discharge Pin, supports device GPIO values
+		UCHAR disenbm;		/// Discharge Enable BM, 0 for "Drive Hi", 1 for "Drive Low", 2 for "Input Mode", 3 for "Don't Care"
+		UCHAR disdisbm;		/// Discharge Disable BM, 0 for "Drive Hi", 1 for "Drive Low", 2 for "Input Mode", 3 for "Don't Care"
+		UCHAR ccselect;		/// CC Select Indicator, supports device GPIO values
+
+		/// ISET Configuration
+		UCHAR iset1;		/// ISET1, supports device GPIO values
+		UCHAR iset2;		/// ISET2, supports device GPIO values
+		UCHAR iset3;		/// ISET3, supports device GPIO values
+		UCHAR extiset;		/// non-zero to enable EXTEND_ISET
+		UCHAR isetpd2;		/// non-zero to enable ISET_PD2
+		UCHAR iseten;		/// non-zero to set ISET_ENABLED
+
+		/// BM Configuration, 0 for "Drive Hi", 1 for "Drive Low", 2 for "Input Mode", 3 for "Don't Care"
+		UCHAR PDO1_GPIO[7];		/// PDO1 GPIO1 to GPIO7
+		UCHAR PDO2_GPIO[7];		/// PDO2 GPIO1 to GPIO7
+		UCHAR PDO3_GPIO[7];		/// PDO3 GPIO1 to GPIO7
+		UCHAR PDO4_GPIO[7];		/// PDO4 GPIO1 to GPIO7
+		UCHAR PDO5_GPIO[7];		/// PDO5 GPIO1 to GPIO7 (FTx233HP only)
+		UCHAR PDO6_GPIO[7];		/// PDO6 GPIO1 to GPIO7 (FTx233HP only)
+		UCHAR PDO7_GPIO[7];		/// PDO7 GPIO1 to GPIO7 (FTx233HP only)
+		UCHAR VSET0V_GPIO[7];	/// PDO7 GPIO1 to GPIO7
+		UCHAR VSAFE5V_GPIO[7];	/// PDO7 GPIO1 to GPIO7
+
+		FT_EEPROM_PD_PDO_mv_ma BM_PDO_Sink;
+		FT_EEPROM_PD_PDO_mv_ma BM_PDO_Source;
+		FT_EEPROM_PD_PDO_mv_ma BM_PDO_Sink_2; // (FTx233HP only)
+
+		/// PD Timers
+		UCHAR srt;			/// Sender Response Timer
+		UCHAR hrt;			/// Hard Reset Timer
+		UCHAR sct;			/// Source Capability Timer
+		UCHAR dit;			/// Discover Identity Timer
+		USHORT srcrt;		/// Source Recover Timer
+		USHORT trt;			/// Transition Timer
+		USHORT sofft;		/// Source off timer
+		USHORT nrt;			/// No Response Timer
+		USHORT swct;		/// Sink Wait Capability Timer
+		USHORT snkrt;		/// Sink Request Timer
+		UCHAR dt;			/// Discharge Timer
+		UCHAR cnst;			/// Chunk not supported timer
+		USHORT it;			/// Idle Timer
+
+		/// PD Control
+		UCHAR i2caddr;		/// I2C Address (hex)
+		UINT prou;			/// Power Reserved for OWN use
+		UINT trim1;			/// TRIM1
+		UINT trim2;			/// TRIM2
+		UCHAR extdc;		/// non-zero to enable ETERNAL_DC_POWER
+	} FT_EEPROM_PD, *PFT_EEPROM_PD;
+
+	/// FT2233HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT2232H with power delivery
+	typedef struct _ft_eeprom_2233hp
+	{
+		FT_EEPROM_2232H	ft2232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_2233HP, *PFT_EEPROM_2233HP;
+
+	/// FT4233HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT4232H with power delivery
+	typedef struct _ft_eeprom_4233hp
+	{
+		FT_EEPROM_4232H	ft4232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_4233HP, *PFT_EEPROM_4233HP;
+
+	/// FT2232HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT2232H with power delivery
+	typedef struct _ft_eeprom_2232hp
+	{
+		FT_EEPROM_2232H	ft2232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_2232HP, *PFT_EEPROM_2232HP;
+
+	/// FT4232HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT4232H with power delivery
+	typedef struct _ft_eeprom_4232hp
+	{
+		FT_EEPROM_4232H	ft4232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_4232HP, *PFT_EEPROM_4232HP;
+
+	/// FT233HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT233H with power delivery
+	typedef struct _ft_eeprom_233hp
+	{
+		FT_EEPROM_232H	ft232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_233HP, *PFT_EEPROM_233HP;
+
+	/// FT232HP EEPROM structure for use with FT_EEPROM_Read and FT_EEPROM_Program
+	/// FT232H with power delivery
+	typedef struct _ft_eeprom_232hp
+	{
+		FT_EEPROM_232H	ft232h;
+		FT_EEPROM_PD	pd;
+	} FT_EEPROM_232HP, *PFT_EEPROM_232HP;
+
+	/** @noop FT_EEPROM_Read
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (XP and later)
+	 * @par Summary 
+	 * Read data from the EEPROM, this command will work for all existing FTDI chipset, and must be 
+	 * used for the FT-X series.
+	 * @param ftHandle Handle of the device.
+	 * @param *eepromData Pointer to a buffer that contains the data to be read.
+	 * Note: This structure is different for each device type.
+	 * @param eepromDataSize Size of the eepromData buffer that contains storage for the data to be read.
+	 * @param *Manufacturer Pointer to a null-terminated string containing the manufacturer	name.
+	 * @param *ManufacturerId Pointer to a null-terminated string containing the manufacturer ID.
+	 * @param *Description Pointer to a null-terminated string containing the device description.
+	 * @param *SerialNumber Pointer to a null-terminated string containing the device serial number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter *eepromDATA as a pointer to a structure matching the device
+	 * type being accessed e.g.
+	 * @li PFT_EEPROM_232B is the structure for FT2xxB devices.
+	 * @li PFT_EEPROM_2232 is the structure for FT2232D devices.
+	 * @li PFT_EEPROM_232R is the structure for FT232R devices.
+	 * @li PFT_EEPROM_2232H is the structure for FT2232H devices.
+	 * @li PFT_EEPROM_4232H is the structure for FT4232H devices.
+	 * @li PFT_EEPROM_232H is the structure for FT232H devices.
+	 * @li PFT_EEPROM_X_SERIES is the structure for FT2xxX devices.
+	 * 
+	 * The function does not perform any checks on buffer sizes, so the buffers passed in the eepromDATA
+	 * structure must be big enough to accommodate their respective strings (including null terminators).
+	 * The sizes shown in the following example are more than adequate and can be rounded down if necessary.
+	 * The restriction is that the Manufacturer string length plus the Description string length is less than or
+	 * equal to 40 characters.
+	 * @note Note that the DLL must be informed which version of the eepromDATA structure is being used. This is
+	 * done through the PFT_EEPROM_HEADER structure. The first element of this structure is deviceType and
+	 * may be FT_DEVICE_BM, FT_DEVICE_AM, FT_DEVICE_2232C, FT_DEVICE_232R, FT_DEVICE_2232H,
+	 * FT_DEVICE_4232H, FT_DEVICE_232H, or FT_DEVICE_X_SERIES as defined in FTD2XX.h.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EEPROM_Read(
+		FT_HANDLE ftHandle,
+		void *eepromData,
+		DWORD eepromDataSize,
+		char *Manufacturer,
+		char *ManufacturerId,
+		char *Description,
+		char *SerialNumber
+		);
+
+	/** @noop FT_EEPROM_Program
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (XP and later)
+	 * @par Summary
+	 * Write data into the EEPROM, this command will work for all existing FTDI chipset, and must be used for
+	 * the FT-X series.
+	 * @param ftHandle Handle of the device.
+	 * @param *eepromData Pointer to a buffer that contains the data to be written.
+	 * Note: This structure is different for each device type.
+	 * @param eepromDataSize Size of the eepromData buffer that contains storage for the data to be written.
+	 * @param *Manufacturer Pointer to a null-terminated string containing the manufacturer name.
+	 * @param *ManufacturerId Pointer to a null-terminated string containing the manufacturer ID.
+	 * @param *Description Pointer to a null-terminated string containing the device description.
+	 * @param *SerialNumber Pointer to a null-terminated string containing the device serial number.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function interprets the parameter *eepromDATA as a pointer to a structure matching the device
+	 * type being accessed e.g.
+	 * @li PFT_EEPROM_232B is the structure for FT2xxB devices.
+	 * @li PFT_EEPROM_2232 is the structure for FT2232D devices.
+	 * @li PFT_EEPROM_232R is the structure for FT232R devices.
+	 * @li PFT_EEPROM_2232H is the structure for FT2232H devices.
+	 * @li PFT_EEPROM_4232H is the structure for FT4232H devices.
+	 * @li PFT_EEPROM_232H is the structure for FT232H devices.
+	 * @li PFT_EEPROM_X_SERIES is the structure for FT2xxX devices.
+	 * 
+	 * The function does not perform any checks on buffer sizes, so the buffers passed in the eepromDATA
+	 * structure must be big enough to accommodate their respective strings (including null terminators).
+	 * @n The sizes shown in the following example are more than adequate and can be rounded down if necessary.
+	 * The restriction is that the Manufacturer string length plus the Description string length is less than or
+	 * equal to 40 characters.
+	 * @note Note that the DLL must be informed which version of the eepromDATA structure is being used. This is
+	 * done through the PFT_EEPROM_HEADER structure. The first element of this structure is deviceType and
+	 * may be FT_DEVICE_BM, FT_DEVICE_AM, FT_DEVICE_2232C, FT_DEVICE_232R, FT_DEVICE_2232H,
+	 * FT_DEVICE_4232H, FT_DEVICE_232H, or FT_DEVICE_X_SERIES as defined in FTD2XX.h.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EEPROM_Program(
+		FT_HANDLE ftHandle,
+		void *eepromData,
+		DWORD eepromDataSize,
+		char *Manufacturer,
+		char *ManufacturerId,
+		char *Description,
+		char *SerialNumber
+		);
+
+/** @} */
+
+/** @name Extended API Functions
+ * The extended API functions do not apply to FT8U232AM or FT8U245AM devices. FTDI’s other USB-UART
+ * and USB-FIFO ICs (the FT2232H, FT4232H, FT232R, FT245R, FT2232, FT232B and FT245B) do support
+ * these functions. Note that there is device dependence in some of these functions.
+ */
+/** @{ */
+
+	/** @noop FT_SetLatencyTimer
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Set the latency timer value.
+	 * @param ftHandle Handle of the device.
+	 * @param ucLatency Required value, in milliseconds, of latency timer. Valid range is 2 - 255.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * In the FT8U232AM and FT8U245AM devices, the receive buffer timeout that is used to flush remaining
+	 * data from the receive buffer was fixed at 16 ms. In all other FTDI devices, this timeout is 
+	 * programmable and can be set at 1 ms intervals between 2ms and 255 ms. This allows the device to 
+	 * be better optimize for protocols requiring faster response times from short data packets.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetLatencyTimer(
+		FT_HANDLE ftHandle,
+		UCHAR ucLatency
+		);
+
+	/** @noop FT_GetLatencyTimer
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Get the current value of the latency timer.
+	 * @param ftHandle Handle of the device.
+	 * @param pucLatency Pointer to unsigned char to store latency timer value.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * In the FT8U232AM and FT8U245AM devices, the receive buffer timeout that is used to flush remaining
+	 * data from the receive buffer was fixed at 16 ms. In all other FTDI devices, this timeout is 
+	 * programmable and can be set at 1 ms intervals between 2ms and 255 ms. This allows the device to  
+	 * be better optimized for protocols requiring faster response times from short data packets.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetLatencyTimer(
+		FT_HANDLE ftHandle,
+		PUCHAR pucLatency
+		);
+
+	/** @noop FT_SetBitMode
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Enables different chip modes.
+	 * @param ftHandle Handle of the device.
+	 * @param ucMask Required value for bit mode mask. This sets up which bits are inputs and outputs.
+	 * A bit value of 0 sets the corresponding pin to an input, a bit value of 1 sets the corresponding 
+	 * pin to an output.
+	 * @n In the case of CBUS Bit Bang, the upper nibble of this value controls which pins are inputs 
+	 * and outputs,	while the lower nibble controls which of the outputs are high and low.
+	 * @param ucEnable Mode value. Can be one of the following:
+	 * @li 0x0 = Reset
+	 * @li 0x1 = Asynchronous Bit Bang
+	 * @li 0x2 = MPSSE (FT2232, FT2232H, FT4232H and FT232H devices only)
+	 * @li 0x4 = Synchronous Bit Bang (FT232R, FT245R, FT2232, FT2232H, FT4232H and FT232H devices only)
+	 * @li 0x8 = MCU Host Bus Emulation Mode (FT2232, FT2232H, FT4232H and FT232H devices only)
+	 * @li 0x10 = Fast Opto-Isolated Serial Mode (FT2232, FT2232H, FT4232H and FT232H devices only)
+	 * @li 0x20 = CBUS Bit Bang Mode (FT232R and FT232H devices only)
+	 * @li 0x40 = Single Channel Synchronous 245 FIFO Mode (FT2232H and FT232H devices only)
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * For a description of available bit modes for the FT232R, see the application note "Bit Bang Modes 
+	 * for the FT232R and FT245R".
+	 * @n For a description of available bit modes for the FT2232, see the application note "Bit Mode
+	 * Functions for the FT2232".
+	 * @n For a description of Bit Bang Mode for the FT232B and FT245B, see the application note 
+	 * "FT232B/FT245B Bit Bang Mode".
+	 * @n Application notes are available for download from the FTDI website.
+	 * Note that to use CBUS Bit Bang for the FT232R, the CBUS must be configured for CBUS Bit Bang in the
+	 * EEPROM.
+	 * @note Note that to use Single Channel Synchronous 245 FIFO mode for the FT2232H, channel A must be
+	 * configured for FT245 FIFO mode in the EEPROM.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetBitMode(
+		FT_HANDLE ftHandle,
+		UCHAR ucMask,
+		UCHAR ucEnable
+		);
+
+	/** @noop FT_GetBitMode
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the instantaneous value of the data bus.
+	 * @param ftHandle Handle of the device.
+	 * @param pucMode Pointer to unsigned char to store the instantaneous data bus value.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * For a description of available bit modes for the FT232R, see the application note "Bit Bang Modes 
+	 * for the FT232R and FT245R".
+	 * @n For a description of available bit modes for the FT2232, see the application note "Bit Mode 
+	 * Functions for the FT2232".
+	 * @n For a description of bit bang modes for the FT232B and FT245B, see the application note
+	 * "FT232B/FT245B Bit Bang Mode".
+	 * @n For a description of bit modes supported by the FT4232H and FT2232H devices, please see the 
+	 * IC data sheets.
+	 * @n These application notes are available for download from the FTDI website.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetBitMode(
+		FT_HANDLE ftHandle,
+		PUCHAR pucMode
+		);
+
+	/** @noop FT_SetUSBParameters
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Set the USB request transfer size.
+	 * @param ftHandle Handle of the device.
+	 * @param ulInTransferSize Transfer size for USB IN request.
+	 * @param ulOutTransferSize Transfer size for USB OUT request.
+	 * @returns
+	 * FT_OK if successful, otherwise the return value is an FT error code.
+	 * @remarks
+	 * This function can be used to change the transfer sizes from the default transfer size of 4096 
+	 * bytes to	better suit the application requirements. Transfer sizes must be set to a multiple 
+	 * of 64 bytes between 64 bytes and 64k bytes.
+	 * @n When FT_SetUSBParameters is called, the change comes into effect immediately and any data 
+	 * that was	held in the driver at the time of the change is lost.
+	 * @note Note that, at present, only ulInTransferSize is supported.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_SetUSBParameters(
+		FT_HANDLE ftHandle,
+		ULONG ulInTransferSize,
+		ULONG ulOutTransferSize
+		);
+
+/** @} */
+
+/** @name FT-Win32 API Functions
+ * The functions in this section are supplied to ease porting from a Win32 serial port application. These
+ * functions are supported under non-Windows platforms to assist with porting existing applications from
+ * Windows. Note that classic D2XX functions and the Win32 D2XX functions should not be mixed unless
+ * stated.
+ */
+/** @{ */
+
+	/** @noop FT_W32_CreateFile
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Opens the specified device and return a handle which will be used for subsequent accesses. 
+	 * The device can be specified by its serial number, device description, or location.
+	 * @n This function must be used if overlapped I/O is required.
+	 * @param lpszName Meaning depends on the value of dwAttrsAndFlags. Can be a pointer to a null 
+	 * terminated string that contains the description or serial number of the device, or can be 
+	 * the location of the device. These values can be obtained from the FT_CreateDeviceInfoList, 
+	 * FT_GetDeviceInfoDetail or FT_ListDevices	functions.
+	 * @param dwAccess Type of access to the device. Access can be GENERIC_READ,
+	 * GENERIC_WRITE or both. Ignored in Linux.
+	 * @param dwShareMode How the device is shared. This value must be set to 0.
+	 * @param lpSecurityAttributes This parameter has no effect and should be set to NULL.
+	 * @param dwCreate This parameter must be set to OPEN_EXISTING. Ignored in Linux.
+	 * @param dwAttrsAndFlags File attributes and flags. This parameter is a combination of
+	 * FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED if overlapped I/O is used,
+	 * FT_OPEN_BY_SERIAL_NUMBER if lpszName is the device’s serial number, and
+	 * FT_OPEN_BY_DESCRIPTION if lpszName is the device’s description.
+	 * @param hTemplate This parameter must be NULL.
+	 * @returns
+	 * If the function is successful, the return value is a handle.
+	 * If the function is unsuccessful, the return value is the Win32 error code INVALID_HANDLE_VALUE.
+	 * @remarks
+	 * The meaning of lpszName depends on dwAttrsAndFlags: if FT_OPEN_BY_SERIAL_NUMBER or
+	 * FT_OPEN_BY_DESCRIPTION is set in dwAttrsAndFlags, lpszName contains a pointer to a null terminated
+	 * string that contains the device's serial number or description; if FT_OPEN_BY_LOCATION is set in
+	 * dwAttrsAndFlags, lpszName is interpreted as a value of type long that contains the location ID of 
+	 * the device. dwAccess can be GENERIC_READ, GENERIC_WRITE or both; dwShareMode must be set to 0;
+	 * lpSecurityAttributes must be set to NULL; dwCreate must be set to OPEN_EXISTING; dwAttrsAndFlags 
+	 * is a combination of FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OVERLAPPED if overlapped I/O is used,
+	 * FT_OPEN_BY_SERIAL_NUMBER or FT_OPEN_BY_DESCRIPTION or FT_OPEN_BY_LOCATION; hTemplate
+	 * must be NULL.
+	 * @note Note that Linux, Mac OS X and Windows CE do not support overlapped IO. Windows CE
+	 * does not support location IDs.
+	 */
+	FTD2XX_API FT_HANDLE WINAPI FT_W32_CreateFile(
+		LPCTSTR					lpszName,
+		DWORD					dwAccess,
+		DWORD					dwShareMode,
+		LPSECURITY_ATTRIBUTES	lpSecurityAttributes,
+		DWORD					dwCreate,
+		DWORD					dwAttrsAndFlags,
+		HANDLE					hTemplate
+		);
+
+	/** @noop FT_W32_CloseHandle
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Close the specified device handle.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_CloseHandle(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_W32_ReadFile
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Read data from the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpBuffer Pointer to a buffer that receives the data from the device.
+	 * @param nBufferSize Number of bytes to read from the device.
+	 * @param lpdwBytesReturned Pointer to a variable that receives the number of bytes read from
+	 * the device.
+	 * @param lpOverlapped Pointer to an overlapped structure.
+	 * @returns 
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function supports both non-overlapped and overlapped I/O, except under Linux, Mac OS X 
+	 * and Windows CE where only non-overlapped IO is supported.
+	 * @n @b Non-overlapped @b I/O
+	 * @n The parameter, lpOverlapped, must be NULL for non-overlapped I/O.
+	 * @n This function always returns the number of bytes read in lpdwBytesReturned.
+	 * This function does not return until dwBytesToRead have been read into the buffer. The number of 
+	 * bytes in the receive queue can be determined by calling FT_GetStatus or FT_GetQueueStatus, and
+	 * passed as dwBytesToRead so that the function reads the device and returns immediately.
+	 * @n When a read timeout has been setup in a previous call to FT_W32_SetCommTimeouts, this function
+	 * returns when the timer expires or dwBytesToRead have been read, whichever occurs first. If a 
+	 * timeout occurred, any available data is read into lpBuffer and the function returns a non-zero value.
+	 * @n An application should use the function return value and lpdwBytesReturned when processing the 
+	 * buffer. If the return value is non-zero and lpdwBytesReturned is equal to dwBytesToRead then the 
+	 * function has	completed normally. If the return value is non-zero and lpdwBytesReturned is less 
+	 * then dwBytesToRead then a timeout has occurred, and the read request has been partially completed. 
+	 * @note Note that if a timeout	occurred and no data was read, the return value is still non-zero.
+	 * @n @b Overlapped @b I/O
+	 * @n When the device has been opened for overlapped I/O, an application can issue a request and 
+	 * perform some additional work while the request is pending. This contrasts with the case 
+	 * of non-overlapped I/O in	which the application issues a request and receives control again only 
+	 * after the request has been completed.
+	 * @n The parameter, lpOverlapped, must point to an initialized OVERLAPPED structure. If there is 
+	 * enough data in the receive queue to satisfy the request, the request completes immediately and 
+	 * the return code is non-zero. The number of bytes read is returned in lpdwBytesReturned.
+	 * @n If there is not enough data in the receive queue to satisfy the request, the request completes
+	 * immediately, and the return code is zero, signifying an error. An application should call
+	 * FT_W32_GetLastError to get the cause of the error. If the error code is ERROR_IO_PENDING, the
+	 * overlapped operation is still in progress, and the application can perform other processing. 
+	 * Eventually, the application checks the result of the overlapped request by calling 
+	 * FT_W32_GetOverlappedResult.
+	 * @n If successful, the number of bytes read is returned in lpdwBytesReturned.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_ReadFile(
+		FT_HANDLE ftHandle,
+		LPVOID lpBuffer,
+		DWORD nBufferSize,
+		LPDWORD lpdwBytesReturned,
+		LPOVERLAPPED lpOverlapped
+		);
+
+	/** @noop FT_W32_WriteFile
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Write data to the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpBuffer Pointer to the buffer that contains the data to write to the device.
+	 * @param nBufferSize Number of bytes to be written to the device.
+	 * @param lpdwBytesWritten Pointer to a variable that receives the number of bytes written to the device.
+	 * @param lpOverlapped Pointer to an overlapped structure.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function supports both non-overlapped and overlapped I/O, except under Linux, Mac OS X and
+	 * Windows CE where only non-overlapped IO is supported.
+	 * @n @b Non-overlapped @b I/O
+	 * @n The parameter, lpOverlapped, must be NULL for non-overlapped I/O.
+	 * @n This function always returns the number of bytes written in lpdwBytesWritten.
+	 * This function does not return until dwBytesToWrite have been written to the device.
+	 * When a write timeout has been setup in a previous call to FT_W32_SetCommTimeouts, this function
+	 * returns when the timer expires or dwBytesToWrite have been written, whichever occurs first. If a 
+	 * timeout occurred, lpdwBytesWritten contains the number of bytes actually written, and the function 
+	 * returns a non-zero value.
+	 * @n An application should always use the function return value and lpdwBytesWritten. If the return 
+	 * value is	non-zero and lpdwBytesWritten is equal to dwBytesToWrite then the function has completed 
+	 * normally. If	the return value is non-zero and lpdwBytesWritten is less then dwBytesToWrite then a 
+	 * timeout has occurred, and the write request has been partially completed. 
+	 * @note Note that if a timeout occurred and no data was written, the return value is still non-zero.
+	 * @n @b Overlapped @b I/O
+	 * @n When the device has been opened for overlapped I/O, an application can issue a request and perform
+	 * some additional work while the request is pending. This contrasts with the case of non-overlapped 
+	 * I/O in which the application issues a request and receives control again only after the request has 
+	 * been	completed.
+	 * @n The parameter, lpOverlapped, must point to an initialized OVERLAPPED structure.
+	 * This function completes immediately, and the return code is zero, signifying an error. An application
+	 * should call FT_W32_GetLastError to get the cause of the error. If the error code is ERROR_IO_PENDING,
+	 * the overlapped operation is still in progress, and the application can perform other processing.
+	 * Eventually, the application checks the result of the overlapped request by calling
+	 * FT_W32_GetOverlappedResult.
+	 * @n If successful, the number of bytes written is returned in lpdwBytesWritten.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_WriteFile(
+		FT_HANDLE ftHandle,
+		LPVOID lpBuffer,
+		DWORD nBufferSize,
+		LPDWORD lpdwBytesWritten,
+		LPOVERLAPPED lpOverlapped
+		);
+
+	/** @noop FT_W32_GetOverlappedResult
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the result of an overlapped operation.
+	 * @param ftHandle Handle of the device.
+	 * @param lpOverlapped Pointer to an overlapped structure.
+	 * @param lpdwBytesTransferred Pointer to a variable that receives the number of bytes transferred
+	 * during the overlapped operation.
+	 * @param bWait Set to TRUE if the function does not return until the operation has been completed.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function is used with overlapped I/O and so is not supported in Linux, Mac OS X or Windows CE. For
+	 * a description of its use, see FT_W32_ReadFile and FT_W32_WriteFile.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_GetOverlappedResult(
+		FT_HANDLE ftHandle,
+		LPOVERLAPPED lpOverlapped,
+		LPDWORD lpdwBytesTransferred,
+		BOOL bWait
+		);
+
+	/** @noop FT_W32_EscapeCommFunction
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Perform an extended function.
+	 * @param ftHandle Handle of the device.
+	 * @param dwFunc The extended function to perform can be one of the following values:
+	 * @li CLRDTR - Clear the DTR signal
+	 * @li CLRRTS - Clear the RTS signal
+	 * @li SETDTR - Set the DTR signal
+	 * @li SETRTS - Set the RTS signal
+	 * @li SETBREAK - Set the BREAK condition
+	 * @li CLRBREAK - Clear the BREAK condition
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_EscapeCommFunction(
+		FT_HANDLE ftHandle,
+		DWORD dwFunc
+		);
+
+	/** @noop FT_W32_GetCommModemStatus
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function gets the current modem control value.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwModemStatus Pointer to a variable to contain modem control value. The modem
+	 * control value can be a combination of the following:
+	 * @li MS_CTS_ON - Clear To Send (CTS) is on
+	 * @li MS_DSR_ON - Data Set Ready (DSR) is on
+	 * @li MS_RING_ON - Ring Indicator (RI) is on
+	 * @li MS_RLSD_ON - Receive Line Signal Detect (RLSD) is on
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_GetCommModemStatus(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwModemStatus
+		);
+
+	/** @noop FT_W32_SetupComm
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the read and write buffers.
+	 * @param ftHandle Handle of the device.
+	 * @param dwReadBufferSize Length, in bytes, of the read buffer.
+	 * @param dwWriteBufferSize Length, in bytes, of the write buffer.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function has no effect. It is the responsibility of the driver to allocate sufficient 
+	 * storage for I/O requests.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_SetupComm(
+		FT_HANDLE ftHandle,
+		DWORD dwReadBufferSize,
+		DWORD dwWriteBufferSize
+		);
+
+/**
+ * Structure for FT_W32_ClearCommError lpftComstat parameter.
+ * @see FT_W32_ClearCommError
+ */
+typedef struct _FTCOMSTAT {
+	DWORD fCtsHold : 1;
+	DWORD fDsrHold : 1;
+	DWORD fRlsdHold : 1;
+	DWORD fXoffHold : 1;
+	DWORD fXoffSent : 1;
+	DWORD fEof : 1;
+	DWORD fTxim : 1;
+	DWORD fReserved : 25;
+	DWORD cbInQue;
+	DWORD cbOutQue;
+} FTCOMSTAT, *LPFTCOMSTAT;
+
+/** Structure for FT_W32_SetCommState and FT_W32_GetCommState lpftDcb parameter.
+ * @see FT_W32_SetCommState
+ * @see FT_W32_GetCommState
+ */
+typedef struct _FTDCB {
+	DWORD DCBlength;              /** sizeof(FTDCB)                        */
+	DWORD BaudRate;               /** Baudrate at which running            */
+	DWORD fBinary : 1;            /** Binary Mode (skip EOF check)         */
+	DWORD fParity : 1;            /** Enable parity checking               */
+	DWORD fOutxCtsFlow : 1;       /** CTS handshaking on output            */
+	DWORD fOutxDsrFlow : 1;       /** DSR handshaking on output            */
+	DWORD fDtrControl : 2;        /** DTR Flow control                     */
+	DWORD fDsrSensitivity : 1;    /** DSR Sensitivity                      */
+	DWORD fTXContinueOnXoff : 1;  /** Continue TX when Xoff sent           */
+	DWORD fOutX : 1;              /** Enable output X-ON/X-OFF             */
+	DWORD fInX : 1;               /** Enable input X-ON/X-OFF              */
+	DWORD fErrorChar : 1;         /** Enable Err Replacement               */
+	DWORD fNull : 1;              /** Enable Null stripping                */
+	DWORD fRtsControl : 2;        /** Rts Flow control                     */
+	DWORD fAbortOnError : 1;      /** Abort all reads and writes on Error  */
+	DWORD fDummy2 : 17;           /** Reserved                             */
+	WORD wReserved;               /** Not currently used                   */
+	WORD XonLim;                  /** Transmit X-ON threshold              */
+	WORD XoffLim;                 /** Transmit X-OFF threshold             */
+	BYTE ByteSize;                /** Number of bits/byte, 4-8             */
+	BYTE Parity;                  /** 0-4=None,Odd,Even,Mark,Space         */
+	BYTE StopBits;                /** FT_STOP_BITS_1 or FT_STOP_BITS_2     */
+	char XonChar;                 /** Tx and Rx X-ON character             */
+	char XoffChar;                /** Tx and Rx X-OFF character            */
+	char ErrorChar;               /** Error replacement char               */
+	char EofChar;                 /** End of Input character               */
+	char EvtChar;                 /** Received Event character             */
+	WORD wReserved1;              /** Fill for now.                        */
+} FTDCB, *LPFTDCB;
+
+/** Structure for FT_W32_SetCommTimeouts and FT_W32_GetCommTimeouts lpftTimeouts parameter.
+ * @see FT_W32_SetCommTimeouts
+ * @see FT_W32_GetCommTimeouts
+ */
+typedef struct _FTTIMEOUTS {
+	DWORD ReadIntervalTimeout;          /** Maximum time between read chars.  */
+	DWORD ReadTotalTimeoutMultiplier;   /** Multiplier of characters.         */
+	DWORD ReadTotalTimeoutConstant;     /** Constant in milliseconds.         */
+	DWORD WriteTotalTimeoutMultiplier;  /** Multiplier of characters.         */
+	DWORD WriteTotalTimeoutConstant;    /** Constant in milliseconds.         */
+} FTTIMEOUTS, *LPFTTIMEOUTS;
+
+	/** @noop FT_W32_SetCommState
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the state of the device according to the contents of a device control block (DCB).
+	 * @param ftHandle Handle of the device.
+	 * @param lpftDcb Pointer to an FTDCB structure.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_SetCommState(
+		FT_HANDLE ftHandle,
+		LPFTDCB lpftDcb
+		);
+
+	/** @noop FT_W32_GetCommState
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function gets the current device state.
+	 * @param ftHandle Handle of the device.
+	 * @param lpftDcb Pointer to an FTDCB structure.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * The current state of the device is returned in a device control block.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_GetCommState(
+		FT_HANDLE ftHandle,
+		LPFTDCB lpftDcb
+		);
+
+	/** @noop FT_W32_SetCommTimeouts
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function sets the timeout parameters for I/O requests.
+	 * @param ftHandle Handle of the device.
+	 * @param pftTimeouts Pointer to an FTTIMEOUTS structure to store timeout information.
+	 * @returns
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * Timeouts are calculated using the information in the FTTIMEOUTS structure.
+	 * @n For read requests, the number of bytes to be read is multiplied by the total timeout 
+	 * multiplier, and added to the total timeout constant. So, if TS is an FTTIMEOUTS structure 
+	 * and the number of bytes to read is dwToRead, the read timeout, rdTO, is calculated as follows.
+	 * @n rdTO = (dwToRead * TS.ReadTotalTimeoutMultiplier) + TS.ReadTotalTimeoutConstant
+	 * @n For write requests, the number of bytes to be written is multiplied by the total timeout 
+	 * multiplier, and added to the total timeout constant. So, if TS is an FTTIMEOUTS structure 
+	 * and the number of bytes to write is dwToWrite, the write timeout, wrTO, is calculated as follows.
+	 * @n wrTO = (dwToWrite * TS.WriteTotalTimeoutMultiplier) + TS.WriteTotalTimeoutConstant
+	 * @n Linux and Mac OS X currently ignore the ReadIntervalTimeout, ReadTotalTimeoutMultiplier and
+	 * WriteTotalTimeoutMultiplier.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_SetCommTimeouts(
+		FT_HANDLE ftHandle,
+		FTTIMEOUTS *pftTimeouts
+		);
+
+	/** @noop FT_W32_GetCommTimeouts
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function gets the current read and write request timeout parameters for the specified device.
+	 * @param ftHandle Handle of the device.
+	 * @param pftTimeouts Pointer to an FTTIMEOUTS structure to store timeout information.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * For an explanation of how timeouts are used, see FT_W32_SetCommTimeouts.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_GetCommTimeouts(
+		FT_HANDLE ftHandle,
+		FTTIMEOUTS *pftTimeouts
+		);
+
+	/** @noop FT_W32_SetCommBreak
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Puts the communications line in the BREAK state.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_SetCommBreak(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_W32_ClearCommBreak
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Puts the communications line in the non-BREAK state.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_ClearCommBreak(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_W32_SetCommMask
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function specifies events that the device has to monitor.
+	 * @param ftHandle Handle of the device.
+	 * @param ulEventMask Mask containing events that the device has to monitor. This can be a combination of 
+	 * the following:
+	 * @li EV_BREAK - BREAK condition detected
+	 * @li EV_CTS - Change in Clear To Send (CTS)
+	 * @li EV_DSR - Change in Data Set Ready (DSR)
+	 * @li EV_ERR - Error in line status
+	 * @li EV_RING - Change in Ring Indicator (RI)
+	 * @li EV_RLSD - Change in Receive Line Signal Detect (RLSD)
+	 * @li EV_RXCHAR - Character received
+	 * @li EV_RXFLAG - Event character received
+	 * @li EV_TXEMPTY - Transmitter empty
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function specifies the events that the device should monitor. An application can call the 
+	 * function FT_W32_WaitCommEvent to wait for an event to occur.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_SetCommMask(
+		FT_HANDLE ftHandle,
+		ULONG ulEventMask
+		);
+
+	/** @noop 6 FT_W32_GetCommMask
+	 * @par Supported Operating Systems
+	 * Windows (2000 and later)
+	 * @par Summary
+	 * Retrieves the events that are currently being monitored by a device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwEventMask Pointer to a location that receives a mask that contains the events that are 
+	 * currently enabled. This parameter can be one or more of the following values:
+	 * @li EV_BREAK - BREAK condition detected
+	 * @li EV_CTS - Change in Clear To Send (CTS)
+	 * @li EV_DSR - Change in Data Set Ready (DSR)
+	 * @li EV_ERR - Error in line status
+	 * @li EV_RING - Change in Ring Indicator (RI)
+	 * @li EV_RLSD - Change in Receive Line Signal Detect (RLSD)
+	 * @li EV_RXCHAR - Character received
+	 * @li EV_RXFLAG - Event character received
+	 * @li EV_TXEMPTY - Transmitter empty
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function returns events currently being monitored by the device. Event monitoring for these 
+	 * events is enabled by the FT_W32_SetCommMask function.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_GetCommMask(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwEventMask
+		);
+
+	/** @noop FT_W32_WaitCommEvent
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function waits for an event to occur.
+	 * @param ftHandle Handle of the device.
+	 * @param pulEvent Pointer to a location that receives a mask that contains the events that occurred.
+	 * @param lpOverlapped Pointer to an overlapped structure.
+	 * @returns 
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function supports both non-overlapped and overlapped I/O, except under Windows CE and Linux
+	 * where only non-overlapped IO is supported.
+	 * @n @b Non-overlapped @b I/O
+	 * The parameter, lpOverlapped, must be NULL for non-overlapped I/O.
+	 * @n This function does not return until an event that has been specified in a call to 
+	 * FT_W32_SetCommMask has occurred. The events that occurred and resulted in this function returning 
+	 * are stored in lpdwEvent.
+	 * @n @b Overlapped @b I/O
+	 * @n When the device has been opened for overlapped I/O, an application can issue a request and perform
+	 * some additional work while the request is pending. This contrasts with the case of non-overlapped 
+	 * I/O in which the application issues a request and receives control again only after the request has 
+	 * been	completed.
+	 * @n The parameter, lpOverlapped, must point to an initialized OVERLAPPED structure.
+	 * This function does not return until an event that has been specified in a call to FT_W32_SetCommMask
+	 * has occurred.
+	 * @n If an event has already occurred, the request completes immediately, and the return code is non-zero.
+	 * @n The events that occurred are stored in lpdwEvent.
+	 * @n If an event has not yet occurred, the request completes immediately, and the return code is zero,
+	 * signifying an error. An application should call FT_W32_GetLastError to get the cause of the error. If 
+	 * the error code is ERROR_IO_PENDING, the overlapped operation is still in progress, and the application 
+	 * can perform other processing. Eventually, the application checks the result of the overlapped request 
+	 * by calling FT_W32_GetOverlappedResult. The events that occurred and resulted in this function 
+	 * returning are stored in lpdwEvent.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_WaitCommEvent(
+		FT_HANDLE ftHandle,
+		PULONG pulEvent,
+		LPOVERLAPPED lpOverlapped
+		);
+
+	/** @noop FT_W32_PurgeComm
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * This function purges the device.
+	 * @param ftHandle Handle of the device.
+	 * @param dwMask Specifies the action to take. The action can be a combination of the following:
+	 * @li PURGE_TXABORT - Terminate outstanding overlapped writes
+	 * @li PURGE_RXABORT - Terminate outstanding overlapped reads
+	 * @li PURGE_TXCLEAR - Clear the transmit buffer
+	 * @li PURGE_RXCLEAR - Clear the receive buffer
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_PurgeComm(
+		FT_HANDLE ftHandle,
+		DWORD dwMask
+		);
+
+	/** @noop FT_W32_GetLastError
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets the last error that occurred on the device.
+	 * @param ftHandle Handle of the device.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 * @remarks
+	 * This function is normally used with overlapped I/O and so is not supported in Windows CE. For a
+	 * description of its use, see FT_W32_ReadFile and FT_W32_WriteFile.
+	 * @n In Linux and Mac OS X, this function returns a DWORD that directly maps to the FT Errors (for 
+	 * example the FT_INVALID_HANDLE error number).
+	 */
+	FTD2XX_API DWORD WINAPI FT_W32_GetLastError(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_W32_ClearCommError
+	 * @par Supported Operating Systems
+	 * Linux
+	 * Mac OS X (10.4 and later)
+	 * Windows (2000 and later)
+	 * Windows CE (4.2 and later)
+	 * @par Summary
+	 * Gets information about a communications error and get current status of the device.
+	 * @param ftHandle Handle of the device.
+	 * @param lpdwErrors Variable that contains the error mask.
+	 * @param lpftComstat Pointer to FTCOMSTAT structure.
+	 * @returns
+	 * If the function is successful, the return value is nonzero.
+	 * If the function is unsuccessful, the return value is zero.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_ClearCommError(
+		FT_HANDLE ftHandle,
+		LPDWORD lpdwErrors,
+		LPFTCOMSTAT lpftComstat
+		);
+
+	/** @noop FT_W32_CancelIo
+	 * Undocumented function.
+	 */
+	FTD2XX_API BOOL WINAPI FT_W32_CancelIo(
+		FT_HANDLE ftHandle
+		);
+
+
+/** @} */
+
+/**
+ * @name FT232H Additional EEPROM Functions
+ */
+/** @{ */
+
+	/** @noop FT_EE_ReadConfig
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_ReadConfig(
+		FT_HANDLE ftHandle,
+		UCHAR ucAddress,
+		PUCHAR pucValue
+		);
+
+	/** @noop FT_EE_WriteConfig
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_WriteConfig(
+		FT_HANDLE ftHandle,
+		UCHAR ucAddress,
+		UCHAR ucValue
+		);
+
+	/** @noop FT_EE_ReadECC
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_EE_ReadECC(
+		FT_HANDLE ftHandle,
+		UCHAR ucOption,
+		LPWORD lpwValue
+		);
+
+	/** @noop FT_GetQueueStatusEx
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_GetQueueStatusEx(
+		FT_HANDLE ftHandle,
+		DWORD *dwRxBytes
+		);
+
+	/** @noop FT_ComPortIdle
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ComPortIdle(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_ComPortCancelIdle
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_ComPortCancelIdle(
+		FT_HANDLE ftHandle
+		);
+
+	/** @noop FT_VendorCmdGet
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_VendorCmdGet(
+		FT_HANDLE ftHandle,
+		UCHAR Request,
+		UCHAR *Buf,
+		USHORT Len
+		);
+
+	/** @noop FT_VendorCmdSet
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_VendorCmdSet(
+		FT_HANDLE ftHandle,
+		UCHAR Request,
+		UCHAR *Buf,
+		USHORT Len
+		);
+
+	/** @noop FT_VendorCmdGetEx
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_VendorCmdGetEx(
+		FT_HANDLE ftHandle,
+		USHORT wValue,
+		UCHAR *Buf,
+		USHORT Len
+		);
+
+	/** @noop FT_VendorCmdSetEx
+	 * Undocumented function.
+	 */
+	FTD2XX_API FT_STATUS WINAPI FT_VendorCmdSetEx(
+		FT_HANDLE ftHandle,
+		USHORT wValue,
+		UCHAR *Buf,
+		USHORT Len
+		);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif	/* FTD2XX_H */

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_common.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_common.h
@@ -1,0 +1,158 @@
+/*!
+ * \file ftdi_common.h
+ *
+ * \author FTDI
+ * \date 20110127
+ *
+ * Copyright  2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: common
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - Changed MAX_CLOCK_RATE from 3.4 to 30MHz
+ * 0.3 - 20111103 - Added MPSSE command definitions for fullduplex transfers
+ * 0.4 - 20200428 - removed unnecessary files and directory structure
+ */
+
+#ifndef FTDI_COMMON_H
+#define FTDI_COMMON_H
+
+/* Default library version number. Overridden by makefile. */
+
+#ifndef FT_VER_MAJOR
+#define FT_VER_MAJOR		1
+#endif // FT_VER_MAJOR
+#ifndef FT_VER_MINOR
+#define FT_VER_MINOR		0
+#endif // FT_VER_MINOR
+#ifndef FT_VER_BUILD
+#define FT_VER_BUILD		1
+#endif // FT_VER_BUILD
+
+/******************************************************************************/
+/*								Macro defines								  */
+/******************************************************************************/
+/* Macros to be called before starting and after ending communication over a MPSSE channel.
+Implement the lock/unlock only if really required, otherwise keep as placeholders */
+#define LOCK_CHANNEL(arg)	{;}
+#define UNLOCK_CHANNEL(arg)	{;}
+
+#define MIN_CLOCK_RATE 					0
+#define MAX_CLOCK_RATE 					30000000
+
+#define MIN_LATENCY_TIMER       		0
+#define MAX_LATENCY_TIMER       		255
+#define USB_INPUT_BUFFER_SIZE			65536
+#define USB_OUTPUT_BUFFER_SIZE			65536
+#define DISABLE_EVENT					0
+#define DISABLE_CHAR					0
+#define DEVICE_READ_TIMEOUT_INFINITE    0
+#define DEVICE_READ_TIMEOUT 			5000
+#define DEVICE_WRITE_TIMEOUT 			5000
+#define INTERFACE_MASK_IN				0x00
+#define INTERFACE_MASK_OUT				0x01
+#define RESET_INTERFACE					0
+#define ENABLE_MPSSE					0X02
+
+/*MPSSE Control Commands*/
+#define MPSSE_CMD_SET_DATA_BITS_LOWBYTE		0x80
+#define MPSSE_CMD_SET_DATA_BITS_HIGHBYTE	0x82
+#define MPSSE_CMD_GET_DATA_BITS_LOWBYTE		0x81
+#define MPSSE_CMD_GET_DATA_BITS_HIGHBYTE	0x83
+
+#define MPSSE_CMD_SEND_IMMEDIATE			0x87
+#define MPSSE_CMD_ENABLE_3PHASE_CLOCKING	0x8C
+#define MPSSE_CMD_DISABLE_3PHASE_CLOCKING	0x8D
+#define MPSSE_CMD_ENABLE_DRIVE_ONLY_ZERO	0x9E
+
+/*MPSSE Data Command - LSB First */
+#define MPSSE_CMD_DATA_LSB_FIRST			0x08
+
+/*MPSSE Data Commands - bit mode - MSB first */
+#define MPSSE_CMD_DATA_OUT_BITS_POS_EDGE	0x12
+#define MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE	0x13
+#define MPSSE_CMD_DATA_IN_BITS_POS_EDGE		0x22
+#define MPSSE_CMD_DATA_IN_BITS_NEG_EDGE		0x26
+#define MPSSE_CMD_DATA_BITS_IN_POS_OUT_NEG_EDGE	0x33
+#define MPSSE_CMD_DATA_BITS_IN_NEG_OUT_POS_EDGE	0x36
+
+
+/*MPSSE Data Commands - byte mode - MSB first */
+#define MPSSE_CMD_DATA_OUT_BYTES_POS_EDGE	0x10
+#define MPSSE_CMD_DATA_OUT_BYTES_NEG_EDGE	0x11
+#define MPSSE_CMD_DATA_IN_BYTES_POS_EDGE	0x20
+#define MPSSE_CMD_DATA_IN_BYTES_NEG_EDGE	0x24
+#define MPSSE_CMD_DATA_BYTES_IN_POS_OUT_NEG_EDGE	0x31
+#define MPSSE_CMD_DATA_BYTES_IN_NEG_OUT_POS_EDGE	0x34
+
+
+/*SCL & SDA directions*/
+#define DIRECTION_SCLIN_SDAIN				0x10
+#define DIRECTION_SCLOUT_SDAIN				0x11
+#define DIRECTION_SCLIN_SDAOUT				0x12
+#define DIRECTION_SCLOUT_SDAOUT				0x13
+
+/*SCL & SDA values*/
+#define VALUE_SCLLOW_SDALOW					0x00
+#define VALUE_SCLHIGH_SDALOW				0x01
+#define VALUE_SCLLOW_SDAHIGH				0x02
+#define VALUE_SCLHIGH_SDAHIGH				0x03
+
+/*Data size in bits*/
+#define DATA_SIZE_8BITS						0x07
+#define DATA_SIZE_1BIT						0x00
+
+/* The I2C master should actually drive the SDA line only when the output is LOW. It should
+tristate the SDA line when the output should be high. This tristating the SDA line during high
+output is supported only in FT232H chip. This feature is called DriveOnlyZero feature and is
+enabled when the following bit is set in the options parameter in function I2C_Init */
+#define I2C_ENABLE_DRIVE_ONLY_ZERO	0x0002
+
+
+
+/******************************************************************************/
+/*								Type defines								  */
+/******************************************************************************/
+
+/*The middle layer is designed to have no knowledge of the legacy protocol used(I2C/JTAG/SPI)
+but it will have to perform certain operations differently for supporting the different protocols. For
+example, the sequence to initilize the hardware for the different protocols will be different. This is
+why we need to have a parameter from the caller(top layer) to specify for which protocol is the
+service(say, hardware initialization) required. The following enumeration is hence used uniformly
+as the first parameter across all the middle layer APIs */
+typedef enum FT_LegacyProtocol_t{SPI, I2C, JTAG}FT_LegacyProtocol;
+
+
+
+/******************************************************************************/
+/*								External variables							  */
+/******************************************************************************/
+
+
+
+
+
+/******************************************************************************/
+/*								Function declarations						  */
+/******************************************************************************/
+
+
+
+
+/******************************************************************************/
+
+
+#endif	/*FTDI_COMMON_H*/
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_i2c.c
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_i2c.c
@@ -1,0 +1,1516 @@
+/*!
+ * \file ftdi_i2c.c
+ *
+ * \author FTDI
+ * \date 20110321
+ *
+ * Copyright  2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: I2C
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - Added 3-phase-clocking functionality in I2C_InitChannel
+ * 0.3 - 20111103 - Added I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE
+ *				  Added I2C_TRANSFER_OPTIONS_FAST_TRANSFER(bit/byte/noAddress modes)
+ * 				  Returns FT_DEVICE_NOT_FOUND if addressed slave doesn't respond
+ *				  Adjustment to clock rate if 3-phase-clocking is enabled
+  * 0.4 - 20200428 - removed unnecessary files and directory structure
+*/
+
+/******************************************************************************/
+/*								Include files					  			  */
+/******************************************************************************/
+#define FTDI_EXPORTS
+#include "ftdi_infra.h"		/*Common portable infrastructure(datatypes, libraries, etc)*/
+#include "ftdi_common.h"	/*Common across I2C, SPI, JTAG modules*/
+#include "ftdi_mid.h"		/*Middle layer*/
+#include "libmpsse_i2c.h"	/*I2C specific*/
+
+
+/******************************************************************************/
+/*								Macro and type defines					  		  */
+/******************************************************************************/
+
+/* Enabling the macro will lead to checking of all parameters that are passed to the library from
+    the user application*/
+#define ENABLE_PARAMETER_CHECKING
+
+/* This macro will enable all code that is needed to support I2C_GETDEVICEID feature */
+#undef I2C_CMD_GETDEVICEID_SUPPORTED
+
+/* This macro will enable the code to read acknowledgements from slaves in I2C_RawWrite */
+#define FASTWRITE_READ_ACK
+
+#define START_DURATION_1	10
+#define START_DURATION_2	20
+
+#define STOP_DURATION_1	10
+#define STOP_DURATION_2	10
+#define STOP_DURATION_3	10
+
+#define SEND_ACK			0x00
+#define SEND_NACK			0x80
+
+#define I2C_ADDRESS_READ_MASK	0x01	/*LSB 1 = Read*/
+#define I2C_ADDRESS_WRITE_MASK	0xFE	/*LSB 0 = Write*/
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+
+/* This enum lists the supported I2C modes*/
+typedef enum I2C_Modes_t{
+	I2C_STANDARD_MODE = 0,
+	I2C_FAST_MODE,
+	I2C_FAST_MODE_PLUS,
+	I2C_HIGH_SPEED_MODE,
+	I2C_MAXIMUM_SUPPORTED_MODES
+} I2C_Modes;
+
+/* This enum lists the various I2C bus condition*/
+typedef enum I2C_Bus_Condition_t{
+	I2C_CONDITION_PRESTART,
+	I2C_CONDITION_START,
+	I2C_CONDITION_POSTSTART,
+	I2C_CONDITION_PRESTOP,
+	I2C_CONDITION_STOP,
+	I2C_CONDITION_POSTSTOP,
+	I2C_MAXIMUM_SUPPORTED_CONDITIONS
+} I2C_Bus_Condition;
+
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+/******************************************************************************/
+/*								Local function declarations					  */
+/******************************************************************************/
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+/*!
+ * \brief Generate I2C bus restart condition
+ *
+ * This function generates the restart condition in the I2C bus
+ *
+ * \param[in] handle Handle of the channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_Restart(FT_HANDLE handle);
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+/*!
+ * \brief Writes 8 bits and gets the ack bit
+ *
+ * This function writes 8 bits of data to the I2C bus and gets the ack bit from the device
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] data The 8bits of data that are to be written to the I2C bus
+ * \param[out] ack The acknowledgment bit returned by the I2C device
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_Write8bitsAndGetAck(FT_HANDLE handle, uint8 data, bool *ack);
+
+/*!
+ * \brief Reads 8 bits of data and sends ack bit
+ *
+ * This function reads 8 bits of data from the I2C bus and then writes an ack bit to the bus
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] *data Pointer to the buffer where the 8bits would be read to
+ * \param[in] ack Gives ack to device if set, otherwise gives nAck
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_Read8bitsAndGiveAck(FT_HANDLE handle, uint8 *data, bool ack);
+
+/*!
+ * \brief Write I2C device address
+ *
+ * This function writes the direction and address bits to the I2C bus, and then gets the ACK
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C device
+ * \param[in] direction 0 = Write; 1 = Read
+ * \param[in] AddLen10Bit Setting this bit specifies 10bit addressing, otherwise 7bit
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_WriteDeviceAddress(FT_HANDLE handle, UCHAR deviceAddress,
+			bool direction, bool AddLen10Bit, bool *ack);
+
+/*!
+ * \brief Saves the channel's configuration data
+ *
+ * This function saves the channel's configuration data
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] config Pointer to ChannelConfig structure(memory to be allocated by caller)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_SaveChannelConfig(FT_HANDLE handle, ChannelConfig *config);
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+/*!
+ * \brief Retrieves channel's configuration data
+ *
+ * This function retrieves the channel's configuration data that was previously saved
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] config Pointer to ChannelConfig structure(memory to be allocated by caller)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_GetChannelConfig(FT_HANDLE handle, ChannelConfig *config);
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+/*!
+ * \brief Generates the I2C Start condition
+ *
+ * This function generates the I2C start condition on the bus.
+ *
+ * \param[in] handle Handle of the channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_Start(FT_HANDLE handle);
+
+/*!
+ * \brief Generates the I2C Stop condition
+ *
+ * This function generates the I2C stop condition on the bus.
+ *
+ * \param[in] handle Handle of the channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS I2C_Stop(FT_HANDLE handle);
+
+/*!
+ * \brief This function generates the START, ADDRESS, DATA(write) & STOP phases in the I2C
+ *		bus without having delays between these phases
+ *
+ * This function allocates memory locally, makes MPSSE command frames to write each data
+ * byte/bit, makes MPSSE command frames to read the acknowledgement bits, and then writes
+ * all these to the MPSSE in one shot. This function is useful where delays between START, DATA
+ * and STOP phases are not prefered.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C Slave. This parameter is ignored if flag
+ *			I2C_TRANSFER_OPTIONS_NO_ADDRESS is set in the options parameter
+ * \param[in] sizeToTransfer Number of bytes or bits to be written, depending on if
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS or
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES is set in options parameter
+ * \param[in] *buffer Pointer to the buffer from where data is to be written. The user application
+ * 			is expected to send a byte array of length sizeToTransfer. However if
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS is set then the length of the byte
+ *			array should be sizeToTransfer/8.
+ * \param[out] *ack Pointer to the buffer to where the ack bits are to be stored. The ack bits are
+ *			 ignored if NULL is passed
+ * \param[out] sizeTransferred Pointer to variable containing the number of bytes/bits written
+ * \param[in] options This parameter specifies data transfer options. Namely if a start/stop
+ *			conditions are required, if size is in bytes or bits, if address is provided.
+ * \return 	Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa		Definitions of I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES,
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS,
+ *			I2C_TRANSFER_OPTIONS_NO_ADDRESS,
+ *			I2C_TRANSFER_OPTIONS_START_BIT,
+ *			I2C_TRANSFER_OPTIONS_STOP_BIT
+ * \note The I2C_TRANSFER_OPTIONS_BREAK_ON_NACK bit in the options parameter is not
+ *          applicable for this function.
+ * \warning
+ */
+static FT_STATUS I2C_FastWrite(FT_HANDLE handle, UCHAR deviceAddress,
+			DWORD bitsToTransfer, UCHAR *buffer, UCHAR *ack, LPDWORD bytesTransferred,
+			uint32 options);
+
+/*!
+ * \brief This function generates the START, ADDRESS, DATA(read) & STOP phases in the I2C
+ *		bus without having delays between these phases
+ *
+ * This function allocates memory locally, makes MPSSE command frames to read each data
+ * byte/bit, makes MPSSE command frames to write the acknowledgement bits, and then writes
+ * all these to the MPSSE in one shot. This function is useful where delays between START, DATA
+ * and STOP phases are not prefered.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] deviceAddress Address of the I2C Slave. This parameter is ignored if flag
+ *			I2C_TRANSFER_OPTIONS_NO_ADDRESS is set in the options parameter
+ * \param[in] sizeToTransfer Number of bytes or bits to be written, depending on if
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS or
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES is set in options parameter
+ * \param[in] *buffer Pointer to the buffer to where data is to be read. The user application
+ * 			is expected to send a byte array of length sizeToTransfer. However if
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS is set then the length of the byte
+ *			array should be sizeToTransfer/8
+ * \param[out] *ack Reserved (place holder for buffer in which user can provide ack/nAck bits)
+ * \param[out] sizeTransferred Pointer to variable containing the number of bytes/bits written
+ * \param[in] options This parameter specifies data transfer options. Namely if a start/stop
+ *			conditions are required, if size is in bytes or bits, if address is provided.
+ * \return 	Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa		Definitions of I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES,
+ *			I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS,
+ *			I2C_TRANSFER_OPTIONS_NO_ADDRESS,
+ *			I2C_TRANSFER_OPTIONS_START_BIT,
+ *			I2C_TRANSFER_OPTIONS_STOP_BIT
+ * \note The I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE bit in the options parameter is not
+ *          applicable for this function.
+ * \warning
+ */
+static FT_STATUS I2C_FastRead(FT_HANDLE handle, UCHAR deviceAddress,
+			DWORD bitsToTransfer, UCHAR *buffer, UCHAR *ack, LPDWORD bytesTransferred,
+			uint32 options);
+
+
+/******************************************************************************/
+/*								Global variables							  */
+/******************************************************************************/
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+/*!
+ * \brief I2C bus condition timings table
+ *
+ * This table contains the minimim time that the I2C bus needs to be held in, in order to register
+ * a condition such as start, stop restart, etc. The table has one row each for the different bus
+ * speeds.
+ *
+ * \sa
+ * \note
+ * \warning
+ */
+const uint64 I2C_Timings[I2C_MAXIMUM_SUPPORTED_MODES]
+[I2C_MAXIMUM_SUPPORTED_CONDITIONS] = {
+	/*Durations for conditions are as follows:
+	pre-start, start, post-start, pre-stop, stop, post-stop */
+	{0, 0,0, 0,0, 0,}, /* I2C_CLOCK_STANDARD_MODE */
+	{0, 0,0, 0,0, 0,}, /*I2C_CLOCK_FAST_MODE */
+	{0, 0,0, 0,0, 0,}, /* I2C_CLOCK_FAST_MODE_PLUS */
+	{0, 0,0, 0,0, 0}	/* I2C_CLOCK_HIGH_SPEED_MODE */
+};
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+
+/******************************************************************************/
+/*						Public function definitions						  */
+/******************************************************************************/
+
+FTDIMPSSE_API FT_STATUS I2C_GetNumChannels(DWORD *numChannels)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+	
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(numChannels);
+#endif // ENABLE_PARAMETER_CHECKING
+	status = FT_GetNumChannels(I2C, numChannels);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_GetChannelInfo(DWORD index,
+					FT_DEVICE_LIST_INFO_NODE *chanInfo)
+{
+	FT_STATUS status;
+	
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(chanInfo);
+#endif // ENABLE_PARAMETER_CHECKING
+	status = FT_GetChannelInfo(I2C, index+1, chanInfo);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_OpenChannel(DWORD index, FT_HANDLE *handle)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+#endif // ENABLE_PARAMETER_CHECKING
+	/* Opens a channel and returns the pointer to its handle */
+	status = FT_OpenChannel(I2C, index+1, handle);
+	DBG(MSG_DEBUG,"index=%u handle=%u\n",(unsigned)index,(unsigned)*handle);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_InitChannel(FT_HANDLE handle, ChannelConfig *config)
+{
+	FT_STATUS status;
+	uint8 buffer[3];//3
+	uint32 noOfBytesToTransfer;
+	DWORD noOfBytesTransferred;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(config);
+	CHECK_NULL_RET(handle);
+#endif // ENABLE_PARAMETER_CHECKING
+	if (!(config->Options & I2C_DISABLE_3PHASE_CLOCKING))
+	{/* Adjust clock rate if 3phase clocking should be enabled */
+		config->ClockRate = (config->ClockRate * 3)/2;
+	}
+	DBG(MSG_DEBUG,"handle = 0x%x ClockRate=%u LatencyTimer=%u Options = 0x%x\n",
+		(unsigned)handle, (unsigned)config->ClockRate,
+		(unsigned)config->LatencyTimer,(unsigned)config->Options);
+	status = FT_InitChannel(I2C, handle, (uint32)config->ClockRate,
+		(uint32)config->LatencyTimer,(uint32)config->Options);
+	CHECK_STATUS(status);
+
+	if (!(config->Options & I2C_DISABLE_3PHASE_CLOCKING))
+	{
+		DBG(MSG_DEBUG,"Enabling 3 phase clocking\n");
+		noOfBytesToTransfer = 1;
+		noOfBytesTransferred = 0;
+		buffer[0] = MPSSE_CMD_ENABLE_3PHASE_CLOCKING;/* MPSSE command */
+		status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+			buffer,&noOfBytesTransferred);
+		CHECK_STATUS(status);
+	}
+
+	/*Save the channel's config data for later use*/
+	status = I2C_SaveChannelConfig(handle, config);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_CloseChannel(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+		CHECK_NULL_RET(handle);
+#endif // ENABLE_PARAMETER_CHECKING
+	status = FT_CloseChannel(I2C, handle);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_DeviceRead(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, LPDWORD sizeTransferred, DWORD options)
+{
+	FT_STATUS status = FT_OK;
+	bool ack = TRUE;
+	uint32 i;
+
+	FN_ENTER;
+	
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(buffer);
+	CHECK_NULL_RET(sizeTransferred);
+	
+	if (deviceAddress > 127)
+	{
+		DBG(MSG_ERR,"deviceAddress(0x%x) is greater than 127\n", (unsigned)deviceAddress);
+		return FT_INVALID_PARAMETER;
+	}
+#endif // ENABLE_PARAMETER_CHECKING
+
+	LOCK_CHANNEL(handle);
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER)
+	{
+		status = I2C_FastRead (handle, deviceAddress, sizeToTransfer, 
+			buffer, NULL, sizeTransferred, options);
+	}
+	else
+	{
+		/* Write START bit */
+		if (options & I2C_TRANSFER_OPTIONS_START_BIT)
+		{
+			status = I2C_Start(handle);
+			CHECK_STATUS(status);
+		}
+
+		if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+		{
+		/* Write device address (with LSB = 1 => READ)  & Get ACK */
+		status = I2C_WriteDeviceAddress(handle, deviceAddress, TRUE, FALSE,&ack);
+		CHECK_STATUS(status);
+		}
+		else
+		{
+			ack = 0;
+		}
+
+		if (!ack) /* check acknowledgement of device address write */
+		{
+			for (i = 0; (i < sizeToTransfer) && (status == FT_OK); i++)
+			{
+				/* Read byte to buffer & give ACK (or nACK if it is last byte and
+				I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE is set)*/
+				status = I2C_Read8bitsAndGiveAck(handle, &(buffer[i]),
+					(i<(sizeToTransfer-1))?TRUE:
+				((options & I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE)?FALSE:TRUE));
+			}
+
+			*sizeTransferred = i;
+			if (*sizeTransferred != sizeToTransfer)
+			{
+				DBG(MSG_ERR," sizeToTransfer=%u sizeTransferred=%u\n",
+					(unsigned)sizeToTransfer, (unsigned)*sizeTransferred);
+				status = FT_IO_ERROR;
+			}
+			else
+			{
+				/* Write STOP bit */
+				if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+				{
+					status = I2C_Stop(handle);
+					CHECK_STATUS(status);
+				}
+			}
+		}
+		else
+		{
+			DBG(MSG_ERR,"I2C device with address 0x%x didn't ack when addressed\n",
+				(unsigned)deviceAddress);
+			/* Write STOP bit */
+			if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+			{
+				status = I2C_Stop(handle);
+				CHECK_STATUS(status);
+			}
+			/*20111102 : FT_IO_ERROR was returned when a device doesn't respond to the
+	 		master when it is addressed, as well as when a data transfer fails. To distinguish
+	 		between these to errors, FT_DEVICE_NOT_FOUND is now returned after a device
+	 		doesn't respond when its addressed*/
+			/* old code: status = FT_IO_ERROR; */
+			status = FT_DEVICE_NOT_FOUND;
+		}
+	}
+	UNLOCK_CHANNEL(handle);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_DeviceWrite(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, LPDWORD sizeTransferred, DWORD options)
+{
+	FT_STATUS status = FT_OK;
+	bool ack = FALSE;
+	uint32 i;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(buffer);
+	CHECK_NULL_RET(sizeTransferred);
+	if ((deviceAddress > 127) && (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS)))
+	{
+		DBG(MSG_WARN,"deviceAddress(0x%x) is greater than 127\n", 
+			(unsigned)deviceAddress);
+	}
+#endif // ENABLE_PARAMETER_CHECKING
+	DBG(MSG_DEBUG,"handle = 0x%x deviceAddress = 0x%x sizeToTransfer=%u options= 0x%x\n",
+		(unsigned)handle, (unsigned)deviceAddress, 
+		(unsigned)sizeToTransfer, (unsigned)options);
+
+	LOCK_CHANNEL(handle);
+	Mid_PurgeDevice(handle);
+
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER)
+	{
+		status = I2C_FastWrite(handle, deviceAddress, sizeToTransfer, buffer,
+			NULL, sizeTransferred, options);
+	}
+	else
+	{
+		/* Write START bit */
+		if (options & I2C_TRANSFER_OPTIONS_START_BIT)
+		{
+			status = I2C_Start(handle);
+			CHECK_STATUS(status);
+		}
+
+		if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+		{
+		/* Write device address (with LSB = 0 => Write) & Get ACK*/
+		status = I2C_WriteDeviceAddress(handle, deviceAddress, FALSE, FALSE,&ack);
+		CHECK_STATUS(status);
+		}
+		else
+		{
+			ack = 0;
+		}
+
+		if (!ack)/*ack bit set actually means device nAcked*/
+		{
+			/* LOOP until sizeToTransfer */
+			for (i = 0; ((i < sizeToTransfer) && (status == FT_OK)); i++)
+			{
+				/* Write byte to buffer & Get ACK */
+				ack = 0;
+				status = I2C_Write8bitsAndGetAck(handle, buffer[i],&ack);
+				DBG(MSG_DEBUG,"handle = 0x%x buffer[%u] = 0x%x ack = 0x%x \n", 
+					(unsigned)handle, (unsigned)i, (unsigned)buffer[i],
+					(unsigned)(1&ack));
+				if (ack)
+				{
+					DBG(MSG_WARN,"I2C device(address 0x%x) nAcked while writing	byte no %d(i.e. 0x%x\n",
+						(unsigned)deviceAddress, (int)i, (unsigned)buffer[i]);
+					/* add bit in options to return with error if device nAcked
+					sizeTransferred = number of correctly transfered bytes */
+					if (options & I2C_TRANSFER_OPTIONS_BREAK_ON_NACK)
+					{
+						/*status = FT_FAILED_TO_WRITE_DEVICE;
+						break;*/
+						DBG(MSG_WARN,"returning FT_FAILED_TO_WRITE_DEVICE options = 0x%x ack = 0x%x\n", 
+							options, ack);
+						
+						/* Write STOP bit */
+						if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+						{
+							status = I2C_Stop(handle);
+							CHECK_STATUS(status);
+						}
+						return FT_FAILED_TO_WRITE_DEVICE;
+					}
+				}
+			}
+			*sizeTransferred = i;
+			if (*sizeTransferred != sizeToTransfer)
+			{
+				DBG(MSG_ERR," sizeToTransfer=%u sizeTransferred=%u\n",
+					(unsigned)sizeToTransfer, (unsigned)*sizeTransferred);
+				status = FT_IO_ERROR;
+			}
+			else
+			{
+				/* Write STOP bit */
+				if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+				{
+					status = I2C_Stop(handle);
+					CHECK_STATUS(status);
+				}
+			}
+		}
+		else
+		{
+			DBG(MSG_ERR,"I2C device with address 0x%x didn't ack when addressed\n",
+				(unsigned)deviceAddress);
+
+			/* Write STOP bit */
+			if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+			{
+				status = I2C_Stop(handle);
+				CHECK_STATUS(status);
+			}
+			/*20111102 : libMPSSE v0.2 returned FT_IO_ERROR both when a device doesn't
+			respond to the master when it is addressed, and when a data transfer fails. To
+			distinguish between these to errors, FT_DEVICE_NOT_FOUND is now returned after
+			a device doesn't respond when its addressed*/
+			status = FT_DEVICE_NOT_FOUND;
+			/* old code: status = FT_IO_ERROR; */
+		}
+	}
+	UNLOCK_CHANNEL(handle);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS I2C_GetDeviceID(FT_HANDLE handle, uint8 deviceAddress,
+	uint8* deviceID)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+	bool ack;
+	FN_ENTER;
+
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(deviceID);
+	
+	if (deviceAddress > 127)
+	{
+		DBG(MSG_WARN,"deviceAddress(0x%x) is greater than 127\n", 
+			(unsigned)deviceAddress);
+		status = FT_INVALID_PARAMETER;
+		return status;
+	}
+#endif // ENABLE_PARAMETER_CHECKING
+
+	status = I2C_Start(handle);
+	CHECK_STATUS(status);
+	status = I2C_Write8bitsAndGetAck(handle,(uint8)I2C_CMD_GETDEVICEID_RD,&ack);
+	CHECK_STATUS(status);
+	status = I2C_Write8bitsAndGetAck(handle, deviceAddress, &ack);
+	CHECK_STATUS(status);
+	status = I2C_Restart(handle);
+	CHECK_STATUS(status);
+	status = I2C_Write8bitsAndGetAck(handle,(uint8)I2C_CMD_GETDEVICEID_WR,&ack);
+	CHECK_STATUS(status);
+	status = I2C_Read8bitsAndGiveAck(handle,&(deviceID[0]),I2C_GIVE_ACK);
+	CHECK_STATUS(status);
+	status = I2C_Read8bitsAndGiveAck(handle,&(deviceID[1]),I2C_GIVE_ACK);
+	CHECK_STATUS(status);
+	/*NACK 3rd byte*/
+	status = I2C_Read8bitsAndGiveAck(handle,&(deviceID[2]),I2C_GIVE_NACK);
+	CHECK_STATUS(status);
+	FN_EXIT;
+
+#else // I2C_CMD_GETDEVICEID_SUPPORTED
+	
+	FN_ENTER;
+	status = FT_NOT_SUPPORTED;
+	FN_EXIT;
+
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+	return status;
+}
+
+/******************************************************************************/
+/*						Local function definitions						  */
+/******************************************************************************/
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+static FT_STATUS I2C_Restart(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	uint8 buffer[3];
+	uint32 noOfBytesToTransfer;
+	DWORD noOfBytesTransferred;
+	I2C_Modes mode;
+
+	FN_ENTER;
+
+#if 0 /* Not necessary */
+	status = I2C_GetChannelConfig(handle, config);
+	CHECK_STATUS(status);
+	CHECK_NULL_RET(config);
+	switch(config->ClockRate)
+	{
+		case I2C_CLOCK_STANDARD_MODE:
+			mode = I2C_STANDARD_MODE;
+		break;
+
+		case I2C_CLOCK_FAST_MODE:
+			mode = I2C_FAST_MODE;
+		break;
+
+		case I2C_CLOCK_FAST_MODE_PLUS:
+			mode = I2C_FAST_MODE_PLUS;
+		break;
+
+		case I2C_CLOCK_HIGH_SPEED_MODE:
+			mode = I2C_HIGH_SPEED_MODE;
+		break;
+
+		default:
+			mode = I2C_MAXIMUM_SUPPORTED_MODES;
+	}
+#else
+	mode = I2C_STANDARD_MODE;
+#endif
+
+	/*Restart condition SDA, SCL: 0, 1->1, 1->1, 0->1, 1->0, 1*/
+
+	/*I2C_CONDITION_RESTART_1*/
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLHIGH_SDALOW; /* Value */
+	buffer[2] = DIRECTION_SCLOUT_SDAOUT; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_PRESTART]);
+
+	/*I2C_CONDITION_RESTART_2*/
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLHIGH_SDAHIGH; /* Value */
+	buffer[2] = DIRECTION_SCLOUT_SDAOUT; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_PRESTART]);
+
+	/*I2C_CONDITION_RESTART_3*/
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLLOW_SDAHIGH; /* Value */
+	buffer[2] = DIRECTION_SCLOUT_SDAOUT; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_PRESTART]);
+
+	/*I2C_CONDITION_RESTART_4*/
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLHIGH_SDAHIGH; /* Value */
+	buffer[2] = DIRECTION_SCLOUT_SDAOUT; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_PRESTART]);
+
+	/*I2C_CONDITION_RESTART_5*/
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLLOW_SDAHIGH; /* Value */
+	buffer[2] = DIRECTION_SCLOUT_SDAOUT; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_PRESTART]);
+
+	/*I2C_CONDITION_RESTART -tristate SCL & SDA */
+	noOfBytesToTransfer = 3;
+	noOfBytesTransferred = 0;
+	buffer[0] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[1] = VALUE_SCLLOW_SDALOW; /* Value(0x00 = SCL low, SDA low) */
+	buffer[2] = DIRECTION_SCLIN_SDAIN; /* Direction */
+	status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+		buffer,&noOfBytesTransferred);
+	if ( (FT_OK != status) && (noOfBytesToTransfer != noOfBytesTransferred) )
+	{
+		Infra_DbgPrintStatus(status);
+		DBG(MSG_ERR,"noOfBytesToTransfer=%d noOfBytesTransferred=%d\n",
+			(int)noOfBytesToTransfer,(int)noOfBytesTransferred);
+	}
+	Infra_Delay(I2C_Timings[mode][I2C_CONDITION_POSTSTOP]);
+
+	FN_EXIT;
+	return status;
+}
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+static FT_STATUS I2C_Write8bitsAndGetAck(FT_HANDLE handle, uint8 data, bool *ack)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	uint8 buffer[20]={0};
+	uint8 inBuffer[3]={0};
+	uint32 noOfBytes = 0;
+	DWORD noOfBytesTransferred;
+
+	FN_ENTER;
+
+	/*set direction*/
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[noOfBytes++] = VALUE_SCLLOW_SDAHIGH; /*Value*/
+	buffer[noOfBytes++] = DIRECTION_SCLOUT_SDAOUT; /*Direction*/
+
+	/* Command to write 8bits */
+	buffer[noOfBytes++]= MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;/* MPSSE command */
+	buffer[noOfBytes++]= DATA_SIZE_8BITS;
+	buffer[noOfBytes++] = data;
+
+	/* Set SDA to input mode before reading ACK bit */
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[noOfBytes++] = VALUE_SCLLOW_SDALOW; /*Value*/
+	buffer[noOfBytes++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+	/* Command to get ACK bit */
+	buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;/* MPSSE command */
+	buffer[noOfBytes++] = DATA_SIZE_1BIT; /*Read only one bit */
+
+	/*Command MPSSE to send data to PC immediately */
+	buffer[noOfBytes++] = MPSSE_CMD_SEND_IMMEDIATE;
+	status = FT_Channel_Write(I2C, handle, noOfBytes, buffer,
+		&noOfBytesTransferred);
+	DBG(MSG_DEBUG, "FT_Channel_Write returned: noOfBytes=%u, noOfBytesTransferred=%u \n", 
+		(unsigned)noOfBytes, (unsigned)noOfBytesTransferred);
+	if (FT_OK != status)
+	{
+		DBG(MSG_DEBUG, "FT_OK != status \n");
+		Infra_DbgPrintStatus(status);
+	}
+	else if (noOfBytes != noOfBytesTransferred)
+	{
+		DBG(MSG_ERR, "Requested to send %u bytes, no. of bytes sent is %u bytes",
+			(unsigned)noOfBytes, (unsigned)noOfBytesTransferred);
+		status = FT_IO_ERROR;
+	}
+	else
+	{/*Get ack*/
+		noOfBytes = 1;
+		noOfBytesTransferred = 0;
+		INFRA_SLEEP(1);
+		status = FT_Channel_Read(I2C, handle, noOfBytes, inBuffer, 
+			&noOfBytesTransferred);
+		DBG(MSG_DEBUG, "FT_Channel_Read returned: noOfBytes=%u, noOfBytesTransferred=%u\n",
+			(unsigned)noOfBytes, (unsigned)noOfBytesTransferred);
+		if (FT_OK != status)
+			Infra_DbgPrintStatus(status);
+		else if (noOfBytes != noOfBytesTransferred)
+		{
+			DBG(MSG_ERR, "Requested to send %u bytes, no. of bytes sent is %u bytes",
+				(unsigned)noOfBytes,(unsigned)noOfBytesTransferred);
+			status = FT_IO_ERROR;
+		}
+		else
+		{
+			*ack = (bool)(inBuffer[0] & 0x01);
+			DBG(MSG_DEBUG,"success ACK= 0x%x; noOfBytes=%d noOfBytesTransferred=%d\n",
+				(unsigned)*ack, (unsigned)noOfBytes, (unsigned)noOfBytesTransferred);
+		}
+	}
+	
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_Read8bitsAndGiveAck(FT_HANDLE handle, uint8 *data, bool ack)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	uint8 buffer[20], inBuffer[5];
+	uint32 noOfBytes = 0;
+	DWORD noOfBytesTransferred;
+
+	FN_ENTER;
+	
+	/*set direction*/
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[noOfBytes++] = VALUE_SCLLOW_SDALOW; /*Value*/
+	buffer[noOfBytes++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+	/*Command to read 8 bits*/
+	buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;
+	buffer[noOfBytes++] = DATA_SIZE_8BITS;/*0x00 = 1bit; 0x07 = 8bits*/
+
+	/*Command MPSSE to send data to PC immediately */
+	buffer[noOfBytes++] = MPSSE_CMD_SEND_IMMEDIATE;
+
+	/* Fix introduced to solve a glitch issue */
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;  
+	buffer[noOfBytes++] = VALUE_SCLLOW_SDALOW ; 
+	buffer[noOfBytes++] = DIRECTION_SCLOUT_SDAIN;                                                                                                      
+	
+	/* Burn off one I2C bit time */
+	buffer[noOfBytes++] = MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;
+	buffer[noOfBytes++] = 0; /*0x00 = 1bit; 0x07 = 8bits*/  
+        buffer[noOfBytes++] = ack ? SEND_ACK : SEND_NACK;/*Only MSB is sent*/
+
+	status = FT_Channel_Write(I2C, handle, noOfBytes, buffer, &noOfBytesTransferred);
+	if (FT_OK != status)
+		Infra_DbgPrintStatus(status);
+	else if (noOfBytes != noOfBytesTransferred)
+	{
+		DBG(MSG_ERR, "Requested to send %u bytes, no. of bytes sent is %u bytes",
+			(unsigned)noOfBytes, (unsigned)noOfBytesTransferred);
+		status = FT_IO_ERROR;
+	}
+	else
+	{
+		noOfBytes = 1;
+		status = FT_Channel_Read(I2C, handle, noOfBytes, inBuffer, &noOfBytesTransferred);
+		if (FT_OK != status)
+		{
+			Infra_DbgPrintStatus(status);
+		}
+		else if (noOfBytes != noOfBytesTransferred)
+		{
+			DBG(MSG_ERR, "Requested to read %u bytes, no. of bytes read is %u bytes",
+				(unsigned)noOfBytes,(unsigned)noOfBytesTransferred);
+			status = FT_IO_ERROR;
+		}
+		else
+		{
+			*data = inBuffer[0];
+			DBG(MSG_DEBUG,"	*data = 0x%x\n", (unsigned)*data);
+		}
+	}
+
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_FastWrite(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, UCHAR *ack, LPDWORD sizeTransferred,
+	uint32 options)
+{
+	FT_STATUS status = FT_OK;
+	uint32 i = 0; /* index of cmdBuffer that is filled */
+	uint32 j = 0; /* scratch register */
+	uint32 sizeTotal;
+	uint32 sizeOverhead;
+	uint8* outBuffer;
+	uint8* inBuffer;
+	uint8  bitsInThisTransfer;
+	DWORD bytesRead;
+	uint32 bytesToTransfer;
+	uint8 tempAddress;
+	uint32 bitsToTransfer;
+	uint32 bitsToRead = 0;
+
+	FN_ENTER;
+
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS)
+	{/* size is in bits */
+		bitsToTransfer = sizeToTransfer;
+	}
+	else
+	{/* size is in bytes */
+	    bitsToTransfer = sizeToTransfer * 8;
+	}
+	bytesToTransfer = (bitsToTransfer > 0)?(((bitsToTransfer/8)==0)?1:((bitsToTransfer/8)+1)):(0);
+
+	/* Calculate size of required buffer */
+	sizeTotal = (bytesToTransfer*(6
+#ifdef FASTWRITE_READ_ACK
+	+5
+#endif
+	)) /*the size of data itself */
+	+ ((!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))?(11):(0))/*for address byte*/
+		+ ((options & I2C_TRANSFER_OPTIONS_START_BIT)?((START_DURATION_1 +	
+			START_DURATION_2+1)*3):0) /* size required for START */
+		+ ((options & I2C_TRANSFER_OPTIONS_STOP_BIT)?((STOP_DURATION_1 +		
+			STOP_DURATION_2+STOP_DURATION_3+1)*3):0); /* size for STOP */
+
+	sizeOverhead = sizeTotal - bytesToTransfer;
+	(void)sizeOverhead; /* NB Not used */
+	
+	/* Allocate buffers */
+	outBuffer = (uint8*) INFRA_MALLOC(sizeTotal);
+	if (NULL == outBuffer)
+	{
+		return FT_INSUFFICIENT_RESOURCES;
+	}
+
+	/* Write START bit */
+	if (options & I2C_TRANSFER_OPTIONS_START_BIT)
+	{
+		DBG(MSG_DEBUG,"adding START condition\n");
+		/* SCL high, SDA high */
+		for (j = 0; j < START_DURATION_1; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA low */
+		for (j = 0; j < START_DURATION_2; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/*SCL low, SDA low */
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		outBuffer[i++] = VALUE_SCLLOW_SDALOW;
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+
+	if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+	{
+		tempAddress = (uint8)deviceAddress;
+		tempAddress = (tempAddress << 1);
+		tempAddress = (tempAddress & I2C_ADDRESS_WRITE_MASK);
+		DBG(MSG_DEBUG,"7bit I2C address plus direction bit = 0x%x\n", tempAddress);
+
+		/*set direction*/
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDAHIGH; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT; /*Direction*/
+
+		/* write address + direction bit */
+		outBuffer[i++]= MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;/* MPSSE command */
+		outBuffer[i++]= DATA_SIZE_8BITS;
+		outBuffer[i++] = tempAddress;
+
+#ifdef FASTWRITE_READ_ACK
+		/* Set SDA to input mode before reading ACK bit */
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDALOW; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+		/* Command to get ACK bit */
+		outBuffer[i++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;/* MPSSE command */
+		outBuffer[i++] = DATA_SIZE_1BIT; /* Read only one bit */
+		bitsToRead++;
+#endif
+	}
+
+	/* add commands & data to buffer */
+	j = 0;
+	while(j < bitsToTransfer)
+	{
+		bitsInThisTransfer = ((bitsToTransfer-j)>8)?8:(bitsToTransfer-j);
+		/*set direction*/
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDAHIGH; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT; /*Direction*/
+
+		/* Command to write 8bits */
+		bitsInThisTransfer = ((bitsToTransfer-j)>8)?8:(bitsToTransfer-j);
+		outBuffer[i++]= MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;/* MPSSE command */
+		outBuffer[i++]= bitsInThisTransfer - 1;
+		outBuffer[i++] = buffer[j/8];
+
+#ifdef FASTWRITE_READ_ACK
+		/* Read 1bit ack after each 8bits written - only in byte mode */
+		if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES)
+		{
+			/* Set SDA to input mode before reading ACK bit */
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+			outBuffer[i++] = VALUE_SCLLOW_SDALOW; /*Value*/
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+			/* Command to get ACK bit */
+			outBuffer[i++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;/* MPSSE command */
+			outBuffer[i++] = DATA_SIZE_1BIT; /* Read only one bit */
+			bitsToRead++;
+		}
+#endif
+		j+= bitsInThisTransfer;
+		DBG(MSG_DEBUG,"i=%u bitsToTransfer=%u bitsInThisTransfer=%u\n",
+			(unsigned)i,(unsigned)bitsToTransfer,(unsigned)bitsInThisTransfer);
+	}
+
+	/* Write STOP bit */
+	if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+	{
+		/* SCL low, SDA low */
+		for (j = 0; j < STOP_DURATION_1; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLLOW_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA low */
+		for (j = 0; j < STOP_DURATION_2; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA high */
+		for (j = 0; j < STOP_DURATION_3; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+		outBuffer[i++] = DIRECTION_SCLIN_SDAIN; /* Tristate the SCL & SDA pins */
+	}
+
+	/* write buffer */
+	DBG(MSG_DEBUG,"i=%u bitsToTransfer=%u bitsInThisTransfer=%u\n", (unsigned)i,
+	(unsigned)bitsToTransfer,(unsigned)bitsInThisTransfer);
+	status = FT_Channel_Write(I2C, handle, i,outBuffer,&bytesRead);
+	*sizeTransferred = sizeToTransfer;
+	CHECK_STATUS(status);
+
+#ifdef FASTWRITE_READ_ACK
+	/* Read ack of address */
+	if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+	{
+		uint8 addAck;
+		status = FT_Channel_Read(I2C, handle, 1, &addAck, &bytesRead);
+		DBG(MSG_DEBUG,"addAck = %u bitsToRead=%u bytesToRead=%u\n", (unsigned)(addAck & 1),
+			(unsigned)bitsToRead, (unsigned)bitsToRead / 8);
+	}
+
+	/* if byte mode: read 1bit ack after each 8bits written */
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES)
+	{
+		inBuffer = INFRA_MALLOC(bytesToTransfer);
+		if (NULL != inBuffer)
+		{
+			status = FT_Channel_Read(I2C, handle, sizeToTransfer, inBuffer, 
+				&bytesRead);
+			CHECK_STATUS(status);
+			if (ack)
+			{/* Copy the ack bits into the ack buffer if provided */
+				INFRA_MEMCPY(ack, inBuffer, bytesRead);
+			}
+			INFRA_FREE(inBuffer);
+		}
+	}
+#endif
+	INFRA_FREE(outBuffer);
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_FastRead(FT_HANDLE handle, UCHAR deviceAddress,
+	DWORD sizeToTransfer, UCHAR *buffer, UCHAR *ack, DWORD *sizeTransferred,
+	uint32 options)
+{
+	FT_STATUS status = FT_OK;
+	uint32 i = 0; /* index of cmdBuffer that is filled */
+	uint32 j = 0; /* scratch register */
+	uint32 sizeTotal;
+	uint32 sizeOverhead;
+	uint8* outBuffer;
+	uint8  bitsInThisTransfer;
+	DWORD bytesRead;
+	uint8  addressAck;
+	uint32 bytesToTransfer;
+	uint8 tempAddress;
+	uint32 bitsToTransfer;
+
+	FN_ENTER;
+
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BITS)
+	{/* size is in bits */
+		bitsToTransfer = sizeToTransfer;
+	}
+	else
+	{/* size is in bytes */
+	    bitsToTransfer = sizeToTransfer * 8;
+	}
+	bytesToTransfer = (bitsToTransfer > 0) ? (((bitsToTransfer/8)==0)?1:(bitsToTransfer/8)): (0);
+
+	/* Calculate size of required buffer */
+	sizeTotal = (bytesToTransfer*12) /* the size of data itself */
+	+ ((!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))?(11):(0))/* for address byte*/
+	+ ((options & I2C_TRANSFER_OPTIONS_START_BIT)?((START_DURATION_1 +	
+			START_DURATION_2+1)*3):0) /* size required for START */
+	+ ((options & I2C_TRANSFER_OPTIONS_STOP_BIT)?((STOP_DURATION_1 +		
+			STOP_DURATION_2+STOP_DURATION_3+1)*3):0); /* size for STOP */
+
+	sizeOverhead = sizeTotal - bytesToTransfer;
+	(void)sizeOverhead; /* NB Not used */
+	
+	/* Allocate buffers */
+	outBuffer = (uint8*) INFRA_MALLOC(sizeTotal);
+	if (NULL == outBuffer)
+	{
+		return FT_INSUFFICIENT_RESOURCES;
+	}
+
+	/* Write START bit */
+	if (options & I2C_TRANSFER_OPTIONS_START_BIT)
+	{
+		/* SCL high, SDA high */
+		for (j = 0; j < START_DURATION_1; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA low */
+		for (j = 0; j < START_DURATION_2; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/*SCL low, SDA low */
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		outBuffer[i++] = VALUE_SCLLOW_SDALOW;
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+
+	if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+	{
+		tempAddress = (uint8)deviceAddress;
+		tempAddress = (tempAddress << 1);
+		tempAddress = (tempAddress | I2C_ADDRESS_READ_MASK);
+		DBG(MSG_DEBUG,"7bit I2C address plus direction bit = 0x%x\n", tempAddress);
+
+		/*set direction*/
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDAHIGH; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT; /*Direction*/
+
+		/* write address + direction bit */
+		outBuffer[i++]= MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;/* MPSSE command */
+		outBuffer[i++]= DATA_SIZE_8BITS;
+		outBuffer[i++] = tempAddress;
+
+#ifdef FASTWRITE_READ_ACK
+		/* Set SDA to input mode before reading ACK bit */
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDALOW; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+		/* Command to get ACK bit */
+		outBuffer[i++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;/* MPSSE command */
+		outBuffer[i++] = DATA_SIZE_1BIT; /* Read only one bit */
+#endif
+	}
+
+	/* add commands & data to buffer */
+	j = 0;
+	while(j < bitsToTransfer)
+	{
+		bitsInThisTransfer = ((bitsToTransfer-j)>8)?8:(bitsToTransfer-j);
+
+		/*set direction*/
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+		outBuffer[i++] = VALUE_SCLLOW_SDALOW; /*Value*/
+		outBuffer[i++] = DIRECTION_SCLOUT_SDAIN; /*Direction*/
+
+		/*Command to read 8 bits*/
+		outBuffer[i++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE;
+		outBuffer[i++] = bitsInThisTransfer - 1;
+
+		/*Command MPSSE to send data to PC immediately */
+		/*buffer[i++] = MPSSE_CMD_SEND_IMMEDIATE;*/
+
+		/* Write 1bit ack after each 8bits read - only in byte mode */
+		if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLLOW_SDALOW ;  
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAIN;
+
+        // Burn off one I2C bit time
+       outBuffer[i++] = MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE;                                                                      //
+			outBuffer[i++] = 0; /*0x00 = 1bit; 0x07 = 8bits*/ 
+        outBuffer[i++] = (j<(bitsToTransfer-1))?(SEND_ACK):	\
+			((options & I2C_TRANSFER_OPTIONS_NACK_LAST_BYTE)?SEND_NACK:SEND_ACK);
+		}
+		j+= bitsInThisTransfer;
+	}
+	*sizeTransferred = j;
+
+	/* Write STOP bit */
+	if (options & I2C_TRANSFER_OPTIONS_STOP_BIT)
+	{
+		/* SCL low, SDA low */
+		for (j = 0; j < STOP_DURATION_1; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLLOW_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA low */
+		for (j = 0; j < STOP_DURATION_2; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDALOW;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		/* SCL high, SDA high */
+		for (j = 0; j < STOP_DURATION_3; j++)
+		{
+			outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+			outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+			outBuffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+		}
+		outBuffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		outBuffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+		outBuffer[i++] = DIRECTION_SCLIN_SDAIN; /* Tristate the SCL & SDA pins */
+	}
+
+	/* write buffer */
+	DBG(MSG_DEBUG,"i=%u bitsToTransfer=%u bitsInThisTransfer=%u\n",
+		(unsigned)i, (unsigned)bitsToTransfer, (unsigned)bitsInThisTransfer);
+	status = FT_Channel_Write(I2C, handle, i,outBuffer,&bytesRead);
+	CHECK_STATUS(status);
+
+	/*read the address ack bit */
+	if (!(options & I2C_TRANSFER_OPTIONS_NO_ADDRESS))
+	{
+		status = FT_Channel_Read(I2C, handle, 1, &addressAck, &bytesRead);
+		CHECK_STATUS(status);
+	}
+
+	/* read the actual data from the MPSSE-chip into the host system */
+	if (options & I2C_TRANSFER_OPTIONS_FAST_TRANSFER_BYTES)
+		status = FT_Channel_Read(I2C, handle, bytesToTransfer, buffer, &bytesRead);
+	else
+		status = FT_Channel_Read(I2C, handle, bytesToTransfer+1, buffer, &bytesRead);
+	CHECK_STATUS(status);
+
+	INFRA_FREE(outBuffer);
+	
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_WriteDeviceAddress(FT_HANDLE handle, UCHAR deviceAddress,
+			bool direction, bool AddLen10Bit, bool *ack)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	uint8 tempAddress;
+	
+	FN_ENTER;
+	
+	if (!AddLen10Bit)
+	{/* 7bit addressing */
+		tempAddress = (uint8)deviceAddress;
+		DBG(MSG_DEBUG,"7bit I2C address = 0x%x\n", tempAddress);
+		tempAddress = (tempAddress << 1);
+		if (direction)
+			tempAddress = (tempAddress | I2C_ADDRESS_READ_MASK);
+		else
+			tempAddress = (tempAddress & I2C_ADDRESS_WRITE_MASK);
+		DBG(MSG_DEBUG,"7bit I2C address plus direction bit = 0x%x\n", tempAddress);
+		status = I2C_Write8bitsAndGetAck(handle, tempAddress, ack);
+		if (FT_OK != status)
+			Infra_DbgPrintStatus(status);
+		if ((*ack))
+		{
+			DBG(MSG_ERR,"Didn't receieve an ACK from the addressed device\n");
+		}
+	}
+	else
+	{/* 10bit addressing */
+		/* TODO: Add support for 10bit addressing */
+		DBG(MSG_ERR, "10 bit addressing yet to be supported\n");
+		status = FT_NOT_SUPPORTED;
+	}
+	
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_SaveChannelConfig(FT_HANDLE handle, ChannelConfig *config)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	FN_ENTER;
+
+	status = FT_OK;
+	FN_EXIT;
+	return status;
+}
+
+#ifdef I2C_CMD_GETDEVICEID_SUPPORTED
+static FT_STATUS I2C_GetChannelConfig(FT_HANDLE handle, ChannelConfig *config)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	
+	FN_ENTER;
+
+	status = FT_OK;
+	
+	FN_EXIT;
+	return status;
+}
+#endif // I2C_CMD_GETDEVICEID_SUPPORTED
+
+static FT_STATUS I2C_Start(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	uint8 buffer[(START_DURATION_1+START_DURATION_2+1)*3];
+	uint32 i = 0, j = 0;
+	DWORD noOfBytesTransferred;
+	
+	FN_ENTER;
+
+	/* SCL high, SDA high */
+	for (j = 0; j < START_DURATION_1; j++)
+	{
+		buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		buffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+		buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+	/* SCL high, SDA low */
+	for (j = 0; j < START_DURATION_2; j++)
+	{
+		buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		buffer[i++] = VALUE_SCLHIGH_SDALOW;
+		buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+	/*SCL low, SDA low */
+	buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+	buffer[i++] = VALUE_SCLLOW_SDALOW;
+	buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+
+	status = FT_Channel_Write(I2C, handle, i,buffer,&noOfBytesTransferred);
+
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS I2C_Stop(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	uint8 buffer[(STOP_DURATION_1+STOP_DURATION_2+STOP_DURATION_3+1)*3];
+	uint32 i = 0, j = 0;
+	DWORD noOfBytesTransferred;
+
+	FN_ENTER;
+	
+	/* SCL low, SDA low */
+	for (j = 0; j < STOP_DURATION_1; j++)
+	{
+		buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		buffer[i++] = VALUE_SCLLOW_SDALOW;
+		buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+	/* SCL high, SDA low */
+	for (j = 0; j < STOP_DURATION_2; j++)
+	{
+		buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		buffer[i++] = VALUE_SCLHIGH_SDALOW;
+		buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+	/* SCL high, SDA high */
+	for (j = 0; j < STOP_DURATION_3; j++)
+	{
+		buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+		buffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+		buffer[i++] = DIRECTION_SCLOUT_SDAOUT;
+	}
+	buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+	buffer[i++] = VALUE_SCLHIGH_SDAHIGH;
+	buffer[i++] = DIRECTION_SCLIN_SDAIN; /* Tristate the SCL & SDA pins */
+
+	status = FT_Channel_Write(I2C, handle, i,buffer,&noOfBytesTransferred);
+
+	FN_EXIT;
+	return status;
+}
+
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_infra.c
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_infra.c
@@ -1,0 +1,513 @@
+/*!
+ * \file infra.c
+ *
+ * \author FTDI
+ * \date 20110317
+ *
+ * Copyright � 2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: Infra
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - exported Init_libMPSSE & Cleanup_libMPSSE for Microsoft toolchain support
+ * 0.3 - 20111103 - commented & cleaned up
+ */
+
+/******************************************************************************/
+/*								Include files					  			  */
+/******************************************************************************/
+#define FTDI_EXPORTS
+#include "ftdi_infra.h"		/*portable infrastructure(datatypes, libraries, etc)*/
+
+
+/******************************************************************************/
+/*								Macro defines					  			  */
+/******************************************************************************/
+
+#ifndef _WIN32
+	#define GET_FUNC(libHandle, symbol)	dlsym(libHandle, symbol)
+	/* Macro to check if dlsym returned correctly */
+	#define CHECK_SYMBOL(exp) {if (!exp)\
+		fprintf(stderr, "dlsym failed: %s\n", dlerror());};
+#else // _WIN32
+	#define GET_FUNC(libHandle, symbol) GetProcAddress(libHandle, symbol)
+	#define CHECK_SYMBOL(exp) {if (GetLastError())\
+		fprintf(stderr, "GetProcAddress failed: 0x%lx\n", GetLastError());};
+#endif // _WIN32
+
+/******************************************************************************/
+/*								Global variables							  */
+/******************************************************************************/
+
+#ifdef INFRA_DEBUG_ENABLE
+	int currentDebugLevel = MSG_INFO;
+	//int currentDebugLevel = MSG_DEBUG;
+#endif
+
+/* Handle to D2XX driver */
+#ifdef _WIN32
+	HANDLE hdll_d2xx;
+#else // _WIN32
+	void *hdll_d2xx;
+#endif // _WIN32
+
+InfraFunctionPtrLst varFunctionPtrLst;
+
+/******************************************************************************/
+/*								Local function declarations					  */
+/******************************************************************************/
+#if 0
+#ifndef _WIN32
+void __attribute__ ((constructor))my_init(void);/*called when lib is loaded*/
+void __attribute__ ((destructor))my_exit(void);/*called when lib is unloaded*/
+#endif // _WIN32
+#endif
+
+/******************************************************************************/
+/*						Global function definitions						  */
+/******************************************************************************/
+
+/*!
+ * \brief Print function return status
+ *
+ * All the functions return a status code. This function prints a text to the debug terminal
+ * that provides the meaning of the status code.
+ *
+ * \param[in] status Status code returned by functions
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Infra_DbgPrintStatus(FT_STATUS status)
+{
+	FN_ENTER;
+
+	switch(status)
+	{
+		case FT_OK:
+			DBG(MSG_ERR, "Status: FT_OK\n");
+		break;
+
+		case FT_INVALID_HANDLE:
+			DBG(MSG_ERR, "Status: FT_INVALID_HANDLE\n");
+		break;
+
+		case FT_DEVICE_NOT_FOUND:
+			DBG(MSG_ERR, "Status: FT_DEVICE_NOT_FOUND\n");
+		break;
+
+		case FT_DEVICE_NOT_OPENED:
+			DBG(MSG_ERR, "Status: FT_DEVICE_NOT_OPENED\n");
+		break;
+
+		case FT_IO_ERROR:
+			DBG(MSG_ERR, "Status: FT_IO_ERROR\n");
+		break;
+
+		case FT_INSUFFICIENT_RESOURCES:
+			DBG(MSG_ERR, "Status: FT_INSUFFICIENT_RESOURCES\n");
+		break;
+
+		case FT_INVALID_PARAMETER:
+			DBG(MSG_ERR, "Status: FT_INVALID_PARAMETER\n");
+		break;
+
+		case FT_INVALID_BAUD_RATE:
+			DBG(MSG_ERR, "Status: FT_INVALID_BAUD_RATE\n");
+		break;
+
+		case FT_DEVICE_NOT_OPENED_FOR_ERASE:
+			DBG(MSG_ERR, "Status: FT_DEVICE_NOT_OPENED_FOR_ERASE\n");
+		break;
+
+		case FT_DEVICE_NOT_OPENED_FOR_WRITE:
+			DBG(MSG_ERR, "Status: FT_DEVICE_NOT_OPENED_FOR_WRITE\n");
+		break;
+
+		case FT_FAILED_TO_WRITE_DEVICE:
+			DBG(MSG_ERR, "Status: FT_FAILED_TO_WRITE_DEVICE\n");
+		break;
+
+		case FT_EEPROM_READ_FAILED:
+			DBG(MSG_ERR, "Status: FT_EEPROM_READ_FAILED\n");
+		break;
+
+		case FT_EEPROM_WRITE_FAILED:
+			DBG(MSG_ERR, "Status: FT_EEPROM_WRITE_FAILED\n");
+		break;
+
+		case FT_EEPROM_ERASE_FAILED:
+			DBG(MSG_ERR, "Status: FT_EEPROM_ERASE_FAILED\n");
+		break;
+
+		case FT_EEPROM_NOT_PRESENT:
+			DBG(MSG_ERR, "Status: FT_EEPROM_NOT_PRESENT\n");
+		break;
+
+		case FT_EEPROM_NOT_PROGRAMMED:
+			DBG(MSG_ERR, "Status: FT_EEPROM_NOT_PROGRAMMED\n");
+		break;
+
+		case FT_INVALID_ARGS:
+			DBG(MSG_ERR, "Status: FT_INVALID_ARGS\n");
+		break;
+
+		case FT_NOT_SUPPORTED:
+			DBG(MSG_ERR, "Status: FT_NOT_SUPPORTED\n");
+		break;
+
+		case FT_OTHER_ERROR:
+			DBG(MSG_ERR, "Status: FT_OTHER_ERROR\n");
+		break;
+
+#ifndef __linux__
+/* gives compilation error in linux - not defined in D2XX for linux */
+		case FT_DEVICE_LIST_NOT_READY:
+			DBG(MSG_ERR, "Status: FT_DEVICE_LIST_NOT_READY\n");
+#endif
+		break;
+			DBG(MSG_ERR, "Status: Unknown Error!\n");
+		default:
+
+			;
+
+	}
+	FN_EXIT;
+	return FT_OK;
+}
+
+
+/******************************************************************************/
+/*						Local function definitions						  */
+/*!
+ * \brief Delay the execution of the thread
+ *
+ * Delay the execution of the thread
+ *
+ * \param[in] delay Value of the delay in milliseconds
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note The macro INFRA_SLEEP has a resolution of 1 second
+ * \warning
+ */
+FT_STATUS Infra_Delay(uint64 delay)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	FN_ENTER;
+
+#ifdef _WIN32
+/*TBD*/
+	/*status = FT_OK;*/
+#else // _WIN32
+/*TBD*/
+	/*status = FT_OK;*/
+#endif
+
+	FN_EXIT;
+	return status;
+}
+
+/******************************************************************************/
+/*						Local function definitions						  */
+/******************************************************************************/
+
+FTDIMPSSE_API void Init_libMPSSE(void)
+{
+	FT_STATUS status;
+	(void)status;
+	FN_ENTER;
+
+/* Load D2XX dynamic library */
+#ifndef _WIN32
+	hdll_d2xx = dlopen("libftd2xx.so", RTLD_LAZY);
+	if (!hdll_d2xx)
+	{
+		fprintf(stderr, "dlopen failed: %s\n", dlerror());
+	}
+#else // _WIN32
+	hdll_d2xx = LoadLibrary("ftd2xx.dll");
+#endif // _WIN32
+
+	CHECK_NULL(hdll_d2xx);
+
+	varFunctionPtrLst.p_FT_GetLibraryVersion = (pfunc_FT_GetLibraryVersion)GET_FUNC(hdll_d2xx, "FT_GetLibraryVersion");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetLibraryVersion);
+	/*FunctionPointer for FT_CreateDeviceInfoList*/
+	varFunctionPtrLst.p_FT_GetNumChannel = (pfunc_FT_GetNumChannel)GET_FUNC(hdll_d2xx,"FT_CreateDeviceInfoList");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetNumChannel);
+	/*function Pointer for FT_GetDeviceInfoList */
+	varFunctionPtrLst.p_FT_GetDeviceInfoList = (pfunc_FT_GetDeviceInfoList)GET_FUNC(hdll_d2xx,"FT_GetDeviceInfoList");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetDeviceInfoList);
+	/*open*/
+	varFunctionPtrLst.p_FT_Open = (pfunc_FT_Open)GET_FUNC(hdll_d2xx,"FT_Open");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_Open);
+	/*close*/
+	varFunctionPtrLst.p_FT_Close = (pfunc_FT_Close)GET_FUNC(hdll_d2xx,"FT_Close");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_Close);
+	/*Reset*/
+	varFunctionPtrLst.p_FT_ResetDevice = (pfunc_FT_ResetDevice)GET_FUNC(hdll_d2xx, "FT_ResetDevice");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_ResetDevice);
+	/*Purge*/
+	varFunctionPtrLst.p_FT_Purge = (pfunc_FT_Purge)GET_FUNC(hdll_d2xx,"FT_Purge");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_Purge);
+	/*SetUSBParameters*/
+	varFunctionPtrLst.p_FT_SetUSBParameters = (pfunc_FT_SetUSBParameters)GET_FUNC(hdll_d2xx,"FT_SetUSBParameters");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_SetUSBParameters);
+	/*SetChars*/
+	varFunctionPtrLst.p_FT_SetChars = (pfunc_FT_SetChars)GET_FUNC(hdll_d2xx,"FT_SetChars");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_SetChars);
+	/*SetTimeouts*/
+	varFunctionPtrLst.p_FT_SetTimeouts = (pfunc_FT_SetTimeouts)GET_FUNC(hdll_d2xx,"FT_SetTimeouts");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_SetTimeouts);
+	/*GetLatencyTimer*/
+    varFunctionPtrLst.p_FT_GetLatencyTimer = (pfunc_FT_GetLatencyTimer)GET_FUNC(hdll_d2xx,"FT_GetLatencyTimer");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetLatencyTimer);
+	/*SetLatencyTimer*/
+    varFunctionPtrLst.p_FT_SetLatencyTimer = (pfunc_FT_SetLatencyTimer)GET_FUNC(hdll_d2xx,"FT_SetLatencyTimer");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_SetLatencyTimer);
+	/*SetBitmode*/
+	varFunctionPtrLst.p_FT_SetBitmode = (pfunc_FT_SetBitmode)GET_FUNC(hdll_d2xx,"FT_SetBitMode");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_SetBitmode);
+	/*FT_GetQueueStatus*/
+	varFunctionPtrLst.p_FT_GetQueueStatus = (pfunc_FT_GetQueueStatus)GET_FUNC(hdll_d2xx,"FT_GetQueueStatus");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetQueueStatus);
+	/*FT_Read*/
+	varFunctionPtrLst.p_FT_Read = (pfunc_FT_Read)GET_FUNC(hdll_d2xx,"FT_Read");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_Read);
+	/*FT_Write*/
+	varFunctionPtrLst.p_FT_Write = (pfunc_FT_Write)GET_FUNC(hdll_d2xx,"FT_Write");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_Write);
+	/*FT_GetDeviceInfo*/
+	varFunctionPtrLst.p_FT_GetDeviceInfo = (pfunc_FT_GetDeviceInfo)GET_FUNC(hdll_d2xx,"FT_GetDeviceInfo");
+	CHECK_SYMBOL(varFunctionPtrLst.p_FT_GetDeviceInfo);
+
+	/*Call module specific initialization functions from here(if at all they are required)
+		Example:
+			Top_Init();	//This may be a function in ftdi_common.c
+						// Inside this function we may have macros (eg: #ifdef(_I2C))
+
+			Mid_Init();
+	*/
+
+	FN_EXIT;
+}
+
+FTDIMPSSE_API void Cleanup_libMPSSE(void)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+	FN_ENTER;
+#ifdef _WIN32
+	if (NULL != hdll_d2xx)
+	{
+		if (FreeLibrary(hdll_d2xx)>0)
+		{
+			DBG(MSG_DEBUG, "D2XX unloaded\n");
+		}
+		else
+		{
+			DBG(MSG_DEBUG, "failed unloading D2XX\n");
+		}
+	}
+	else
+	{
+		DBG(MSG_INFO, "handle to D2XX is NULL\n");
+	}
+#endif // _WIN32
+
+	FN_EXIT;
+}
+
+
+#ifdef _WIN32
+
+/*!
+ * \brief Module entry point for Windows DLL
+ *
+ * This function is called by Windows OS when an application loads/unloads libMPSSE as a DLL
+ *
+ * \param[in] hModule			Handle
+ * \param[in] reason_for_call	Reason for being called
+ * \param[in] lpReserved		Reserved
+ * \return none
+ * \sa
+ * \note
+ * \warning
+ */
+BOOL APIENTRY DllMain(HANDLE hModule, DWORD reason_for_call, LPVOID lpReserved)
+{
+	FN_ENTER;
+
+    switch (reason_for_call)
+  	{
+		case DLL_PROCESS_ATTACH:
+			DBG(MSG_DEBUG,"reason_for_call = DLL_PROCESS_ATTACH\n");
+			Init_libMPSSE();
+		break;
+		case DLL_THREAD_ATTACH:
+			DBG(MSG_DEBUG,"reason_for_call = DLL_THREAD_ATTACH\n");
+
+      	break;
+
+		case DLL_THREAD_DETACH:
+			DBG(MSG_DEBUG,"reason_for_call = DLL_THREAD_DETACH\n");
+
+		break;
+		case DLL_PROCESS_DETACH:
+			DBG(MSG_DEBUG,"reason_for_call = DLL_PROCESS_DETACH\n");
+			Cleanup_libMPSSE();
+		break;
+
+		default:
+			DBG(MSG_WARN,"DllMain was called with an unknown reason\n");
+    }
+
+	FN_EXIT;
+    return TRUE;
+}
+#endif /*_WIN32*/
+
+
+#if 0
+/*!
+ * \brief Module entry point for Windows Static Library and Linux
+ * Dynamic & Static Libraries
+ *
+ * This function is the entry point for the module when it is loaded as a
+ * static library(libMPSSE.lib or libMPSSE.a) in windows, and when it is loaded
+ * as either a static library(libMPSSE.a) or a dynamic library(libMPSSE.so) in
+ * linux
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note
+ * \warning
+ */
+void my_init(void)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+
+	FN_ENTER;
+
+	Init_libMPSSE();
+
+	FN_EXIT;
+}
+
+/*!
+ * \brief Module exit point for Windows Static Library and Linux
+ * Dynamic & Static Libraries
+ *
+ * This function is the exit point for the module when it is loaded as a
+ * static library(libMPSSE.lib or libMPSSE.a) in windows, and when it is loaded
+ * as either a static library(libMPSSE.a) or a dynamic library(libMPSSE.so) in
+ * linux
+ *
+ * \param[in] none
+ * \param[out] none
+ * \return none
+ * \sa
+ * \note
+ * \warning
+ */
+void my_exit(void)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+
+	FN_ENTER;
+
+	Cleanup_libMPSSE();
+
+	FN_EXIT;
+}
+#endif
+
+/******************************************************************************/
+/*						Public function definitions						  */
+/******************************************************************************/
+
+/**
+ * Construct a DWORD with major, minor and build version numbers.
+ *
+ * The format matches that published in the D2XX Programmer's Guide,
+ * where each individual byte contains a value which, when displayed
+ * as hexadecimal, represents the version number.  For example, "15"
+ * is stored as 21.
+ *
+ * @return Version numbers as a single DWORD.
+ */
+static DWORD versionNumberToHex(void)
+{
+#if !defined(FT_VER_MAJOR) || !defined(FT_VER_MINOR) || !defined(FT_VER_BUILD)
+    #error "The Makefile must define major, minor and build version numbers."
+    return (DWORD)0;
+#else
+    char  buf[7]; /* enough for '123456' and terminator */
+    char *endPtr = NULL;
+    long int versionNumber;
+
+#define COMPILE_TIME_ASSERT(pred) switch(0){case 0:case pred:;}
+    COMPILE_TIME_ASSERT(FT_VER_MAJOR < 99);
+    COMPILE_TIME_ASSERT(FT_VER_MINOR < 99);
+    COMPILE_TIME_ASSERT(FT_VER_BUILD < 99);
+
+#ifdef _WIN32
+    sprintf_s(buf, 7, "%02d%02d%02d", FT_VER_MAJOR, FT_VER_MINOR, FT_VER_BUILD);
+#else
+    sprintf(buf, "%02d%02d%02d", FT_VER_MAJOR, FT_VER_MINOR, FT_VER_BUILD);
+#endif
+    versionNumber = strtol(buf, &endPtr, 16);
+
+    return (DWORD)versionNumber;
+
+#endif /* !defined(FT_VER_MAJOR) || !defined(FT_VER_MINOR) || !defined(FT_VER_BUILD) */
+}
+
+/*!
+ * \brief Version Number Function
+ *
+ * Returns libMPSSE and libFTD2XX version number
+ *
+ * \param[out]  *libmpsse	MPSSE version number is returned
+ * \param[out]  *libftd2xx	D2XX version number is returned
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS Ver_libMPSSE(LPDWORD libmpsse, LPDWORD libftd2xx)
+{
+	FT_STATUS status = FT_INVALID_PARAMETER;
+
+	FN_ENTER;
+
+    if ((libmpsse) && (libftd2xx))
+    {
+        *libmpsse = versionNumberToHex();
+
+		CHECK_NULL_RET(varFunctionPtrLst.p_FT_GetLibraryVersion);
+		status = varFunctionPtrLst.p_FT_GetLibraryVersion(libftd2xx);
+	}
+
+	FN_EXIT;
+	return status;
+}
+
+
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_infra.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_infra.h
@@ -1,0 +1,261 @@
+/*!
+ * \file ftdi_infra.h
+ *
+ * \author FTDI
+ * \date 20110127
+ *
+ * Copyright  2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: Infra
+ *
+ * This file abstracts everything that is specific to CPU, OS and Platform to ensure portability
+ * These abstractions are datatypes, function calls, etc
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - added memory related macros
+ * 0.3 - 20111103 - added 64bit linux support, cleaned up
+ *
+ */
+
+#ifndef FTDI_INFRA_H
+#define FTDI_INFRA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************************************/
+/*								Macro defines								  */
+/******************************************************************************/
+
+#ifdef _WIN32
+
+#include <winsock2.h>
+#include <windows.h>
+
+#else // _WIN32
+
+#include <dlfcn.h>	/*for dlopen() & dlsym()*/
+#include <stdarg.h>	/*for va_start() & va_arg()*/
+#include <unistd.h>	/*for Sleep()*/
+
+#endif // _WIN32
+
+#include <inttypes.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ftd2xx.h"
+
+
+/******************************************************************************/
+/*								Macro defines								  */
+/******************************************************************************/
+
+#ifndef FTDIMPSSE_API
+#ifdef _WIN32
+// The following ifdef block is the standard way of creating macros
+// which make exporting from a DLL simpler.  All files within this DLL
+// are compiled with the FTDIMPSSE_EXPORTS symbol defined on the command line.
+// This symbol should not be defined on any project that uses this DLL.
+// This way any other project whose source files include this file see
+// FTDIMPSSE_API functions as being imported from a DLL, whereas this DLL
+// sees symbols defined with this macro as being exported.
+
+#ifdef FTDIMPSSE_EXPORTS
+#define FTDIMPSSE_API __declspec(dllexport)
+#elif defined(FTDIMPSSE_STATIC)
+// Avoid decorations when linking statically.
+#define FTDIMPSSE_API
+#else
+#define FTDIMPSSE_API __declspec(dllimport)
+#endif
+
+#else // _WIN32
+
+// Compiling on non-Windows platform.
+#include "WinTypes.h"
+// No decorations needed.
+#define FTDIMPSSE_API
+
+#endif // _WIN32
+#endif // FTDIMPSSE_API
+
+/* Macro for calling convention, if required */
+#ifdef _WIN32
+	#define CAL_CONV	__stdcall
+#else
+	#define CAL_CONV
+#endif
+
+/* Uncomment the #define INFRA_DEBUG_ENABLE in makefile to enable debug messages */
+#define MSG_EMERG	0 /*Used for emergency messages, usually those that precede a crash*/
+#define MSG_ALERT	1 /*A situation requiring immediate action */
+#define MSG_CRIT	2 /*Critical conditions, often related to serious hw/sw failures */
+#define MSG_ERR		3 /*Used to report error conditions */
+#define MSG_WARN	4 /*Warnings about problematic situations that do not, in themselves,
+						create serious problems with the system */
+#define MSG_NOTICE	5 /*Situations that are normal, but still worthy of note. */
+#define MSG_INFO	6 /*Informational messages */
+#define MSG_DEBUG	7 /*Used for debugging messages */
+
+#ifdef INFRA_DEBUG_ENABLE
+	extern int currentDebugLevel;
+	#define DBG(level,...) do { if (level <= currentDebugLevel){ \
+		printf("%s:%d:%s():", __FILE__, __LINE__, __FUNCTION__);	\
+		printf(__VA_ARGS__); }} while (0)
+#else
+	#define DBG(level, fmt,...)	;
+#endif
+
+/* Macros to provide branch prediction information to compiler */
+#ifndef _WIN32
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+#else // _WIN32
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#endif // _WIN32
+
+/* Macro to check null expression and exit if true */
+#define CHECK_NULL(exp) {if (unlikely((exp) == NULL)){ printf("%s:%d:%s(): NULL" \
+	" expression encountered\n", __FILE__, __LINE__, __FUNCTION__);exit(1);};};
+
+/* Macro to check null expression and return if true */
+#define CHECK_NULL_RET(exp){if (unlikely((exp) == NULL)){ printf("%s:%d:%s(): NULL" \
+	" expression encountered\n", __FILE__, __LINE__, __FUNCTION__);\
+	status=FT_INVALID_PARAMETER ; return(status);};};
+
+/* Macro to check status  code and only print debug message */
+#define CHECK_STATUS_NORET(exp) {if (unlikely((exp) != FT_OK)){DBG(MSG_ERR," status" \
+	" != FT_OK\n"); Infra_DbgPrintStatus(exp);};};
+
+/* Macro to check status  code and return if not FT_OK */
+#define CHECK_STATUS(exp) {if (unlikely(exp!=FT_OK)){DBG(MSG_ERR," status \
+	!= FT_OK\n");Infra_DbgPrintStatus(exp);return(exp);}else{;}};
+
+#ifndef __BORLANDC__
+	#define FN_ENTER	DBG(MSG_DEBUG,"Entering function\n");
+	#define FN_EXIT		DBG(MSG_DEBUG,"Exiting function status=%u\n",(unsigned)status);
+	#define FN_PT		DBG(MSG_DEBUG,"Path taken\n");
+#else
+	#define FN_ENTER	;
+	#define FN_EXIT     ;
+	#define FN_PT		;
+#endif
+
+/* sleep function abstraction */
+#ifndef _WIN32
+	#define INFRA_SLEEP(exp)			usleep((exp)*1000);
+#else // _WIN32
+	#define INFRA_SLEEP(exp)			Sleep(exp);
+#endif // _WIN32
+
+/* Memory allocating, freeing & copying macros -  */
+#define INFRA_MALLOC(exp)			malloc(exp); \
+	DBG(MSG_DEBUG,"INFRA_MALLOC %ubytes\n", exp);
+#define INFRA_FREE(exp)				free(exp); \
+	DBG(MSG_DEBUG,"INFRA_FREE 0x%x\n", exp);
+#define INFRA_MEMCPY(dest, src, siz)	memcpy(dest, src, siz);\
+	DBG(MSG_DEBUG,"INFRA_MEMCPY dest:0x%x src:0x%x size:0x%x\n", dest, src, siz);
+
+/******************************************************************************/
+/*								Define platform								  */
+/******************************************************************************/
+
+/******************************************************************************/
+/*								Type defines								  */
+/******************************************************************************/
+
+/* Match types with WinTypes.h for non-windows platforms. */
+typedef UCHAR   uint8;
+typedef USHORT  uint16;
+typedef ULONGLONG uint64;
+
+typedef signed char   int8;
+typedef signed short  int16;
+typedef signed long long int64;
+
+typedef BOOL	bool;
+
+typedef unsigned int   uint32;
+typedef signed int   int32;
+
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetLibraryVersion)(LPDWORD lpdwVersion);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetNumChannel)(LPDWORD lpdwNumDevs);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetDeviceInfoList)(FT_DEVICE_LIST_INFO_NODE *pDest, LPDWORD lpdwNumDevs);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_Open) (int iDevice, FT_HANDLE *ftHandle);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_Close) (FT_HANDLE ftHandle);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_ResetDevice) (FT_HANDLE ftHandle);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_Purge) (FT_HANDLE ftHandle, DWORD dwMask);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_SetUSBParameters) (FT_HANDLE ftHandle, DWORD dwInTransferSize, DWORD dwOutTransferSize);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_SetChars) (FT_HANDLE ftHandle, UCHAR uEventCh, UCHAR uEventChEn, UCHAR uErrorCh, UCHAR uErrorChEn);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_SetTimeouts) (FT_HANDLE ftHandle, DWORD dwReadTimeout, DWORD dwWriteTimeout);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_SetLatencyTimer) (FT_HANDLE ftHandle, UCHAR ucTimer);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetLatencyTimer) (FT_HANDLE ftHandle, UCHAR *ucTimer);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_SetBitmode) (FT_HANDLE ftHandle, UCHAR ucMask, UCHAR ucMode);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetQueueStatus) (FT_HANDLE ftHandle, LPDWORD lpdwAmountInRxQueue);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_Read) (FT_HANDLE ftHandle, LPVOID lpBuffer, DWORD dwBytesToRead, LPDWORD lpdwBytesReturned);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_Write) (FT_HANDLE ftHandle, LPVOID lpBuffer, DWORD dwBytesToWrite, LPDWORD lpdwBytesWritten);
+typedef FT_STATUS (CAL_CONV *pfunc_FT_GetDeviceInfo)(FT_HANDLE ftHandle, FT_DEVICE *lpftDevice, LPDWORD lpdwID, PCHAR SerialNumber, PCHAR Description, LPVOID Dummy);
+
+typedef struct InfraFunctionPtrLst_t
+{
+	pfunc_FT_GetLibraryVersion p_FT_GetLibraryVersion;
+	pfunc_FT_GetNumChannel p_FT_GetNumChannel;
+	pfunc_FT_GetDeviceInfoList p_FT_GetDeviceInfoList;
+	pfunc_FT_Open p_FT_Open;
+	pfunc_FT_Close p_FT_Close;
+	pfunc_FT_ResetDevice p_FT_ResetDevice;
+	pfunc_FT_Purge p_FT_Purge;
+	pfunc_FT_SetUSBParameters p_FT_SetUSBParameters;
+	pfunc_FT_SetChars p_FT_SetChars;
+	pfunc_FT_SetTimeouts p_FT_SetTimeouts;
+	pfunc_FT_SetLatencyTimer p_FT_SetLatencyTimer;
+	pfunc_FT_GetLatencyTimer p_FT_GetLatencyTimer;
+	pfunc_FT_SetBitmode p_FT_SetBitmode;
+	pfunc_FT_GetQueueStatus p_FT_GetQueueStatus;
+	pfunc_FT_Read p_FT_Read;
+	pfunc_FT_Write p_FT_Write;
+	pfunc_FT_GetDeviceInfo p_FT_GetDeviceInfo;
+} InfraFunctionPtrLst;
+
+/******************************************************************************/
+/*								External variables							  */
+/******************************************************************************/
+#ifdef _WIN32
+	extern HANDLE hdll_d2xx;
+#else // _WIN32
+	extern void *hdll_d2xx;
+#endif // _WIN32
+
+extern InfraFunctionPtrLst varFunctionPtrLst;
+
+/******************************************************************************/
+/*								Function declarations						  */
+/******************************************************************************/
+FT_STATUS Infra_DbgPrintStatus(FT_STATUS status);
+FT_STATUS Infra_Delay(uint64 delay);
+
+/******************************************************************************/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/*FTDI_INFRA_H*/
+
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_mid.c
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_mid.c
@@ -1,0 +1,1279 @@
+/*!
+ * \file ftdi_mid.c
+ *
+ * \author FTDI
+ * \date 20110321
+ *
+ * Copyright � 2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: Middle Layer
+ *
+ * Revision History:
+ * 0.1 -  initial version
+ * 0.2 -  20110524 - updated for SPI and cleaned up
+ * 0.21- 20110708 - Added functions FT_ReadGPIO & FT_WriteGPIO
+ * 0.3 -  20111103 - Added MPSSE_CMD_ENABLE_DRIVE_ONLY_ZERO
+ */
+
+
+/******************************************************************************/
+/*								Include files					  			  */
+/******************************************************************************/
+#define FTDI_EXPORTS
+#include "ftdi_infra.h"		/*Common portable infrastructure(datatypes, libraries, etc)*/
+#include "ftdi_common.h"	/*Common across I2C, SPI, JTAG modules*/
+#include "ftdi_mid.h"		/*Midlayer specific specific*/
+#include "string.h"
+
+
+/******************************************************************************/
+/*								Macro defines					  			  */
+/******************************************************************************/
+
+
+
+
+/******************************************************************************/
+/*								Local function declarations					  */
+/******************************************************************************/
+
+
+
+
+/******************************************************************************/
+/*								Global variables							  */
+/******************************************************************************/
+
+
+
+/******************************************************************************/
+/*						Public function definitions						  */
+/******************************************************************************/
+
+/*!
+ * \brief Returns the number of MPSSE channels a available
+ *
+ * This function returns the number of MPSSE channels that are connected to the host system
+ * Although all the MPSSE channels that are available in the current chips support SPI/I2C/JTAG,
+ * future versions of MPSSE may have support for other legacy protocols too. The caller of this
+ * function (i.e. I2C_GetNumChannel, SPI_GetNumChannel, etc) should check if all the channels
+ * reported by this function support the legacy protocol that the caller needs to support.
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[out] *numChans
+ * \return status
+ * \sa
+ * \note This function doesn't return the number of FTDI chips connected to the host system
+ * \note FT2232D has 1 MPSSE port
+ * \note FT2232H has 2 MPSSE ports
+ * \note FT4232H has 4 ports but only 2 of them have MPSSEs
+ * so a call to this function will return 2 if a FT4232 is connected to it.
+ * \warning
+ */
+FT_STATUS FT_GetNumChannels(FT_LegacyProtocol Protocol, DWORD *numChans)
+{
+	DWORD tempNumChannels;
+	FT_DEVICE_LIST_INFO_NODE *pDeviceList;
+	FT_DEVICE_LIST_INFO_NODE deviceList;
+
+	FT_STATUS status;
+	DWORD devLoop = MID_NO_CHANNEL_FOUND;
+
+	FN_ENTER;
+	/*initalize *numChansto 0 */
+	*numChans = MID_NO_CHANNEL_FOUND;
+
+	/*Get the number of devices connected to the system with
+	  FT_CreateDeviceInfoList */
+	status = varFunctionPtrLst.p_FT_GetNumChannel(&tempNumChannels);
+	/*Check if the status is Ok */
+	if (status == FT_OK)
+	{
+
+		/*Check if No of channel is greater than 0*/
+		if (tempNumChannels > MID_NO_CHANNEL_FOUND)
+		{
+			/*Allocate space for getting the information about the device (based on
+			number of devices)*/
+			pDeviceList = INFRA_MALLOC(sizeof(FT_DEVICE_LIST_INFO_NODE) * tempNumChannels);
+			if (NULL == pDeviceList)
+			{
+				return FT_INSUFFICIENT_RESOURCES;
+			}
+			/*get the devices information(FT_GetDeviceInfoList)*/
+			status = varFunctionPtrLst.p_FT_GetDeviceInfoList(pDeviceList, &tempNumChannels);
+			while(devLoop < tempNumChannels)
+			{
+				deviceList = pDeviceList[devLoop];
+				/*check if device is I2C*/
+				if (Mid_CheckMPSSEAvailable(deviceList))
+				{
+					/*increment *numChans*/
+					*numChans = *numChans + 1;
+				}
+				devLoop++;
+			}
+			INFRA_FREE(pDeviceList);
+		}
+		else
+		{
+			*numChans = tempNumChannels;
+        }
+	}
+	else
+	{
+		*numChans = tempNumChannels;
+	}
+
+	/*return status*/
+	FN_EXIT;
+	return status;
+}
+
+FT_STATUS FT_GetChannelInfo(FT_LegacyProtocol Protocol, DWORD index,
+			FT_DEVICE_LIST_INFO_NODE *chanInfo)
+{
+	DWORD tempNumChannels, channelCount;
+	FT_DEVICE_LIST_INFO_NODE *pDeviceList;
+	FT_DEVICE_LIST_INFO_NODE deviceList;
+
+	FT_STATUS status;
+	DWORD devLoop = MID_NO_CHANNEL_FOUND;
+
+	FN_ENTER;
+
+	/*initalize *numChansto 0 */
+	channelCount = MID_NO_CHANNEL_FOUND;
+
+	/*Get the number of devices connected to the system with
+	  FT_CreateDeviceInfoList */
+	status = varFunctionPtrLst.p_FT_GetNumChannel(&tempNumChannels);
+	CHECK_STATUS(status);
+
+	/*Check if No of channel is greater than 0*/
+	if (tempNumChannels >= index)
+	{
+		/*Allocate space for getting the information about the device (based on
+		number of devices)*/
+		pDeviceList = INFRA_MALLOC(sizeof(FT_DEVICE_LIST_INFO_NODE) * tempNumChannels);
+		if (NULL == pDeviceList)
+		{
+			return FT_INSUFFICIENT_RESOURCES;
+		}
+
+		/*get the devices information with FT_GetDeviceInfoList */
+		status = varFunctionPtrLst.p_FT_GetDeviceInfoList(pDeviceList, &tempNumChannels);
+		CHECK_STATUS(status);
+
+		while(devLoop < tempNumChannels)
+		{
+			deviceList = pDeviceList[devLoop];
+			if (Mid_CheckMPSSEAvailable(deviceList))
+			{
+				/*increment *numChans*/
+				channelCount++;
+			}
+			/*check if the index matches the I2C channel count*/
+			if (channelCount == index)
+			{
+				INFRA_MEMCPY(chanInfo,&deviceList, sizeof(FT_DEVICE_LIST_INFO_NODE));
+				break;
+			}
+			devLoop++;
+		}
+		INFRA_FREE(pDeviceList);
+	}
+	else
+	{
+		/* The index of the device is greater than the max number of devices available */
+		return FT_INVALID_HANDLE;
+	}
+
+	/*return status*/
+	FN_EXIT;
+	return status;
+}
+
+
+/*!
+ * \brief Opens a channel and returns a handle to it
+ *
+ * This function opens the indexed channel and returns a handle to it
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[in] index Index of the channel
+ * \param[out] handle Pointer to the handle
+ * \return status
+ * \sa
+ * \note Trying to open an already open channel will return an error code
+ * \warning
+ */
+FT_STATUS FT_OpenChannel(FT_LegacyProtocol Protocol, DWORD index,
+			FT_HANDLE *handle)
+{
+	/* Opens a channel and returns the pointer to its handle */
+	DWORD tempNumChannels, channelCount;
+	FT_DEVICE_LIST_INFO_NODE *pDeviceList;
+	FT_DEVICE_LIST_INFO_NODE deviceList;
+
+	FT_STATUS status;
+	DWORD devLoop = MID_NO_CHANNEL_FOUND;
+	FN_ENTER;
+
+	/*initalize *numChansto 0 */
+	channelCount = MID_NO_CHANNEL_FOUND;
+
+	/*Get the number of devices connected to the system with
+	  FT_CreateDeviceInfoList */
+	status = varFunctionPtrLst.p_FT_GetNumChannel(&tempNumChannels);
+	CHECK_STATUS(status);
+
+	/*Check if No of channel is greater than 0*/
+	if (tempNumChannels >= index)
+	{
+		/*Allocate space for getting the information about the device (based on
+		number of devices)*/
+		pDeviceList = INFRA_MALLOC(sizeof(FT_DEVICE_LIST_INFO_NODE) * tempNumChannels);
+		if (NULL == pDeviceList)
+		{
+			return FT_INSUFFICIENT_RESOURCES;
+		}
+		/*get the devices information(FT_GetDeviceInfoList)*/
+		status = varFunctionPtrLst.p_FT_GetDeviceInfoList(pDeviceList, &tempNumChannels);
+		CHECK_STATUS(status);
+
+		/*loop until No of devices */
+		while(devLoop < tempNumChannels)
+		{
+			deviceList = pDeviceList[devLoop];
+			/*check if device is I2C*/
+			if (Mid_CheckMPSSEAvailable(deviceList))
+			{
+				/*increment *numChans*/
+				channelCount++;
+			}
+			/*check if the index matches the I2C channel count*/
+			if (channelCount == index)
+			{
+				/*call FT_Open*/
+				status = varFunctionPtrLst.p_FT_Open(devLoop, handle);
+                break;
+            }
+			devLoop++;
+		}
+		INFRA_FREE(pDeviceList);
+	}
+	else
+	{
+		/* The index of the device is greater than the max number of devices available */
+		return FT_INVALID_HANDLE;
+	}
+
+	/*return status*/
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief Initializes a channel
+ *
+ * This function initializes the channel and the communication parameters associated with it. The
+ * function takes variable number of parameters. For example, if channelType is I2C then the
+ * number of variable parameters will be equal to the number of members in the structure
+ * ChannelConfig. The variable parameters will be passed to this function in the same order as
+ * they appear in the structure defination
+ * The function performs the USB function specific initialization followed by MPSSE initialization.
+ * Once that is done it will configure MPSSE with the legacy protocol specific initializations(SPI/
+ * I2C/JTAG) with the help of that parameters that are passed by the caller
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[in] handle Handle of the channel
+ * \param[in] varArg1 Clock rate
+ * \param[in] varArg2 Latency timer
+ * \param[in] varArg3 Configuration options
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS FT_InitChannel(FT_LegacyProtocol Protocol, FT_HANDLE handle,...)
+{
+	va_list argumentList;
+	uint32	clockRate, latencyTimer, configOptions;
+	FT_STATUS status;
+	FT_DEVICE ftDevice;
+
+	FN_ENTER;
+
+	/*initialise the argument list*/
+	va_start(argumentList, handle);
+	/*Get the value for Clockrate*/
+	clockRate = va_arg(argumentList, uint32);
+	/*latencyTimer*/
+	latencyTimer = va_arg(argumentList, uint32);
+	/* The options parameter passed in I2C_Init, SPI_Init */
+	configOptions = va_arg(argumentList, uint32);
+	/*Check parameters*/
+	if ((clockRate < MIN_CLOCK_RATE)
+		|| (clockRate > MAX_CLOCK_RATE)
+		|| (latencyTimer < MIN_LATENCY_TIMER)
+		|| (latencyTimer > MAX_LATENCY_TIMER))
+				return FT_INVALID_PARAMETER;
+
+	/*Get the device type*/
+	status = Mid_GetFtDeviceType(handle, &ftDevice);
+	CHECK_STATUS(status);
+	/*reset the device*/
+	status = Mid_ResetDevice(handle);
+	CHECK_STATUS(status);
+	/*Purge*/
+	status = Mid_PurgeDevice(handle);
+	CHECK_STATUS(status);
+	/*set USB buffer size*/
+	status = Mid_SetUSBParameters(handle,
+		USB_INPUT_BUFFER_SIZE, USB_OUTPUT_BUFFER_SIZE);
+	CHECK_STATUS(status);
+	/*sets the special characters for the device,
+	disable event and error characters*/
+	status = Mid_SetDeviceSpecialChar(handle, FALSE, DISABLE_EVENT, FALSE, DISABLE_CHAR);
+	CHECK_STATUS(status);
+	/*SetTimeOut*/
+	status = Mid_SetDeviceTimeOut(handle, DEVICE_READ_TIMEOUT, DEVICE_WRITE_TIMEOUT);
+	CHECK_STATUS(status);
+	/*SetLatencyTimer*/
+	status = Mid_SetLatencyTimer(handle,(UCHAR)latencyTimer);
+	CHECK_STATUS(status);
+	/*ResetMPSSE*/
+	status = Mid_ResetMPSSE(handle);
+	CHECK_STATUS(status);
+	/*EnableMPSSEInterface*/
+	status = Mid_EnableMPSSEIn(handle);
+	CHECK_STATUS(status);
+	/*20110608 - enabling loopback before sync*/
+	status = Mid_SetDeviceLoopbackState(handle, MID_LOOPBACK_TRUE);
+	CHECK_STATUS(status);
+	/*Sync MPSSE */
+	status = Mid_SyncMPSSE(handle);
+	CHECK_STATUS(status);
+	/*wait for USB*/
+	INFRA_SLEEP(50);
+	/*set Clock frequency*/
+	status = Mid_SetClock(handle, ftDevice, clockRate);
+	CHECK_STATUS(status);
+	DBG(MSG_INFO, "Mid_SetClock Status Ok return 0x%x\n",(unsigned)status);
+	INFRA_SLEEP(20);
+	/*Stop Loop back*/
+	status = Mid_SetDeviceLoopbackState(handle, MID_LOOPBACK_FALSE);
+	CHECK_STATUS(status);
+	DBG(MSG_INFO, "Mid_SetDeviceLoopbackState Status Ok return 0x%x\n", (unsigned)status);
+	status = Mid_EmptyDeviceInputBuff(handle);
+	CHECK_STATUS(status);
+	DBG(MSG_INFO, "Mid_EmptyDeviceInputBuff Status Ok return 0x%x\n", (unsigned) status);
+
+	switch(Protocol)
+	{
+		case I2C:
+		{
+			/*Set i/o pin states*/
+			status = Mid_SetGPIOLow(handle, MID_SET_LOW_BYTE_DATA_BITS_DATA,
+				MID_SET_LOW_BYTE_DATA_BITS_DATA);
+			CHECK_STATUS(status);
+
+			/* The I2C master should actually drive the SDA line only when the output is LOW.
+			It should tristate the SDA line when the output should be high. This tristating
+			the SDA line during output HIGH is supported only in FT232H chip*/
+			if ((ftDevice == FT_DEVICE_232H) && (configOptions & I2C_ENABLE_DRIVE_ONLY_ZERO))
+			{
+				uint8 buffer[3];//3
+				DWORD noOfBytesToTransfer;
+				DWORD noOfBytesTransferred;
+				DBG(MSG_DEBUG,"Enabling DRIVE_ONLY_ZERO\n");
+				noOfBytesToTransfer = 3;
+				noOfBytesTransferred = 0;
+				buffer[0] = MPSSE_CMD_ENABLE_DRIVE_ONLY_ZERO;/* MPSSE command */
+				buffer[1] = 0x03; /* LowByte */
+				buffer[2] = 0x00; /* HighByte */
+				status = FT_Channel_Write(I2C, handle, noOfBytesToTransfer,
+					buffer,&noOfBytesTransferred);
+				CHECK_STATUS(status);
+			}
+		}
+		break;
+
+		case SPI:
+		break;
+
+		case JTAG:
+
+		break;
+
+		default:
+			DBG(MSG_WARN, "undefined protocol value(%u)\n",(unsigned)Protocol);
+	}
+	FN_EXIT;
+	return FT_OK;
+
+}
+
+/*!
+ * \brief Closes a channel
+ *
+ * Closes a channel and frees all resources that were used by it
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[in] handle Handle of the channel
+ * \param[out] none
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS FT_CloseChannel(FT_LegacyProtocol Protocol, FT_HANDLE handle)
+{
+	FT_STATUS status;
+	FN_ENTER;
+	status = varFunctionPtrLst.p_FT_Close(handle);
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief Reads data from channel
+ *
+ * This function reads the specified number of bytes from channel.
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[in] handle Handle of the channel
+ * \param[in] noOfBytes Number of bytes to be read
+ * \param[out] buffer Pointer to the buffer where data is to be read
+ * \param[out] noOfBytesTransferred The actual number of bytes transfered
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+
+
+
+FT_STATUS FT_Channel_Read(FT_LegacyProtocol Protocol, FT_HANDLE handle,
+				DWORD noOfBytes, uint8* buffer, LPDWORD noOfBytesTransferred)
+{
+	FT_STATUS status;
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_Read(handle, buffer, noOfBytes, noOfBytesTransferred);
+
+#ifdef INFRA_DEBUG_ENABLE
+	{
+		DWORD i;
+		printf("FT_Channel_Read called with noOfBytes=%u\n", (unsigned)noOfBytes);
+		for (i = 0; i < noOfBytes; i++)
+		{
+			printf(" 0x%x", buffer[i]);
+		}
+		printf("\n");
+	}
+#endif
+
+	FN_EXIT;
+    return status;
+
+
+}
+
+/*!
+ * \brief Writes data to the channel
+ *
+ * This function writes the specified number of bytes to the channel
+ *
+ * \param[in] Protocol Specifies the protocol type(I2C/SPI/JTAG)
+ * \param[in] handle Handle of the channel
+ * \param[in] noOfBytes Number of bytes to be written
+ * \param[in] buffer Pointer to the buffer from where data is to be written
+ * \param[out] noOfBytesTransferred The actual number of bytes transfered
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS FT_Channel_Write(FT_LegacyProtocol Protocol, FT_HANDLE handle,
+			DWORD noOfBytes, uint8* buffer, LPDWORD noOfBytesTransferred)
+{
+	FT_STATUS status;
+	FN_ENTER;
+
+#ifdef INFRA_DEBUG_ENABLE
+	{
+		DWORD i;
+		printf("FT_Channel_Write called with noOfBytes=%u\n",(unsigned)noOfBytes);
+		for (i = 0; i < noOfBytes; i++)
+		{
+			printf(" 0x%x", buffer[i]);
+		}
+		printf("\n");
+	}
+#endif
+
+	status = varFunctionPtrLst.p_FT_Write(handle, buffer, noOfBytes, noOfBytesTransferred);
+
+	FN_EXIT;
+  	return status;
+}
+
+
+/*
+*\brief Check if the device has MPSSE
+* This function looks for the device type if it matches then look for the Location Id to determine
+* the availability of MPSSE if  matches then returns 1 otherwise returns 0
+*\Param[in] FT_DEVICE_LIST_INFO_NODE device info node wich contains the information about the device
+*\return bool return a boolean value
+*/
+bool Mid_CheckMPSSEAvailable(FT_DEVICE_LIST_INFO_NODE devList)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+	bool isMPSSEAvailable = MID_NO_MPSSE;
+	FN_ENTER;
+
+	size_t  los = strlen(devList.Description);
+
+	/*check TYPE field*/
+	switch(devList.Type)
+	{
+		case FT_DEVICE_2232C:
+			if (devList.Description[los-1] == 0x41)   //Last character = 0x41 = ASCII "A"
+			{
+				isMPSSEAvailable =	MID_MPSSE_AVAILABLE;
+			}
+			break;
+		case FT_DEVICE_2232H:
+		case FT_DEVICE_2233HP:
+		case FT_DEVICE_2232HP:
+		case FT_DEVICE_2232HA:
+			if ((devList.Description[los - 1] == 0x41) || (devList.Description[los - 1] == 0x42))  //Last character = 0x41 = ASCII "A", 0x42 = ASCII "B"
+			{
+				isMPSSEAvailable =	MID_MPSSE_AVAILABLE;
+			}
+			break;
+		case FT_DEVICE_4232H:
+		case FT_DEVICE_4233HP:
+		case FT_DEVICE_4232HP:
+		case FT_DEVICE_4232HA:
+			if ((devList.Description[los - 1] == 0x41) || (devList.Description[los - 1] == 0x42))  //Last character = 0x41 = ASCII "A", 0x42 = ASCII "B"
+			{
+				isMPSSEAvailable =	MID_MPSSE_AVAILABLE;
+			}
+			break;
+		case FT_DEVICE_232H:
+		case FT_DEVICE_232HP:
+		case FT_DEVICE_233HP:
+				isMPSSEAvailable =	MID_MPSSE_AVAILABLE;
+			break;
+		default:
+			break;
+	};
+
+	FN_EXIT;
+	return isMPSSEAvailable;
+}
+
+
+/*!
+ * \brief Reset the device
+ *
+ * This function calles the FT_Reset to reset the device
+ * \param[in] handle of the device
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_ResetDevice(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	FN_ENTER;
+	status = varFunctionPtrLst.p_FT_ResetDevice(handle);
+	FN_EXIT;
+	return status;
+
+}
+
+/*!
+ * \brief Purge the device
+ *
+ * This function clears the Input and Output buffer of the device
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_PurgeDevice (FT_HANDLE handle)
+{
+	FT_STATUS status;
+	FN_ENTER;
+	status = varFunctionPtrLst.p_FT_Purge(handle, FT_PURGE_RX | FT_PURGE_TX);
+	FN_EXIT;
+	return status;
+}
+
+
+/*!
+ * \brief Sets the Input and Output buffer size
+ *
+ * This function sets the Input and Output buffer size as requested in the parameter.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] inputBufSize Size of the Input buffer
+ * \param[in] outputBufSize Size of the Output buffer
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetUSBParameters(FT_HANDLE handle, DWORD inputBufSize, DWORD outputBufSize)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetUSBParameters(handle, inputBufSize, outputBufSize);
+
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief Sets  the events and error characters
+ *
+ * This function sets  the events and special characters as requested in the parameter.
+ * \param[in] handle Handle of the channel
+ * \param[in] eventCh event char to set
+ * \param[in] eventStatus 0 if event character disabled, non-zero otherwise
+ * \param[in] errorCh error char to set
+ * \param[in] errorStatus 0 if error character disabled, non-zero otherwise
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetDeviceSpecialChar(FT_HANDLE handle, UCHAR eventCh,
+						UCHAR eventStatus, UCHAR errorCh, UCHAR errorStatus)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetChars(handle, eventCh, eventStatus, errorCh, errorStatus);
+
+	FN_EXIT;
+	return status;
+}
+
+
+/*!
+ * \brief sets read and write timeout
+ *
+ * This function set the read and write timeout as requested in the parameter
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] rdTimeOut timeout valu for read
+ * \param[in] wrTimeOut timeout valu for write
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetDeviceTimeOut(FT_HANDLE handle, DWORD rdTimeOut, DWORD wrTimeOut)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetTimeouts(handle, rdTimeOut, wrTimeOut);
+
+	FN_EXIT;
+	return status;
+}
+
+ /*!
+  * \brief sets the latency timer
+  *
+  * This function set the latency timer for the device as requested in the parameter
+
+  * \param[in] handle Handle of the channel
+  * \param[in] milliSecond time in millisecond to be set for latencytimer
+  * \return status
+  * \sa
+  * \note
+  * \warning
+  */
+FT_STATUS Mid_SetLatencyTimer (FT_HANDLE handle, UCHAR milliSecond)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetLatencyTimer(handle, milliSecond);
+
+	FN_EXIT;
+	return status;
+ }
+
+/*!
+ * \brief Set the bit mode to zero
+ *
+ * This function sets the bit mode to 0
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_ResetMPSSE(FT_HANDLE handle)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetBitmode(handle, INTERFACE_MASK_IN, RESET_INTERFACE);
+
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief enable MPSSE
+ *
+ * This function set the bit 2 to enable the MPSSE
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_EnableMPSSEIn(FT_HANDLE handle)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+
+	status = varFunctionPtrLst.p_FT_SetBitmode(handle, INTERFACE_MASK_IN, ENABLE_MPSSE);
+
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief syncronize MPSSE Channel
+ *
+ * This function syncronice the MPSSE by continiously sending 0XAA until it is it is readback
+ *and then sends 0XAB once and read until we get it back
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SyncMPSSE(FT_HANDLE handle)
+{
+	FT_STATUS status;
+
+	UCHAR cmdEchoed;
+
+	FN_ENTER;
+
+	status = Mid_EmptyDeviceInputBuff(handle);
+	CHECK_STATUS(status);
+	/*send and receive command*/
+	status = Mid_SendReceiveCmdFromMPSSE(handle, MID_ECHO_COMMAND_CONTINUOUSLY,	MID_ECHO_CMD_1, &cmdEchoed);
+	CHECK_STATUS(status);
+
+	if (cmdEchoed == MID_CMD_ECHOED)
+	{
+        status = Mid_SendReceiveCmdFromMPSSE(handle, MID_ECHO_COMMAND_ONCE,	MID_ECHO_CMD_2, &cmdEchoed);
+		CHECK_STATUS(status);
+		if (cmdEchoed != MID_CMD_ECHOED)
+		{
+			status = FT_OTHER_ERROR;
+		}
+	}
+	else
+	{
+		status = FT_OTHER_ERROR;
+    }
+
+	FN_EXIT;
+	return status;
+}
+
+
+
+/*!
+ * \brief sends the data and read it back from the device
+ *
+ * This function sends the ecoCmd based on the ecoCmdFlag(continiously/Once) and reads it back
+ * \param[in] handle Handle of the channel
+ * \param[in] echoCmdFlag specifies whether to sen char continiously or once
+ * \param[in] ecoCmd char to be sent
+ * \param[out] cmdEchoed 1 if char echoed from device otherwise 0
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+
+
+
+FT_STATUS Mid_SendReceiveCmdFromMPSSE(FT_HANDLE handle, UCHAR echoCmdFlag, UCHAR ecoCmd, UCHAR *cmdEchoed)
+{
+	FT_STATUS status;
+	DWORD bytesInInputBuf = 0;
+	DWORD numOfBytesRead = 0;
+	DWORD bytesWritten;
+	DWORD byteCounter;
+	UCHAR cmdResponse = MID_CMD_NOT_ECHOED;
+	int loopCounter = 0;
+	UCHAR *readBuffer = NULL;
+
+	FN_ENTER;
+
+	readBuffer = (UCHAR*)INFRA_MALLOC(MID_MAX_IN_BUF_SIZE);
+	if (NULL == readBuffer)
+	{
+		return FT_INSUFFICIENT_RESOURCES;
+	}
+	/*initialize cmdEchoed to MID_CMD_NOT_ECHOED*/
+	*cmdEchoed = MID_CMD_NOT_ECHOED;
+	/* check whether command has to be sent only once*/
+	if (echoCmdFlag == MID_ECHO_COMMAND_ONCE)
+	{
+		status = varFunctionPtrLst.p_FT_Write(handle,&ecoCmd, 1,&bytesWritten);
+		CHECK_STATUS(status);
+	}
+
+	do
+	{
+		DBG(MSG_DEBUG,"In Loop Mid_SendReceiveCmdFromMPSSE loopCounter = %d \n", loopCounter);
+		/*check whether command has to be sent every time in the loop*/
+		if (echoCmdFlag == MID_ECHO_COMMAND_CONTINUOUSLY)
+		{
+		  status = varFunctionPtrLst.p_FT_Write(handle,&ecoCmd, 1,&bytesWritten);
+		 CHECK_STATUS(status);
+		}
+		/*read the no of bytes available in Receive buffer*/
+		status = varFunctionPtrLst.p_FT_GetQueueStatus(handle,&bytesInInputBuf);
+		CHECK_STATUS(status);
+		INFRA_SLEEP(1);
+		DBG(MSG_DEBUG,"bytesInInputBuf size =  %d\n", bytesInInputBuf);
+		if (bytesInInputBuf >0)
+		{
+			MID_CHK_IN_BUF_OK(bytesInInputBuf);
+			status = varFunctionPtrLst.p_FT_Read(handle, readBuffer, bytesInInputBuf,&numOfBytesRead);
+			CHECK_STATUS(status);
+			if (numOfBytesRead >0)
+			{
+				byteCounter = 0;
+				do
+				{
+					if (byteCounter <= (numOfBytesRead-1))
+                    {
+						if (readBuffer[byteCounter]==MID_BAD_COMMAND_RESPONSE)
+                        {
+							cmdResponse = MID_BAD_COMMAND_RESPONSE;
+						}
+						else
+						{
+							if (cmdResponse == MID_BAD_COMMAND_RESPONSE)
+							{
+								if (readBuffer[byteCounter]==ecoCmd)
+								{
+                                    *cmdEchoed = MID_CMD_ECHOED;
+                                }
+							}
+							cmdResponse = MID_CMD_NOT_ECHOED;
+                        }
+					}
+					byteCounter++;
+				}while((byteCounter < bytesInInputBuf)&&(*cmdEchoed == MID_CMD_NOT_ECHOED));
+			}
+		}
+
+		/*for breaking the loop */
+		loopCounter++;
+		if (loopCounter > MID_MAX_IN_BUF_SIZE)
+		{
+			DBG(MSG_DEBUG,"Loop breaked after executing %u times\n",(unsigned)MID_MAX_IN_BUF_SIZE);
+			status = FT_OTHER_ERROR;
+			break;
+		}
+	}while((*cmdEchoed == MID_CMD_NOT_ECHOED) && (status == FT_OK));
+	if (NULL != readBuffer)
+	{
+		INFRA_FREE(readBuffer);
+	}
+
+	FN_EXIT;
+    return status;
+}
+
+
+/*!
+ * \brief sets the pin state
+ *
+ * This function  sets the pin state to 0x13 for low bits data and 0x0f for high bit data
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetGPIOLow(FT_HANDLE handle, uint8 value, uint8 direction)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+	UCHAR inputBuffer[10];
+	DWORD bytesWritten = 0;
+	DWORD bufIdx = 0;
+
+	FN_ENTER;
+
+	inputBuffer[bufIdx++] = MID_SET_LOW_BYTE_DATA_BITS_CMD;
+	inputBuffer[bufIdx++] = value;//0x13;
+	inputBuffer[bufIdx++] = direction;//0x13;
+
+	FN_EXIT;
+
+	return varFunctionPtrLst.p_FT_Write(handle, inputBuffer, bufIdx,&bytesWritten);
+
+}
+
+FT_STATUS Mid_GetFtDeviceType(FT_HANDLE handle, FT_DEVICE *ftDevice)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	DWORD deviceID;
+	CHAR pSerialNumber[32]; // Maximum size 16
+	CHAR pDescription[128]; // Maximum size 64
+	VOID *Dummy = NULL;
+
+	FN_ENTER;
+	status = varFunctionPtrLst.p_FT_GetDeviceInfo(handle, ftDevice, &deviceID, \
+		(PCHAR)pSerialNumber, (PCHAR)pDescription, Dummy);
+
+#ifdef INFRA_DEBUG_ENABLE
+	switch(*ftDevice)
+	{
+		case FT_DEVICE_BM:
+			DBG(MSG_DEBUG,"Detected device is a BM chip\n");
+			break;
+		case FT_DEVICE_AM:
+			DBG(MSG_DEBUG,"Detected device is an AM chip\n");
+			break;
+		case FT_DEVICE_100AX:
+			DBG(MSG_DEBUG,"Detected device is a 110AX chip\n");
+			break;
+		case FT_DEVICE_2232C:
+			DBG(MSG_DEBUG,"Detected device is a FT2232C chip\n");
+			break;
+		case FT_DEVICE_232R:
+			DBG(MSG_DEBUG,"Detected device is a FT232R chip\n");
+			break;
+		case FT_DEVICE_2232H:
+			DBG(MSG_DEBUG,"Detected device is a FT2232H chip\n");
+			break;
+		case FT_DEVICE_4232H:
+			DBG(MSG_DEBUG,"Detected device is a FT4232H chip\n");
+			break;
+		case FT_DEVICE_232H:
+			DBG(MSG_DEBUG,"Detected device is a FT232H chip\n");
+			break;
+		case FT_DEVICE_UNKNOWN:
+		default:
+		/*If the value of ftDevice is 3 then this may indicate some problem in the driver or the
+		setup. If the value of ftDevice is greater than 8 then this may indicate a newer chip*/
+			DBG(MSG_DEBUG,"Detected device is an unknown(0x%x) chip\n",\
+				*ftDevice);
+	}
+#endif
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief sets the clock
+ *
+ * This function fids the device type. based on the device type calculate the value for the clock
+ * requested in the parameter and sets it.
+ * \param[in] handle Handle of the channel
+ * \param[in] clock Clock value to be set
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetClock(FT_HANDLE handle, FT_DEVICE ftDevice, uint32 clock)
+
+{
+    UCHAR inputBuffer[10];
+	DWORD bytesWritten = 0;
+	DWORD bufIdx = 0;
+	uint8 valueH, valueL;
+	uint32 value;
+	FT_STATUS status;
+
+	FN_ENTER;
+	switch(ftDevice)
+	{
+		case FT_DEVICE_2232C:/* This is actually FT2232D but defined is FT_DEVICE_2232C
+			in D2XX. Also, it is the only FS device that supports MPSSE */
+			value = (MID_6MHZ/clock) - 1;
+			break;
+
+		default:/* Assuming all new chips will he HS MPSSE devices */
+			DBG(MSG_DEBUG,"Unknown device type(0x%x). Assuming high speed device",(unsigned)ftDevice);
+			/* Fall through */
+		case FT_DEVICE_2232H:
+		case FT_DEVICE_4232H:
+		case FT_DEVICE_232H:
+			DBG(MSG_DEBUG,"handle = 0x%x value = 0x%x DISABLE_CLOCK_DIVIDE\n", (unsigned)handle,(unsigned)value);
+			value = DISABLE_CLOCK_DIVIDE;
+			status = varFunctionPtrLst.p_FT_Write(handle,&value, 1, &bytesWritten);
+			CHECK_STATUS(status);
+			value = (MID_30MHZ/clock) - 1;
+			break;
+	}
+	/*calculate valueH and ValueL*/
+	valueL = (uint8)value;
+	valueH = (uint8)(value>>8);
+	/*set the clock*/
+    inputBuffer[bufIdx++] = MID_SET_CLOCK_FREQUENCY_CMD;
+	DBG(MSG_DEBUG,"valueL = 0x%x valueH = 0x%x \n", valueL, valueH);
+	inputBuffer[bufIdx++] = valueL;
+	inputBuffer[bufIdx++] = valueH;
+
+	FN_EXIT;
+	return varFunctionPtrLst.p_FT_Write(handle, inputBuffer, bufIdx,&bytesWritten);
+}
+
+/*!
+ * \brief enable or disable the loopback
+ *
+ * This function enables or disables the loopback based on the loopBackFlag
+ * \param[in] handle Handle of the channel
+ * \param[in] loopBackFlag flag to specify to turn off/on loopback
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_SetDeviceLoopbackState(FT_HANDLE handle, uint8 loopBackFlag)
+{
+	FT_STATUS status = FT_OK;
+	(void)status;
+    UCHAR inputBuffer[10];
+	DWORD bytesWritten = 0;
+	DWORD bufIdx = 0;
+
+	FN_ENTER;
+
+	if (loopBackFlag == MID_LOOPBACK_FALSE)
+	{
+		inputBuffer[bufIdx++] = MID_TURN_OFF_LOOPBACK_CMD;
+	}
+	else
+	{
+		inputBuffer[bufIdx++] = MID_TURN_ON_LOOPBACK_CMD;
+    }
+
+	FN_EXIT;
+   return varFunctionPtrLst.p_FT_Write(handle, inputBuffer, bufIdx,&bytesWritten);
+}
+
+/*!
+ * \brief empty the device read buffer
+ *
+ * This function checks if any data available in the Rx buffer if true read all the data available in
+ * the buffer
+ * \param[in] handle Handle of the channel
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FT_STATUS Mid_EmptyDeviceInputBuff(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	UCHAR *readBuffer;
+	DWORD bytesInInputBuf = 0;
+	DWORD numOfBytesRead = 0;
+
+	FN_ENTER;
+	readBuffer = (UCHAR*)INFRA_MALLOC(MID_MAX_IN_BUF_SIZE);
+	if (NULL == readBuffer)
+	{
+		return FT_INSUFFICIENT_RESOURCES;
+	}
+	status = varFunctionPtrLst.p_FT_GetQueueStatus(handle,&bytesInInputBuf);
+	CHECK_STATUS(status);
+	if (bytesInInputBuf > 0)
+	{
+		do
+		{
+			if (bytesInInputBuf >MID_MAX_IN_BUF_SIZE)
+			{
+				status = varFunctionPtrLst.p_FT_Read(handle, readBuffer,
+					MID_MAX_IN_BUF_SIZE,&numOfBytesRead);
+				CHECK_STATUS(status);
+				bytesInInputBuf = bytesInInputBuf - numOfBytesRead;
+			}
+			else
+			{
+				status = varFunctionPtrLst.p_FT_Read(handle, readBuffer,
+					bytesInInputBuf,&numOfBytesRead);
+				CHECK_STATUS(status);
+				bytesInInputBuf = bytesInInputBuf - numOfBytesRead;
+			}
+		}while((status == FT_OK)&&(bytesInInputBuf!=0));
+	}
+	if (NULL != readBuffer)
+	{
+		INFRA_FREE(readBuffer);//Bug12
+	}
+	FN_EXIT;
+	return status;
+
+}
+
+
+/*!
+ * \brief Writes to the 8 GPIO lines
+ *
+ * Writes to the 8 GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] dir The direction of the 8 lines. 0 for in and 1 for out
+ * \param[in] value Output state of the 8 GPIO lines
+ * \return status
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_WriteGPIO(FT_HANDLE handle, uint8 dir, uint8 value)
+{
+	FT_STATUS status;
+	uint8 buffer[3];
+	DWORD bytesWritten = 0;
+	DWORD bufIdx = 0;
+
+	FN_ENTER;
+
+	buffer[bufIdx++] = MPSSE_CMD_SET_DATA_BITS_HIGHBYTE;
+	buffer[bufIdx++] = value;
+	buffer[bufIdx++] = dir;
+	status = varFunctionPtrLst.p_FT_Write(handle, buffer, bufIdx,&bytesWritten);
+
+	FN_EXIT;
+	return status;
+}
+
+/*
+ * FTDI libMPSSE is dumb and doesn't have a function for writing the lower GPIO bits which the
+ * FT4232H only has. So I'm adding this.
+ */
+FTDIMPSSE_API FT_STATUS FT_WriteGPIOL(FT_HANDLE handle, uint8 dir, uint8 value)
+{
+	FT_STATUS status;
+	uint8 buffer[3];
+	DWORD bytesWritten = 0;
+	DWORD bufIdx = 0;
+
+	FN_ENTER;
+
+	buffer[bufIdx++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+	buffer[bufIdx++] = value;
+	buffer[bufIdx++] = dir;
+	status = varFunctionPtrLst.p_FT_Write(handle, buffer, bufIdx,&bytesWritten);
+
+	FN_EXIT;
+	return status;
+}
+
+/*!
+ * \brief Reads from the 8 GPIO lines
+ *
+ * This function reads the GPIO lines associated with the high byte of the MPSSE channel
+ *
+ * \param[in] handle Handle of the channel
+ * \param[out] *value Input state of the 8 GPIO lines(1 = high)
+ * \return status
+ * \sa
+ * \note The directions of the GPIO pins have to be first set to input mode using FT_WriteGPIO
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS FT_ReadGPIO(FT_HANDLE handle, uint8 *value)
+{
+	FT_STATUS status;
+	uint8 buffer[2];
+	DWORD bytesTransfered = 0;
+	DWORD bytesToTransfer = 0;
+	UCHAR readBuffer[10];
+
+	FN_ENTER;
+
+	buffer[bytesToTransfer++] = MPSSE_CMD_GET_DATA_BITS_HIGHBYTE;
+	buffer[bytesToTransfer++] = MPSSE_CMD_SEND_IMMEDIATE;
+	status = varFunctionPtrLst.p_FT_Write(handle, buffer, bytesToTransfer, &bytesTransfered);
+	CHECK_STATUS(status);
+	DBG(MSG_DEBUG,"bytesToTransfer = 0x%x bytesTransfered = 0x%x\n", (unsigned)bytesToTransfer, (unsigned)bytesTransfered);
+	bytesToTransfer = 1;
+	bytesTransfered = 0;
+	status = varFunctionPtrLst.p_FT_Read(handle, readBuffer, bytesToTransfer, &bytesTransfered);
+	CHECK_STATUS(status);
+	DBG(MSG_DEBUG,"bytesToTransfer = 0x%x bytesTransfered = 0x%x\n", (unsigned)bytesToTransfer, (unsigned)bytesTransfered);
+	if (bytesToTransfer != bytesTransfered)
+		status = FT_IO_ERROR;
+	*value = readBuffer[0];
+
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS FT_ReadGPIOL(FT_HANDLE handle, uint8 *value)
+{
+	FT_STATUS status;
+	uint8 buffer[2];
+	DWORD bytesTransfered = 0;
+	DWORD bytesToTransfer = 0;
+	UCHAR readBuffer[10];
+
+	FN_ENTER;
+
+	buffer[bytesToTransfer++] = MPSSE_CMD_GET_DATA_BITS_LOWBYTE;
+	buffer[bytesToTransfer++] = MPSSE_CMD_SEND_IMMEDIATE;
+	status = varFunctionPtrLst.p_FT_Write(handle, buffer, bytesToTransfer, &bytesTransfered);
+	CHECK_STATUS(status);
+	DBG(MSG_DEBUG,"bytesToTransfer = 0x%x bytesTransfered = 0x%x\n", (unsigned)bytesToTransfer, (unsigned)bytesTransfered);
+	bytesToTransfer = 1;
+	bytesTransfered = 0;
+	status = varFunctionPtrLst.p_FT_Read(handle, readBuffer, bytesToTransfer, &bytesTransfered);
+	CHECK_STATUS(status);
+	DBG(MSG_DEBUG,"bytesToTransfer = 0x%x bytesTransfered = 0x%x\n", (unsigned)bytesToTransfer, (unsigned)bytesTransfered);
+	if (bytesToTransfer != bytesTransfered)
+		status = FT_IO_ERROR;
+	*value = readBuffer[0];
+
+	FN_EXIT;
+	return status;
+}
+

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_mid.h
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_mid.h
@@ -1,0 +1,120 @@
+/*
+ * \file ftdi_mid.h
+ *
+ * \author FTDI
+ * \date 20110323
+ *
+ * Copyright  2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: MiddleLayer
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708	Added functions FT_ReadGPIO & FT_WriteGPIO
+ * 0.3 - 20111102	Added function Mid_GetFtDeviceType
+ *				Modified function Mid_SetClock
+ */
+
+#ifndef FTDI_MID_H
+#define FTDI_MID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ftdi_common.h"	/*Common across I2C, SPI, JTAG modules*/
+#include "ftdi_infra.h"		/*Common prrtable infrastructure(datatypes, libraries, etc)*/
+
+#define MID_COMMENTED_AFTER_REVIEW_COMMENT  			0
+#define MID_COMMENTED_AFTER_REVIEW_COMMENT_ENTRY_EXIT 	0
+
+#define MID_NO_CHANNEL_FOUND	0
+
+#define MID_NO_MPSSE					0
+#define MID_MPSSE_AVAILABLE				1
+
+#define MID_MAX_IN_BUF_SIZE         	4096
+
+#define MID_ECHO_COMMAND_ONCE			0
+#define MID_ECHO_COMMAND_CONTINUOUSLY   1
+#define MID_ECHO_CMD_1					0xAA
+#define MID_ECHO_CMD_2					0xAB
+#define MID_BAD_COMMAND_RESPONSE        0xFA
+#define MID_CMD_NOT_ECHOED				0
+#define MID_CMD_ECHOED					1
+
+/*clock*/
+#define MID_SET_LOW_BYTE_DATA_BITS_CMD	0x80
+#define MID_GET_LOW_BYTE_DATA_BITS_CMD	0x81
+#define MID_SET_HIGH_BYTE_DATA_BITS_CMD	0x82
+#define MID_GET_HIGH_BYTE_DATA_BITS_CMD	0x83
+#define MID_SET_CLOCK_FREQUENCY_CMD		0x86
+#define MID_SET_LOW_BYTE_DATA_BITS_DATA 0x13
+#define MID_SET_HIGH_BYTE_DATA_BITS_DATA 0x0F
+
+#define MID_6MHZ						6000000
+#define MID_30MHZ						30000000
+
+#define DISABLE_CLOCK_DIVIDE			0x8A
+#define ENABLE_CLOCK_DIVIDE				0x8B
+
+#define MID_LOOPBACK_FALSE				0
+#define MID_LOOPBACK_TRUE				1
+#define MID_TURN_ON_LOOPBACK_CMD		0x84
+#define MID_TURN_OFF_LOOPBACK_CMD		0x85
+
+#define MID_LEN_MAX_ERROR_STRING		500
+
+#define MID_CHK_IN_BUF_OK(size)	{if (size > MID_MAX_IN_BUF_SIZE) \
+	{ return FT_INSUFFICIENT_RESOURCES;}}
+
+FT_STATUS FT_GetNumChannels(FT_LegacyProtocol Protocol, DWORD *numChans);
+FT_STATUS FT_GetChannelInfo(FT_LegacyProtocol Protocol, DWORD index,
+			FT_DEVICE_LIST_INFO_NODE *chanInfo);
+FT_STATUS FT_OpenChannel(FT_LegacyProtocol Protocol, DWORD index,
+			FT_HANDLE *handle);
+FT_STATUS FT_InitChannel(FT_LegacyProtocol Protocol, FT_HANDLE handle,...);
+FT_STATUS FT_CloseChannel(FT_LegacyProtocol Protocol, FT_HANDLE handle);
+FT_STATUS FT_Channel_Read(FT_LegacyProtocol Protocol, FT_HANDLE handle,
+				DWORD noOfBytes, uint8* buffer, LPDWORD noOfBytesTransferred);
+FT_STATUS FT_Channel_Write(FT_LegacyProtocol Protocol, FT_HANDLE handle,
+			DWORD noOfBytes, uint8* buffer, LPDWORD noOfBytesTransferred);
+extern bool Mid_CheckMPSSEAvailable(FT_DEVICE_LIST_INFO_NODE);
+
+extern FT_STATUS Mid_ResetDevice(FT_HANDLE handle);
+extern FT_STATUS Mid_PurgeDevice (FT_HANDLE handle);
+extern FT_STATUS Mid_SetUSBParameters(FT_HANDLE handle, DWORD inputBufSize,
+										DWORD outputBufSize);
+extern FT_STATUS Mid_SetDeviceSpecialChar(FT_HANDLE handle,
+			UCHAR eventCh, UCHAR eventStatus,
+			UCHAR errorCh, UCHAR errorStatus);
+extern FT_STATUS Mid_SetDeviceTimeOut(FT_HANDLE handle,
+										DWORD rdTimeOut, DWORD wrTimeOut);
+extern FT_STATUS Mid_SetLatencyTimer (FT_HANDLE handle, UCHAR milliSecond);
+extern FT_STATUS Mid_ResetMPSSE(FT_HANDLE handle);
+extern FT_STATUS Mid_EnableMPSSEIn(FT_HANDLE handle);
+extern FT_STATUS Mid_SyncMPSSE(FT_HANDLE handle);
+extern FT_STATUS Mid_SendReceiveCmdFromMPSSE(FT_HANDLE handle, 
+			UCHAR echoCmdFlag, UCHAR ecoCmd, UCHAR *cmdEchoed);
+extern FT_STATUS Mid_SetGPIOLow(FT_HANDLE handle, uint8 value, uint8 direction);
+extern FT_STATUS Mid_SetClock(FT_HANDLE handle, FT_DEVICE ftDevice, uint32 clock);
+extern FT_STATUS Mid_GetFtDeviceType(FT_HANDLE handle, FT_DEVICE *ftDevice);
+extern FT_STATUS Mid_SetDeviceLoopbackState(FT_HANDLE handle, uint8 loopBackFlag);
+extern FT_STATUS Mid_EmptyDeviceInputBuff(FT_HANDLE handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FTDI_MID_H */

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_spi.c
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/ftdi_spi.c
@@ -1,0 +1,1305 @@
+/*!
+ * \file ftdi_spi.c
+ *
+ * \author FTDI
+ * \date 20110523
+ *
+ * Copyright � 2000-2014 Future Technology Devices International Limited
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FUTURE TECHNOLOGY DEVICES INTERNATIONAL LIMITED
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Project: libMPSSE
+ * Module: SPI
+ *
+ * Revision History:
+ * 0.1 - initial version
+ * 0.2 - 20110708 - added function SPI_ChangeCS, moved SPI_Read/WriteGPIO to middle layer
+ * 0.3 - 20111103 - bugfix: sizeTransferred 0 when SPI_TRANSFER_OPTIONS_SIZE_IN_BYTE
+ *				  ENABLE_MULTI_BYTE_TRANSFER - transfer multiple bytes per USB frame
+ *				  added function SPI_ReadWrite
+ */
+
+/******************************************************************************/
+/*								Include files					  			  */
+/******************************************************************************/
+#define FTDI_EXPORTS
+#include "ftdi_infra.h"		/*Common prortable infrastructure(datatypes, libraries, etc)*/
+#include "ftdi_common.h"	/*Common across I2C, SPI, JTAG modules*/
+#include "ftdi_mid.h"		/*Middle layer*/
+#include "libmpsse_spi.h"	/*SPI specific*/
+
+
+/******************************************************************************/
+/*								Macro and type defines					  		  */
+/******************************************************************************/
+/*Comment the following line to disable parameter checking at the start of each function*/
+#define ENABLE_PARAMETER_CHECKING	1
+
+/*The following macros will be used only during development/debugging phase*/
+
+/*Enable to allow only one chip select(DBUS3)*/
+/* #define DEVELOPMENT_FIXED_CS		1 */
+
+/*Enable to for no linked list implimentation(only 1 fixed channel)*/
+/* #define NO_LINKED_LIST		1 */
+
+/* The early implimentation allowed only one byte data transfer per USB frame.
+This macro enables the code to transfer multiple bytes per frame when
+SPI_TRANSFER_OPTIONS_SIZE_IN_BYTES bit is set in the transferOptions parameter when
+calling SPI_Read or SPI_Write */
+#define ENABLE_MULTI_BYTE_TRANSFER	1
+
+
+/******************************************************************************/
+/*								Local function declarations					  */
+/******************************************************************************/
+/* List management functions */
+
+/*!
+ * \brief Allocates storage in the system to store channel configuration data
+ *
+ * This function adds a link in a linked list to store channel configuration
+ * information when they are passed by the user in SPI_OpenChannel.
+ *
+ * \param[in] handle Handle of the channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note This function should be called after a channel has been successfully
+ *	     opened and a handle to it has been assigned
+ * \warning
+ */
+static FT_STATUS SPI_AddChannelConfig(FT_HANDLE handle);
+
+/*!
+ * \brief Deletes storage allocated for channel configuration data
+ *
+ * This function traverses the channel configuration data linked list,
+ * finds the channel with the given handle and then deletes it
+ *
+ * \param[in] handle Handle of the channel
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS SPI_DelChannelConfig(FT_HANDLE handle);
+
+/*!
+ * \brief Saves the channel's configuration data
+ *
+ * This function traverses the channel configuration data linked list
+ * and if the node with the provided handle is founed then saves the
+ * channel configuration data that is provided into the memory locations
+ * that were previously allocated using SPI_AddChannelConfig
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] config Pointer to ChannelConfig structure
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS SPI_SaveChannelConfig(FT_HANDLE handle, ChannelConfig *config);
+
+/*!
+ * \brief Retrieves the pointer to the channel's configuration data
+ *
+ * This function traverses the channel configuration data linked list
+ * and if the node with the provided handle is founed then it provides
+ * the address of the associated channel configuration data structure
+ * in the pointer provided in the second parameter of the function
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] config Pointer to ChannelConfig structure
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+#if 0
+static FT_STATUS SPI_GetChannelConfig(FT_HANDLE handle, ChannelConfig **config);
+#endif
+
+/*!
+ * \brief Display the contents of linked list
+ *
+ * This function traverses the channel configuration data linked list
+ * and prints the data at each node.
+ *
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note	Useful for debuging
+ * \warning
+ */
+#ifdef INFRA_DEBUG_ENABLE
+static FT_STATUS SPI_DisplayList(void);
+#endif
+
+/* Read/Write functions */
+
+/*!
+ * \brief Writes 8 or less bits to the SPI device
+ *
+ * This function is called by SPI_Write to write 8 or few number of bits
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] byte Data of length 8 or less bits
+ * \param[in] len Length of data in bits(maximum 8)
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS SPI_Write8bits(FT_HANDLE handle, uint8 byte, uint8 len, uint8 lsb);
+
+/*!
+ * \brief Reads 8 or less bits to the SPI device
+ *
+ * This function is called by SPI_Read to read 8 or few number of bits
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] byte Data of length 8 or less bits
+ * \param[in] len Length of data in bits(maximum 8)
+ * \param[in] mode SPI mode
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+static FT_STATUS SPI_Read8bits(FT_HANDLE handle, uint8 *byte, uint8 len, uint8 lsb);
+
+/******************************************************************************/
+/*								Global variables							  */
+/******************************************************************************/
+
+#ifdef NO_LINKED_LIST
+	ChannelContext channelContext;
+#else
+/*Root of the linked list that holds channel configurations*/
+	ChannelContext *ListHead = NULL;
+#endif
+
+
+/******************************************************************************/
+/*						Public function definitions						  */
+/******************************************************************************/
+
+FTDIMPSSE_API FT_STATUS SPI_GetNumChannels(DWORD *numChannels)
+{
+	FT_STATUS status;
+
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(numChannels);
+#endif
+	status = FT_GetNumChannels(SPI, numChannels);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_GetChannelInfo(DWORD index,
+					FT_DEVICE_LIST_INFO_NODE *chanInfo)
+{
+	FT_STATUS status;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(chanInfo);
+#endif
+	status = FT_GetChannelInfo(SPI, index+1, chanInfo);
+	CHECK_STATUS(status);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_OpenChannel(DWORD index, FT_HANDLE *handle)
+{
+	FT_STATUS status;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+#endif
+	/* 1 is added to index because mid layer accepts indices starting from 1*/
+	status = FT_OpenChannel(SPI, index+1, handle);
+	DBG(MSG_DEBUG,"index=%u handle=%u\n",(unsigned)index,(unsigned)*handle);
+	CHECK_STATUS(status);
+	if (FT_OK == status)
+	{
+		status = SPI_AddChannelConfig(*handle);
+		CHECK_STATUS(status);
+	}
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_InitChannel(FT_HANDLE handle, ChannelConfig *config)
+{
+	FT_STATUS status;
+	uint8 buffer[5];
+	uint32 noOfBytes = 0;
+	DWORD noOfBytesTransferred;
+	uint8 mode;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(config);
+	CHECK_NULL_RET(handle);
+#endif
+	/*This is to ensure that the library puts the lines to correct directions
+	even if wrong values are passed by the user */
+	/* Set initial direction of line SCLK  as OUT */
+	config->Pin |= 0x00000001;/*Note: Direction is out if bit is 1!!! */
+	/* Set initial direction of  MOSI line as OUT */
+	config->Pin |= 0x00000002;
+	/* Set initial direction of MISO line as IN */
+	config->Pin &= 0xFFFFFFFB;
+	/* Set initial direction of CS line as OUT */
+	config->Pin |= \
+		((1<<((config->configOptions & SPI_CONFIG_OPTION_CS_MASK)>>2))<<3);
+
+	/*Set initial state of clock line*/
+	mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+	switch(mode)
+	{
+		case 0:
+		case 1:
+			/* clock idle low */
+			config->Pin &= 0xFFFFFEFF;
+			break;
+
+		case 2:
+		case 3:
+			/* clock idle high */
+			config->Pin |= 0x00000100;
+			break;
+		default:
+			DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+	}
+
+
+	/* Copy initial state values to present state variable */
+	config->currentPinState = (uint16)config->Pin;
+
+	DBG(MSG_DEBUG,"handle = 0x%x ClockRate=%u LatencyTimer=%u Options = 0x%x\n",\
+		(unsigned)handle,(unsigned)config->ClockRate,	\
+		(unsigned)config->LatencyTimer,(unsigned)config->configOptions);
+
+	status = FT_InitChannel(SPI, handle,(uint32)config->ClockRate,	\
+		(uint32)config->LatencyTimer,(uint32)config->configOptions,
+		(uint32)config->Pin);
+	CHECK_STATUS(status);
+	if (FT_OK == status)
+	{
+		/* Set the directions and values to the lines */
+		buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/*MPSSE command*/
+		buffer[noOfBytes++] = (uint8)((config->currentPinState & 0xFF00)>>8);
+		buffer[noOfBytes++] = (uint8)(config->currentPinState & 0x00FF); /*Dir*/
+		status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+			&noOfBytesTransferred);
+		CHECK_STATUS(status);
+
+		if (FT_OK == status)
+		{
+			DBG(MSG_DEBUG,"line %u handle = 0x%x\n", __LINE__,(unsigned)handle);
+			status = SPI_SaveChannelConfig(handle, config);
+			CHECK_STATUS(status);
+		}
+	}
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_CloseChannel(FT_HANDLE handle)
+{
+	FT_STATUS status;
+	ChannelConfig *config = NULL;
+	UCHAR dir, val;
+	UCHAR buffer[5];
+	DWORD noOfBytes = 0;
+	DWORD noOfBytesTransferred;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+		CHECK_NULL_RET(handle);
+#endif
+	/* Retrieve final state values for the lines */
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	dir = (UCHAR)((config->Pin & 0x00FF0000)>>16);
+	val = (UCHAR)((config->Pin & 0xFF000000)>>24);
+
+	/* Set lines to final state */
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[noOfBytes++] = val; /*Value*/
+	buffer[noOfBytes++] = dir; /*Direction*/
+	status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+		&noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	status = FT_CloseChannel(SPI, handle);
+	CHECK_STATUS(status);
+	if (FT_OK == status)
+	{
+		status = SPI_DelChannelConfig(handle);
+		CHECK_STATUS(status);
+	}
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_Read(FT_HANDLE handle, UCHAR *buffer,
+	DWORD sizeToTransfer, LPDWORD sizeTransferred, DWORD transferOptions)
+{
+	FT_STATUS status;
+	//uint32 i;
+	uint8 byte = 0;
+	uint8 bitsToTransfer = 0;
+	uint8 lsb = 0;
+
+
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(buffer);
+	CHECK_NULL_RET(sizeTransferred);
+#endif
+	LOCK_CHANNEL(handle);
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_LSB_FIRST)
+	{
+		lsb = MPSSE_CMD_DATA_LSB_FIRST;
+	}
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE)
+	{
+		/* Enable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, TRUE);
+		CHECK_STATUS(status);
+	}
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_SIZE_IN_BITS)
+	{/*sizeToTransfer is in bits*/
+		*sizeTransferred = 0;
+		while(*sizeTransferred < sizeToTransfer)
+		{
+			if ((sizeToTransfer - *sizeTransferred)>=8)
+				bitsToTransfer = 8;
+			else
+				bitsToTransfer = (UCHAR)(sizeToTransfer - *sizeTransferred);
+			status = SPI_Read8bits(handle, &byte, bitsToTransfer, lsb);
+			buffer[(*sizeTransferred+1)/8] = byte;
+			CHECK_STATUS(status);
+			if (FT_OK == status)
+				*sizeTransferred += bitsToTransfer;
+		}
+	}
+	else
+	{/*sizeToTransfer is in bytes*/
+		DWORD noOfBytesTransferred = 0, CurrentXferSize = 0;
+		uint8 cmdBuffer[4];
+		ChannelConfig *config = NULL;
+		uint8 mode;
+
+		status = SPI_GetChannelConfig(handle, &config);
+		CHECK_STATUS(status);
+		/*mode is given by bit1-bit0 of ChannelConfig.Options*/
+		mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+		/* Command to write 8bits */
+		switch(mode)
+		{
+			case 0:
+				cmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_POS_EDGE | lsb;
+				break;
+			case 1:
+				cmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_NEG_EDGE | lsb;
+				break;
+			case 2:
+				cmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_NEG_EDGE | lsb;
+				break;
+			case 3:
+				cmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_POS_EDGE | lsb;
+				break;
+			default:
+				DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+		}
+
+		*sizeTransferred = 0;
+		while(*sizeTransferred < sizeToTransfer)
+		{
+
+			CurrentXferSize = ((sizeToTransfer - *sizeTransferred) > 64*1024)? 64*1024:(sizeToTransfer - *sizeTransferred);
+			/* length LSB */
+			cmdBuffer[1] = (uint8)((CurrentXferSize-1) & 0x000000FF) ;
+			/* length MSB */
+			cmdBuffer[2] = (uint8)(((CurrentXferSize-1) & 0x0000FF00)>>8);
+
+			/*Command MPSSE to send data to PC immediately */
+			cmdBuffer[3] = MPSSE_CMD_SEND_IMMEDIATE;
+			status = FT_Channel_Write(SPI, handle, 4, cmdBuffer,
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+			noOfBytesTransferred = 0;
+			status = FT_Channel_Read(SPI, handle, CurrentXferSize, &buffer[*sizeTransferred],
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+
+			*sizeTransferred += noOfBytesTransferred;
+		}
+
+		DBG(MSG_DEBUG,"sizeToTransfer=%u sizeTransferred=%u cmdBuffer[0] = 0x%x  \
+			cmdBuffer[1] = 0x%x cmdBuffer[2] = 0x%x buffer[0] = 0x%x buffer[1] = 0x%x\n"
+			,sizeToTransfer, sizeTransferred, cmdBuffer[0],cmdBuffer[1],
+			cmdBuffer[2],buffer[0],buffer[1]);
+	}
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE)
+	{
+		/* Disable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, FALSE);
+		CHECK_STATUS(status);
+	}
+	UNLOCK_CHANNEL(handle);
+	DBG(MSG_DEBUG,"sizeToTransfer=%u  sizeTransferred=%u BitMode=%u \
+		CS_Enable=%u CS_Disable=%u\n", sizeToTransfer,*sizeTransferred,
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_SIZE_IN_BITS),
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE),
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE));
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_Write(FT_HANDLE handle, UCHAR *buffer,
+	DWORD sizeToTransfer, LPDWORD sizeTransferred, DWORD transferOptions)
+{
+	FT_STATUS status;
+	ChannelConfig *config = NULL;
+	uint8 byte;
+	uint8 bitsToTransfer = 0;
+
+	uint8 lsb = 0;
+	FN_ENTER;
+
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(buffer);
+	CHECK_NULL_RET(sizeTransferred);
+#endif
+	LOCK_CHANNEL(handle);
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	/* Mode is given by bit1-bit0 of ChannelConfig.Options */
+	DBG(MSG_DEBUG,"configOptions = 0x%x\n",(unsigned)config->configOptions);
+	DBG(MSG_DEBUG,"LatencyTimer=%u\n",(unsigned)config->LatencyTimer);
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_LSB_FIRST)
+	{
+		lsb = MPSSE_CMD_DATA_LSB_FIRST;
+	}
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE)
+	{
+		/* enable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, TRUE);
+		CHECK_STATUS(status);
+	}
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_SIZE_IN_BITS)
+	{/* sizeToTransfer is in bits */
+		*sizeTransferred = 0;
+		/* loop until all the bits are transferred */
+		while(*sizeTransferred < sizeToTransfer)
+		{
+			if ((sizeToTransfer - *sizeTransferred)>=8)
+				bitsToTransfer = 8;
+			else
+				bitsToTransfer = (UCHAR)(sizeToTransfer - *sizeTransferred);
+			byte = buffer[(*sizeTransferred+1)/8];
+			status = SPI_Write8bits(handle, byte, bitsToTransfer, lsb);
+			CHECK_STATUS(status);
+			if (FT_OK == status)
+				*sizeTransferred += bitsToTransfer;
+		}
+	}
+	else
+	{/* sizeToTransfer is in bytes */
+		DWORD noOfBytesTransferred = 0, CurrentXferSize = 0;
+		uint8 cmdBuffer[3];
+		ChannelConfig *config = NULL;
+		uint8 mode;
+
+		status = SPI_GetChannelConfig(handle, &config);
+		CHECK_STATUS(status);
+		/*mode is given by bit1-bit0 of ChannelConfig.Options*/
+		mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+		/* Command to write 8bits */
+		switch(mode)
+		{
+			case SPI_CONFIG_OPTION_MODE0:
+				cmdBuffer[0] = MPSSE_CMD_DATA_OUT_BYTES_NEG_EDGE | lsb;
+				break;
+			case SPI_CONFIG_OPTION_MODE1:
+				cmdBuffer[0] = MPSSE_CMD_DATA_OUT_BYTES_POS_EDGE | lsb;
+				break;
+			case SPI_CONFIG_OPTION_MODE2:
+				cmdBuffer[0] = MPSSE_CMD_DATA_OUT_BYTES_POS_EDGE | lsb;
+				break;
+			case SPI_CONFIG_OPTION_MODE3:
+				cmdBuffer[0] = MPSSE_CMD_DATA_OUT_BYTES_NEG_EDGE | lsb;
+				break;
+			default:
+				DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+		}
+
+		*sizeTransferred = 0;
+
+		while(*sizeTransferred < sizeToTransfer)
+		{
+
+			CurrentXferSize = ((sizeToTransfer - *sizeTransferred) > 64*1024)? 64*1024:(sizeToTransfer - *sizeTransferred);
+			/* length low byte */
+			cmdBuffer[1] = (uint8)((CurrentXferSize-1) & 0x000000FF);
+			/* length high byte */
+			cmdBuffer[2] = (uint8)(((CurrentXferSize-1) & 0x0000FF00)>>8);
+			/* write command */
+			status = FT_Channel_Write(SPI, handle, 3, cmdBuffer,\
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+			/* write data */
+			status = FT_Channel_Write(SPI, handle, CurrentXferSize, buffer,\
+				&noOfBytesTransferred);
+			*sizeTransferred += noOfBytesTransferred;
+
+			CHECK_STATUS(status);
+
+		}
+	}
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE)
+	{
+		/* disable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, FALSE);
+		CHECK_STATUS(status);
+	}
+	UNLOCK_CHANNEL(handle);
+	DBG(MSG_DEBUG,"sizeToTransfer=%u  sizeTransferred=%u BitMode=%u \
+		CS_Enable=%u CS_Disable=%u\n", sizeToTransfer,*sizeTransferred,		\
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_SIZE_IN_BITS),	\
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE),\
+		(unsigned)(transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE));
+	FN_EXIT;
+	return status;
+}
+#if 1
+
+FTDIMPSSE_API FT_STATUS SPI_ReadWrite(FT_HANDLE handle, UCHAR *inBuffer,
+	UCHAR *outBuffer, DWORD sizeToTransfer, LPDWORD sizeTransferred,
+	DWORD transferOptions)
+{
+	FT_STATUS status;
+	ChannelConfig *config = NULL;
+	UCHAR mode;
+	UCHAR bitsToTransfer = 0;
+	DWORD noOfBytesTransferred = 0;
+	UCHAR cmdBuffer[10];
+	FN_ENTER;
+
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+	CHECK_NULL_RET(inBuffer);
+	CHECK_NULL_RET(outBuffer);
+	CHECK_NULL_RET(sizeTransferred);
+#endif
+
+	LOCK_CHANNEL(handle);
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+
+	/*mode is given by bit1-bit0 of ChannelConfig.Options*/
+	mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_ENABLE)
+	{
+		/* enable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, TRUE);
+		CHECK_STATUS(status);
+	}
+
+	/* start of transfer */
+	if (transferOptions & SPI_TRANSFER_OPTIONS_SIZE_IN_BITS)
+	{/* sizeToTransfer is in bits */
+		*sizeTransferred = 0;
+		/* Command to write 8bits */
+		switch(mode)
+		{
+			case SPI_CONFIG_OPTION_MODE0:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BITS_IN_POS_OUT_NEG_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE1:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BITS_IN_NEG_OUT_POS_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE2:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BITS_IN_NEG_OUT_POS_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE3:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BITS_IN_POS_OUT_NEG_EDGE;
+				break;
+			default:
+				DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+		}
+
+		while(*sizeTransferred < sizeToTransfer)
+		{
+			if ((sizeToTransfer - *sizeTransferred)>=8)
+				bitsToTransfer = 8;
+			else
+				bitsToTransfer = (UCHAR)(sizeToTransfer - *sizeTransferred);
+			cmdBuffer[1] = bitsToTransfer - 1; /*takes value 0 for 1 bit; 7 for 8 bits*/
+			cmdBuffer[2] = outBuffer[(*sizeTransferred+1)/8];
+
+			/*Write command and data*/
+			status = FT_Channel_Write(SPI, handle, 3, cmdBuffer,\
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+			if (3 > noOfBytesTransferred)
+			{/*timeout occured if FT_OK is returned but transferred length is requested len*/
+				DBG(MSG_WARN,"Timeout occured. RequestedTxLen = 3 TxLen=%u \n",\
+					(unsigned)noOfBytesTransferred);
+			}
+
+
+			/*Read from buffer*/
+			status = FT_Channel_Read(SPI, handle, 1,\
+				inBuffer+((*sizeTransferred+1)/8), &noOfBytesTransferred);
+			CHECK_STATUS(status);
+			if (1 > noOfBytesTransferred)
+			{/*timeout occured if FT_OK is returned but transferred length is requested len*/
+				DBG(MSG_WARN,"Timeout occured. RequestedTxLen = 1 TxLen=%u \n",\
+					(unsigned)noOfBytesTransferred);
+			}
+
+			if (FT_OK == status)
+				*sizeTransferred += bitsToTransfer;
+		}
+	}
+	else
+	{
+		uint32 CurrentXferSize = 0;
+		/* Command to write 8bits */
+		switch(mode)
+		{
+			case SPI_CONFIG_OPTION_MODE0:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BYTES_IN_POS_OUT_NEG_EDGE;
+//				rCmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_POS_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE1:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BYTES_IN_NEG_OUT_POS_EDGE;
+//				rCmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_NEG_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE2:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BYTES_IN_NEG_OUT_POS_EDGE;
+//				rCmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_NEG_EDGE;
+				break;
+			case SPI_CONFIG_OPTION_MODE3:
+				cmdBuffer[0] = MPSSE_CMD_DATA_BYTES_IN_POS_OUT_NEG_EDGE;
+//				rCmdBuffer[0] = MPSSE_CMD_DATA_IN_BYTES_POS_EDGE;
+				break;
+			default:
+				DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+				break;
+		}
+
+
+
+		///
+		*sizeTransferred = 0;
+		while(*sizeTransferred < sizeToTransfer)
+		{
+
+			CurrentXferSize = ((sizeToTransfer - *sizeTransferred) > 64*1024)? 64*1024:(sizeToTransfer - *sizeTransferred);
+			/* length LSB */
+			cmdBuffer[1] = (uint8)((CurrentXferSize-1) & 0x000000FF) ;
+			/* length MSB */
+			cmdBuffer[2] = (uint8)(((CurrentXferSize-1) & 0x0000FF00)>>8);
+			//cmdBuffer[3] = MPSSE_CMD_SEND_IMMEDIATE;
+
+//			memcpy(&cmdBuffer[3],outBuffer, CurrentXferSize);
+
+			/*Write command*/
+			status = FT_Channel_Write(SPI, handle, 3,cmdBuffer,
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+			noOfBytesTransferred = 0;
+#if 1
+			status = FT_Channel_Write(SPI, handle, CurrentXferSize, &outBuffer[*sizeTransferred],\
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+#endif
+#if 0
+			{//for debugging
+				int i;
+					printf("\nnoOfBytes=%d noOfBytesTransferred=%d data=", noOfBytes, noOfBytesTransferred);
+				for (i = 0; i < noOfBytes; i++)
+				{
+					printf(" 0x%x", outBuffer[i]);
+				}
+				printf("\n");
+			}
+#endif
+#if 0
+			/* length LSB */
+			rCmdBuffer[1] = (uint8)((CurrentXferSize-1) & 0x000000FF) ;
+			/* length MSB */
+			rCmdBuffer[2] = (uint8)(((CurrentXferSize-1) & 0x0000FF00)>>8);
+
+			/*Command MPSSE to send data to PC immediately */
+			rCmdBuffer[3] = MPSSE_CMD_SEND_IMMEDIATE;
+			status = FT_Channel_Write(SPI, handle, 4, rCmdBuffer,
+				&noOfBytesTransferred);
+
+#endif
+			noOfBytesTransferred = 0;
+			status = FT_Channel_Read(SPI, handle, CurrentXferSize, &inBuffer[*sizeTransferred],
+				&noOfBytesTransferred);
+			CHECK_STATUS(status);
+#if 0
+			{//for debugging
+				int i;
+				printf("\nsizeToTransfer=%d sizeTransferred=%d data=", sizeToTransfer,*sizeTransferred);
+				for (i = 0; i<*sizeTransferred; i++)
+				{
+					printf(" 0x%x", outBuffer[i]);
+				}
+				printf("\n");
+			}
+#endif
+			*sizeTransferred += noOfBytesTransferred;
+		}
+	}
+	/* end of transfer */
+
+	if (transferOptions & SPI_TRANSFER_OPTIONS_CHIPSELECT_DISABLE)
+	{
+		/* disable CHIPSELECT line for the channel */
+		status = SPI_ToggleCS(handle, FALSE);
+		CHECK_STATUS(status);
+	}
+	UNLOCK_CHANNEL(handle);
+
+	FN_EXIT;
+	return status;
+}
+#else
+/*!
+ * \brief Reads and writes data from/to a SPI slave device
+ *
+ * This function transfers data in both directions between a SPI master and a slave. One bit is
+ * clocked out and one bit is clocked in during every clock.
+ *
+ * \param[in] handle Handle of the channel
+ * \param[in] *inBuffer Pointer to buffer to which data read will be stored
+ * \param[in] *outBuffer Pointer to buffer that contains data to be transferred to the slave
+ * \param[in] sizeToTransfer Size of data to be transferred
+ * \param[out] sizeTransfered Pointer to variable containing the size of data
+ *			that got transferred
+ * \param[in] transferOptions This parameter specifies data transfer options
+ *				if BIT0 is 0 then size is in bytes, otherwise in bits
+ *				if BIT1 is 1 then CHIP_SELECT line will be enables at start of transfer
+ *				if BIT2 is 1 then CHIP_SELECT line will be disabled at end of transfer
+ *
+ * \return Returns status code of type FT_STATUS(see D2XX Programmer's Guide)
+ * \sa
+ * \note
+ * \warning
+ */
+FTDIMPSSE_API FT_STATUS SPI_ReadWrite(FT_HANDLE handle, UCHAR *inBuffer,
+	UCHAR *outBuffer, DWORD sizeToTransfer, LPDWORD sizeTransferred,
+	uint32 transferOptions)
+{
+	FT_STATUS status;
+	status = SPI_Write(handle, outBuffer, sizeToTransfer, sizeTransferred, transferOptions);
+	if (FT_OK == status)
+	{
+		status = SPI_Read(handle, inBuffer, sizeToTransfer, sizeTransferred, transferOptions);
+	}
+	FN_EXIT;
+	return status;
+}
+#endif
+
+FTDIMPSSE_API FT_STATUS SPI_IsBusy(FT_HANDLE handle, bool *state)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	DWORD noOfBytes = 0, noOfBytesTransferred = 0;
+	uint8 buffer[10];
+
+	FN_ENTER;
+	/*Enable CS*/
+	SPI_ToggleCS(handle, TRUE);
+	/*Send command to read*/
+	buffer[noOfBytes++] = MPSSE_CMD_GET_DATA_BITS_LOWBYTE;
+	buffer[noOfBytes++] = MPSSE_CMD_SEND_IMMEDIATE;
+	status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+		&noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	/*Read*/
+	noOfBytes = 1;
+	noOfBytesTransferred = 0;
+	status = FT_Channel_Read(SPI, handle, noOfBytes, buffer, &noOfBytesTransferred);
+	CHECK_STATUS(status);
+	DBG(MSG_DEBUG,"Low byte read = 0x%x\n", buffer[0]);
+	if (0 == (buffer[0] & 0x04))
+		*state = FALSE;
+	else
+		*state = TRUE;
+
+	/*Disable CS*/
+	SPI_ToggleCS(handle, FALSE);
+	FN_EXIT;
+	return status;
+}
+
+FTDIMPSSE_API FT_STATUS SPI_ChangeCS(FT_HANDLE handle, DWORD configOptions)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	uint8 mode;
+#if 1
+	uint8 buffer[5];
+	uint32 noOfBytes = 0;
+	DWORD noOfBytesTransferred;
+#endif
+	ChannelConfig *config = NULL;
+	FN_ENTER;
+#ifdef ENABLE_PARAMETER_CHECKING
+	CHECK_NULL_RET(handle);
+#endif
+
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	/* Replace config options with new values */
+	config->configOptions = configOptions;
+	/* Ensure new CS lins is set as OUT */
+	config->currentPinState |= \
+		((1<<((config->configOptions & SPI_CONFIG_OPTION_CS_MASK)>>2))<<3);
+
+	DBG(MSG_DEBUG,"handle = 0x%x configOptions = 0x%x \n",\
+		(unsigned)handle,(unsigned)configOptions);
+
+	/*Set initial state of clock line*/
+	mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+	switch(mode)
+	{
+		case 0:
+		case 1:
+			/* clock idle low */
+			config->currentPinState &= 0xFEFF;
+			break;
+
+		case 2:
+		case 3:
+			/* clock idle high */
+			config->currentPinState |= 0x0100;
+			break;
+		default:
+			DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+	}
+
+	buffer[noOfBytes++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;/* MPSSE command */
+	buffer[noOfBytes++] = (uint8)((config->currentPinState & 0xFF00)>>8);/*Val*/
+	buffer[noOfBytes++] = (uint8)(config->currentPinState & 0x00FF); /*Dir*/
+
+	status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+			&noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	status = SPI_SaveChannelConfig(handle, config);
+	CHECK_STATUS(status);
+
+	FN_EXIT;
+	return status;
+}
+
+FT_STATUS SPI_ToggleCS(FT_HANDLE handle, bool state)
+{
+	ChannelConfig *config = NULL;
+	bool activeLow;
+	FT_STATUS status = FT_OTHER_ERROR;
+	uint8 buffer[5];
+	uint32 i = 0;
+	DWORD noOfBytesTransferred;
+	uint8 value, oldValue, direction;
+
+	FN_ENTER;
+
+#ifdef DEVELOPMENT_FIXED_CS
+	/* For initial development only - assuming only ADBUS0 will be used for CS*/
+	buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+	if (TRUE == state)
+	{
+		//buffer[i++] = 0x08;		/*value*/
+		buffer[i++] = 0x09;		/*value - mode2, 3 clock idle high*/
+	}
+	else
+	{
+		//buffer[i++] = 0x00;		/*value*/
+		buffer[i++] = 0x01;		/*value - mode2, 3 clock idle high*/
+	}
+	buffer[i++] = 0x0B;//direction;	/*direction*/
+	status = FT_Channel_Write(SPI, handle, i, buffer, &noOfBytesTransferred);
+	CHECK_STATUS(status);
+#else
+	/*Get a pointer to the channel's configuration data and manipulate there directly*/
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	activeLow = (config->configOptions & \
+		SPI_CONFIG_OPTION_CS_ACTIVELOW)?TRUE:FALSE;
+
+	DBG(MSG_DEBUG,"config->configOptions = 0x%x activeLow = 0x%x\n",
+		(unsigned)config->configOptions,(unsigned)activeLow);
+
+	//direction = (uint8)config->currentPinState;/*get current state*/
+	direction = (uint8)(config->currentPinState & 0x00FF);//20110718
+	direction |= \
+		((1<<((config->configOptions & SPI_CONFIG_OPTION_CS_MASK)>>2))<<3);
+	DBG(MSG_DEBUG,"config->currentPinState = 0x%x direction = 0x%x\n",
+		(unsigned)config->currentPinState,(unsigned)direction);
+
+	//oldValue = (uint8)(8>>config->currentPinState);
+	oldValue =  (uint8)((config->currentPinState & 0xFF00)>>8);//20110718
+	value = ((1<<((config->configOptions & SPI_CONFIG_OPTION_CS_MASK)>>2))<<3);
+
+	DBG(MSG_DEBUG,"oldValue = 0x%x value = 0x%x\n", oldValue, value);
+
+	if ((TRUE == state && FALSE == activeLow) || (FALSE == state && TRUE == activeLow))
+		value = oldValue | value; /* set the CS line high */
+	if ((TRUE == state && TRUE == activeLow) || (FALSE == state && FALSE == activeLow))
+		value = oldValue & ~value;/* set the CS line low */
+
+	config->currentPinState = ((uint16)value<<8) | direction;/*save  dirn & value*/
+	DBG(MSG_DEBUG,"config->currentPinState = 0x%x\n",
+		(unsigned)config->currentPinState);
+
+	/*MPSSE command to set low bytes*/
+	buffer[i++] = MPSSE_CMD_SET_DATA_BITS_LOWBYTE;
+	buffer[i++] = value;		/*value*/
+	buffer[i++] = direction;	/*direction*/
+	DBG(MSG_DEBUG,"direction = 0x%x value = 0x%x\n", direction, value);
+	status = FT_Channel_Write(SPI, handle, i,buffer, &noOfBytesTransferred);
+	CHECK_STATUS(status);
+#endif
+	FN_EXIT;
+	return status;
+}
+
+/******************************************************************************/
+/*						Local function definitions						  */
+/******************************************************************************/
+
+static FT_STATUS SPI_AddChannelConfig(FT_HANDLE handle)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	ChannelContext *tempNode = NULL;
+	ChannelContext *lastNode = NULL;
+	FN_ENTER;
+	DBG(MSG_DEBUG,"line %u handle = 0x%x\n", __LINE__,(unsigned)handle);
+
+#ifdef NO_LINKED_LIST
+	status = FT_OK;
+#else
+	if (NULL == ListHead)
+	{/* Add first node */
+		ListHead = (ChannelContext *) INFRA_MALLOC(sizeof(ChannelContext));
+		if (NULL == ListHead)
+		{
+			status = FT_INSUFFICIENT_RESOURCES;
+			DBG(MSG_ERR,"Failed allocating memory\n");
+		}
+		else
+		{
+			ListHead->handle = handle;
+			ListHead->next = NULL;
+			status = FT_OK;
+		}
+	}
+	else
+	{/* Add subsequent nodes */
+		/* Traverse list */
+		for (tempNode = ListHead; NULL != tempNode; tempNode = tempNode->next)
+		{
+			lastNode = tempNode;
+		}
+		tempNode = (ChannelContext *) INFRA_MALLOC(sizeof(ChannelContext));
+		if (NULL == tempNode)
+		{
+			status = FT_INSUFFICIENT_RESOURCES;
+			DBG(MSG_ERR,"Failed allocating memory\n");
+		}
+		else
+		{
+			tempNode->handle = handle;
+			tempNode->next = NULL;
+			lastNode->next = tempNode;
+			status = FT_OK;
+		}
+	}
+#endif
+	FN_EXIT;
+#ifdef INFRA_DEBUG_ENABLE
+	SPI_DisplayList();
+#endif
+	return status;
+}
+
+static FT_STATUS SPI_DelChannelConfig(FT_HANDLE handle)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	ChannelContext *tempNode;
+	ChannelContext *lastNode = NULL;
+	FN_ENTER;
+
+#ifdef NO_LINKED_LIST
+	status = FT_OK;
+#else
+	if (NULL == ListHead)
+	{
+		DBG(MSG_NOTICE,"List is empty\n");
+	}
+	else
+	{
+		for (tempNode = ListHead; NULL != tempNode;
+			lastNode = tempNode, tempNode = tempNode->next)
+		{
+			if (tempNode->handle == handle)
+			{/*Node found*/
+				if (tempNode == ListHead)
+				{/* Is the first node */
+
+					ListHead = tempNode->next;
+					INFRA_FREE(tempNode);
+				}
+				else if (NULL == tempNode->next)
+				{/*Last node*/
+					lastNode->next = NULL;
+					INFRA_FREE(tempNode);
+				}
+				else
+				{/* Middle node */
+					lastNode->next = tempNode->next;
+					INFRA_FREE(tempNode);
+				}
+				status = FT_OK;
+				break;
+			}
+		}
+	}
+#endif
+	status = FT_OK;
+	FN_EXIT;
+#ifdef INFRA_DEBUG_ENABLE
+	SPI_DisplayList();
+#endif
+	return status;
+}
+
+static FT_STATUS SPI_SaveChannelConfig(FT_HANDLE handle, ChannelConfig *config)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	ChannelContext *tempNode = NULL;
+	FN_ENTER;
+
+#ifdef NO_LINKED_LIST
+		memcpy(&channelContext.config, config, sizeof(ChannelConfig));
+		channelContext.handle = handle;
+		status = FT_OK;
+#else
+	if (NULL == ListHead)
+	{
+		DBG(MSG_NOTICE,"List is empty\n");
+	}
+	else
+	{
+		tempNode = ListHead;
+		for (tempNode = ListHead; 0 != tempNode; tempNode = tempNode->next)
+		{
+			DBG(MSG_DEBUG,"line=%d tempNode->handle = 0x%x handle = 0x%x tempNode->\
+				next = 0x%x\n", __LINE__,(unsigned)tempNode->handle,
+				(unsigned)handle, (unsigned)tempNode->next);
+			if (tempNode->handle == handle)
+			{/*Node found*/
+				INFRA_MEMCPY(&(tempNode->config), config, sizeof(ChannelConfig));
+				status = FT_OK;
+			}
+		}
+	}
+#endif
+
+	FN_EXIT;
+#ifdef INFRA_DEBUG_ENABLE
+	SPI_DisplayList();
+#endif
+	return status;
+}
+
+FT_STATUS SPI_GetChannelConfig(FT_HANDLE handle, ChannelConfig **config)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	ChannelContext *tempNode = NULL;
+	FN_ENTER;
+
+#ifdef NO_LINKED_LIST
+		if (handle == channelContext.handle)
+		{
+			*config= &(channelContext.config);
+			status = FT_OK;
+		}
+		else
+			DBG(MSG_DEBUG,"handle not found in channel config list\n");
+#else
+	if (NULL == ListHead)
+	{
+		DBG(MSG_NOTICE,"List is empty\n");
+	}
+	else
+	{
+		for (tempNode = ListHead; NULL != tempNode; tempNode = tempNode->next)
+		{
+			if (tempNode->handle == handle)
+			{/*Node found*/
+				*config = &(tempNode->config);
+				status = FT_OK;
+			}
+		}
+	}
+#endif
+
+	FN_EXIT;
+#ifdef INFRA_DEBUG_ENABLE
+	SPI_DisplayList();
+#endif
+	return status;
+}
+
+#ifdef INFRA_DEBUG_ENABLE
+static FT_STATUS SPI_DisplayList(void)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	ChannelContext *tempNode = NULL;
+	FN_ENTER;
+	printf("%s:%d:%s():\n", __FILE__, __LINE__, __FUNCTION__);
+	for (tempNode = ListHead; 0 != tempNode; tempNode = tempNode->next)
+	{
+		//if (currentDebugLevel>=MSG_DEBUG)
+		{
+			printf("\ttempNode->handle = 0x%x\n",(unsigned)tempNode->handle);
+			printf("\ttempNode-->next = 0x%x\n",(unsigned)tempNode->next);
+			printf("\ttempNode->config->ClockRate=%u\n",
+				(unsigned)tempNode->config.ClockRate);
+		}
+	}
+	printf("------------------------------------------------------\n");
+	FN_EXIT;
+	return status;
+}
+#endif
+
+static FT_STATUS SPI_Write8bits(FT_HANDLE handle, uint8 byte, uint8 len, uint8 lsb)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	DWORD noOfBytes = 0, noOfBytesTransferred = 0;
+	uint8 buffer[10];
+	ChannelConfig *config = NULL;
+	uint8 mode;
+	FN_ENTER;
+
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	/*mode is given by bit1-bit0 of ChannelConfig.Options*/
+	mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+	/* Command to write 8bits */
+	switch(mode)
+	{
+		case 0:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE | lsb;
+			break;
+		case 1:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_OUT_BITS_POS_EDGE | lsb;
+			break;
+		case 2:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_OUT_BITS_POS_EDGE | lsb;
+			break;
+		case 3:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_OUT_BITS_NEG_EDGE | lsb;
+			break;
+		default:
+			DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+	}
+	buffer[noOfBytes++] = len-1;/* 1bit->arg = 0, for 8bits->arg = 7 */
+	buffer[noOfBytes++] = byte;
+	DBG(MSG_DEBUG,"SPIMODE=%u buffer[0] = 0x%x writing data = 0x%x len=%u\n",
+		(unsigned)mode,(unsigned)buffer[0],(unsigned)byte,(unsigned)len);
+	status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+		&noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	FN_EXIT;
+	return status;
+}
+
+static FT_STATUS SPI_Read8bits(FT_HANDLE handle, uint8 *byte, uint8 len, uint8 lsb)
+{
+	FT_STATUS status = FT_OTHER_ERROR;
+	DWORD noOfBytes = 0, noOfBytesTransferred = 0;
+	uint8 buffer[10];
+	ChannelConfig *config = NULL;
+	uint8 mode;
+
+	FN_ENTER;
+	status = SPI_GetChannelConfig(handle, &config);
+	CHECK_STATUS(status);
+	/*mode is given by bit1-bit0 of ChannelConfig.Options*/
+	mode = (config->configOptions & SPI_CONFIG_OPTION_MODE_MASK);
+	/* Command to write 8bits */
+	switch(mode)
+	{
+		case 0:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE | lsb;
+			break;
+		case 1:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_NEG_EDGE | lsb;
+			break;
+		case 2:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_NEG_EDGE | lsb;
+			break;
+		case 3:
+			buffer[noOfBytes++] = MPSSE_CMD_DATA_IN_BITS_POS_EDGE | lsb;
+			break;
+		default:
+			DBG(MSG_ERR,"invalid mode(%u)\n",(unsigned)mode);
+	}
+	buffer[noOfBytes++] = len-1;/* 1bit->arg = 0, for 8bits->arg = 7 */
+
+	/*Command MPSSE to send data to PC immediately */
+	buffer[noOfBytes++] = MPSSE_CMD_SEND_IMMEDIATE;
+
+	DBG(MSG_DEBUG,"writing data = 0x%x len=%u\n",(unsigned)byte,(unsigned)len);
+	status = FT_Channel_Write(SPI, handle, noOfBytes, buffer,\
+		&noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	noOfBytes = 1;
+	noOfBytesTransferred = 0;
+	status = FT_Channel_Read(SPI, handle, noOfBytes, buffer, &noOfBytesTransferred);
+	CHECK_STATUS(status);
+
+	*byte = buffer[0];
+	DBG(MSG_DEBUG,"SPI_Read8bits len=%u(in bits) byte = 0x%x mode=%u\n",\
+		(unsigned)len,*byte,(unsigned)mode);
+
+	FN_EXIT;
+	return status;
+}

--- a/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/memcpy.c
+++ b/feeds/morse/utils/morsectrl/src/transport/libmpsse/source/memcpy.c
@@ -1,0 +1,30 @@
+/* This file allows libmpsse to depend on an old version of GLibC's memcpy.
+ * Without this, we depend on version 2.14 which is too new for some of our
+ * customers.
+ * This solution is copied from:
+ * http://stackoverflow.com/questions/8823267/linking-against-older-symbol-version-in-a-so-file/8862631#8862631
+ * and requires the linker option --wrap=memcpy
+ */
+
+#include <string.h>
+
+#if !defined(ANDROID) && !defined(_OSX_) && (defined(__LP64__) || defined(_LP64)) && \
+    defined(__x86_64__) && !defined(__ILP32__) && defined(__GNU_LIBRARY__)
+// Most other GLibC functions are version 2.2.5 in 64 bit builds
+asm (".symver memcpy, memcpy@GLIBC_2.2.5");
+
+void *__wrap_memcpy(void *dest, const void *src, size_t n)
+{
+    return memcpy(dest, src, n);
+}
+
+#else
+// For all other architectures, just use the real memcpy.
+
+void *__real_memcpy(void *dest, const void *src, size_t n);
+
+void *__wrap_memcpy(void *dest, const void *src, size_t n)
+{
+    return __real_memcpy(dest, src, n);
+}
+#endif // !ANDROID && !_OSX_ && (__LP64__ || _LP64)

--- a/feeds/morse/utils/morsectrl/src/transport/nl80211.c
+++ b/feeds/morse/utils/morsectrl/src/transport/nl80211.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <linux/nl80211.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/family.h>
+#include <net/if.h>
+#include <netlink/attr.h>
+
+#include "../utilities.h"
+#include "transport.h"
+#include "transport_private.h"
+
+#define MORSE_OUI 0x0CBF74
+#define MORSE_VENDOR_CMD_TO_MORSE 0x00
+#define NL80211_BUFFER_SIZE (8192)
+
+
+static const struct morsectrl_transport_ops nl80211_ops;
+
+/** @brief Configuration for the NL80211 interface. */
+struct morsectrl_nl80211_cfg
+{
+    const char *interface_name;
+};
+
+/** @brief State information for the NL80211 interface. */
+struct morsectrl_nl80211_state
+{
+    int interface_index;
+    int nl80211_id;
+    size_t *len;
+    uint8_t *data;
+    struct nl_sock* nl_socket;
+    struct nl_cb *cb;
+    struct nl_cb *s_cb;
+    bool wait_for_ack;
+};
+
+/** @brief Data structure used to represent an instance of this trasport. */
+struct morsectrl_nl80211_transport
+{
+    struct morsectrl_transport common;
+    struct morsectrl_nl80211_cfg config;
+    struct morsectrl_nl80211_state state;
+};
+
+/** Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *  config field. */
+static struct morsectrl_nl80211_cfg *nl80211_cfg(struct morsectrl_transport *transport)
+{
+    struct morsectrl_nl80211_transport *nl80211_transport =
+        (struct morsectrl_nl80211_transport *)transport;
+    return &nl80211_transport->config;
+}
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *        state field.
+ */
+static struct morsectrl_nl80211_state *nl80211_state(struct morsectrl_transport *transport)
+{
+    struct morsectrl_nl80211_transport *nl80211_transport =
+        (struct morsectrl_nl80211_transport *)transport;
+    return &nl80211_transport->state;
+}
+
+
+/**
+ * @brief Prints an error message if possible.
+ *
+ * @param transport     Transport to print the error message from.
+ * @param error_code    Error code.
+ * @param error_msg     Error message.
+ */
+static void morsectrl_nl80211_error(int error_code, char *error_msg)
+{
+    morsectrl_transport_err("NL80211", error_code, error_msg);
+}
+
+static int morsectrl_nl80211_parse(struct morsectrl_transport **transport,
+                                   bool debug,
+                                   const char *iface_opts,
+                                   const char *cfg_opts)
+{
+    struct morsectrl_nl80211_cfg *cfg;
+
+    struct morsectrl_nl80211_transport *nl80211_transport = calloc(1, sizeof(*nl80211_transport));
+    if (!nl80211_transport)
+    {
+        mctrl_err("Transport memory allocation failure\n");
+        return -ETRANSNOMEM;
+    }
+    nl80211_transport->common.tops = &nl80211_ops;
+    nl80211_transport->common.debug = debug;
+    *transport = &nl80211_transport->common;
+    cfg = nl80211_cfg(*transport);
+
+    (void)cfg_opts;
+
+    if (!iface_opts)
+    {
+        cfg->interface_name = DEFAULT_INTERFACE_NAME;
+    }
+    else
+    {
+        cfg->interface_name = iface_opts;
+    }
+
+    if (nl80211_transport->common.debug)
+    {
+        mctrl_print("Using %s interface\n", cfg->interface_name);
+    }
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief Handle errors from the netlink interface.
+ *
+ * @param nla   Netlink socket address.
+ * @param nlerr Netlink error.
+ * @param arg   @ref morsectrl_transport opaque pointer.
+ * @return      NL_STOP always.
+ */
+static int morsectrl_nl80211_error_handler(struct sockaddr_nl *nla,
+                                           struct nlmsgerr *nlerr,
+                                           void *arg)
+{
+    morsectrl_nl80211_error(nlerr->error, "Error callback called");
+
+    return NL_STOP;
+}
+
+/**
+ * @brief Handle acks from the netlink interface.
+ *
+ * @param msg   Netlink message.
+ * @param arg   @ref morsectrl_transport opaque pointer.
+ * @return      NL_STOP always.
+ */
+static int morsectrl_nl80211_ack_handler(struct nl_msg *msg, void *arg)
+{
+    struct morsectrl_transport *transport = (struct morsectrl_transport *)arg;
+
+    if (transport)
+    {
+        nl80211_state(transport)->wait_for_ack = false;
+
+        if (transport->debug) {
+            mctrl_print("nla_msg_dump\n");
+            nl_msg_dump(msg, stdout);
+        }
+    }
+
+    return NL_STOP;
+}
+
+/**
+ * @brief Handle reception of response messages from the netlink interface.
+ *
+ * @param msg   Netlink message.
+ * @param arg   @ref morsectrl_transport opaque pointer.
+ * @return      NL_SKIP if reponse is missing otherwise NL_OK.
+ */
+static int morsectrl_nl80211_receive_handler(struct nl_msg *msg, void *arg)
+{
+    struct morsectrl_transport *transport = (struct morsectrl_transport *)arg;
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    struct nlattr *attr;
+    struct morsectrl_nl80211_state *state;
+    uint8_t *data;
+    int len;
+
+    if (!transport)
+    {
+        morsectrl_nl80211_error(-ETRANSNL80211ERR, "Transport for receive invalid");
+        return NL_SKIP;
+    }
+
+    state = nl80211_state(transport);
+
+    if (transport->debug)
+    {
+        mctrl_print("nla_msg_dump\n");
+        nl_msg_dump(msg, stdout);
+    }
+
+    attr = nla_find(genlmsg_attrdata(gnlh, 0),
+                    genlmsg_attrlen(gnlh, 0),
+                    NL80211_ATTR_VENDOR_DATA);
+    if (!attr)
+    {
+        morsectrl_nl80211_error(0, "Vendor data attribute missing");
+        return NL_SKIP;
+    }
+
+    data = (uint8_t *) nla_data(attr);
+    len = nla_len(attr);
+
+    if (len > *state->len)
+    {
+        morsectrl_nl80211_error(-ETRANSNL80211ERR, "Output buffer too small limiting output");
+        len = *state->len;
+    }
+
+    memcpy(state->data, data, len);
+    *state->len = len;
+    return NL_OK;
+}
+
+static int morsectrl_nl80211_init(struct morsectrl_transport *transport)
+{
+    struct morsectrl_nl80211_state *state;
+    struct morsectrl_nl80211_cfg *cfg;
+    int ret = 0;
+#ifdef NETLINK_EXT_ACK
+    int option_value;
+#endif
+
+    if (!transport)
+        return -ETRANSNL80211ERR;
+
+    cfg = nl80211_cfg(transport);
+    state = nl80211_state(transport);
+    state->interface_index = if_nametoindex(cfg->interface_name);
+
+    if (state->interface_index == 0)
+    {
+        morsectrl_nl80211_error(state->interface_index, "Invalid interface index");
+
+        return -ETRANSNL80211ERR;
+    }
+
+    state->wait_for_ack = false;
+    state->nl_socket = nl_socket_alloc();
+
+    if (state->nl_socket == NULL)
+    {
+        ret = -ENOMEM;
+        morsectrl_nl80211_error(ret, "Failed to allocate netlink socket");
+        goto exit;
+    }
+
+    ret = genl_connect(state->nl_socket);
+    if (ret < ETRANSSUCC)
+    {
+        morsectrl_nl80211_error(ret, "genl_connect failed");
+        goto exit_socket_free;
+    }
+    nl_socket_set_buffer_size(state->nl_socket,
+                              NL80211_BUFFER_SIZE,
+                              NL80211_BUFFER_SIZE);
+#ifdef NETLINK_EXT_ACK
+    /* try to set NETLINK_EXT_ACK to 1, ignoring errors */
+    option_value = 1;
+    setsockopt(nl_socket_get_fd(state->nl_socket),
+               SOL_NETLINK, NETLINK_EXT_ACK,
+               &option_value, sizeof(option_value));
+#endif
+    state->nl80211_id = genl_ctrl_resolve(state->nl_socket, "nl80211");
+    if (state->nl80211_id < 0)
+    {
+        ret = -ENOENT;
+        morsectrl_nl80211_error(ret, "Failed to get netlink id");
+        goto exit_socket_free;
+    }
+
+    state->s_cb = nl_cb_alloc(transport->debug ? NL_CB_DEBUG : NL_CB_DEFAULT);
+    state->cb = nl_cb_alloc(NL_CB_DEFAULT);
+    if (!state->cb || !state->s_cb)
+    {
+        ret = -ENOMEM;
+        morsectrl_nl80211_error(ret, "Failed to allocate netlink callbacks");
+        goto exit_cb_free;
+    }
+
+    nl_cb_err(state->cb, NL_CB_CUSTOM, morsectrl_nl80211_error_handler, transport);
+    nl_cb_set(state->cb, NL_CB_VALID, NL_CB_CUSTOM, morsectrl_nl80211_receive_handler, transport);
+    nl_cb_set(state->cb, NL_CB_ACK, NL_CB_CUSTOM, morsectrl_nl80211_ack_handler, transport);
+    nl_socket_set_cb(state->nl_socket, state->s_cb);
+
+    return ret;
+
+exit_cb_free:
+    nl_cb_put(state->cb);
+    nl_cb_put(state->s_cb);
+exit_socket_free:
+    nl_socket_free(state->nl_socket);
+exit:
+    return ret;
+}
+
+static int morsectrl_nl80211_deinit(struct morsectrl_transport *transport)
+{
+    struct morsectrl_nl80211_state *state;
+
+    if (!transport)
+        return -ETRANSNL80211ERR;
+
+    state = nl80211_state(transport);
+    nl_cb_put(state->cb);
+    nl_cb_put(state->s_cb);
+    nl_socket_free(state->nl_socket);
+    memset(state, 0, sizeof(*state));
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief Allocate @ref morsectrl_transport_buff for commands and responses.
+ *
+ * @param size  Size of command and morse headers.
+ * @return      Allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+static struct morsectrl_transport_buff *morsectrl_nl80211_alloc(size_t size)
+{
+    struct morsectrl_transport_buff *buff;
+
+    if (size <= 0)
+        return NULL;
+
+    buff = (struct morsectrl_transport_buff *)malloc(sizeof(struct morsectrl_transport_buff));
+    if (!buff)
+        return NULL;
+
+    buff->capacity = size;
+    buff->memblock = (uint8_t *)malloc(buff->capacity);
+    if (!buff->memblock)
+    {
+        free(buff);
+        return NULL;
+    }
+
+    /* In this case there isn't any framing required in a contiguous block of memory. */
+    buff->data = buff->memblock;
+    buff->data_len = buff->capacity;
+
+    return buff;
+}
+
+static struct morsectrl_transport_buff *morsectrl_nl80211_write_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport)
+        return NULL;
+
+    return morsectrl_nl80211_alloc(size);
+}
+
+static struct morsectrl_transport_buff *morsectrl_nl80211_read_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport)
+        return NULL;
+
+    return morsectrl_nl80211_alloc(size);
+}
+
+static int morsectrl_nl80211_send(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *cmd,
+                                  struct morsectrl_transport_buff *resp)
+{
+    int ret = ETRANSSUCC;
+    void* header;
+    struct morsectrl_nl80211_state *state;
+    struct nl_msg* msg;
+
+    if (!transport)
+        return -ETRANSNL80211ERR;
+
+    state = nl80211_state(transport);
+    state->data = resp->data;
+    state->len = &resp->data_len;
+
+    msg = nlmsg_alloc();
+    if (msg == NULL)
+    {
+        ret = -ENOMEM;
+        morsectrl_nl80211_error(ret, "Failed to allocate netlink message");
+        goto exit;
+    }
+
+    header = genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, state->nl80211_id,
+                         0, 0, NL80211_CMD_VENDOR, 0);
+    if (header == NULL)
+    {
+        ret = -ENOMEM;
+        morsectrl_nl80211_error(ret, "Unable to put msg");
+        goto exit_message_free;
+    }
+
+    ret = nla_put_u32(msg, NL80211_ATTR_IFINDEX, state->interface_index);
+    if (ret < ETRANSSUCC)
+    {
+        morsectrl_nl80211_error(ret, "Unable to put interface index");
+        goto exit_message_free;
+    }
+
+    NLA_PUT_U32(msg, NL80211_ATTR_VENDOR_ID, MORSE_OUI);
+    NLA_PUT_U32(msg, NL80211_ATTR_VENDOR_SUBCMD, MORSE_VENDOR_CMD_TO_MORSE);
+    NLA_PUT(msg, NL80211_ATTR_VENDOR_DATA, cmd->data_len, cmd->data);
+
+    state->wait_for_ack = true;
+    ret = nl_send_auto_complete(state->nl_socket, msg);
+    if (ret < ETRANSSUCC)
+    {
+        morsectrl_nl80211_error(ret, "Failed to send_auto_complete");
+        goto exit_message_free;
+    }
+
+    ret = nl_recvmsgs(state->nl_socket, state->cb);
+
+    if (ret < ETRANSSUCC)
+    {
+        morsectrl_nl80211_error(ret, "Failed to rcvmsgs");
+        goto exit_message_free;
+    }
+
+    if (state->wait_for_ack)
+    {
+        ret = nl_wait_for_ack(state->nl_socket);
+        if (ret < 0)
+        {
+            morsectrl_nl80211_error(ret, "Failed to wait for ACK");
+        }
+    }
+
+nla_put_failure:
+exit_message_free:
+    state->wait_for_ack = false;
+    nlmsg_free(msg);
+exit:
+    return ret;
+}
+
+const char *morsectrl_nl80211_get_ifname(struct morsectrl_transport *transport)
+{
+    return nl80211_cfg(transport)->interface_name;
+}
+
+
+static const struct morsectrl_transport_ops nl80211_ops = {
+    .name = "nl80211",
+    .description = "Linux kernel netlink interface",
+    .has_reset = false,
+    .has_driver = true,
+    .parse = morsectrl_nl80211_parse,
+    .init = morsectrl_nl80211_init,
+    .deinit = morsectrl_nl80211_deinit,
+    .write_alloc = morsectrl_nl80211_write_alloc,
+    .read_alloc = morsectrl_nl80211_read_alloc,
+    .send = morsectrl_nl80211_send,
+    .reg_read = NULL,
+    .reg_write = NULL,
+    .mem_read = NULL,
+    .mem_write = NULL,
+    .raw_read = NULL,
+    .raw_write = NULL,
+    .raw_read_write = NULL,
+    .reset_device = NULL,
+    .get_ifname = morsectrl_nl80211_get_ifname,
+};
+
+REGISTER_TRANSPORT(nl80211_ops);

--- a/feeds/morse/utils/morsectrl/src/transport/sdio_over_spi.c
+++ b/feeds/morse/utils/morsectrl/src/transport/sdio_over_spi.c
@@ -1,0 +1,1008 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "../utilities.h"
+#include "transport.h"
+#include "transport_private.h"
+#include "sdio_over_spi.h"
+#include "../portable_endian.h"
+
+#define MM_ADDR_BOUNDARY                (0xFFFF0000)
+#define MM_ADDR_BOUNDARY_OFFSET         (0x00010000)
+#define MM_KEYHOLE_ADDR_WIN0            (BIT(16))
+#define MM_KEYHOLE_ADDR_WIN1            (BIT(16) | BIT(0))
+#define MM_KEYHOLE_ADDR_CFG             (BIT(16) | BIT(1))
+#define MM_ADDR_TO_KEYHOLE_WIN0(addr)   (((addr) >> 16) & 0xFF)
+#define MM_ADDR_TO_KEYHOLE_WIN1(addr)   (((addr) >> 24) & 0xFF)
+#define MM_SIZE_TO_CFG(size)            ((size) & 0x3)
+
+#define SDIO_FUNC_REG                   (2)
+#define SDIO_FUNC_MEM_BLOCK             (2)
+
+#define SDIO_CMD_HDR_EXTRA_LEN          (13)
+#define SDIO_CMD_HDR_LEN                (7)
+
+#define SDIO_KEYHOLE_SIZE               (2)
+
+#define SDIO_MULTI_BLOCK_START_TOKEN    (0xFC)
+#define SDIO_BLOCK_END_TOKEN            (0xFD)
+#define SDIO_SINGLE_START_TOKEN         (0xFE)
+#define SDIO_TOKEN_LEN                  (1)
+#define SDIO_TOKEN_BLOCK_READ_LEN       (2)
+#define SDIO_TOKEN_BYTE_READ_LEN        (4)
+#define SDIO_JUNK_TOKEN                 (0xFF)
+#define SDIO_JUNK_TOKEN_LEN             (1)
+#define SDIO_DATA_RESP_TOKEN_MASK       (0x1F)
+#define SDIO_DATA_RESP_TOKEN_VALID_MASK (0x11)
+#define SDIO_DATA_RESP_TOKEN_VALID      (0x01)
+#define SDIO_DATA_RESP_TOKEN_ACPT       (0x05)
+#define SDIO_DATA_RESP_TOKEN_CRCE       (0x0B)
+#define SDIO_DATA_RESP_TOKEN_WE         (0x0D)
+#define SDIO_CMD_RESP_TOKEN_MASK        (0xFE)
+#define SDIO_CMD_RESP_EARLY_TRANS       (0xFE)
+#define SDIO_CMD_RESP_TOKEN_SUCC        (0x00)
+
+#define SDIO_CMD53_ADDR_MASK            (0xFFFF)
+#define SDIO_CMD53_RESP_SIZE            (4)
+
+#define SDIO_STOP_BIT                   BIT(0)
+#define SDIO_DIR_BIT                    BIT(6)
+#define SDIO_RW_BIT                     BIT(7)
+#define SDIO_CMD_MASK                   (0x3F)
+#define SDIO_FUNC_OFFSET                (4)
+#define SDIO_BLOCK_BIT                  BIT(3)
+#define SDIO_RAW_BIT                    BIT(3)
+#define SDIO_OP_BIT                     BIT(2)
+#define SDIO_COUNT_MASK                 (0x01)
+#define SDIO_COUNT_OFFSET               (8)
+#define SDIO_ADDR0_OFFSET               (1)
+#define SDIO_ADDR0_BITS                 (8 - SDIO_ADDR0_OFFSET)
+#define SDIO_ADDR1_OFFSET               (SDIO_ADDR0_BITS)
+#define SDIO_ADDR1_BITS                 (8)
+#define SDIO_ADDR2_OFFSET               (SDIO_ADDR0_BITS + SDIO_ADDR1_BITS)
+#define SDIO_ADDR2_BITS                 (17 - SDIO_ADDR0_BITS - SDIO_ADDR1_BITS)
+#define SDIO_CRC_OFFSET                 (1)
+#define SDIO_CRC_BITS                   (8 * 5)
+#define SDIO_CRC_OCTETS                 (2)
+#define SDIO_CRC_READ_OCTETS            (4)
+
+#define SDIO_R5_IDLE_BIT                BIT(0)
+#define SDIO_R5_ILG_CMD_BIT             BIT(2)
+#define SDIO_R5_CRC_ERR_BIT             BIT(3)
+#define SDIO_R5_FUNC_ERR_BIT            BIT(4)
+#define SDIO_R5_PAR_ERR_BIT             BIT(6)
+
+#define SDIO_CMD_TIMEOUT_ATTEMPTS       (5000)
+
+/* An optimisation would be to calculate this from the frequency. */
+#define SDIO_INTERBLOCK_DELAY_OCTETS    (250UL)
+
+/* TODO Optimise this value. */
+#define SDIO_POST_BYTE_DELAY_OCTETS     (30)
+#define SDIO_POST_CMD53_DELAY_OCTETS    (4)
+
+#define MM610X_REG_RESET_ADDR           (0x10054050)
+#define MM610X_REG_RESET_VALUE          (0xDEAD)
+#define MM610X_REG_CLK_CTRL_ADDR        (0x1005406C)
+#define MM610X_REG_CLK_CTRL_EARLY_VALUE (0xE5)
+#define MM610X_REG_CHIP_ID_ADDR         (0x10054d20)
+#define MM610X_REG_HOST_MAN_PTR_ADDR    (0x10054d40)
+
+static uint32_t fn_max_block_size[] = { 4, 8, 512 };
+
+/**
+ * @brief Prints an error message if possible.
+ *
+ * @param transport     Transport to print the error message from.
+ * @param error_code    Error code.
+ * @param error_msg     Error message.
+ */
+static void sdio_over_spi_error(struct morsectrl_transport *transport,
+                                int error_code, char *error_msg)
+{
+    morsectrl_transport_err("SPI", error_code, error_msg);
+}
+
+/**
+ * @brief Allocate a memory buffer for an SDIO over SPI command.
+ *
+ * @param transport The transport structure.
+ * @param cmd       The SDIO CMD to allocate.
+ * @return          Returns a transport memory buffer or NULL on failure.
+ */
+static struct morsectrl_transport_buff *sdio_over_spi_alloc_cmd(
+    struct morsectrl_transport *transport,
+    uint8_t cmd)
+{
+    switch (cmd)
+    {
+    case 0:
+    case 63:
+    case 52:
+        return transport->tops->write_alloc(transport, SDIO_CMD_HDR_LEN + SDIO_CMD_HDR_EXTRA_LEN);
+
+    case 53:
+    default:
+        break;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Prepares an SDIO CMD by setting/clearing bits common between commands.
+ *
+ * @param cmd       The CMD to prepare.
+ * @param cmd_hdr   Pointer to the command header.
+ */
+static void sdio_over_spi_prep_cmd(uint8_t cmd, uint8_t *cmd_hdr)
+{
+    if (!cmd_hdr)
+        return;
+
+    /* MSB first is the norm and what the FTDI4232H does. First octet send is junk. */
+    cmd_hdr[0] = SDIO_JUNK_TOKEN;
+    /* Add (start bit), direction and command. */
+    cmd_hdr[1] = SDIO_DIR_BIT + (cmd & SDIO_CMD_MASK);
+    /* Add stop bit. */
+    cmd_hdr[6] = 0x01;
+    memset(&cmd_hdr[SDIO_CMD_HDR_LEN], SDIO_JUNK_TOKEN, SDIO_CMD_HDR_EXTRA_LEN);
+}
+
+/**
+ * @brief Calculate the CRC7 for the SDIO CMD.
+ *
+ * @param data  Pointer to the start of the SDIO CMD from the octet with the start bit.
+ * @return      CRC7
+ */
+static uint8_t sdio_over_spi_calc_cmd_crc_octet(uint8_t *data)
+{
+    uint8_t crc7;
+    uint64_t number = (((uint64_t)data[0]) << 32) |
+                      ((uint64_t)data[1] << 24) |
+                      ((uint64_t)data[2] << 16) |
+                      ((uint64_t)data[3] << 8) |
+                      ((uint64_t)data[4]);
+
+    crc7 = crc7_gen(number, SDIO_CRC_BITS);
+    return ((crc7 << SDIO_CRC_OFFSET) | SDIO_STOP_BIT);
+}
+
+/**
+ * @brief Find the response to an SDIO CMD.
+ *
+ * @param transport The transport structure.
+ * @param data      Pointer to the start of data to search for the response.
+ * @param size      The size of the data to search.
+ * @return          a pointer to the the first octet after the response on success, otherwise NULL.
+ */
+static uint8_t *sdio_over_spi_cmd_find_resp(struct morsectrl_transport *transport,
+                                            uint8_t *data, uint32_t size)
+{
+    uint32_t ii;
+
+    for (ii = 0; ii < (size - 1); ii++)
+    {
+        if ((data[ii] == SDIO_JUNK_TOKEN) || (data[ii] == SDIO_CMD_RESP_EARLY_TRANS))
+            continue;
+
+        /* If we find the token return the start of the data. */
+        if ((data[ii] & SDIO_CMD_RESP_TOKEN_MASK) == SDIO_CMD_RESP_TOKEN_SUCC)
+        {
+            /* There can sometimes be an additional status byte. */
+            if ((ii < size - 2) &&
+                ((data[ii + 1] & SDIO_CMD_RESP_TOKEN_MASK) == SDIO_CMD_RESP_TOKEN_SUCC))
+            {
+                return &data[ii + 2];
+            }
+
+            return &data[ii + 1];
+        }
+
+        sdio_over_spi_error(transport, data[ii], "CMD Response Error");
+
+        return NULL;
+    }
+
+    sdio_over_spi_error(transport, -ETRANSERR, "CMD Response Missing");
+    return NULL;
+}
+
+/*
+ * CMD0 bits
+ * | Start bit  | 1
+ * | Direction  | 1
+ * | Command    | 6
+ * | Data       | 32
+ * | CRC7       | 7
+ * | End bit    | 1
+ *
+ * Data should be 0 when we send this.
+ */
+
+/**
+ * @brief Send an SDIO CMD0 (reset).
+ *
+ * @param transport The transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int sdio_over_spi_cmd0(struct morsectrl_transport *transport)
+{
+    const struct morsectrl_transport_ops *tops = transport->tops;
+    struct morsectrl_transport_buff *cmd_buff = sdio_over_spi_alloc_cmd(transport, 0);
+    struct morsectrl_transport_buff *resp_buff;
+    int ret = ETRANSSUCC;
+
+    if (!cmd_buff)
+    {
+        return -ETRANSERR;
+    }
+
+    resp_buff = transport->tops->read_alloc(transport, cmd_buff->data_len);
+    if (!resp_buff)
+    {
+        ret = -ETRANSERR;
+        goto exit;
+    }
+
+    sdio_over_spi_prep_cmd(0, cmd_buff->data);
+    memset(&cmd_buff->data[2], 0, sizeof(*(cmd_buff->data)) * 4);
+    cmd_buff->data[6] = sdio_over_spi_calc_cmd_crc_octet(&cmd_buff->data[1]);
+    memset(&cmd_buff->data[7], SDIO_JUNK_TOKEN, SDIO_CMD_HDR_EXTRA_LEN);
+
+    ret = tops->raw_read_write(transport, resp_buff, cmd_buff, true, true);
+    if (ret)
+        goto exit;
+
+    if (!sdio_over_spi_cmd_find_resp(transport,
+                                     &resp_buff->data[SDIO_CMD_HDR_LEN],
+                                     SDIO_CMD_HDR_EXTRA_LEN))
+    {
+        ret = -ETRANSERR;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_buff);
+    morsectrl_transport_buff_free(resp_buff);
+    return ret;
+}
+
+/**
+ * @brief Send an SDIO CMD63 (enter SPI mode).
+ *
+ * @param transport The transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int sdio_over_spi_cmd63(struct morsectrl_transport *transport)
+{
+    struct morsectrl_transport_buff *cmd_buff = sdio_over_spi_alloc_cmd(transport, 63);
+    struct morsectrl_transport_buff *resp_buff;
+    const struct morsectrl_transport_ops *tops = transport->tops;
+    int ret = ETRANSSUCC;
+
+    if (!cmd_buff)
+    {
+        return -ETRANSERR;
+    }
+
+    resp_buff = transport->tops->read_alloc(transport, cmd_buff->data_len);
+    if (!resp_buff)
+    {
+        ret = -ETRANSERR;
+        goto exit;
+    }
+
+    sdio_over_spi_prep_cmd(63, cmd_buff->data);
+    memset(&cmd_buff->data[2], 0, sizeof(*(cmd_buff->data)) * 4);
+    cmd_buff->data[6] = sdio_over_spi_calc_cmd_crc_octet(&cmd_buff->data[1]);
+    memset(&cmd_buff->data[SDIO_CMD_HDR_LEN], SDIO_JUNK_TOKEN, SDIO_CMD_HDR_EXTRA_LEN);
+
+    ret = tops->raw_read_write(transport, resp_buff, cmd_buff, true, true);
+    if (ret)
+        goto exit;
+
+    if (!sdio_over_spi_cmd_find_resp(transport,
+                                     &resp_buff->data[SDIO_CMD_HDR_LEN],
+                                     SDIO_CMD_HDR_EXTRA_LEN))
+    {
+        ret = -ETRANSERR;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_buff);
+    morsectrl_transport_buff_free(resp_buff);
+    return ret;
+}
+
+/*
+ * CMD52 bits
+ * | Start bit  | 1
+ * | Direction  | 1
+ * | Command    | 6
+ * | R/W        | 1
+ * | Func       | 3
+ * | RAW        | 1
+ * | Stuff      | 1
+ * | Reg Addr   | 17
+ * | Stuff      | 1
+ * | Data       | 8
+ * | CRC7       | 7
+ * | End bit    | 1
+ *
+ * Data is included in the command (8-bit value).
+ */
+
+/**
+ * @brief Send an SDIO CMD52. This allows reading and writing of an 8-bit data value in the SDIO
+ *        memory space (17-bit). If the upper address bit is set then the read/write is from/to a
+ *        keyhole register to set the upper 16 address bits for the chip memory space.
+ *
+ * @param transport The transport structure.
+ * @param write     Whether this command is a write (otherwise it is a read).
+ * @param func      The function to perform the CMD52 on.
+ * @param addr      The address to write to or read from.
+ * @param data      The buffer to read data from or write data to.
+ * @return          0 on success otherwise relevant error.
+ */
+static int sdio_over_spi_cmd52(struct morsectrl_transport *transport,
+                               bool write,
+                               uint8_t func,
+                               uint32_t addr,
+                               uint8_t *data)
+{
+    int ret = ETRANSSUCC;
+    struct morsectrl_transport_buff *cmd_buff = sdio_over_spi_alloc_cmd(transport, 52);
+    struct morsectrl_transport_buff *resp_buff;
+
+    if (!cmd_buff)
+    {
+        return -ETRANSERR;
+    }
+
+    resp_buff = transport->tops->read_alloc(transport, cmd_buff->data_len);
+    if (!resp_buff)
+    {
+        ret = -ETRANSERR;
+        goto exit;
+    }
+
+    sdio_over_spi_prep_cmd(52, cmd_buff->data);
+    cmd_buff->data[2] = (func << SDIO_FUNC_OFFSET);
+    cmd_buff->data[2] |= (addr >> SDIO_ADDR2_OFFSET);
+    cmd_buff->data[3] = (addr >> SDIO_ADDR1_OFFSET);
+    cmd_buff->data[4] = (addr << SDIO_ADDR0_OFFSET);
+    cmd_buff->data[5] = *data;
+
+    if (write)
+    {
+        if (transport->debug)
+            mctrl_print("CMD52 Write 0x%02x to 0x%08x\n", *data, addr);
+
+        cmd_buff->data[2] |= SDIO_RW_BIT;
+    }
+    else
+    {
+        if (transport->debug)
+            mctrl_print("CMD52 Read from 0x%08x\n", addr);
+    }
+
+    cmd_buff->data[6] = sdio_over_spi_calc_cmd_crc_octet(&cmd_buff->data[1]);
+    memset(&cmd_buff->data[SDIO_CMD_HDR_LEN], SDIO_JUNK_TOKEN, SDIO_CMD_HDR_EXTRA_LEN);
+
+    ret = transport->tops->raw_read_write(transport, resp_buff, cmd_buff, true, true);
+    if (ret)
+    {
+        sdio_over_spi_error(transport, ret, "Failed to perform CMD52 transaction");
+        goto exit;
+    }
+
+    if (!sdio_over_spi_cmd_find_resp(transport,
+                                     &resp_buff->data[SDIO_CMD_HDR_LEN],
+                                     SDIO_CMD_HDR_EXTRA_LEN))
+    {
+        ret = -ETRANSERR;
+        sdio_over_spi_error(transport, ret, "Failed to find CMD52 response");
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_buff);
+    morsectrl_transport_buff_free(resp_buff);
+    return ret;
+}
+
+/*
+ * CMD53 bits
+ * | Start bit  | 1
+ * | Direction  | 1
+ * | Command    | 6
+ * | R/W        | 1
+ * | Func       | 3
+ * | Block mode | 1
+ * | OP Code    | 1
+ * | Reg Addr   | 17
+ * | Count      | 9
+ * | CRC7       | 7
+ * | End bit    | 1
+ *
+ * Data follows this.
+ */
+
+/**
+ * @brief Find the block start token to an SDIO CMD53.
+ *
+ * @param transport The transport structure.
+ * @param data      Pointer to the start of data to search for the response.
+ * @param size      The size of the data to search.
+ * @return          a pointer to the the first octet after the block start token on success,
+ *                  otherwise NULL.
+ */
+static uint8_t *sdio_over_spi_cmd53_find_token(struct morsectrl_transport *transport,
+                                               uint8_t *data, uint32_t size)
+{
+    uint32_t ii;
+
+    for (ii = 0; ii < (size - 1); ii++)
+    {
+        if (data[ii] == SDIO_JUNK_TOKEN)
+            continue;
+
+        /* If we find the token return the start of the data. */
+        if ((data[ii] == SDIO_MULTI_BLOCK_START_TOKEN) || (data[ii] == SDIO_SINGLE_START_TOKEN))
+            return &data[ii + 1];
+
+        sdio_over_spi_error(transport, -ETRANSERR, "Unrecognised block start token");
+
+        return NULL;
+    }
+
+    sdio_over_spi_error(transport, -ETRANSERR, "Failed to find block start token");
+    return NULL;
+}
+
+/**
+ * @brief Find the acknowledge to an SDIO CMD53 data block transmission.
+ *
+ * @param transport The transport structure.
+ * @param data      Pointer to the start of data to search for the acknowledgement.
+ * @param size      The size of the data to search.
+ * @return          a pointer to the the first octet after the acknowledgment on success, otherwise NULL.
+ */
+static uint8_t *sdio_over_spi_cmd53_find_ack(struct morsectrl_transport *transport,
+                                             uint8_t *data, uint32_t size)
+{
+    uint32_t ii;
+
+    for (ii = 0; ii < (size - 1); ii++)
+    {
+        if (data[ii] == SDIO_JUNK_TOKEN)
+        {
+            continue;
+        }
+
+        /* If we find the token return the start of the data. */
+        if (((data[ii] & SDIO_DATA_RESP_TOKEN_VALID_MASK) == SDIO_DATA_RESP_TOKEN_VALID) &&
+            ((data[ii] & SDIO_DATA_RESP_TOKEN_MASK) == SDIO_DATA_RESP_TOKEN_ACPT))
+        {
+            return &data[ii + 1];
+        }
+
+        if ((data[ii] & SDIO_DATA_RESP_TOKEN_MASK) == SDIO_DATA_RESP_TOKEN_CRCE)
+        {
+            sdio_over_spi_error(transport, -ETRANSERR, "Block CRC Error");
+        }
+        else
+        {
+            sdio_over_spi_error(transport, -ETRANSERR, "Unknown Block Response");
+        }
+
+        return NULL;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Perform an SDIO CMD53. Read/writes word aligned data from/to a 32-bit chip memory address.
+ *
+ * @note The upper 16-bits of the address must be set using CMD52 to write the keyhole registers
+ *       first.
+ *
+ * @param transport     The transport structure.
+ * @param data          Buffer to read data from or write data into.
+ * @param write         Whether this command is a write (otherwise it is a read).
+ * @param func          Function to perform the command on.
+ * @param block_mode    Whether transaction uses block mode.
+ * @param addr          Address to write to or read from.
+ * @param count         Number of blocks in block mode, otherwise number of octets (word aligned).
+ * @return              0 on success otherwise relevant error.
+ */
+static int sdio_over_spi_cmd53(struct morsectrl_transport *transport,
+                               struct morsectrl_transport_buff *data,
+                               bool write,
+                               uint8_t func,
+                               bool block_mode,
+                               uint32_t addr,
+                               uint16_t count)
+{
+    const struct morsectrl_transport_ops *tops = transport->tops;
+    struct morsectrl_transport_buff *full_trans;
+    struct morsectrl_transport_buff *resp;
+    uint8_t *cmd_hdr;
+    size_t full_trans_size;
+    uint32_t block_size = block_mode ? fn_max_block_size[func] : count;
+    uint16_t post_block_delay_bytes;
+    size_t total_block_size;
+    uint16_t loop_count = block_mode ? count : 1;
+    int ii;
+    uint8_t offset;
+    int ret;
+    uint16_t crc16;
+
+    /* Constuct a complete transaction with CMD, CMD response, Read/Write. */
+    if (write)
+    {
+        post_block_delay_bytes =
+            block_mode ? SDIO_INTERBLOCK_DELAY_OCTETS : SDIO_POST_BYTE_DELAY_OCTETS;
+        total_block_size = SDIO_TOKEN_LEN + block_size + SDIO_CRC_OCTETS + post_block_delay_bytes;
+        if (!block_mode)
+        {
+            full_trans_size = SDIO_CMD_HDR_LEN +
+                              SDIO_CMD53_RESP_SIZE +
+                              SDIO_POST_CMD53_DELAY_OCTETS +
+                              total_block_size;
+        }
+        else
+        {
+            full_trans_size = SDIO_CMD_HDR_LEN +
+                              SDIO_CMD53_RESP_SIZE +
+                              SDIO_POST_CMD53_DELAY_OCTETS +
+                              (count * total_block_size);
+        }
+    }
+    else /* Read */
+    {
+        if (!block_mode)
+        {
+            /* Interblock delay is timing based so scale with size when less than a full block.
+             * TODO optimise this value.
+             */
+            post_block_delay_bytes =
+                SDIO_INTERBLOCK_DELAY_OCTETS;
+
+            total_block_size = SDIO_TOKEN_BYTE_READ_LEN +
+                               block_size +
+                               SDIO_CRC_READ_OCTETS +
+                               post_block_delay_bytes;
+
+            full_trans_size = SDIO_CMD_HDR_LEN + SDIO_POST_CMD53_DELAY_OCTETS + total_block_size;
+        }
+        else
+        {
+            post_block_delay_bytes = SDIO_POST_BYTE_DELAY_OCTETS;
+            total_block_size = SDIO_TOKEN_BLOCK_READ_LEN +
+                               block_size +
+                               post_block_delay_bytes;
+
+            full_trans_size = SDIO_CMD_HDR_LEN +
+                              SDIO_CMD53_RESP_SIZE +
+                              SDIO_POST_CMD53_DELAY_OCTETS +
+                              (total_block_size * count);
+        }
+    }
+
+    if (transport->debug)
+    {
+        mctrl_print("block_mode: %s\n", block_mode ? "true" : "false");
+        mctrl_print("post_block_delay_bytes: %u\n", post_block_delay_bytes);
+        mctrl_print("total_block_size: %zu\n", total_block_size);
+        mctrl_print("block_size: %u\n", block_size);
+        mctrl_print("full_trans_size: %zu\n", full_trans_size);
+        mctrl_print("loop_count: %u\n", loop_count);
+    }
+
+    /* Allocate some buffers. */
+    full_trans = morsectrl_transport_raw_write_alloc(transport, full_trans_size);
+    resp = morsectrl_transport_raw_read_alloc(transport, full_trans_size);
+    if (!full_trans || !resp)
+    {
+        ret = -ETRANSERR;
+        sdio_over_spi_error(transport, ret, "CMD53 failed to allocate buffers");
+        morsectrl_transport_buff_free(full_trans);
+        morsectrl_transport_buff_free(resp);
+        return ret;
+    }
+
+    cmd_hdr = full_trans->data;
+    sdio_over_spi_prep_cmd(53, cmd_hdr);
+
+    cmd_hdr[2] = (func << SDIO_FUNC_OFFSET);
+    cmd_hdr[2] |= write ? SDIO_RW_BIT : 0;
+    cmd_hdr[2] |= block_mode ? SDIO_BLOCK_BIT : 0;
+    cmd_hdr[2] |= SDIO_OP_BIT;
+    cmd_hdr[2] |= ((addr & SDIO_CMD53_ADDR_MASK) >> SDIO_ADDR2_OFFSET);
+    cmd_hdr[3] = ((addr & SDIO_CMD53_ADDR_MASK) >> SDIO_ADDR1_OFFSET);
+    cmd_hdr[4] = ((addr & SDIO_CMD53_ADDR_MASK) << SDIO_ADDR0_OFFSET);
+    cmd_hdr[4] |= (count >> SDIO_COUNT_OFFSET) & SDIO_COUNT_MASK;
+    cmd_hdr[5] = (uint8_t)count;
+    cmd_hdr[6] = sdio_over_spi_calc_cmd_crc_octet(&cmd_hdr[1]);
+
+    if (write)
+    {
+        offset = SDIO_CMD_HDR_LEN + SDIO_CMD53_RESP_SIZE + SDIO_POST_CMD53_DELAY_OCTETS;
+        memset(&full_trans->data[SDIO_CMD_HDR_LEN], SDIO_JUNK_TOKEN, offset - SDIO_CMD_HDR_LEN);
+
+        for (ii = 0; ii < loop_count; ii++)
+        {
+            size_t token_offset = offset + (ii * total_block_size);
+            size_t block_offset = token_offset + SDIO_TOKEN_LEN;
+            size_t crc_offset = block_offset + block_size;
+            size_t interblock_offset = crc_offset + SDIO_CRC_OCTETS;
+
+            /* Write the start token. */
+            if (block_mode)
+                full_trans->data[token_offset] = SDIO_MULTI_BLOCK_START_TOKEN;
+            else
+                full_trans->data[token_offset] = SDIO_SINGLE_START_TOKEN;
+
+            /* Copy a data block. */
+            memcpy(&full_trans->data[block_offset],
+                   &data->data[ii * block_size],
+                   block_size);
+
+            crc16 = crc16_gen(&data->data[ii * block_size], block_size);
+            full_trans->data[crc_offset] = crc16 >> 8;
+            full_trans->data[crc_offset + 1] = crc16 & 0xFF;
+
+            /* Copy 0xFF for interblock or post byte writing. */
+            memset(&full_trans->data[interblock_offset],
+                   SDIO_JUNK_TOKEN,
+                   post_block_delay_bytes);
+        }
+    }
+    else
+    {
+        offset = SDIO_CMD_HDR_LEN + SDIO_CMD53_RESP_SIZE;
+        memset(&full_trans->data[SDIO_CMD_HDR_LEN],
+               SDIO_JUNK_TOKEN,
+               full_trans->data_len - SDIO_CMD_HDR_LEN);
+    }
+
+    /* Send the entire command, including the data. */
+    ret = tops->raw_read_write(transport, resp, full_trans, true, true);
+    if (ret)
+    {
+        sdio_over_spi_error(transport, ret, "CMD53 Read/Write error");
+        goto exit;
+    }
+
+    /* Check for command success. */
+    if (!sdio_over_spi_cmd_find_resp(transport,
+                                     &resp->data[SDIO_CMD_HDR_LEN],
+                                     SDIO_CMD53_RESP_SIZE))
+    {
+        ret = -ETRANSERR;
+        sdio_over_spi_error(transport, ret, "CMD53 Error");
+        goto exit;
+    }
+
+    /* Process write acks. */
+    if (write)
+    {
+        uint8_t *ptr = &resp->data[offset];
+
+        for (ii = 0; ii < loop_count; ii++)
+        {
+            size_t start_idx = ii * total_block_size;
+            uint8_t *ack;
+
+            ack = sdio_over_spi_cmd53_find_ack(transport, &ptr[start_idx], total_block_size);
+            if (!ack)
+            {
+                ret = -ETRANSERR;
+                sdio_over_spi_error(transport, ret, "CMD53 Write block ack error");
+                goto exit;
+            }
+        }
+    }
+    /* Process read. */
+    else
+    {
+        uint8_t *ptr = &resp->data[offset];
+
+        for (ii = 0; ii < loop_count; ii++)
+        {
+            ptr = sdio_over_spi_cmd53_find_token(transport, ptr, post_block_delay_bytes);
+
+            if (!ptr)
+            {
+                ret = -ETRANSERR;
+                sdio_over_spi_error(transport, ret, "CMD53 Read start token missing.");
+                goto exit;
+            }
+
+            if (!crc16_check(ptr, block_size, (ptr[block_size] << 8) + ptr[block_size + 1]))
+            {
+                ret = -ETRANSERR;
+                sdio_over_spi_error(transport, ret, "CMD53 Read block CRC error");
+                goto exit;
+            }
+
+            memcpy(&data->data[ii * block_size], ptr, block_size);
+            ptr += block_size + SDIO_CRC_READ_OCTETS;
+        }
+    }
+
+exit:
+    morsectrl_transport_buff_free(full_trans);
+    morsectrl_transport_buff_free(resp);
+
+    return ret;
+}
+
+int sdio_over_spi_read_reg_32bit(struct morsectrl_transport *transport,
+                                 uint32_t addr,
+                                 uint32_t *data)
+{
+    struct morsectrl_transport_buff *read;
+    int ret;
+
+    if (!transport || !transport->tops || !transport->tops->raw_read)
+        return -ETRANSERR;
+
+    read = transport->tops->read_alloc(transport, sizeof(uint32_t));
+
+    if (!read)
+        return -ETRANSERR;
+
+    ret = sdio_over_spi_read_memblock(transport, read, addr);
+    if (ret)
+    {
+        morsectrl_transport_buff_free(read);
+        return ret;
+    }
+
+    memcpy((uint8_t *)data, read->data, sizeof(*data));
+    *data = le32toh(*data);
+
+    morsectrl_transport_buff_free(read);
+    return ETRANSSUCC;
+}
+
+int sdio_over_spi_write_reg_32bit(struct morsectrl_transport *transport,
+                                  uint32_t addr,
+                                  uint32_t data)
+{
+    struct morsectrl_transport_buff *write;
+    uint32_t le_data;
+    int ret;
+
+    if (!transport || !transport->tops || !transport->tops->raw_write)
+        return -ETRANSERR;
+
+    write = transport->tops->write_alloc(transport, sizeof(uint32_t));
+
+    if (!write)
+        return -ETRANSERR;
+
+    le_data = htole32(data);
+    memcpy(write->data, (uint8_t *)&le_data, sizeof(data));
+
+    if (transport->debug)
+    {
+        mctrl_print("data: 0x%08x, %02x %02x %02x %02x\n", data,
+               write->data[0], write->data[1], write->data[2], write->data[3]);
+    }
+
+    ret = sdio_over_spi_write_memblock(transport, write, addr);
+
+    morsectrl_transport_buff_free(write);
+    return ret;
+}
+
+static int sdio_over_spi_setup_keyhole(struct morsectrl_transport *transport,
+                                       uint32_t addr, size_t size)
+{
+    int ret;
+    uint8_t key_win0 = MM_ADDR_TO_KEYHOLE_WIN0(addr);
+    uint8_t key_win1 = MM_ADDR_TO_KEYHOLE_WIN1(addr);
+    uint8_t key_cfg = MM_SIZE_TO_CFG(size);
+
+    /* Always write keyhole registers because the overhead should be small. */
+    ret = sdio_over_spi_cmd52(transport, true, SDIO_FUNC_REG, MM_KEYHOLE_ADDR_WIN0, &key_win0);
+    if (ret)
+    {
+        sdio_over_spi_error(transport, ret, "Failed to set window0 keyhole reg");
+        return ret;
+    }
+    ret = sdio_over_spi_cmd52(transport, true, SDIO_FUNC_REG, MM_KEYHOLE_ADDR_WIN1, &key_win1);
+    if (ret)
+    {
+        sdio_over_spi_error(transport, ret, "Failed to set window1 keyhole reg");
+        return ret;
+    }
+    ret = sdio_over_spi_cmd52(transport, true, SDIO_FUNC_REG, MM_KEYHOLE_ADDR_CFG, &key_cfg);
+    if (ret)
+    {
+        sdio_over_spi_error(transport, ret, "Failed to set cfg keyhole reg");
+        return ret;
+    }
+
+    return ret;
+}
+
+static int sdio_over_spi_memblock_common(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *buff,
+                                  bool write,
+                                  uint32_t addr)
+{
+    int ret = ETRANSSUCC;
+    uint8_t *orig_data = buff->data;
+    size_t orig_data_len = buff->data_len;
+    size_t remaining_data_len = buff->data_len;
+    uint32_t chip_mem_addr = addr;
+    uint16_t num_blocks;
+
+    if (transport->debug)
+    {
+        mctrl_print("Total %s size 0x%08zX\n", write ? "write" : "read", orig_data_len);
+        mctrl_print("Start address for %s 0x%08" PRIX32 "\n", write ? "write" : "read", addr);
+    }
+
+    /* Perform writes withing 64k boundaries. */
+    while (remaining_data_len)
+    {
+        size_t current_section_end = (chip_mem_addr & MM_ADDR_BOUNDARY) + MM_ADDR_BOUNDARY_OFFSET;
+        size_t current_size = MIN(current_section_end - chip_mem_addr, remaining_data_len);
+        uint32_t byte_mode_count;
+
+        if (transport->debug)
+        {
+            mctrl_print("%s from 0x%08X to 0x%08zX\n", write ? "write" : "read",
+                   chip_mem_addr, chip_mem_addr + current_size - 1);
+        }
+
+        ret = sdio_over_spi_setup_keyhole(transport, chip_mem_addr, SDIO_KEYHOLE_SIZE);
+        if (ret)
+        {
+            sdio_over_spi_error(transport, ret, "Failed to set keyhole registers");
+            return ret;
+        }
+
+        num_blocks = current_size / fn_max_block_size[SDIO_FUNC_MEM_BLOCK];
+        byte_mode_count = current_size % fn_max_block_size[SDIO_FUNC_MEM_BLOCK];
+        if (transport->debug)
+            mctrl_print("%d blocks\n", num_blocks);
+
+        if (current_size / fn_max_block_size[SDIO_FUNC_MEM_BLOCK])
+        {
+            /* Read/write blocks first. */
+            ret = sdio_over_spi_cmd53(transport,
+                                      buff,
+                                      write,
+                                      SDIO_FUNC_MEM_BLOCK,
+                                      true,
+                                      chip_mem_addr,
+                                      current_size / fn_max_block_size[SDIO_FUNC_MEM_BLOCK]);
+        }
+        buff->data += (current_size - byte_mode_count);
+
+        if (transport->debug)
+        {
+            mctrl_print("chip mem addr 0x%08x, currentsize %zu, byte_mode_count %u\n",
+                   chip_mem_addr, current_size, byte_mode_count);
+            mctrl_print("%d octets 'cleanup'\n", byte_mode_count);
+        }
+
+        /* Read/write octets to cleanup if required. */
+        if (byte_mode_count)
+        {
+            /* Align to words, extra octets can be garbage. Upper layers should have done the
+             * alignment already but enforce it here. */
+            size_t aligned_count = align_size(byte_mode_count, sizeof(uint32_t));
+
+            ret = sdio_over_spi_cmd53(transport,
+                                      buff,
+                                      write,
+                                      SDIO_FUNC_MEM_BLOCK,
+                                      false,
+                                      chip_mem_addr + current_size - byte_mode_count,
+                                      aligned_count);
+        }
+
+        chip_mem_addr += current_size;
+        buff->data += byte_mode_count;
+        remaining_data_len -= current_size;
+    }
+
+    /* Restore data pointer and length. */
+    buff->data = orig_data;
+    buff->data_len = orig_data_len;
+
+    return ret;
+}
+
+int sdio_over_spi_read_memblock(struct morsectrl_transport *transport,
+                                struct morsectrl_transport_buff *buff,
+                                uint32_t addr)
+{
+    return sdio_over_spi_memblock_common(transport, buff, false, addr);
+}
+
+int sdio_over_spi_write_memblock(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *buff,
+                                 uint32_t addr)
+{
+    return sdio_over_spi_memblock_common(transport, buff, true, addr);
+}
+
+int sdio_over_spi_post_hard_reset(struct morsectrl_transport *transport)
+{
+    const struct morsectrl_transport_ops *tops = transport->tops;
+    int ii;
+    int ret;
+    uint32_t data32;
+
+    /* First Send a CMD63 */
+    for (ii = 0; ii < 3; ii++)
+    {
+        sdio_over_spi_cmd63(transport);
+        sdio_over_spi_cmd0(transport);
+    }
+
+    ret = tops->reg_read(transport, MM610X_REG_CHIP_ID_ADDR, &data32);
+    if (ret)
+    {
+        morsectrl_transport_err("Pre Firmware DL", -ETRANSERR, "Failed to read chip id reg\n");
+        return ret;
+    }
+
+    if (transport->debug)
+        mctrl_print("Chip ID: 0x%08x\n", data32);
+
+    for (ii = 0; ii < 3; ii++)
+    {
+        /* Register writes to get things moving. */
+        ret = tops->reg_write(transport, MM610X_REG_RESET_ADDR, MM610X_REG_RESET_VALUE);
+        if (ret)
+        {
+            morsectrl_transport_err("Pre Firmware DL", -ETRANSERR, "Failed to write reset reg\n");
+
+            sleep_ms(400);
+            continue;
+        }
+
+        sleep_ms(400);
+
+        ret = tops->reg_write(transport, MM610X_REG_CLK_CTRL_ADDR, MM610X_REG_CLK_CTRL_EARLY_VALUE);
+        if (ret)
+        {
+            morsectrl_transport_err("Pre Firmware DL", -ETRANSERR,
+                                    "Failed to write clk ctrl reg\n");
+            continue;
+        }
+        else
+            break;
+    }
+    if (ret)
+    {
+        return ret;
+    }
+
+    /* Invalidation of host manifest pointer? */
+    ret = tops->reg_write(transport, MM610X_REG_HOST_MAN_PTR_ADDR, 0);
+    if (ret)
+    {
+        morsectrl_transport_err("Pre Firmware DL", -ETRANSERR,
+                                "Failed to reset host manifest ptr\n");
+        return ret;
+    }
+
+    return ret;
+}

--- a/feeds/morse/utils/morsectrl/src/transport/sdio_over_spi.h
+++ b/feeds/morse/utils/morsectrl/src/transport/sdio_over_spi.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "transport.h"
+#include "../utilities.h"
+
+/**
+ * @brief Read a 32bit register (or word aligned memory location).
+ *
+ * @param transport The transport structure.
+ * @param addr      The address to read from.
+ * @param data      Pointer to where to write the value.
+ * @return          0 on success otherwise relevant error.
+ */
+int sdio_over_spi_read_reg_32bit(struct morsectrl_transport *transport,
+                                 uint32_t addr,
+                                 uint32_t *data);
+
+/**
+ * @brief Write a 32bit register (or word aligned memory location).
+ *
+ * @param transport The transport structure.
+ * @param addr      The address to write to.
+ * @param data      Value to write.
+ * @return          0 on success otherwise relevant error.
+ */
+int sdio_over_spi_write_reg_32bit(struct morsectrl_transport *transport,
+                                  uint32_t addr,
+                                  uint32_t data);
+
+/**
+ * @brief Read a block of word aligned memory.
+ *
+ * @param transport The transport structure.
+ * @param buff      Buffer to read memory into.
+ * @param addr      Address to read from.
+ * @return          0 on success otherwise relevant error.
+ */
+int sdio_over_spi_read_memblock(struct morsectrl_transport *transport,
+                                struct morsectrl_transport_buff *buff,
+                                uint32_t addr);
+
+/**
+ * @brief Write a block of word aligned memory.
+ *
+ * @param transport The transport structure.
+ * @param buff      Buffer to write memory from.
+ * @param addr      Address to write to.
+ * @return          0 on success otherwise relevant error.
+ */
+int sdio_over_spi_write_memblock(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *buff,
+                                 uint32_t addr);
+
+/**
+ * @brief Perform actions required after a hard reset (i.e. before firmware can be loaded).
+ *
+ * @param transport The transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+int sdio_over_spi_post_hard_reset(struct morsectrl_transport *transport);

--- a/feeds/morse/utils/morsectrl/src/transport/slip.c
+++ b/feeds/morse/utils/morsectrl/src/transport/slip.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include "slip.h"
+
+enum slip_special_chars
+{
+    SLIP_FRAME_END      = 0xc0,
+    SLIP_FRAME_ESC      = 0xdb,
+    SLIP_FRAME_ESC_END  = 0xdc,
+    SLIP_FRAME_ESC_ESC  = 0xdd,
+};
+
+static enum slip_rx_status slip_rx_append(struct slip_rx_state *state, uint8_t c)
+{
+    if (state->length == state->buffer_length)
+    {
+        return SLIP_RX_BUFFER_LIMIT;
+    }
+
+    state->buffer[state->length] = c;
+    state->length++;
+
+    return SLIP_RX_IN_PROGRESS;
+}
+
+enum slip_rx_status slip_rx(struct slip_rx_state *state, uint8_t c)
+{
+    if (c == SLIP_FRAME_END)
+    {
+        if (state->escape)
+        {
+            state->escape = false;
+            state->length = 0;
+            return SLIP_RX_ERROR;
+        }
+        else if (state->length > 0)
+        {
+            return SLIP_RX_COMPLETE;
+        }
+        else
+        {
+            return SLIP_RX_IN_PROGRESS;
+        }
+    }
+    else if (state->escape)
+    {
+        state->escape = false;
+        if (c == SLIP_FRAME_ESC_END)
+        {
+            return slip_rx_append(state, SLIP_FRAME_END);
+        }
+        else if (c == SLIP_FRAME_ESC_ESC)
+        {
+            return slip_rx_append(state, SLIP_FRAME_ESC);
+        }
+        else
+        {
+            state->length = 0;
+            return SLIP_RX_ERROR;
+        }
+    }
+    else if (c == SLIP_FRAME_ESC)
+    {
+        state->escape = true;
+        return SLIP_RX_IN_PROGRESS;
+    }
+    else
+    {
+        return slip_rx_append(state, c);
+    }
+}
+
+int slip_tx(slip_transport_tx_fn transport_tx_fn, void *transport_tx_arg,
+            const uint8_t *packet, size_t packet_len)
+{
+    int ret = 0;
+
+    transport_tx_fn(SLIP_FRAME_END, transport_tx_arg);
+
+    while (packet_len-- > 0)
+    {
+        uint8_t c = *packet++;
+        switch (c)
+        {
+            case SLIP_FRAME_ESC:
+                ret = transport_tx_fn(SLIP_FRAME_ESC, transport_tx_arg);
+                if (ret != 0)
+                {
+                    break;
+                }
+                ret = transport_tx_fn(SLIP_FRAME_ESC_ESC, transport_tx_arg);
+                break;
+
+            case SLIP_FRAME_END:
+                ret = transport_tx_fn(SLIP_FRAME_ESC, transport_tx_arg);
+                if (ret != 0)
+                {
+                    break;
+                }
+                ret = transport_tx_fn(SLIP_FRAME_ESC_END, transport_tx_arg);
+                break;
+
+            default:
+                ret = transport_tx_fn(c, transport_tx_arg);
+                break;
+        }
+    }
+
+    transport_tx_fn(SLIP_FRAME_END, transport_tx_arg);
+
+    return ret;
+}

--- a/feeds/morse/utils/morsectrl/src/transport/slip.h
+++ b/feeds/morse/utils/morsectrl/src/transport/slip.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+/*
+ * Serial Line Internet Protocol (SLIP) implementation.
+ *
+ * SLIP was originally designed as an encapsulation for IP over serial ports, but can be used
+ * for framing of any packet-based data for transmission over a serial port.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define SLIP_RX_BUFFER_SIZE     (2000)
+
+struct slip_rx_state
+{
+    uint8_t *buffer;
+    size_t buffer_length;
+    size_t length;
+    bool escape;
+};
+
+#define SLIP_RX_STATE_INIT(_buffer, _buffer_length) { _buffer, _buffer_length, 0, false }
+
+static inline void slip_rx_state_reset(struct slip_rx_state *state)
+{
+    state->escape = false;
+    state->length = 0;
+}
+
+
+enum slip_rx_status
+{
+    SLIP_RX_COMPLETE,       /**< @brief A complete packet with length > 0 has been received. */
+    SLIP_RX_IN_PROGRESS,    /**< @brief Receive is still in progress. */
+    SLIP_RX_BUFFER_LIMIT,   /**< @brief Receive buffer limit has been reached. */
+    SLIP_RX_ERROR,          /**< @brief An erroneous packet has been received. */
+};
+
+/**
+ * @brief Handle reception of a character in a SLIP stream.
+ *
+ * When reception of a packet is successful, this will return @c SLIP_RX_COMPLETE and the
+ * packet can be found in `state->buffer` with length `state->length`.
+ *
+ * @param state Current slip state. Will be updated by this function.
+ * @param c     The received character.
+ *
+ * @return an appropriate value of @ref slip_rx_status.
+ */
+enum slip_rx_status slip_rx(struct slip_rx_state *state, uint8_t c);
+
+/**
+ * @brief Function to send a character on the slip transport.
+ *
+ * @param c     The character to transmit
+ * @param arg   Opaque argument, as passed to @c slip_tx().
+ *
+ * @return 0 on success, otherwise a negative error code.
+ */
+typedef int (*slip_transport_tx_fn)(uint8_t c, void *arg);
+
+/**
+ * @brief Transmit a packet with with SLIP framing.
+ *
+ * @param transport_tx_fn   Function to invoke to send characters on the transport.
+ * @param transport_tx_arg  Argument to pass to @p transport_tx_fn.
+ * @param packet            The packet to transmit.
+ * @param packet_len        The length of the packet.
+ *
+ * @return 0 on success, otherwise an error code as returned by @p transport_tx_fn.
+ */
+int slip_tx(slip_transport_tx_fn transport_tx_fn, void *transport_tx_arg,
+            const uint8_t *packet, size_t packet_len);

--- a/feeds/morse/utils/morsectrl/src/transport/transport.c
+++ b/feeds/morse/utils/morsectrl/src/transport/transport.c
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "transport.h"
+#include "transport_private.h"
+#include "../command.h"
+#include "../utilities.h"
+
+/** Maximum length of the string (excluding null-terminator) to return from
+ *  @ref morsectrl_transport_get_regex(). */
+#define TRANSPORT_REGEX_MAXLEN  (127)
+
+/* These are the start and end of the custom section transport_ops_table and are provided
+ * by the linker script. */
+extern const struct morsectrl_transport_ops * const __start_transport_ops_table[];
+extern const struct morsectrl_transport_ops * const __stop_transport_ops_table[];
+
+
+static const struct morsectrl_transport_ops * const *ops_table_iterator_next(
+    const struct morsectrl_transport_ops * const *iter)
+{
+    /* We loop until we find a transport ops entry whose name is not NULL. A NULL name indicates
+     * the "dummy" entry that we use a placeholder to ensure the table is never empty. */
+    do
+    {
+        const struct morsectrl_transport_ops *tops;
+
+        iter += 1;
+        if (iter >= __stop_transport_ops_table)
+        {
+            return NULL;
+        }
+
+        tops = *iter;
+        MCTRL_ASSERT(tops, "Malformed transport table");
+    } while ((*iter)->name == NULL);
+
+    return iter;
+}
+
+static const struct morsectrl_transport_ops * const *get_ops_table_iterator(void)
+{
+    const struct morsectrl_transport_ops * const *iter = __start_transport_ops_table;
+
+    if (iter < __stop_transport_ops_table)
+    {
+        /* A NULL name indicates the "dummy" entry that we use a placeholder to ensure the table
+         * is never empty. We need to skip it. */
+        if ((*iter)->name == NULL)
+        {
+            return ops_table_iterator_next(iter);
+        }
+        else
+        {
+            return iter;
+        }
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+
+static bool ops_table_iter_is_first(const struct morsectrl_transport_ops * const *iter)
+{
+    return iter == __start_transport_ops_table;
+}
+
+const struct morsectrl_transport_ops *find_transport_ops(const char *transport_name)
+{
+    const struct morsectrl_transport_ops * const *iter;
+
+    for (iter = get_ops_table_iterator(); iter != NULL; iter = ops_table_iterator_next(iter))
+    {
+        const struct morsectrl_transport_ops *tops = *iter;
+
+        if (!transport_name || strcmp(transport_name, tops->name) == 0)
+        {
+            return tops;
+        }
+    }
+
+    return NULL;
+}
+
+char *morsectrl_transport_get_regex(void)
+{
+    char *str = calloc(1, TRANSPORT_REGEX_MAXLEN);
+    int len = 0;
+    bool first = true;
+    const struct morsectrl_transport_ops * const *iter;
+
+    for (iter = get_ops_table_iterator(); iter != NULL; iter = ops_table_iterator_next(iter))
+    {
+        const struct morsectrl_transport_ops *tops = *iter;
+        int name_len = strlen(tops->name);
+
+        if ((name_len + 1) == (TRANSPORT_REGEX_MAXLEN - len))
+        {
+            mctrl_print("Error constructing transport regex\n");
+            free(str);
+            return NULL;
+        }
+
+        if (first)
+        {
+            str[len++] = '(';
+            first = false;
+        }
+        else
+        {
+            str[len++] = '|';
+        }
+
+        memcpy(str + len, tops->name, name_len);
+        len += name_len;
+    }
+
+    if (len == 0)
+    {
+        mctrl_print("No transports supported\n");
+        free(str);
+        return NULL;
+    }
+
+    if ((TRANSPORT_REGEX_MAXLEN - len) <= 1)
+    {
+        mctrl_print("Error constructing transport regex\n");
+        free(str);
+        return NULL;
+    }
+
+    str[len++] = ')';
+    return str;
+}
+
+void morsectrl_transport_list_available(void)
+{
+    const struct morsectrl_transport_ops * const *iter;
+
+    mctrl_print("\nTransports Available:\n");
+
+    /*
+     * Important note
+     *
+     * We use the first transport as the default transport. The order of transports is
+     * given by the order we pass the object files to the linker. Therefore, to prioritise
+     * one transport over another, ensure it comes earlier in the link order.
+     */
+
+    for (iter = get_ops_table_iterator();  iter != NULL; iter = ops_table_iterator_next(iter))
+    {
+        const struct morsectrl_transport_ops *tops = *iter;
+        const char *default_str = ops_table_iter_is_first(iter) ? " [default]" : "";
+
+        mctrl_print("\t%-15s%s%s\n", tops->name, tops->description, default_str);
+    }
+}
+
+bool morsectrl_transport_driver_commands_supported(void)
+{
+    const struct morsectrl_transport_ops * const *iter;
+
+    for (iter = get_ops_table_iterator();  iter != NULL; iter = ops_table_iterator_next(iter))
+    {
+        const struct morsectrl_transport_ops *tops = *iter;
+
+        if (tops->has_driver)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+int morsectrl_transport_parse(struct morsectrl_transport **transport,
+                              bool debug,
+                              const char *trans_opts,
+                              const char *iface_opts,
+                              const char *cfg_opts)
+{
+    int ret = -ETRANSERR;
+    const struct morsectrl_transport_ops *tops;
+
+    *transport = NULL;
+
+    tops = find_transport_ops(trans_opts);
+    if (!tops)
+    {
+        morsectrl_transport_err("Transport parsing", -ETRANSERR, "Invalid transport");
+        return -ETRANSNODEV;
+    }
+
+    if (debug)
+    {
+        if (!trans_opts)
+        {
+            mctrl_print("Transport set to default: %s\n", tops->name);
+        }
+        else
+        {
+            mctrl_print("Transport set to: %s\n", tops->name);
+        }
+    }
+
+    ret = tops->parse(transport, debug, iface_opts, cfg_opts);
+
+    return ret;
+}
+
+const char *morsectrl_transport_name(struct morsectrl_transport *transport)
+{
+    if (!transport || !transport->tops)
+    {
+        return "<invalid>";
+    }
+
+    return transport->tops->name;
+}
+
+int morsectrl_transport_init(struct morsectrl_transport *transport)
+{
+    if (transport->tops && transport->tops->init)
+        return transport->tops->init(transport);
+
+    return -ETRANSERR;
+}
+
+int morsectrl_transport_deinit(struct morsectrl_transport *transport)
+{
+    int ret = ETRANSSUCC;
+
+    if (transport->tops && transport->tops->deinit)
+        ret = transport->tops->deinit(transport);
+
+    transport->tops = NULL;
+
+    return ret;
+}
+
+struct morsectrl_transport_buff *morsectrl_transport_cmd_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport->tops)
+        return NULL;
+
+    /* Add the size of the command header and pass down to the correct transport. */
+    return transport->tops->write_alloc(transport, sizeof(struct command) + size);
+}
+
+struct morsectrl_transport_buff *morsectrl_transport_resp_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport->tops)
+        return NULL;
+
+    /* Add the size of the response header and pass down to the correct transport. */
+    return transport->tops->read_alloc(transport, sizeof(struct response) + size);
+}
+
+struct morsectrl_transport_buff *morsectrl_transport_raw_read_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport->tops || !transport->tops->read_alloc)
+        return NULL;
+
+    /* Add the size of the response header and pass down to the correct transport. */
+    return transport->tops->read_alloc(transport, size);
+}
+
+struct morsectrl_transport_buff *morsectrl_transport_raw_write_alloc(
+    struct morsectrl_transport *transport, size_t size)
+{
+    if (!transport->tops || !transport->tops->write_alloc)
+        return NULL;
+
+    /* Add the size of the response header and pass down to the correct transport. */
+    return transport->tops->write_alloc(transport, size);
+}
+
+int morsectrl_transport_buff_free(struct morsectrl_transport_buff *buff)
+{
+    if (!buff)
+        return -ETRANSERR;
+
+    free(buff->memblock);
+    free(buff);
+
+    return ETRANSSUCC;
+}
+
+void morsectrl_transport_set_cmd_data_length(struct morsectrl_transport_buff *tbuff,
+                                             uint16_t length)
+{
+    tbuff->data_len = sizeof(struct command) + length;
+}
+
+int morsectrl_transport_reg_read(struct morsectrl_transport *transport,
+                                 uint32_t addr, uint32_t *value)
+{
+    if (!transport->tops || !transport->tops->reg_read)
+        return -ETRANSERR;
+
+    return transport->tops->reg_read(transport, addr, value);
+}
+
+int morsectrl_transport_reg_write(struct morsectrl_transport *transport,
+                                  uint32_t addr, uint32_t value)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    if (!transport->tops->reg_write)
+        return -ETRANSNOTSUP;
+
+    return transport->tops->reg_write(transport, addr, value);
+}
+
+int morsectrl_transport_mem_read(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *read,
+                                 uint32_t addr)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    if (!transport->tops->mem_read)
+        return -ETRANSNOTSUP;
+
+    return transport->tops->mem_read(transport, read, addr);
+}
+
+int morsectrl_transport_mem_write(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *write,
+                                  uint32_t addr)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    if (!transport->tops->mem_write)
+        return -ETRANSNOTSUP;
+
+    return transport->tops->mem_write(transport, write, addr);
+}
+
+int morsectrl_transport_send(struct morsectrl_transport *transport,
+                             struct morsectrl_transport_buff *cmd,
+                             struct morsectrl_transport_buff *resp)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    return transport->tops->send(transport, cmd, resp);
+}
+
+int morsectrl_transport_raw_read(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *read,
+                                 bool start,
+                                 bool finish)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    return transport->tops->raw_read(transport, read, start, finish);
+}
+
+int morsectrl_transport_raw_write(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *write,
+                                  bool start,
+                                  bool finish)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    return transport->tops->raw_write(transport, write, start, finish);
+}
+
+int morsectrl_transport_raw_read_write(struct morsectrl_transport *transport,
+                                       struct morsectrl_transport_buff *read,
+                                       struct morsectrl_transport_buff *write,
+                                       bool start,
+                                       bool finish)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    return transport->tops->raw_read_write(transport, read, write, start, finish);
+} /* NOLINT */
+
+int morsectrl_transport_reset_device(struct morsectrl_transport *transport)
+{
+    if (!transport->tops)
+        return -ETRANSERR;
+
+    if (!transport->tops->reset_device)
+        return -ETRANSNOTSUP;
+
+
+    return transport->tops->reset_device(transport);
+}
+
+const char *morsectrl_transport_get_ifname(struct morsectrl_transport *transport)
+{
+    if (!transport->tops || !transport->tops->get_ifname)
+        return NULL;
+
+    return transport->tops->get_ifname(transport);
+}
+
+bool morsectrl_transport_has_reset(struct morsectrl_transport *transport)
+{
+    if (transport != NULL && transport->tops != NULL)
+    {
+        return transport->tops->has_reset;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool morsectrl_transport_has_driver(struct morsectrl_transport *transport)
+{
+    if (transport != NULL && transport->tops != NULL)
+    {
+        return transport->tops->has_driver;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+void morsectrl_transport_err(const char *prefix, int error_code, const char *error_msg)
+{
+    mctrl_err("%s, code %d: %s\n", prefix, error_code, error_msg);
+}
+
+void morsectrl_transport_debug(struct morsectrl_transport *transport, const char *fmt, ...)
+{
+    if (transport != NULL && transport->debug)
+    {
+        va_list args;
+        va_start(args, fmt);
+        mctrl_print(fmt, args);
+        va_end(args);
+    }
+}
+
+/* Dummy transport to ensure the transport_ops table always exists. */
+const struct morsectrl_transport_ops dummy = { };
+REGISTER_TRANSPORT(dummy);

--- a/feeds/morse/utils/morsectrl/src/transport/transport.h
+++ b/feeds/morse/utils/morsectrl/src/transport/transport.h
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#pragma once
+
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+
+enum moresctrl_transport_errnum
+{
+    ETRANSSUCC          = 0,
+    ETRANSERR           = 2,
+    ETRANSNL80211ERR    = 3,
+    ETRANSFTDISPIERR    = 4,
+    ETRANSNOTSUP        = 5,
+    /* The following codes correspond to the errno equivalents. */
+    ETRANSNOMEM         = 12,
+    ETRANSNODEV         = 19,
+};
+
+/* Helper macros :) */
+#define TBUFF_TO_CMD(cmd_tbuf, cmdtype) ((cmdtype *)((struct command *)cmd_tbuf->data)->data)
+#define TBUFF_TO_RSP(rsp_tbuf, cmdtype) ((cmdtype *)((struct response *)rsp_tbuf->data)->data)
+
+#define MAX_SERIAL_NUMBER_LEN (16)
+
+struct morsectrl_transport;
+
+/** Contains memory used to store commands and framing. */
+struct morsectrl_transport_buff
+{
+    /** Memory block to be allocated with room for commands and transport framing. */
+    uint8_t *memblock;
+    /** Total capacity of the allocated memory block. */
+    size_t capacity;
+    /**
+     * Pointer into the memory block to where the data starts (whichever is first out of commands
+     * and framing).
+     */
+    uint8_t *data;
+    /** Current size of the data (can be data or data and framing). */
+    size_t data_len;
+};
+
+/**
+ * Gets a regular expression string representing the supported transports.
+ *
+ * For example if the supported transports are called `nl80211` and `ftdi_spi` then this
+ * will return `(nl80211|ftdi_spi)`.
+ *
+ * @returns the regular expression string, allocated using malloc. It is the responsibility
+ *          of the caller to free it. @c NULL if no transports supported or error.
+*/
+char *morsectrl_transport_get_regex(void);
+
+/**
+ * Prints a list of available transports.
+ */
+void morsectrl_transport_list_available(void);
+
+/**
+ * @brief Checks whether one or more of the available transports support driver commands.
+ *
+ * @returns @c true if one or more of the available transports support driver commands;
+ *          @c false if none of the transports support driver commands.
+*/
+bool morsectrl_transport_driver_commands_supported(void);
+
+/**
+ * @brief Parses the commandline options to set the correct transport and fill the configuration.
+ *
+ * @param[out] transport    On success a an opaque transport data structure instance will be
+ *                          returned via this out argument.
+ * @param debug             Indicates whether debug messages should be enabled.
+ * @param trans_opts        Transport string from the commandline.
+ * @param iface_opts        Interface string from the commandline.
+ * @param cfg_opts          Configuration string from the commandline.
+ * @return                  0 on success or relevant error.
+ */
+int morsectrl_transport_parse(struct morsectrl_transport **transport,
+                              bool debug,
+                              const char *trans_opts,
+                              const char *iface_opts,
+                              const char *cfg_opts);
+
+/**
+ * @brief Get the name of the given transport.
+ *
+ * @param transport     Transport instance to get the name of.
+ *
+ * @returns a null-terminated string that is the name of the transport, or "?" on error.
+ */
+const char *morsectrl_transport_name(struct morsectrl_transport *transport);
+
+/**
+ * @brief Initialises the transport.
+ *
+ * @param transport Initalised transport (has parse the configuration)
+ * @return          0 on success or relevant error.
+ */
+int morsectrl_transport_init(struct morsectrl_transport *transport);
+
+/**
+ * @brief Deinitialises the transport
+ *
+ * @param transport Transport to deinit.
+ * @return          0 on success or relevant error.
+ */
+int morsectrl_transport_deinit(struct morsectrl_transport *transport);
+
+/**
+ * @brief Allocates memory for a command to send using the provided transport.
+ *
+ * @param transport Transport to allocate command memory for.
+ * @param size      Size of the commnd to allocate memory for. Includes the morse command header.
+ * @return          the allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+struct morsectrl_transport_buff *morsectrl_transport_cmd_alloc(
+    struct morsectrl_transport *transport, size_t size);
+
+/**
+ * @brief Allocates memory for a response to send using the provided transport.
+ *
+ * @param transport Transport to allocate command memory for.
+ * @param size      Size of the response to allocate memory for. Includes the morse response header.
+ * @return          the allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+struct morsectrl_transport_buff *morsectrl_transport_resp_alloc(
+    struct morsectrl_transport *transport, size_t size);
+
+/**
+ * @brief Allocates memory for writing raw data using the provided transport.
+ *
+ * @param transport Transport to allocate command memory for.
+ * @param size      Size of the data to allocate memory for.
+ * @return          the allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+struct morsectrl_transport_buff *morsectrl_transport_raw_write_alloc(
+    struct morsectrl_transport *transport, size_t size);
+
+/**
+ * @brief Allocates memory for reading raw data using the provided transport.
+ *
+ * @param transport Transport to allocate command memory for.
+ * @param size      Size of the data to allocate memory for.
+ * @return          the allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+struct morsectrl_transport_buff *morsectrl_transport_raw_read_alloc(
+    struct morsectrl_transport *transport, size_t size);
+
+/**
+ * @brief Frees memory for a @ref morsectrl_transport_buff.
+ *
+ * @param transport Transport to free memory for.
+ * @return          0 on success or relevant error.
+ */
+int morsectrl_transport_buff_free(struct morsectrl_transport_buff *buff);
+
+int morsectrl_transport_reg_read(struct morsectrl_transport *transport,
+                                 uint32_t addr, uint32_t *value);
+
+int morsectrl_transport_reg_write(struct morsectrl_transport *transport,
+                                  uint32_t addr, uint32_t value);
+
+int morsectrl_transport_mem_read(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *read,
+                                 uint32_t addr);
+
+int morsectrl_transport_mem_write(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *write,
+                                  uint32_t addr);
+
+/**
+ * @brief Send a command using the specified transport.
+ *
+ * @param transport Transport to send the command on.
+ * @param cmd       Buffer containing command to send.
+ * @param resp      Buffer to received response into.
+ * @return          0 on success or relevant error.
+ */
+int morsectrl_transport_send(struct morsectrl_transport *transport,
+                             struct morsectrl_transport_buff *cmd,
+                             struct morsectrl_transport_buff *resp);
+
+/**
+ * @brief Reads raw data from the transport.
+ *
+ * @param transport Transport to read raw data from.
+ * @param read      Buffer to read data into.
+ * @param finish    Finishes the transaction if true, otherwise leave open for
+ *                  more raw reads/writes/read writes.
+ * @return int      0 on success or relevenat error.
+ */
+int morsectrl_transport_raw_read(struct morsectrl_transport *transport,
+                                 struct morsectrl_transport_buff *read,
+                                 bool start,
+                                 bool finish);
+
+/**
+ * @brief Writes raw data to the transport.
+ *
+ * @param transport Transport to read raw data from.
+ * @param write     Buffer to write data from.
+ * @param finish    Finishes the transaction if true, otherwise leave open for
+ *                  more raw reads/writes/read writes.
+ * @return int      0 on success or relevenat error.
+ */
+int morsectrl_transport_raw_write(struct morsectrl_transport *transport,
+                                  struct morsectrl_transport_buff *write,
+                                  bool start,
+                                  bool finish);
+
+/**
+ * @brief Reads and writes raw data to/from the transport.
+ *
+ * @note If read and write buffer lengths differ, behaviour is transport dependent.
+ *
+ * @param transport Transport to read/write raw data from/to.
+ * @param read      Buffer to read data into.
+ * @param write     Buffer to write data from.
+ * @param finish    Finishes the transaction if true, otherwise leave open for
+ *                  more raw reads/writes/read writes.
+ * @return int      0 on success or relevenat error.
+ */
+int morsectrl_transport_raw_read_write(struct morsectrl_transport *transport,
+                                       struct morsectrl_transport_buff *read,
+                                       struct morsectrl_transport_buff *write,
+                                       bool start,
+                                       bool finish);
+
+/**
+ * @brief Reset a device using transport's hardware methods.
+ *
+ * @param transport Transport to perform hard reset.
+ * @return int      0 on success or relevant error.
+ */
+int morsectrl_transport_reset_device(struct morsectrl_transport *transport);
+
+/**
+ * @brief Get the interface name
+ *
+ * @param transport Transport
+ *
+ * @return Interface name, or NULL if not defined.
+ */
+const char *morsectrl_transport_get_ifname(struct morsectrl_transport *transport);
+
+/**
+ * @brief Set the length of the data actually used in a command
+ *
+ * @param tbuff Command transport buffer
+ * @param length Length of command data
+ */
+void morsectrl_transport_set_cmd_data_length(struct morsectrl_transport_buff *tbuff,
+                                             uint16_t length);
+
+/**
+ * @brief Checks whether the given transport has reset support.
+ *
+ * @param transport The transport instance.
+ *
+ * @return @c true if the transport has reset support else @c false.
+ */
+bool morsectrl_transport_has_reset(struct morsectrl_transport *transport);
+
+/**
+ * @brief Checks whether the given transport supports driver commands or interfaces directly to
+ *        firmware.
+ *
+ * @param transport The transport instance.
+ *
+ * @return @c true if the transport supports driver commands else @c false.
+ */
+bool morsectrl_transport_has_driver(struct morsectrl_transport *transport);
+
+/**
+ * Print an error message.
+ *
+ * @param prefix        Message prefix
+ * @param error_code    Integer error code
+ * @param error_msg     Textual error message with some human readable information about the error.
+ */
+void morsectrl_transport_err(const char *prefix, int error_code, const char *error_msg);
+
+/**
+ * @brief Print a debug message, if enabled.
+ *
+ * @param transport The transport instance.
+ * @param fmt       The printf format string.
+ * @param ...       Optional printf arguments.
+ */
+void morsectrl_transport_debug(struct morsectrl_transport *transport, const char *fmt, ...);

--- a/feeds/morse/utils/morsectrl/src/transport/transport_private.h
+++ b/feeds/morse/utils/morsectrl/src/transport/transport_private.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+/*
+ * WARNING: this function is for internal use within the transport subsystem only! Do not include
+ *          from outside the transport directory. All access to transport interfaces must go
+ *          via transport.h.
+ */
+
+#pragma once
+
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "transport.h"
+
+/**
+ * @brief Transport operations and information data structure
+ *
+ * Each transport must register a const instance of this data structure using REGISTER_TRANSPORT().
+ */
+struct morsectrl_transport_ops
+{
+    const char *name;
+    const char *description;
+    bool has_reset;
+    bool has_driver;
+    /** Parse the configuration for the chosen transport. */
+    int (*parse)(struct morsectrl_transport **transport,
+                 bool debug,
+                 const char *iface_opts,
+                 const char *cfg_opts);
+    /** Initialise the provided transport. */
+    int (*init)(struct morsectrl_transport *transport);
+    /** Deinitialise the provided transport. */
+    int (*deinit)(struct morsectrl_transport *transport);
+    /** Allocate memory for a command. */
+    struct morsectrl_transport_buff *(*write_alloc)(
+        struct morsectrl_transport *transport, size_t size);
+    /** Allocate memory for a response. */
+    struct morsectrl_transport_buff *(*read_alloc)(
+        struct morsectrl_transport *transport, size_t size);
+    /** Send a command and receive a response. */
+    int (*send)(struct morsectrl_transport *transport,
+                struct morsectrl_transport_buff *cmd,
+                struct morsectrl_transport_buff *resp);
+    /** Read a 32bit register. */
+    int (*reg_read)(struct morsectrl_transport *transport,
+                    uint32_t addr, uint32_t *value);
+    /** Write a 32bit register. */
+    int (*reg_write)(struct morsectrl_transport *transport,
+                     uint32_t addr, uint32_t value);
+    /** Read a word aligned memory block. */
+    int (*mem_read)(struct morsectrl_transport *transport,
+                    struct morsectrl_transport_buff *read,
+                    uint32_t addr);
+    /** Write a word aligned memory block. */
+    int (*mem_write)(struct morsectrl_transport *transport,
+                     struct morsectrl_transport_buff *write,
+                     uint32_t addr);
+    /** Perform a raw read from the transport. */
+    int (*raw_read)(struct morsectrl_transport *transport,
+                    struct morsectrl_transport_buff *read,
+                    bool start,
+                    bool finish);
+    /** Perform a raw write from the transport. */
+    int (*raw_write)(struct morsectrl_transport *transport,
+                     struct morsectrl_transport_buff *write,
+                     bool start,
+                     bool finish);
+    /** Perform a raw read and write simultaneously from the transport. */
+    int (*raw_read_write)(struct morsectrl_transport *transport,
+                          struct morsectrl_transport_buff *read,
+                          struct morsectrl_transport_buff *write,
+                          bool start,
+                          bool finish);
+    /** Reset the device. */
+    int (*reset_device)(struct morsectrl_transport *transport);
+    /** Retrieve the interface name, if supported (optional; may be NULL if not supported). */
+    const char *(*get_ifname)(struct morsectrl_transport *transport);
+};
+
+/**
+ * @brief Common transport  data.
+ *
+ * This is "subclassed" by transports by making it the first member of a super struct.
+ */
+struct morsectrl_transport
+{
+    /** Transport operations data structure for this transport. */
+    const struct morsectrl_transport_ops *tops;
+    /** Flag indicating whether debug messages are enabled. */
+    bool debug;
+};
+
+
+#define REGISTER_TRANSPORT(_ops) \
+    const struct morsectrl_transport_ops * const \
+    __attribute__((section("transport_ops_table"))) transport_##_ops = &(_ops)

--- a/feeds/morse/utils/morsectrl/src/transport/uart.h
+++ b/feeds/morse/utils/morsectrl/src/transport/uart.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+/*
+ * UART platform abstration API.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct uart_ctx;
+
+#define UART_MAX_DEVICE_NAME_LEN         (256)
+
+struct uart_config
+{
+    char dev_name[UART_MAX_DEVICE_NAME_LEN];
+
+    int baudrate;
+};
+
+struct uart_ctx *uart_init(const struct uart_config *cfg);
+
+int uart_deinit(struct uart_ctx *ctx);
+
+int uart_read(struct uart_ctx *ctx, uint8_t *buf, size_t len);
+
+int uart_write(struct uart_ctx *ctx, const uint8_t *buf, size_t len);

--- a/feeds/morse/utils/morsectrl/src/transport/uart_linux.c
+++ b/feeds/morse/utils/morsectrl/src/transport/uart_linux.c
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "uart.h"
+#include "../utilities.h"
+
+struct uart_ctx
+{
+    int fd;
+};
+
+struct uart_ctx *uart_init(const struct uart_config *config)
+{
+    int ret;
+    struct termios tty = {};
+    struct uart_ctx *ctx = calloc(1, sizeof(*ctx));
+    speed_t uart_baud;
+    MCTRL_ASSERT(ctx != NULL, "Memory allocation failure");
+
+    switch (config->baudrate)
+    {
+        case 9600:
+            uart_baud = B9600;
+            break;
+        case 19200:
+            uart_baud = B19200;
+            break;
+        case 38400:
+            uart_baud = B38400;
+            break;
+        case 57600:
+            uart_baud = B57600;
+            break;
+        case 115200:
+            uart_baud = B115200;
+            break;
+        case 230400:
+            uart_baud = B230400;
+            break;
+        case 460800:
+            uart_baud = B460800;
+            break;
+        case 500000:
+            uart_baud = B500000;
+            break;
+        case 576000:
+            uart_baud = B576000;
+            break;
+        case 921600:
+            uart_baud = B921600;
+            break;
+        case 1000000:
+            uart_baud = B1000000;
+            break;
+        case 1152000:
+            uart_baud = B1152000;
+            break;
+        case 1500000:
+            uart_baud = B1500000;
+            break;
+        case 2000000:
+            uart_baud = B2000000;
+            break;
+        case 2500000:
+            uart_baud = B2500000;
+            break;
+        case 3000000:
+            uart_baud = B3000000;
+            break;
+        case 3500000:
+            uart_baud = B3500000;
+            break;
+        case 4000000:
+            uart_baud = B4000000;
+            break;
+        default:
+            mctrl_err("Invalid baudrate %d\n", config->baudrate);
+            free(ctx);
+            return NULL;
+        }
+
+    ret = open(config->dev_name, O_RDWR | O_NOCTTY | O_NDELAY);
+    if (ret <= 0)
+    {
+        mctrl_err("Failed to open UART device\n");
+        free(ctx);
+        return NULL;
+    }
+
+    ctx->fd = ret;
+    fcntl(ctx->fd, F_SETFL, 0);
+
+    /* Configure as 8N1, no flow control or modem status lines */
+    tty.c_cflag = CS8 | CLOCAL;
+    cfsetospeed(&tty, uart_baud);
+    cfsetispeed(&tty, uart_baud);
+
+    ret = tcsetattr(ctx->fd, TCSANOW, &tty);
+    if (ret)
+    {
+        mctrl_err("Failed tcsetattr on UART device\n");
+        free(ctx);
+        return NULL;
+    }
+
+    ret = tcsetattr(ctx->fd, TCSANOW, &tty);
+    if (ret)
+    {
+        mctrl_err("Failed tcsetattr on UART device\n");
+        free(ctx);
+        return NULL;
+    }
+    return ctx;
+}
+
+int uart_deinit(struct uart_ctx *ctx)
+{
+    int ret = 0;
+    if (ctx != NULL)
+    {
+        if (ctx->fd > 0)
+        {
+            ret = close(ctx->fd);
+        }
+        free(ctx);
+    }
+    return ret;
+}
+
+int uart_read(struct uart_ctx *ctx, uint8_t *buf, size_t len)
+{
+    if (ctx->fd <= 0)
+    {
+        return -ETRANSERR;
+    }
+
+    return read(ctx->fd, buf, len);
+}
+
+int uart_write(struct uart_ctx *ctx, const uint8_t *buf, size_t len)
+{
+    if (ctx->fd <= 0)
+    {
+        return -ETRANSERR;
+    }
+
+    return write(ctx->fd, buf, len);
+}

--- a/feeds/morse/utils/morsectrl/src/transport/uart_slip.c
+++ b/feeds/morse/utils/morsectrl/src/transport/uart_slip.c
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+/*
+ * Transport layer for communication over UART interface to an embedded device with SLIP framing.
+ *
+ * Transport frame format:
+ *
+ *          +-----------------------------------------+-----------+-----------+
+ *          |       Command/Response Payload          |   Seq #   |   CRC16   |
+ *          +-----------------------------------------+-----------+-----------+
+ *
+ * * Seq # is used to match command to response. The content is arbitrary and the response will
+ *   echoed the value provided in the command.
+ * * The command and response payload are opaque to this layer.
+ * * CRC16 is a CRC16 calculated over the sequence # and payload. See below for implementation
+ *   details.
+ *
+ * The above frame is then slip encoded before transmission over the UART. On the receive
+ * side it is SLIP decoded before the CRC16 is validated and sequence # checked.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "transport.h"
+#include "transport_private.h"
+#include "../utilities.h"
+
+#include "slip.h"
+#include "uart.h"
+
+#define DEFAULT_BAUDRATE            (115200)
+
+#define SEQNUM_LEN                  (4)
+#define CRC_LEN                     (2)
+
+static const struct morsectrl_transport_ops uart_slip_ops;
+
+/** @brief Data structure used to represent an instance of this trasport. */
+struct morsectrl_uart_slip_transport
+{
+    struct morsectrl_transport common;
+    struct uart_config uart_config;
+    struct uart_ctx *uart_ctx;
+};
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *        uart_config field.
+ */
+static struct uart_config *uart_slip_cfg(struct morsectrl_transport *transport)
+{
+    struct morsectrl_uart_slip_transport *uart_slip_transport =
+        (struct morsectrl_uart_slip_transport *)transport;
+    return &uart_slip_transport->uart_config;
+}
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, set the uart_ctx field.
+ */
+static void uart_slip_ctx_set(struct morsectrl_transport *transport, struct uart_ctx *ctx)
+{
+    struct morsectrl_uart_slip_transport *uart_slip_transport =
+        (struct morsectrl_uart_slip_transport *)transport;
+    uart_slip_transport->uart_ctx = ctx;
+}
+
+/**
+ * @brief Given a pointer to a @ref morsectrl_transport instance, return a reference to the
+ *        uart_ctx field.
+ */
+static struct uart_ctx *uart_slip_ctx(struct morsectrl_transport *transport)
+{
+    struct morsectrl_uart_slip_transport *uart_slip_transport =
+        (struct morsectrl_uart_slip_transport *)transport;
+    return uart_slip_transport->uart_ctx;
+}
+
+/**
+ * @brief Prints an error message if possible.
+ *
+ * @param transport     Transport to print the error message from.
+ * @param error_code    Error code.
+ * @param error_msg     Error message.
+ */
+static void uart_slip_error(int error_code, char *error_msg)
+{
+    morsectrl_transport_err("UART_SLIP", error_code, error_msg);
+}
+
+/**
+ * @brief Parse the configuration for the SLIP over UART interface.
+ *
+ * @param transport     The transport structure.
+ * @param debug         Indicates whether debug print statements are enabled.
+ * @param iface_opts    String containing the interface to use. May be NULL.
+ * @param cfg_opts      Comma separated string with SLIP over UART configuration options.
+ * @return              0 on success otherwise relevant error.
+ */
+static int uart_slip_parse(struct morsectrl_transport **transport,
+                           bool debug,
+                           const char *iface_opts,
+                           const char *cfg_opts)
+{
+    struct uart_config *config;
+
+    struct morsectrl_uart_slip_transport *uart_slip_transport =
+        calloc(1, sizeof(*uart_slip_transport));
+    if (!uart_slip_transport)
+    {
+        mctrl_err("Transport memory allocation failure\n");
+        return -ETRANSNOMEM;
+    }
+
+    uart_slip_transport->common.debug = debug;
+    uart_slip_transport->common.tops = &uart_slip_ops;
+    *transport = &uart_slip_transport->common;
+    config = uart_slip_cfg(*transport);
+
+    if (cfg_opts == NULL || strlen(cfg_opts) == 0)
+    {
+        mctrl_err("Must specify the path to the UART file. For example: -c /dev/ttyACM0\n");
+        return -ETRANSNOMEM;
+    }
+
+    strncpy(config->dev_name, cfg_opts, sizeof(config->dev_name) - 1);
+    config->baudrate = DEFAULT_BAUDRATE;
+
+    return 0;
+}
+
+
+/**
+ * @brief Initalise an SLIP over UART interface.
+ *
+ * @note This should be done after parsing the configuration.
+ *
+ * @param transport Transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int uart_slip_init(struct morsectrl_transport *transport)
+{
+    struct uart_ctx *ctx;
+    struct uart_config *config = uart_slip_cfg(transport);
+
+
+    srand(time(NULL));
+
+    ctx = uart_init(config);
+    if (ctx == NULL)
+        return ETRANSERR;
+    uart_slip_ctx_set(transport, ctx);
+
+    return ETRANSSUCC;
+}
+
+/**
+ * @brief De-initalise an FTDI Transport.
+ *
+ * @param transport The transport structure.
+ * @return          0 on success otherwise relevant error.
+ */
+static int uart_slip_deinit(struct morsectrl_transport *transport)
+{
+    struct uart_ctx *ctx = uart_slip_ctx(transport);
+
+    uart_slip_ctx_set(transport, NULL);
+
+    return uart_deinit(ctx);
+}
+
+
+/**
+ * @brief Allocate @ref morsectrl_transport_buff.
+ *
+ * @param transport Transport structure.
+ * @param size      Size of command and morse headers or raw data.
+ * @return          Allocated @ref morsectrl_transport_buff or NULL on failure.
+ */
+static struct morsectrl_transport_buff *uart_slip_alloc(struct morsectrl_transport *transport,
+                                                        size_t size)
+{
+    struct morsectrl_transport_buff *buff;
+
+    if (!transport)
+        return NULL;
+
+    if (size <= 0)
+        return NULL;
+
+    buff = calloc(1, sizeof(*buff));
+    if (!buff)
+        return NULL;
+
+    buff->capacity = size + SEQNUM_LEN + CRC_LEN;
+    buff->memblock = calloc(1, buff->capacity);
+    if (!buff->memblock)
+    {
+        free(buff);
+        return NULL;
+    }
+    buff->data = buff->memblock;
+    buff->data_len = size;
+
+    return buff;
+}
+
+static int uart_slip_tx_char(uint8_t c, void *arg)
+{
+    int ret;
+    struct morsectrl_transport *transport = arg;
+    struct uart_ctx *ctx = uart_slip_ctx(transport);
+
+
+    ret = uart_write(ctx, &c, 1);
+    if (ret == 1)
+    {
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+/**
+ * Static table used for the table_driven implementation.
+ */
+static const uint16_t crc16_lookup_table[256] = {
+    0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
+    0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
+    0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
+    0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de,
+    0x2462, 0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485,
+    0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+    0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4,
+    0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc,
+    0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
+    0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b,
+    0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
+    0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a,
+    0x6ca6, 0x7c87, 0x4ce4, 0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41,
+    0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49,
+    0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70,
+    0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78,
+    0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f,
+    0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
+    0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+    0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256,
+    0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d,
+    0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+    0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c,
+    0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615, 0x5634,
+    0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab,
+    0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3,
+    0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
+    0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92,
+    0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9,
+    0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1,
+    0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
+    0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
+};
+
+/**
+ * @brief Compute the CRC-16 for the data buffer using the XMODEM model.
+ *
+ * @param crc       Seed for CRC calc, zero in most cases this is zero (0).
+ * @param data      Pointer to the start of the data to calculate the crc over.
+ * @param data_len  Length of the data array in bytes.
+ *
+ * @return Returns the CRC value.
+ *
+ * @note This implementation(with a few modifications) and corresponding table was generated using
+ *       pycrc v0.9.2 (MIT) using the XMODEM model. https://pycrc.org/. The code generated by pycrc
+ *       is not considered a substantial portion of the software, therefore the licence does not
+ *       cover the generated code, and the author of pycrc will not claim any copyright on the
+ *       generated code (https://pypi.org/project/pycrc/0.9.2/).
+ */
+static uint16_t morse_crc16(uint16_t crc, const void *data, size_t data_len)
+{
+    const uint8_t *d = (const uint8_t *)data;
+
+    while (data_len--)
+    {
+        crc = (crc16_lookup_table[((crc >> 8) ^ *d++)] ^ (crc << 8));
+    }
+    return crc;
+}
+
+static int uart_slip_send(struct morsectrl_transport *transport,
+                         struct morsectrl_transport_buff *cmd,
+                         struct morsectrl_transport_buff *resp)
+{
+    struct uart_ctx *ctx;
+    int ret = -ETRANSERR;
+    int i;
+    uint8_t *cmd_seq_num_field;
+    uint8_t *rsp_seq_num_field;
+    uint8_t *crc_field;
+    uint16_t crc;
+    size_t original_cmd_data_len;
+    struct slip_rx_state slip_rx_state = SLIP_RX_STATE_INIT(resp->data, resp->capacity);
+    enum slip_rx_status slip_rx_status = SLIP_RX_IN_PROGRESS;
+
+    if (!transport || !transport->tops || !cmd || !resp)
+    {
+        return -ETRANSERR;
+    }
+
+    /* We need to restore the data_len field before the function returns, so we stash the
+     * value here. */
+    original_cmd_data_len = cmd->data_len;
+
+    /* Append random sequence number */
+    cmd_seq_num_field = cmd->data + cmd->data_len;
+    cmd->data_len += SEQNUM_LEN;
+    MCTRL_ASSERT(cmd->data_len <= cmd->capacity, "Tx buffer insufficient (%u < %u)",
+                 cmd->capacity, cmd->data_len);
+    for (i = 0; i < SEQNUM_LEN; i++)
+    {
+        /* NOLINTNEXTLINE(runtime/threadsafe_fn)*/
+        cmd_seq_num_field[i] = rand();
+    }
+
+    /* Append CRC16 */
+    crc = morse_crc16(0, cmd->data, cmd->data_len);
+    crc_field = cmd->data + cmd->data_len;
+    cmd->data_len += CRC_LEN;
+    MCTRL_ASSERT(cmd->data_len <= cmd->capacity, "Tx buffer insufficient (%u < %u)",
+                 cmd->capacity, cmd->data_len);
+    crc_field[0] = crc & 0x0ff;
+    crc_field[1] = (crc >> 8) & 0x0ff;
+
+    /* Slip encode and transmit the packet */
+    ret = slip_tx(uart_slip_tx_char, transport, cmd->data, cmd->data_len);
+    cmd->data_len = original_cmd_data_len;
+
+    if (ret != 0)
+    {
+        uart_slip_error(ret, "Failed to send command");
+        goto fail;
+    }
+
+    resp->data_len = 0;
+
+    ctx = uart_slip_ctx(transport);
+
+    while (true)
+    {
+        slip_rx_state_reset(&slip_rx_state);
+        do
+        {
+            uint8_t rx_char;
+            ret = uart_read(ctx, &rx_char, 1);
+            if (ret < 0)
+            {
+                uart_slip_error(ret, "Failed to rx command");
+                goto fail;
+            }
+            else if (ret == 0)
+            {
+                continue;
+            }
+
+            slip_rx_status = slip_rx(&slip_rx_state, rx_char);
+        } while (slip_rx_status == SLIP_RX_IN_PROGRESS);
+
+        if (slip_rx_status != SLIP_RX_COMPLETE)
+        {
+            if (slip_rx_status == SLIP_RX_BUFFER_LIMIT)
+            {
+                uart_slip_error(-ETRANSERR, "Response exceeded allocated buffer");
+            }
+            uart_slip_error(-ETRANSERR, "Slip RX transfer incomplete");
+            ret = -ETRANSERR;
+            goto fail;
+        }
+
+        resp->data_len = slip_rx_state.length;
+        if (resp->data_len < SEQNUM_LEN + CRC_LEN)
+        {
+            if (resp->data_len > 0)
+            {
+                uart_slip_error(-ETRANSERR, "Received frame too short. Ignoring it...");
+            }
+            continue;
+        }
+
+        /* Remove and validate CRC */
+        resp->data_len -= CRC_LEN;
+        crc = morse_crc16(0, resp->data, resp->data_len);
+        crc_field = resp->data + resp->data_len;
+        if ((crc_field[0] != (crc & 0xff)) || crc_field[1] != ((crc >> 8) & 0xff))
+        {
+            uart_slip_error(-ETRANSERR, "CRC error for received frame. Ignoring it...");
+            continue;
+        }
+
+        /* Remove and validate sequence number */
+        resp->data_len -= SEQNUM_LEN;
+        rsp_seq_num_field = resp->data + resp->data_len;
+
+        if (memcmp(cmd_seq_num_field, rsp_seq_num_field, SEQNUM_LEN) != 0)
+        {
+            uart_slip_error(-ETRANSERR, "Seq # incorrect for received frame. Ignoring it...");
+            continue;
+        }
+
+        return ETRANSSUCC;
+    }
+fail:
+    return ret;
+}
+
+static const struct morsectrl_transport_ops uart_slip_ops = {
+    .name = "uart_slip",
+    .description = "Tunnel commands over a UART interface using SLIP framing",
+    .has_reset = false,
+    .has_driver = false,
+    .parse = uart_slip_parse,
+    .init = uart_slip_init,
+    .deinit = uart_slip_deinit,
+    .write_alloc = uart_slip_alloc,
+    .read_alloc = uart_slip_alloc,
+    .send = uart_slip_send,
+    .reg_read = NULL,
+    .reg_write = NULL,
+    .mem_read = NULL,
+    .mem_write = NULL,
+    .raw_read = NULL,
+    .raw_write = NULL,
+    .raw_read_write = NULL,
+    .reset_device = NULL,
+    .get_ifname = NULL,
+};
+
+REGISTER_TRANSPORT(uart_slip_ops);

--- a/feeds/morse/utils/morsectrl/src/transport/uart_win.c
+++ b/feeds/morse/utils/morsectrl/src/transport/uart_win.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <winsock2.h>
+#include <windows.h>
+
+#include "uart.h"
+#include "../utilities.h"
+
+#define TX_BUF_SIZE (512)
+#define RX_BUF_SIZE (2064)
+
+struct uart_ctx
+{
+    HANDLE hnd;
+};
+
+struct uart_ctx *uart_init(const struct uart_config *config)
+{
+    BOOL ok;
+    struct uart_ctx *ctx;
+    COMMTIMEOUTS comm_timeouts = {
+        .ReadIntervalTimeout = 1000,
+        .ReadTotalTimeoutMultiplier = 0,
+        .ReadTotalTimeoutConstant = 0,
+        .WriteTotalTimeoutMultiplier = 10,
+        .WriteTotalTimeoutConstant = 100,
+    };
+    DCB dcb = {
+        .DCBlength = sizeof(dcb),
+        .BaudRate = config->baudrate,
+        .fBinary = TRUE,
+        .fParity = FALSE,
+        .fOutxCtsFlow = FALSE,
+        .fOutxDsrFlow = FALSE,
+        .fDtrControl = DTR_CONTROL_DISABLE,
+        .fDsrSensitivity = FALSE,
+        .fTXContinueOnXoff = FALSE,
+        .fOutX = FALSE,
+        .fInX = FALSE,
+        .fErrorChar = FALSE,
+        .fNull = FALSE,
+        .fRtsControl = RTS_CONTROL_DISABLE,
+        .fAbortOnError = TRUE,
+        .ByteSize = 8,
+        .Parity = NOPARITY,
+        .StopBits = ONESTOPBIT,
+    };
+
+    ctx = calloc(1, sizeof(*ctx));
+    MCTRL_ASSERT(ctx != NULL, "Memory allocation failure");
+
+    ctx->hnd = CreateFile(config->dev_name, GENERIC_READ | GENERIC_WRITE,
+                          0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (ctx->hnd == INVALID_HANDLE_VALUE)
+    {
+        mctrl_err("Failed to open UART device\n");
+        free(ctx);
+        return NULL;
+    }
+
+    ok = SetupComm(ctx->hnd, RX_BUF_SIZE, TX_BUF_SIZE);
+    if (!ok)
+    {
+        mctrl_err("Failed to configure UART device buffers\n");
+        free(ctx);
+        return NULL;
+    }
+
+    ok = SetCommTimeouts(ctx->hnd, &comm_timeouts);
+    if (!ok)
+    {
+        mctrl_err("Failed to configure UART device timeouts\n");
+        free(ctx);
+        return NULL;
+    }
+
+    ok = SetCommState(ctx->hnd, &dcb);
+    if (!ok)
+    {
+        mctrl_err("Failed to configure UART device\n");
+        free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+int uart_deinit(struct uart_ctx *ctx)
+{
+    int ret = 0;
+    if (ctx != NULL)
+    {
+        if (ctx->hnd != INVALID_HANDLE_VALUE)
+        {
+            bool ok = CloseHandle(ctx->hnd);
+            ret = ok ? 0 : -ETRANSERR;
+        }
+        free(ctx);
+    }
+    return ret;
+}
+
+int uart_read(struct uart_ctx *ctx, uint8_t *buf, size_t len)
+{
+    bool ok;
+    DWORD actual_read_len;
+
+    ok = ReadFile(ctx->hnd, buf, len, &actual_read_len, NULL);
+    if (!ok)
+    {
+        return -ETRANSERR;
+    }
+
+    return actual_read_len;
+}
+
+int uart_write(struct uart_ctx *ctx, const uint8_t *buf, size_t len)
+{
+    bool ok;
+    DWORD actual_write_len;
+
+    ok = WriteFile(ctx->hnd, buf, len, &actual_write_len, NULL);
+    if (!ok)
+    {
+        return -ETRANSERR;
+    }
+
+    return actual_write_len;
+}

--- a/feeds/morse/utils/morsectrl/src/transraw.c
+++ b/feeds/morse/utils/morsectrl/src/transraw.c
@@ -1,0 +1,459 @@
+
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "morsectrl.h"
+#include "transport/transport.h"
+#include "utilities.h"
+
+#define TRANSRAW_OK_TYPE(x) (((x) == TRANSRAW_READ) || \
+                             ((x) == TRANSRAW_READ_TO_FILE) || \
+                             ((x) == TRANSRAW_WRITE) || \
+                             ((x) == TRANSRAW_WRITE_FROM_FILE))
+
+
+#define CHIP_ID_ADDR                (0x10054d20)
+
+#define IMEM_BANK0_ADDR             (0x00100000)
+#define IMEM_BANK1_ADDR             (0x00110000)
+#define IMEM_BANK2_ADDR             (0x00120000)
+#define IMEM_BANK3_ADDR             (0x00130000)
+#define IMEM_BANK4_ADDR             (0x00140000)
+#define IMEM_BANK5_ADDR             (0x00150000)
+#define IMEM_BANK6_ADDR             (0x00158000)
+
+#define DMEM_BANK0_ADDR             (0x80100000)
+#define DMEM_BANK1_ADDR             (0x80200000)
+#define DMEM_BANK2_ADDR             (0x80300000)
+#define DMEM_BANK3_ADDR             (0x80400000)
+
+#define REG_TEST_VALUE_BASE         (0x12340000)
+#define BYTE_TEST_VALUE_BASE        (0x23450000)
+#define BLOCK_TEST_VALUE_BASE       (0x34560000)
+#define BLOCK1_5_TEST_VALUE_BASE    (0x45670000)
+#define BLOCK2_TEST_VALUE_BASE      (0x56780000)
+#define BLOCK2_5_TEST_VALUE_BASE    (0x67890000)
+#define BOUND_TEST_VALUE_BASE       (0x789A0000)
+
+#define BYTE_TEST_SIZE              (sizeof(uint32_t) * 16)
+#define BLOCK_TEST_SIZE             (512)
+#define BLOCK1_5_TEST_SIZE          (512 + 256)
+#define BLOCK2_TEST_SIZE            (2 * 512)
+#define BLOCK2_5_TEST_SIZE          ((2 * 512) + 256)
+#define BOUND_TEST_SIZE             (UINT16_MAX + 1 + BLOCK1_5_TEST_SIZE)
+
+typedef enum
+{
+    TRANSRAW_UNKNOWN,
+    TRANSRAW_UNKNOWN_FILE,
+    TRANSRAW_WRITE,
+    TRANSRAW_WRITE_FROM_FILE,
+    TRANSRAW_READ,
+    TRANSRAW_READ_TO_FILE,
+    TRANSRAW_TEST,
+} transraw_type_t;
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\ttransraw [-a <address> [-w <value>] [-w -f <path to binary>] [-r <read_value>]] [-t]\n"); /* NOLINT */
+    mctrl_print("\t\t\t\tWrites or reads raw memory in the chip via transport\n");
+    mctrl_print(
+        "\t\t\t\tThis command only supports transports that interface directly to the chip\n");
+}
+
+static bool transport_buff_is_equal(struct morsectrl_transport_buff *a,
+                                    struct morsectrl_transport_buff *b)
+{
+    if (!a || !b)
+        return false;
+
+    if (a->data_len != b->data_len)
+        return false;
+
+    return !memcmp(a->data, b->data, a->data_len);
+}
+
+/**
+ * @brief Runs a memory tests to exercise a piece of memory.
+ *
+ * @param transport     The transport structure.
+ * @param base_addr     The address to start writing/reading to/from.
+ * @param size          The size of the memory to exercise.
+ * @param base_value    A starting data value. Unique values should be used when exercising multiple
+ *                      memory spaces/or sizes to prevent creating false positives.
+ * @return              0 on success otherwise relevant error.
+ */
+static int transraw_memtest(struct morsectrl_transport *transport,
+                            uint32_t base_addr,
+                            uint32_t size,
+                            uint32_t base_value)
+{
+    int ret;
+    uint32_t ii;
+
+    struct morsectrl_transport_buff *write_buff;
+    struct morsectrl_transport_buff *read_buff;
+
+    write_buff = morsectrl_transport_raw_write_alloc(transport, size);
+    read_buff = morsectrl_transport_raw_read_alloc(transport, size);
+
+    if (!write_buff || !read_buff)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    for (ii = 0; (ii + 3) < write_buff->data_len; ii += 4)
+    {
+        write_buff->data[ii] = ii & 0xFF;
+        write_buff->data[ii + 1] = (ii >> 8) & 0xFF;
+        write_buff->data[ii + 2] = (base_value >> 16) & 0xFF;
+        write_buff->data[ii + 3] = (base_value >> 24) & 0xFF;
+    }
+
+    ret = morsectrl_transport_mem_write(transport, write_buff, base_addr);
+    if (ret)
+    {
+        mctrl_err("Mem write failed\n");
+        goto exit;
+    }
+
+    ret = morsectrl_transport_mem_read(transport, read_buff, base_addr);
+    if (ret)
+    {
+        mctrl_err("Mem read failed\n");
+        goto exit;
+    }
+
+    if (!transport_buff_is_equal(write_buff, read_buff))
+    {
+        ret = -1;
+        mctrl_err("Mem write not equal to read\n");
+
+        for (ii = 0; ii < write_buff->data_len; ii++)
+        {
+            if (write_buff->data[ii] != read_buff->data[ii])
+                mctrl_err("Difference starts at octet 0x%08x: 0x%02x != 0x%02x\n",
+                       ii, write_buff->data[ii], read_buff->data[ii]);
+        }
+    }
+
+exit:
+    morsectrl_transport_buff_free(write_buff);
+    morsectrl_transport_buff_free(read_buff);
+
+    return ret;
+}
+
+
+ /**
+  * @brief Runs a memory tests to exercise different sizes and types of writes/reads.
+  *
+  * @note The sizes of writes/reads are targeted to SDIO but maybe useful for other transports.
+  *
+  * @param transport    The transport structure.
+  * @return             0 on success, otherwise relevant error.
+  */
+static int transraw_test(struct morsectrl_transport *transport)
+{
+    int ret;
+    uint32_t reg_write_val = REG_TEST_VALUE_BASE;
+    uint32_t reg_read_val;
+    int ii;
+
+    mctrl_print("Beginning transport test\n");
+
+    /* Read Chip ID. */
+    ret = morsectrl_transport_reg_read(transport, CHIP_ID_ADDR, &reg_read_val);
+    if (ret)
+        goto exit;
+
+    mctrl_print("\nChip ID: 0x%04x\n", reg_read_val);
+
+    /* Write some single registers first. */
+    mctrl_print("\nWrite and read registers:\n");
+    for (ii = IMEM_BANK0_ADDR; ii <= IMEM_BANK5_ADDR; ii += IMEM_BANK1_ADDR - IMEM_BANK0_ADDR)
+    {
+        ret = morsectrl_transport_reg_write(transport, ii, reg_write_val);
+        if (ret)
+            goto exit;
+
+        reg_write_val++;
+    }
+
+    /* Read the registers to make sure the values are as expected. */
+    reg_write_val = REG_TEST_VALUE_BASE;
+    for (ii = IMEM_BANK0_ADDR; ii <= IMEM_BANK5_ADDR; ii += IMEM_BANK1_ADDR - IMEM_BANK0_ADDR)
+    {
+        bool passed;
+        ret = morsectrl_transport_reg_read(transport, ii, &reg_read_val);
+        if (ret)
+            goto exit;
+
+        passed = (reg_write_val == reg_read_val);
+        mctrl_print("0x%08x: 0x%08x %c= 0x%08x - %s\n",
+               ii + 1,
+               reg_write_val, passed ? '=' : '!',
+               reg_read_val, passed ? "Pass" : "Fail");
+
+        if (!passed)
+        {
+            ret = -1;
+            goto exit;
+        }
+
+        reg_write_val++;
+    }
+
+    mctrl_print("\nWrite and read memory blocks:\n");
+    mctrl_print("Write and read bytes (IMEM Bank 0)                              - ");
+    /* Write some memory. */
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BYTE_TEST_SIZE, BYTE_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+
+    mctrl_print("Write and read bytes (IMEM Bank 1)                              - ");
+    /* Write some memory to a different bank. */
+    ret = transraw_memtest(transport, IMEM_BANK1_ADDR,
+                           BYTE_TEST_SIZE, BYTE_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+    mctrl_print("Write and read single block                                     - ");
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BLOCK_TEST_SIZE, BLOCK_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+    mctrl_print("Write and read single block and then bytes                      - ");
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BLOCK1_5_TEST_SIZE, BLOCK2_5_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+    mctrl_print("Write and read multi blocks                                     - ");
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BLOCK2_TEST_SIZE, BLOCK2_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+    mctrl_print("Write and read multi blocks and then bytes                      - ");
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BLOCK2_5_TEST_SIZE, BLOCK2_5_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+    mctrl_print("Write and read multi blocks and then bytes across 64kB boundary - ");
+    ret = transraw_memtest(transport, IMEM_BANK0_ADDR,
+                           BOUND_TEST_SIZE, BOUND_TEST_VALUE_BASE);
+    if (ret)
+    {
+        mctrl_err("Fail\n");
+        goto exit;
+    }
+    mctrl_print("Pass\n");
+
+exit:
+    return ret;
+}
+
+int transraw(struct morsectrl *mors, int argc, char *argv[])
+{
+    char *path;
+    int option;
+    uint32_t addr = 0;
+    transraw_type_t type = TRANSRAW_UNKNOWN;
+    FILE *file;
+    size_t file_size;
+    uint32_t read_val;
+    uint32_t write_val;
+    struct morsectrl_transport *transport = mors->transport;
+    struct morsectrl_transport_buff *buff = NULL;
+    int ret = 0;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    while ((option = getopt(argc, argv, "a:f:w:rt")) != -1)
+    {
+        switch (option)
+        {
+        case 'a':
+            if (str_to_uint32(optarg, &addr))
+            {
+                mctrl_err("Invalid address\n");
+                return -1;
+            }
+            break;
+
+        case 'w':
+            str_to_uint32(optarg, &write_val);
+
+            switch (type)
+            {
+            case TRANSRAW_UNKNOWN:
+                type = TRANSRAW_WRITE;
+                break;
+
+            case TRANSRAW_UNKNOWN_FILE:
+                type = TRANSRAW_WRITE_FROM_FILE;
+                break;
+
+            default:
+                usage(mors);
+                return -1;
+            }
+            break;
+
+        case 'r':
+            switch (type)
+            {
+            case TRANSRAW_UNKNOWN:
+                type = TRANSRAW_READ;
+                break;
+
+            case TRANSRAW_UNKNOWN_FILE:
+                type = TRANSRAW_READ_TO_FILE;
+                break;
+
+            default:
+                usage(mors);
+                return -1;
+            }
+            break;
+
+        case 'f':
+            path = optarg;
+            switch (type)
+            {
+            case TRANSRAW_UNKNOWN:
+                type = TRANSRAW_UNKNOWN_FILE;
+                break;
+
+            case TRANSRAW_READ:
+                type = TRANSRAW_READ_TO_FILE;
+                break;
+
+            case TRANSRAW_WRITE:
+                type = TRANSRAW_WRITE_FROM_FILE;
+                break;
+
+            default:
+                usage(mors);
+                return -1;
+            }
+            break;
+
+        case 't':
+            type = TRANSRAW_TEST;
+            break;
+
+        default:
+            usage(mors);
+            return -1;
+        }
+    }
+
+    switch (type)
+    {
+    case TRANSRAW_READ_TO_FILE:
+        file = fopen(path, "wb");
+        if (!file)
+        {
+            ret = -1;
+            goto fail;
+        }
+        buff = morsectrl_transport_raw_read_alloc(transport, read_val);
+        ret = morsectrl_transport_mem_read(transport, buff, addr);
+        if (fwrite(buff->data, sizeof(*buff->data), read_val, file) != read_val)
+            ret = -1;
+        fclose(file);
+        break;
+
+    case TRANSRAW_WRITE_FROM_FILE:
+        file = fopen(path, "rb");
+        if (!file)
+        {
+            ret = -1;
+            goto fail;
+        }
+        file_size = get_file_size(file);
+        buff = morsectrl_transport_raw_write_alloc(transport, file_size);
+        if (!buff)
+        {
+            ret = -1;
+            fclose(file);
+            goto fail;
+        }
+        load_file(file, &buff->data);
+        ret = morsectrl_transport_mem_write(transport, buff, addr);
+        fclose(file);
+        break;
+
+    case TRANSRAW_READ:
+        morsectrl_transport_reg_read(transport, addr, &read_val);
+        mctrl_print("0x%08x\n", read_val);
+        break;
+
+    case TRANSRAW_WRITE:
+        morsectrl_transport_reg_write(transport, addr, write_val);
+        mctrl_print("0x%08x\n", write_val);
+        break;
+
+    case TRANSRAW_TEST:
+        return transraw_test(mors->transport);
+
+    case TRANSRAW_UNKNOWN:
+    case TRANSRAW_UNKNOWN_FILE:
+    default:
+        usage(mors);
+        return -1;
+    }
+
+    morsectrl_transport_buff_free(buff);
+
+fail:
+    if (ret)
+        mctrl_print("Transport RAW read/write failure\n");
+
+    return ret;
+}
+
+MM_CLI_HANDLER(transraw, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/tsf.c
+++ b/feeds/morse/utils/morsectrl/src/tsf.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_get_tsf_req
+{
+};
+
+struct PACKED command_get_tsf_cfm
+{
+    /** The current TSF of the BSS the interface is associated on */
+    uint64_t now_tsf;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\ttsf\t\t\tretrieve the TSF (in hex)\n");
+}
+
+int tsf(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_get_tsf_req *cmd;
+    struct command_get_tsf_cfm *rsp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_get_tsf_req);
+    rsp = TBUFF_TO_RSP(rsp_tbuff, struct command_get_tsf_cfm);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_TSF,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("TSF is not available\n");
+    }
+    else
+    {
+        mctrl_print("%" PRIx64 "\n", le64toh(rsp->now_tsf));
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(tsf, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/turbo.c
+++ b/feeds/morse/utils/morsectrl/src/turbo.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_turbo_mode
+{
+    uint32_t aid;
+    uint16_t vif_id;
+    uint8_t enabled;
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tturbo [enable|disable]\n");
+    mctrl_print("\t\t\t\t'enable' will enable Morse Micro turbo mode\n");
+    mctrl_print("\t\t\t\t'disable' will disable Morse Micro turbo mode\n");
+}
+
+int turbo(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int enabled;
+    struct set_turbo_mode *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc < 2)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    enabled = expression_to_int(argv[1]);
+
+    if (enabled == -1)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_turbo_mode);
+    cmd->aid = 0;       /* Unused */
+    cmd->vif_id = 0;    /* Unused */
+    cmd->enabled = enabled;
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_TURBO,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set turbo mode\n");
+    }
+    else
+    {
+        mctrl_print("\tTurbo Mode: %s\n",
+            (cmd->enabled) ? "enabled" : "disabled");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(turbo, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/twt.c
+++ b/feeds/morse/utils/morsectrl/src/twt.c
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+#define TWT_WAKE_DURATION_UNIT                      (256)
+#define TWT_WAKE_INTERVAL_EXPONENT_MAX_VAL          (31)
+#define TWT_WAKE_DURATION_MAX_US                    (65280) /* UINT8_MAX * TWT_WAKE_DURATION_UNIT */
+#define TWT_MAX_SETUP_COMMAND_VAL                   (7)
+#define TWT_MAX_FLOW_ID_VAL                         (7)
+
+typedef enum {
+    TWT_CONF_SUBCMD_CONFIGURE,
+    TWT_CONF_SUBCMD_FORCE_INSTALL_AGREEMENT,
+    TWT_CONF_SUBCMD_REMOVE_AGREEMENT,
+    TWT_CONF_SUBCMD_CONFIGURE_EXPLICIT,
+} twt_subcommands_t;
+
+struct PACKED command_set_twt_conf {
+    /** The target wake time (TSF) for the first TWT service period */
+    uint64_t target_wake_time;
+    /** Wake interval (us) */
+    union {
+        uint64_t wake_interval_us;
+        struct {
+            uint16_t wake_interval_mantissa;
+            uint8_t wake_interval_exponent;
+            uint8_t __padding[5];
+        } explicit;
+    };
+    /** Minimum wake duration during TWT service period (us) */
+    uint32_t wake_duration_us;
+    /** TWT setup command to use (0: request, 1: suggest, 2: demand) */
+    uint8_t twt_setup_command;
+    uint8_t __padding[3];
+};
+
+struct PACKED command_twt_req {
+    /** TWT subcommands, see @ref twt_subcommands_t */
+    uint8_t cmd;
+    /** The flow (TWT) identifier for the agreement to set, install or remove */
+    uint8_t flow_id;
+    union {
+        uint8_t opaque[0];
+        struct command_set_twt_conf set_twt_conf;
+    };
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print(
+        "\ttwt <command>\tinstall or remove a TWT agreement on a STA interface (test only)\n");
+    mctrl_print("\t\tconf [options]\n");
+    mctrl_print("\t\t    -w <wake interval>\twake interval (us)\n");
+    mctrl_print(
+            "\t\t    -d <min wake duration>\tminimum wake duration during TWT service period (us). "
+            "Max value:%d\n", TWT_WAKE_DURATION_MAX_US);
+    mctrl_print("\t\t    -c <setup command>\ttwt setup commad to use "
+           "(0: request, 1: suggest, 2: demand)\n");
+#if !defined(MORSE_CLIENT)
+    mctrl_print("\t\tinstall [options]\n");
+    mctrl_print("\t\t    -f <flow id>\tflow id for TWT agreement\n");
+    mctrl_print("\t\t    -w <wake interval>\twake interval(us)\n");
+    mctrl_print(
+            "\t\t    -d <min wake duration>\tminimum wake duration during TWT service period (us). "
+            "Max value:%d\n", TWT_WAKE_DURATION_MAX_US);
+    mctrl_print("\t\t    -t <target wake time>\tthe target wake time (TSF) for the first TWT "
+            "service period\n");
+    mctrl_print("\t\texplicit [options]\n");
+    mctrl_print(
+            "\t\t    -d <min wake duration>\tminimum wake duration during TWT service period (us). "
+            "Max value:%d\n", TWT_WAKE_DURATION_MAX_US);
+    mctrl_print("\t\t    -m <wake interval mantissa>\twake interval mantissa\n");
+    mctrl_print("\t\t    -e <wake interval exponent>\twake interval exponent\n");
+    mctrl_print("\t\t    -c <setup command>\ttwt setup commad to use "
+           "(0: request, 1: suggest, 2: demand)\n");
+    mctrl_print("\t\tremove [options]\n");
+    mctrl_print("\t\t    -f <flow id>\tflow id for TWT agreement\n");
+#endif
+}
+
+static int twt_get_cmd(char str[])
+{
+    if (strcmp("conf", str) == 0) return TWT_CONF_SUBCMD_CONFIGURE;
+#if !defined(MORSE_CLIENT)
+    if (strcmp("install", str) == 0) return TWT_CONF_SUBCMD_FORCE_INSTALL_AGREEMENT;
+    else if (strcmp("remove", str) == 0) return TWT_CONF_SUBCMD_REMOVE_AGREEMENT;
+    else if (strcmp("explicit", str) == 0) return TWT_CONF_SUBCMD_CONFIGURE_EXPLICIT;
+#endif
+    else
+    {
+        return -1;
+    }
+}
+
+int twt(struct morsectrl *mors, int argc, char *argv[])
+{
+    int cmd_id;
+    int ret = -1;
+    int option;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+    uint8_t flow_id = 0; /* flow id always set to 0 for now */
+    uint32_t wake_duration_us = 0;
+    uint64_t wake_interval_us = 0;
+    uint16_t wake_interval_mantissa = 0;
+    uint8_t wake_interval_exponent = 0;
+    uint64_t target_wake_time = 0;
+    uint8_t setup_cmd = 0;
+    uint32_t temp;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 3)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_id = twt_get_cmd(argv[1]);
+    if (cmd_id < 0)
+    {
+        mctrl_err("Invalid TWT command '%s'\n", argv[1]);
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!rsp_tbuff)
+        goto exit;
+
+    argc -= 1;
+    argv += 1;
+
+    switch (cmd_id)
+    {
+        case TWT_CONF_SUBCMD_CONFIGURE:
+        case TWT_CONF_SUBCMD_CONFIGURE_EXPLICIT:
+        case TWT_CONF_SUBCMD_FORCE_INSTALL_AGREEMENT:
+        {
+            struct command_twt_req *twt_conf = NULL;
+
+            cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*twt_conf));
+            if (!cmd_tbuff)
+                goto exit;
+
+            twt_conf = TBUFF_TO_CMD(cmd_tbuff, struct command_twt_req);
+
+            while ((option = getopt(argc, argv, "f:w:d:t:c:m:e:")) != -1)
+            {
+                switch (option)
+                {
+                    case 'f' :
+                        if (str_to_uint32_range(optarg, &temp, 0, TWT_MAX_FLOW_ID_VAL) < 0)
+                        {
+                            mctrl_err("Flow ID not valid\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        flow_id = temp;
+                        break;
+                    case 'w' :
+                    {
+                        if (str_to_uint64(optarg, &wake_interval_us) < 0)
+                        {
+                            mctrl_err("Wake interval is not a valid uint64_t value\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+
+                        break;
+                    }
+                    case 'd' :
+                        if (str_to_uint32_range(optarg, &wake_duration_us,
+                            0, TWT_WAKE_DURATION_MAX_US) < 0)
+                        {
+                            mctrl_err("Wake duration cannot exceed %u us\n",
+                                    TWT_WAKE_DURATION_MAX_US);
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        break;
+                    case 't':
+                    {
+                        if (str_to_uint64(optarg, &target_wake_time) < 0)
+                        {
+                            mctrl_err("Target Wake Time is not a valid uint64_t value\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        break;
+                    }
+                    case 'c':
+                    {
+                        if (str_to_uint32_range(optarg, &temp, 0, TWT_MAX_SETUP_COMMAND_VAL) < 0)
+                        {
+                            mctrl_err("Setup command is not valid\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        setup_cmd = temp;
+                        break;
+                    }
+                    case 'm':
+                    {
+                        if (str_to_uint16(optarg, &wake_interval_mantissa))
+                        {
+                            mctrl_err("Wake interval mantissa is not valid\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        break;
+                    }
+                    case 'e':
+                    {
+                        if (str_to_uint8_range(optarg, &wake_interval_exponent, 0,
+                            TWT_WAKE_INTERVAL_EXPONENT_MAX_VAL) < 0)
+                        {
+                            mctrl_err("Wake interval exponent cannot exceed %u\n",
+                                TWT_WAKE_INTERVAL_EXPONENT_MAX_VAL);
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        break;
+                    }
+                    default :
+                    {
+                        mctrl_err("Invalid argument (%c)\n", option);
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                    }
+                }
+            }
+
+            twt_conf->flow_id = flow_id;
+            twt_conf->cmd = cmd_id;
+
+            if (cmd_id == TWT_CONF_SUBCMD_CONFIGURE_EXPLICIT)
+            {
+                /* Set here for logging later on */
+                wake_interval_us = wake_interval_mantissa * (1ULL << wake_interval_exponent);
+                twt_conf->set_twt_conf.explicit.wake_interval_exponent = wake_interval_exponent;
+                twt_conf->set_twt_conf.explicit.wake_interval_mantissa = wake_interval_mantissa;
+            }
+            else
+            {
+                twt_conf->set_twt_conf.wake_interval_us = wake_interval_us;
+            }
+
+            twt_conf->set_twt_conf.wake_duration_us = wake_duration_us;
+            twt_conf->set_twt_conf.twt_setup_command = setup_cmd;
+
+            if (cmd_id == TWT_CONF_SUBCMD_FORCE_INSTALL_AGREEMENT)
+                twt_conf->set_twt_conf.target_wake_time = target_wake_time;
+        }
+        break;
+        case TWT_CONF_SUBCMD_REMOVE_AGREEMENT:
+        {
+            struct command_twt_req* remove = NULL;
+
+            cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*remove));
+
+            if (!cmd_tbuff)
+                goto exit;
+
+            remove = TBUFF_TO_CMD(cmd_tbuff, struct command_twt_req);
+
+            while ((option = getopt(argc, argv, "f:")) != -1)
+            {
+                switch (option)
+                {
+                    case 'f' :
+                        if (str_to_uint32_range(optarg, &temp, 0, TWT_MAX_FLOW_ID_VAL) < 0)
+                        {
+                            mctrl_err("Flow ID not valid\n");
+                            usage(mors);
+                            ret = -1;
+                            goto exit;
+                        }
+                        flow_id = temp;
+                        break;
+                    default :
+                        mctrl_err("Invalid argument (%c)\n", option);
+                        usage(mors);
+                        ret = -1;
+                        goto exit;
+                }
+            }
+
+            remove->flow_id = flow_id;
+            remove->cmd = cmd_id;
+        }
+        break;
+        default:
+        {
+            mctrl_err("Error: TWT command '%s'\n", argv[1]);
+            usage(mors);
+            ret = -1;
+            goto exit;
+        }
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_TWT_SET_CONF, cmd_tbuff,
+            rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Command error (%d)\n", ret);
+    }
+    else if (cmd_id == TWT_CONF_SUBCMD_CONFIGURE ||
+        cmd_id == TWT_CONF_SUBCMD_CONFIGURE_EXPLICIT ||
+        cmd_id == TWT_CONF_SUBCMD_FORCE_INSTALL_AGREEMENT)
+    {
+        mctrl_print("Installed TWT Agreement[flowid:%d]\n", flow_id);
+        mctrl_print("\tWake interval: %" PRId64 " us\n", wake_interval_us);
+        mctrl_print("\tWake duration: %d us\n", wake_duration_us);
+        mctrl_print("\tTarget Wake Time: %" PRId64 "\n", target_wake_time);
+        mctrl_print("\tImplict: true\n");
+    }
+    else if (cmd_id == TWT_CONF_SUBCMD_REMOVE_AGREEMENT)
+    {
+        mctrl_print("Removed TWT Agreement[flowid:%d]\n", flow_id);
+    }
+
+    if (cmd_tbuff)
+    {
+        morsectrl_transport_buff_free(cmd_tbuff);
+    }
+    if (rsp_tbuff)
+    {
+        morsectrl_transport_buff_free(rsp_tbuff);
+    }
+    return ret;
+}
+
+MM_CLI_HANDLER(twt, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/tx_pkt_lifetime_us.c
+++ b/feeds/morse/utils/morsectrl/src/tx_pkt_lifetime_us.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "command.h"
+#include "utilities.h"
+
+/* Lifetime packet expiry in us */
+#define TX_PACKET_EXPIRY_MIN_US 50000
+#define TX_PACKET_EXPIRY_MAX_US 500000
+
+struct PACKED set_tx_pkt_lifetime_us_command
+{
+    uint32_t lifetime_us;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print(
+        "\ttx_pkt_lifetime_us <value>\t\tset Tx-pkt lifetime expiry within %d-%d\n",
+        TX_PACKET_EXPIRY_MIN_US, TX_PACKET_EXPIRY_MAX_US);
+}
+
+int tx_pkt_lifetime_us(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct set_tx_pkt_lifetime_us_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    uint32_t lifetime_us;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_tx_pkt_lifetime_us_command);
+
+    if (str_to_uint32_range(argv[1], &lifetime_us,
+            TX_PACKET_EXPIRY_MIN_US, TX_PACKET_EXPIRY_MAX_US))
+    {
+        mctrl_err("Invalid value [%d to %d] us\n",
+                    TX_PACKET_EXPIRY_MIN_US, TX_PACKET_EXPIRY_MAX_US);
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->lifetime_us = htole32(lifetime_us);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_TX_PKT_LIFETIME_US,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set tx pkt lifetime\n");
+    }
+    else
+    {
+        mctrl_print("\t Tx-pkt lifetime expriy is set : %d us\n", cmd->lifetime_us);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(tx_pkt_lifetime_us, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/tx_pwr_adj.c
+++ b/feeds/morse/utils/morsectrl/src/tx_pwr_adj.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+/** TX power adjustments available in the system, values can be or'ed together to create a mask */
+enum tx_pwr_adj_type {
+    /** MCS based adjustment */
+    TX_PWR_ADJ_MCS             = (1 << 0),
+    /** Sub band adjustment */
+    TX_PWR_ADJ_SUBBAND         = (1 << 1),
+    /** Temperature adjustment */
+    TX_PWR_ADJ_TEMPERATURE     = (1 << 2),
+    /** Channel based adjustment */
+    TX_PWR_ADJ_CHANNEL         = (1 << 3),
+    /** MAX */
+    TX_PWR_ADJ_MAX = UINT32_MAX
+};
+
+/** Structure to send power adjustment commands to chip */
+struct PACKED tx_pwr_adj_command
+{
+    /** The flags to se/get power adjustments */
+    uint8_t flag;
+    /** Bitmask to enable/disable power adujstments */
+    uint32_t en_tx_pwr_adj_mask;
+};
+
+/** Structure to store response from chip */
+struct PACKED tx_pwr_adj_cfm
+{
+    /** Bit mask variable to specify enable/disable of tx power adjustment */
+    uint32_t en_tx_pwr_adj_mask;
+    /** Sub-band 1in8 scale values in qdB */
+    int32_t sb_1in_8[4];
+    /** Sub-band 2in8 scale values in qdB */
+    int32_t sb_2in_8[2];
+    /** Teperature based scaler value in linear scale */
+    int32_t temp_power_scaler;
+    /** Current sub-band scale value in linear scale */
+    int32_t subband_scale;
+    /** txscaler value in linear scale */
+    int32_t tx_linear_power_scaler;
+    /** Transmit power control */
+    uint32_t tx_power_drift_lin;
+    /** Chip's base power in qdBm */
+    int8_t base_power_qdbm;
+    /** Chip's max power in qdBm */
+    int8_t max_tx_power_qdbm;
+    /** Current transmit power in qdBm */
+    int8_t current_tx_power_qdbm;
+    /** Scale values of MCS 0-10 */
+    int8_t scale_value_db[11];
+    /** Board's antenna gain in dBi */
+    int8_t tx_antenna_gain_dbi;
+    /** Regulatory domain's transmit power limit in dBm */
+    int8_t regulatory_limit_dbm;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\ttx_pwr_adj <adjustment options> <value>\n");
+    mctrl_print("\t\t\tget chip's TX power state if none of [-m|-s|-t|-c] given\n");
+    mctrl_print("\t\t\t-m <1/0> enable/disable mcs based adjustment\n");
+    mctrl_print("\t\t\t-s <1/0> enable/disable subband based adjustment\n");
+    mctrl_print("\t\t\t-t <1/0> enable/disable temperature based adjustment\n");
+    mctrl_print("\t\t\t-c <1/0> enable/disable channel based adjustment\n");
+}
+
+static void process_power_state(struct tx_pwr_adj_cfm* cfm)
+{
+    mctrl_print("TX power state information\n");
+    mctrl_print("\tBase power: %.3f dBm\n\tMax power: %.3f dBm\n\tCurrent power: %.3f dBm\n",
+            ((float) cfm->base_power_qdbm)/4.0,
+            ((float) cfm->max_tx_power_qdbm)/4.0,
+            ((float) cfm->current_tx_power_qdbm)/4.0);
+    mctrl_print("\tRegulatory limit: %.3f dBm\n",
+            ((float) cfm->regulatory_limit_dbm)/4.0);
+    mctrl_print("\tSubband power adjustment: %.3f dB\n",
+            (float) 10*log10((cfm->subband_scale/65536.0)));
+    mctrl_print("\tTemperature power adjustment: %.3f dB\n",
+            (float) 10*log10((cfm->temp_power_scaler/65536.0)));
+    mctrl_print("\tArbitrary txscaler: %.3f dB\n",
+            (float) 20*log10((cfm->tx_linear_power_scaler/65536.0)));
+    mctrl_print("\tTx power drift: %.3f dB\n",
+            (float) 10*log10((cfm->tx_power_drift_lin/65536.0)));
+    mctrl_print("\tTX antenna gain: %d dBi\n",
+            cfm->tx_antenna_gain_dbi);
+    mctrl_print("\tTX power adjustement mask: %d\n",
+            cfm->en_tx_pwr_adj_mask);
+    mctrl_print("\tEnable MCS based adjustment: %d\n",
+            (cfm->en_tx_pwr_adj_mask & TX_PWR_ADJ_MCS) && 1);
+    mctrl_print("\tEnable sub-band based adjustment: %d\n",
+            (cfm->en_tx_pwr_adj_mask & TX_PWR_ADJ_SUBBAND) && 1);
+    mctrl_print("\tEnable temperature based adjustment: %d\n",
+            (cfm->en_tx_pwr_adj_mask & TX_PWR_ADJ_TEMPERATURE) && 1);
+    mctrl_print("\tEnable channel based adjustment: %d\n",
+            (cfm->en_tx_pwr_adj_mask & TX_PWR_ADJ_CHANNEL) && 1);
+    for (int i = 0; i < 10 ; i++)
+    {
+        mctrl_print("\tMCS%d: %.3f dBm\n", i,
+                ((float) (cfm->scale_value_db[i]+cfm->base_power_qdbm))/4.0);
+    }
+}
+
+int tx_pwr_adj(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1, option;
+    uint8_t flag = 0;
+    uint32_t en_tx_pwr_adj_mask;
+    struct tx_pwr_adj_command *cmd = {0};
+    struct tx_pwr_adj_cfm *cfm = {0};
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    int32_t tmp;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*cfm));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct tx_pwr_adj_command);
+    cfm = TBUFF_TO_RSP(rsp_tbuff, struct tx_pwr_adj_cfm);
+
+    if (argc == 1)
+    {
+        /** Get the tx power adjustments */
+        flag = 1;
+        en_tx_pwr_adj_mask = 0;
+    }
+    else if (argc > 1)
+    {
+        /** Set the tx power adjustments */
+        flag = 2;
+        /** Read the cuurent mask and update with user input */
+        cmd->flag = htole32(1);
+        cmd->en_tx_pwr_adj_mask = 0;
+        ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_TX_PWR_ADJ,
+                                 cmd_tbuff, rsp_tbuff);
+        if (ret < 0)
+        {
+            mctrl_err("Failed to execute command\n");
+            goto exit;
+        }
+        en_tx_pwr_adj_mask = cfm->en_tx_pwr_adj_mask;
+        while ((option = getopt(argc, argv, "m:s:t:c:")) != -1)
+        {
+            switch (option)
+            {
+                case 'm':
+                    if (str_to_int32(optarg, &tmp))
+                    {
+                        mctrl_err("Invalid MCS based power adjustment\n");
+                        ret = -1;
+                        goto exit;
+                    }
+                    en_tx_pwr_adj_mask = (en_tx_pwr_adj_mask & (~TX_PWR_ADJ_MCS))
+                        | (tmp & 0x01);
+                    mctrl_print("MCS based power adjustment: %d\n", tmp);
+                    break;
+                case 's':
+                    if (str_to_int32(optarg, &tmp))
+                    {
+                        mctrl_err("Invalid Subband based power adjustment\n");
+                        ret = -1;
+                        goto exit;
+                    }
+
+                    en_tx_pwr_adj_mask = (en_tx_pwr_adj_mask & (~TX_PWR_ADJ_SUBBAND))
+                        | ((tmp & 0x01) << 1);
+                    mctrl_print("Subband based power adjustment: %d\n", tmp);
+                    break;
+                case 't':
+                    if (str_to_int32(optarg, &tmp))
+                    {
+                        mctrl_err("Invalid tmperature based power adjustment\n");
+                        ret = -1;
+                        goto exit;
+                    }
+
+                    en_tx_pwr_adj_mask = (en_tx_pwr_adj_mask & (~TX_PWR_ADJ_TEMPERATURE))
+                        | ((tmp & 0x01) << 2);
+                    mctrl_print("Temperature based power adjustment: %d\n", tmp);
+                    break;
+                case 'c':
+                    if (str_to_int32(optarg, &tmp))
+                    {
+                        mctrl_err("Invalid channel based power adjustment\n");
+                        ret = -1;
+                        goto exit;
+                    }
+
+                    en_tx_pwr_adj_mask = (en_tx_pwr_adj_mask & (~TX_PWR_ADJ_CHANNEL))
+                        | ((tmp & 0x01) << 3);
+                    mctrl_print("Channel based power adjustment: %d\n", tmp);
+                    break;
+                default:
+                    usage(mors);
+                    goto exit;
+                    break;
+            }
+        }
+    }
+    else
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->flag = htole32(flag);
+    cmd->en_tx_pwr_adj_mask = htole32(en_tx_pwr_adj_mask);
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_TX_PWR_ADJ,
+                                 cmd_tbuff, rsp_tbuff);
+    if (flag == 1)
+    {
+        process_power_state(cfm);
+    }
+exit:
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(tx_pwr_adj, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/txop.c
+++ b/feeds/morse/utils/morsectrl/src/txop.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+
+struct PACKED set_txop_command
+{
+    /** The flags of this message */
+    uint8_t txop;
+};
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\ttxop [0-9]\t\tminimum packets to start TXOP (0 for disable)\n");
+}
+
+int txop(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t txop;
+    struct set_txop_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_txop_command);
+
+    if (str_to_uint32_range(argv[1], &txop, 0, 10))
+    {
+        mctrl_err("Invalid txop value.\n");
+        usage(mors);
+        ret = -1;
+        goto exit;
+    }
+
+    cmd->txop = htole32(txop);
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_TXOP,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set txop\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(txop, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/txscaler.c
+++ b/feeds/morse/utils/morsectrl/src/txscaler.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED set_tx_scaler_command
+{
+    /** The flags of this message */
+    int32_t tx_scaler;
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\ttxscaler <value>\tscales tx power (-15 to +15 dB, requires DVT firmware)\n");
+}
+
+static int32_t db2linear(int32_t db)
+{
+    return((int32_t) (pow(10.0, (db/20.0))*65536));
+}
+
+int txscaler(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int32_t tx_scaler;
+    struct set_tx_scaler_command *cmd;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    if (str_to_int32_range(argv[1], &tx_scaler, -30, 30))
+    {
+        mctrl_err("Invalid txscaler value.\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_tx_scaler_command);
+    cmd->tx_scaler = htole32(db2linear(tx_scaler));
+    ret = morsectrl_send_command(mors->transport, MORSE_TEST_COMMAND_SET_TX_SCALER,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Failed to set txscaler\n");
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(txscaler, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/uapsd.c
+++ b/feeds/morse/utils/morsectrl/src/uapsd.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#ifndef MORSE_WIN_BUILD
+#include <net/if.h>
+#endif
+#include "portable_endian.h"
+
+#include "command.h"
+#include "utilities.h"
+
+#define AUTO_TRIGGER_DISABLED           ((uint8_t)0)
+#define AUTO_TRIGGER_ENABLED            ((uint8_t)1)
+#define AUTO_TRIGGER_FLAG_DEFAULT       ((uint8_t)0xFF)
+#define AUTO_TRIGGER_TIMEOUT_MIN        (100U)
+#define AUTO_TRIGGER_TIMEOUT_MAX        (10000U)
+#define AUTO_TRIGGER_TIMEOUT_DEFAULT    (0U)
+
+
+struct PACKED set_uapsd
+{
+    /** Auto trigger enabled/disabled flag */
+    uint8_t auto_trigger_enabled;
+
+    /** Timeout(ms) at which frame is triggered */
+    uint32_t auto_trigger_timeout;
+};
+
+struct PACKED uapsd_cfm
+{
+    /** Confirm auto trigger enabled/disabled */
+    uint8_t auto_trigger_enabled;
+};
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tuapsd -a <enable/disable> -t <timeout in ms>\n");
+    mctrl_print("\t\tU-APSD auto trigger frame control\n");
+    mctrl_print("\t\t-a <value>\tEnable/Disable auto trigger frame\n");
+    mctrl_print("\t\t-t <value>\tTimeout at which trigger frame is send when enabled\n");
+}
+
+int uapsd(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    int option;
+    uint8_t is_auto_trigger_enabled = AUTO_TRIGGER_FLAG_DEFAULT;
+    uint32_t timeout_in_ms = AUTO_TRIGGER_TIMEOUT_DEFAULT;
+    struct set_uapsd *cmd;
+    struct uapsd_cfm *rsp;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2 || argc > 7)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct set_uapsd);
+
+    memset(cmd, 0, sizeof(*cmd));
+    while ((option = getopt(argc, argv, "a:t:")) != -1)
+    {
+        switch (option) {
+        case 'a' :
+            if (str_to_uint8_range(optarg, &is_auto_trigger_enabled,
+                AUTO_TRIGGER_DISABLED, AUTO_TRIGGER_ENABLED) < 0)
+            {
+                mctrl_err("Auto trigger enable flag %u must be either disabled %u : enabled %u\n",
+                        is_auto_trigger_enabled, AUTO_TRIGGER_DISABLED, AUTO_TRIGGER_ENABLED);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->auto_trigger_enabled = is_auto_trigger_enabled;
+            break;
+        case 't' :
+            if (str_to_uint32_range(optarg, &timeout_in_ms,
+                AUTO_TRIGGER_TIMEOUT_MIN, AUTO_TRIGGER_TIMEOUT_MAX) < 0)
+            {
+                mctrl_err("Auto trigger timeout %u must be between min %u : max %u\n",
+                        timeout_in_ms, AUTO_TRIGGER_TIMEOUT_MIN, AUTO_TRIGGER_TIMEOUT_MAX);
+                usage(mors);
+                ret = -1;
+                goto exit;
+            }
+            cmd->auto_trigger_timeout = timeout_in_ms;
+            break;
+        case '?' :
+            usage(mors);
+            goto exit;
+        default :
+            mctrl_err("Invalid argument\n");
+            usage(mors);
+            goto exit;
+        }
+    }
+
+    if (is_auto_trigger_enabled == AUTO_TRIGGER_FLAG_DEFAULT)
+    {
+        mctrl_err("Invalid is_auto_trigger_enabled %d\n", is_auto_trigger_enabled);
+        usage(mors);
+        goto exit;
+    }
+
+    if ((is_auto_trigger_enabled == AUTO_TRIGGER_ENABLED &&
+        timeout_in_ms == AUTO_TRIGGER_TIMEOUT_DEFAULT) ||
+        (is_auto_trigger_enabled == AUTO_TRIGGER_DISABLED &&
+        timeout_in_ms != AUTO_TRIGGER_TIMEOUT_DEFAULT))
+    {
+        mctrl_err("Invalid timeout_in_ms %d\n", timeout_in_ms);
+        usage(mors);
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_UAPSD_CONFIG,
+                                 cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to set U-APSD config with error %d\n", ret);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(uapsd, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/utilities.c
+++ b/feeds/morse/utils/morsectrl/src/utilities.c
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#include <ctype.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef MORSE_WIN_BUILD
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "utilities.h"
+
+int str_to_ip(const char* s, ipv4_addr_t* out)
+{
+    uint32_t addr;
+    int ret = inet_pton(AF_INET, s, &addr);
+
+    if (ret != 1)
+    {
+        return -1;
+    }
+
+    out->as_u32 = addr;
+    return 0;
+}
+
+bool check_string_is_int(const char *str)
+{
+    if (*str == '-' && *(str+1) != '\0')
+    {
+        str++;
+    }
+    while (*str != '\0')
+    {
+        if (!isdigit(*str))
+        {
+            return false;
+        }
+        str++;
+    }
+    return true;
+}
+
+int str_to_uint16(char *str, uint16_t *val)
+{
+    uint32_t local;
+    int ret = str_to_uint32(str, &local);
+
+    *val = (uint16_t) local;
+
+    return ret;
+}
+
+int str_to_int8(char *str, int8_t *val)
+{
+    int32_t local;
+    int ret = str_to_int32(str, &local);
+
+    *val = (int8_t) local;
+
+    return ret;
+}
+
+int str_to_int8_range(const char *str, int8_t *val, const int8_t min, const int8_t max)
+{
+    int32_t local;
+    int ret = str_to_int32_range(str, &local, min, max);
+
+    *val = (int8_t) local;
+
+    return ret;
+}
+
+int str_to_uint8(char *str, uint8_t *val)
+{
+    uint32_t local;
+    int ret = str_to_uint32(str, &local);
+
+    *val = (uint8_t) local;
+
+    return ret;
+}
+
+int str_to_uint8_range(const char *str, uint8_t *val, const uint8_t min, const uint8_t max)
+{
+    uint32_t local;
+    int ret = str_to_uint32_range(str, &local, min, max);
+
+    *val = (uint8_t) local;
+
+    return ret;
+}
+
+int str_to_uint16_range(const char *str, uint16_t *val, const uint16_t min, const uint16_t max)
+{
+    uint32_t local;
+    int ret = str_to_uint32_range(str, &local, min, max);
+
+    *val = (uint16_t) local;
+
+    return ret;
+}
+
+int str_to_int32(char *str, int32_t *val)
+{
+    char *endptr = NULL;
+    *val = strtol(str, &endptr, 0);
+
+    if (endptr != str + strlen(str))
+        return -1;
+    return 0;
+}
+
+int str_to_uint32(const char *str, uint32_t *val)
+{
+    char *endptr = NULL;
+    *val = strtoul(str, &endptr, 0);
+
+    if (endptr != str + strlen(str))
+        return -1;
+    return 0;
+}
+
+int str_to_int32_range(const char *str, int32_t *val, const int32_t min, const int32_t max)
+{
+    char *endptr = NULL;
+    *val = strtol(str, &endptr, 0);
+
+    if ((endptr != str + strlen(str)) || (*val < min) || (*val > max))
+        return -1;
+    return 0;
+}
+
+int str_to_uint32_range(const char *str, uint32_t *val, const uint32_t min, const uint32_t max)
+{
+    char *endptr = NULL;
+    *val = strtoul(str, &endptr, 0);
+
+    if ((endptr != str + strlen(str)) || (*val < min) || (*val > max))
+        return -1;
+    return 0;
+}
+
+int str_to_uint64(const char *str, uint64_t *val)
+{
+    char *endptr = NULL;
+    *val = strtoull(str, &endptr, 0);
+
+    if (endptr != str + strlen(str))
+        return -1;
+    return 0;
+}
+
+static int hex2num(char c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+
+    return -1;
+}
+
+static int hex2byte(const char *hex)
+{
+    int a, b;
+
+    a = hex2num(*hex++);
+    if (a < 0)
+        return -1;
+    b = hex2num(*hex++);
+    if (b < 0)
+        return -1;
+
+    return (a << 4) | b;
+}
+
+uint32_t popcount(uint32_t x)
+{
+    x  = x - ((x >> 1) & 0x55555555);
+    x  = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+    x  = x + (x >> 4);
+    x &= 0xF0F0F0F;
+    return (x * 0x01010101) >> 24;
+}
+
+int32_t ctz(uint32_t x)
+{
+    uint32_t c = 32;
+
+    if (!x)
+    {
+        return -1;
+    }
+
+    x &= ~x + 1;
+
+    if (x) c--;
+    if (x & 0x0000FFFF) c -= 16;
+    if (x & 0x00FF00FF) c -= 8;
+    if (x & 0x0F0F0F0F) c -= 4;
+    if (x & 0x33333333) c -= 2;
+    if (x & 0x55555555) c -= 1;
+
+    return c;
+}
+
+int hexstr2bin(const char *hex, uint8_t *buf, size_t len)
+{
+    size_t i;
+    int a;
+    const char *ipos = hex;
+    uint8_t *opos = buf;
+
+    for (i = 0; i < len; i++) {
+        a = hex2byte(ipos);
+        if (a < 0)
+            return -1;
+        *opos++ = a;
+        ipos += 2;
+    }
+    return 0;
+}
+
+void tolower_str(char *str)
+{
+    while (*str != '\0')
+    {
+        *str = tolower(*str);
+        str++;
+    }
+}
+
+#define MAX_EXPR_WIDTH  10
+#define NUMBER_OF_EXPR  6
+
+int expression_to_int(const char *str)
+{
+    char FALSE_EXPR[NUMBER_OF_EXPR][MAX_EXPR_WIDTH] = {
+        "false",
+        "disable",
+        "no",
+        "f",
+        "n",
+        "0"
+    };
+
+    char TRUE_EXPR[NUMBER_OF_EXPR][MAX_EXPR_WIDTH] = {
+        "true",
+        "enable",
+        "yes",
+        "t",
+        "y",
+        "1"
+    };
+
+    for (int i = 0; i < NUMBER_OF_EXPR; i++)
+    {
+        if (strncasecmp(TRUE_EXPR[i], str, MAX(strlen(str), strlen(TRUE_EXPR[i]))) == 0)
+        {
+            return 1;
+        }
+        else if (strncasecmp(FALSE_EXPR[i], str, MAX(strlen(str), strlen(FALSE_EXPR[i]))) == 0)
+        {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+char *strip(char *s)
+{
+    if (!s)
+        return s;
+
+    char *start = s;
+    char *end = s + strlen(s) - 1;
+
+    while (isspace(*start))
+    {
+        start++;
+    }
+
+    while ((end >= start) && isspace(*end))
+    {
+        *end-- = '\0';
+    }
+    return start;
+}
+
+uint8_t crc7_gen(uint64_t number, uint8_t bit_count)
+{
+    int ii;
+    uint32_t reg_val = 0;
+
+    for (ii = bit_count; ii > 0; ii -= 8)
+    {
+        uint32_t bit_idx;
+        uint8_t shift_val = ii - 8;
+        uint8_t octet_val = (number >> shift_val) & 0xFF;
+
+        for (bit_idx = 0; bit_idx < 8; bit_idx++)
+        {
+            reg_val <<= 1;
+            if (((octet_val ^ reg_val) & 0x80) > 0)
+                reg_val ^= 9;
+
+            octet_val = (octet_val << 1) & 0xFF;
+        }
+
+        reg_val &= 0x7F;
+    }
+
+    return (uint8_t)reg_val;
+}
+
+uint16_t crc16_gen(uint8_t *buff, size_t len)
+{
+    int ii, jj;
+    uint32_t crc = 0;
+    uint32_t round = 0;
+    size_t bit_count = len * 8;
+
+    for (ii = 0; ii < len; ii ++)
+    {
+        /* Let's go from MSb first. */
+        for (jj = 7; jj >= 0; jj--)
+        {
+            uint32_t val = ((buff[ii] >> jj) ^ (crc >> 15)) & 0x1;
+
+            crc ^= ((val << 4) | (val << 11));
+            crc = (crc << 1) | val;
+            bit_count -= 1;
+            round += 1;
+            if (bit_count == 0)
+                break;
+        }
+        if (bit_count == 0)
+            break;
+    }
+
+    return (crc & 0xFFFF);
+}
+
+bool crc16_check(uint8_t *buff, size_t len, uint16_t crc16)
+{
+    uint16_t buff_crc16;
+
+    if (!buff)
+        return false;
+
+    buff_crc16 = crc16_gen(buff, len);
+
+    return (crc16 == buff_crc16);
+}
+
+size_t get_file_size(FILE *infile)
+{
+    struct stat file_stats;
+
+    if (!fstat(fileno(infile), &file_stats))
+        return file_stats.st_size;
+
+    return -1;
+}
+
+void load_file(FILE *infile, uint8_t **buf)
+{
+    struct stat file_stats;
+    uint8_t *ptr = NULL;
+    size_t bytes_read = 0;
+
+    *buf = NULL;
+
+    errno = 0;
+    if (fstat(fileno(infile), &file_stats) != 0)
+    {
+        mctrl_err("File stat failed - errno %d\n", errno);
+        return;
+    }
+
+    if (fseek(infile, 0, SEEK_SET))
+    {
+        mctrl_err("Seek failed - errno %d\n", errno);
+        return;
+    }
+
+    ptr = malloc(file_stats.st_size);
+    if (ptr == NULL)
+    {
+        return;
+    }
+
+    while (bytes_read < file_stats.st_size)
+    {
+        bytes_read += fread(ptr + bytes_read, 1, file_stats.st_size - bytes_read, infile);
+        if (ferror(infile))
+        {
+            mctrl_err("error reading file\n");
+            free(ptr);
+            return;
+        }
+    }
+
+    *buf = ptr;
+}
+
+static inline int _mkdir(const char *dir)
+{
+#ifdef __WINDOWS__
+    return mkdir(dir);
+#else
+    return mkdir(dir, S_IRWXU | S_IRWXG);
+#endif
+}
+
+int mkdir_path(const char *dir)
+{
+    char tmp[MORSE_FILENAME_LEN_MAX];
+    char *p = NULL;
+    size_t len;
+
+    snprintf(tmp, sizeof(tmp), "%s", dir);
+    len = strlen(tmp);
+    if (tmp[len - 1] == '/')
+        tmp[len - 1] = 0;
+    for (p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = 0;
+            if ((_mkdir(tmp) != 0) && (errno != EEXIST))
+                return errno;
+            *p = '/';
+        }
+    }
+    if ((_mkdir(tmp) != 0) && (errno != EEXIST))
+        return -1;
+
+    return 0;
+}
+
+bool is_file(const char *path)
+{
+    struct stat statbuf;
+    if (stat(path, &statbuf) == -1)
+    {
+        return false; /* does not exist */
+    }
+
+    if (statbuf.st_mode & S_IFREG)
+    {
+        return true;
+    }
+    return false;
+}
+
+bool is_dir(const char *path)
+{
+    struct stat statbuf;
+    if (stat(path, &statbuf) == -1)
+    {
+        return false; /* does not exist */
+    }
+
+    if (statbuf.st_mode & S_IFDIR)
+    {
+        return true;
+    }
+    return false;
+}
+
+void mctrl_print(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vfprintf(stdout, format, args);
+    va_end(args);
+}
+
+void mctrl_err(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+}

--- a/feeds/morse/utils/morsectrl/src/utilities.h
+++ b/feeds/morse/utils/morsectrl/src/utilities.h
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2021 Morse Micro
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef MORSE_WIN_BUILD
+#include <winsock2.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+#include <dirent.h>
+
+#include "morsectrl.h"
+#include "portable_endian.h"
+
+#define XSTR(s) #s
+#define STR(s)  XSTR(s)
+
+#define MAX(a, b) ({ __typeof__(a) _a = (a); __typeof__(b) _b = (b); _a > _b ? _a : _b; })
+#define MIN(a, b) ({ __typeof__(a) _a = (a); __typeof__(b) _b = (b); _a < _b ? _a : _b; })
+
+#define BIT(N) (1UL << (N))
+
+#define MAC_ADDR_LEN    (6)
+#define MACSTR          "%02x:%02x:%02x:%02x:%02x:%02x"
+#define MAC2STR(a)      (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
+
+#define IPSTR          "%d.%d.%d.%d"
+#define IP2STR(a)      (a)[0], (a)[1], (a)[2], (a)[3]
+
+#define MORSE_FILENAME_LEN_MAX (sizeof(((struct dirent *)0)->d_name))
+
+#ifndef IFNAMSIZ
+#define IFNAMSIZ 16
+#endif
+
+#define SECS_TO_MSECS(_secs) ((_secs) * 1000)
+
+#define NSS_IDX_TO_NSS(x) ((x) + 1)
+#define NSS_TO_NSS_IDX(x) ((x) - 1)
+
+/* Bitmap utilities */
+#define BMGET(_v, _f)     (((_v) & (_f)) >> ctz(_f))
+#define BMSET(_v, _f)     (((_v) << ctz(_f)) & (_f))
+
+#define MORSE_IS_BIT_SET(_field, _bit) (!!((_field) & BIT(_bit)))
+
+/**
+ * Validate the given condition -- if false, print a message and exit.
+ *
+ * @param _condition    The condition to check, should evaluate to @c true in the normal case.
+ * @param _message      The message to display on error.
+ */
+#define MCTRL_ASSERT(_condition, _message, ...)                         \
+    do {                                                                \
+        if (!(_condition)) {                                            \
+            mctrl_err("Assertion failure at %s:%d: " _message "\n",     \
+                      __FILE__, __LINE__, ##__VA_ARGS__);               \
+            abort();                                                    \
+        }                                                               \
+    } while (0)
+
+typedef union
+{
+    uint32_t as_u32;
+    uint8_t octet[4];
+} ipv4_addr_t;
+
+/**
+ * @brief Print a message to stdout
+ *
+ * @param format The format of the message
+ * @param ... Variable length arguments
+ */
+void mctrl_print(const char* format, ...);
+
+/**
+ * @brief Print a message to stderr
+ *
+ * @param format The format of the message
+ * @param ... Variable length arguments
+ */
+void mctrl_err(const char* format, ...);
+
+/**
+ * @brief Convert str to ipv4_addr_t
+ *
+ * @param s String
+ * @param out Object to store the IP address in.
+
+ * @return 0 if success else -1
+ */
+int str_to_ip(const char* s, ipv4_addr_t* out);
+
+/**
+ *  Checks if a string is an integer (ie contains only numerals).
+ *
+ * @note Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ *
+ * @return `true` if string contains only digits, `false` otherwise
+ */
+bool check_string_is_int(const char *str);
+
+/**
+ *  Converts dec/hex int string to int32 variable
+ *
+ * @note Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_int32(char str[], int32_t *val);
+
+/**
+ *  Converts dec/hex uint string to uint32 variable
+ *
+ * Note: Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint32(const char str[], uint32_t *val);
+
+/**
+ *  Converts dec/hex uint string to uint16 variable
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint16(char *str, uint16_t *val);
+
+/**
+ *  Converts dec/hex int string to int8 variable
+ *
+ * @note Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_int8(char *str, int8_t *val);
+
+/**
+ *  Converts dec/hex int string to uint8 variable
+ *
+ * @note Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint8(char *str, uint8_t *val);
+
+/**
+ *  Converts dec/hex uint string to int32 variable within the min and max
+ *
+ * Note: Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ * @param min Acceptable min value of the converted value
+ * @param max Acceptable max value of the converted value
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_int32_range(const char *str, int32_t *val, const int32_t min, const int32_t max);
+
+/**
+ *  Converts dec/hex uint string to uint32 variable within the min and max
+ *
+ * Note: Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ * @param min Acceptable min value of the converted value
+ * @param max Acceptable max value of the converted value
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint32_range(const char *str, uint32_t *val, const uint32_t min, const uint32_t max);
+
+/**
+ *  Converts dec/hex uint string to int8 variable within the min and max
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ * @param min Acceptable min value of the converted value
+ * @param max Acceptable max value of the converted value
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_int8_range(const char *str, int8_t *val, const int8_t min, const int8_t max);
+
+/**
+ *  Converts dec/hex uint string to uint8 variable within the min and max
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ * @param min Acceptable min value of the converted value
+ * @param max Acceptable max value of the converted value
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint8_range(const char *str, uint8_t *val, const uint8_t min, const uint8_t max);
+
+/**
+ *  Converts dec/hex uint string to uint16 variable within the min and max
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ * @param min Acceptable min value of the converted value
+ * @param max Acceptable max value of the converted value
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint16_range(const char *str, uint16_t *val, const uint16_t min, const uint16_t max);
+
+/**
+ *  Converts dec/hex uint string to uint64 variable
+ *
+ * Note: Does not ignore whitespace.
+ *
+ * @param str A null terminated string
+ * @param val A pointer to store the converted value into
+ *
+ * @return 0 if successful conversion, -1 otherwise
+ */
+int str_to_uint64(const char *str, uint64_t *val);
+
+/**
+ * Convert an ASCII hex string into binary data
+ * @hex: ASCII hex string (e.g., "01ab")
+ * @buf: Buffer for the binary data
+ * @len: Length of the text to convert in bytes (of buf); hex will be double
+ * this size
+ * Returns: 0 on success, -1 on failure (invalid hex string)
+ */
+int hexstr2bin(const char *hex, uint8_t *buf, size_t len);
+
+/**
+ *  Converts any uppercase characters in a given string to lowercases
+ * @param str A null terminated string
+ */
+void tolower_str(char *str);
+
+/**
+ *  Checks if the given expression string is a valid true/false and
+ *  returns that otherwise returns a fail (-1)
+ * @param str A null terminated string
+ *
+ * @return `true/false` if string a recognised expression, `-1` otherwise
+ */
+int expression_to_int(const char *str);
+
+/**
+ *  Strips the spaces off the start and end of a string.
+ *  Modifies the contents of the string.
+ * @param str A null terminated string
+ *
+ * @return pointer to stripped string
+ */
+char *strip(char *s);
+
+/**
+ * @brief Simple inefficient calculation of CRC7
+ *
+ * @param number    value to run CRC on
+ * @param bit_count number of bits of @c value to to run CRC on
+ *
+ * @return          CRC7 value
+ */
+uint8_t crc7_gen(uint64_t number, uint8_t bit_count);
+
+/**
+ * @brief Simple inefficient calculation of CRC16
+ *
+ * @param buff  Buffer of octets to run CRC16 on
+ * @param len   Number of octets to run CRC16 on
+ * @return      CRC16 value
+ */
+uint16_t crc16_gen(uint8_t *buff, size_t len);
+
+/**
+ * @brief Calculate the CRC16 of a buffer and compare against a reference value.
+ *
+ * @param buff  Buffer to perform the CRC16 check on.
+ * @param len   Length of the buffer.
+ * @param crc16 Reference CRC16 value.
+ * @return      true if calculated CRC16 matches the reference value, otherwise false.
+ */
+bool crc16_check(uint8_t *buff, size_t len, uint16_t crc16);
+
+/**
+ * @brief Get the file size of a file.
+ *
+ * @param infile    The file to get the size of.
+ * @return          the size of the file.
+ */
+size_t get_file_size(FILE *infile);
+
+/**
+ * @brief Utility function to read a complete file into memory.
+ *
+ * @param infile    File to read into memory.
+ * @param buf       Pointer to memory buffer to write the file into.
+ */
+void load_file(FILE *infile, uint8_t **buf);
+
+/**
+ * @brief Sleep for the given value in ms.
+ *
+ * @param ms    Time to sleep for in ms.
+ */
+static inline void sleep_ms(uint32_t ms)
+{
+#ifdef MORSE_WIN_BUILD
+    Sleep(ms);
+#else
+    sleep(ms / 1000);
+    /* usleep can only deal with upto 1s (1000000us). */
+    usleep((ms % 1000) * 1000);
+#endif
+}
+
+/**
+ * Convert a MAC address string into a byte array.
+ *
+ * @param mac       Array to hold the output
+ * @param str       MAC address string in the format xx:xx:xx:xx:xx:xx
+ *
+ * @return          0 for success or -1 for failure
+ */
+static inline int str_to_mac_addr(uint8_t *mac, const char *str)
+{
+        if (sscanf(str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+            &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]) != MAC_ADDR_LEN)
+        {
+            return -1;
+        }
+
+        return 0;
+}
+
+/**
+ * Create a directory, including parent directories as needed (equivalent to mkdir -p)
+ *
+ * @param dir       Directory name
+ *
+ * @return          0 for success or -1 for failure, in which case errno is set
+ */
+int mkdir_path(const char *dir);
+
+/**
+ * @brief Check if a filepath is a regular file
+ *
+ * @param path  path to file
+ * @return      true if a regular file, else false
+ */
+bool is_file(const char *path);
+
+/**
+ * @brief Check if a filepath is a directory
+ *
+ * @param path  path to file
+ * @return      true if a directory, else false
+ */
+bool is_dir(const char *path);
+
+/**
+ * @brief Counts the number of bits which are set
+ * @param x an unsigned number
+ * @return number of set bits
+ */
+uint32_t popcount(uint32_t x);
+
+/**
+ * @brief Counts the number of trailing zero bits on the right
+ * @param x an unsigned number
+ * @return number of consecutive zeros bits, or -1 for failure
+ */
+int32_t ctz(uint32_t x);
+
+/**
+ * @brief Calculate the aligned size of a memory region
+ * @param unaligned_size original size of the memory region
+ * @param alignment_octets desired alignment in octets
+ * @return aligned memory size, adding padding if needed
+ */
+static inline size_t align_size(size_t unaligned_size, size_t alignment_octets)
+{
+    size_t remainder;
+
+    if (alignment_octets > 0)
+    {
+        remainder = unaligned_size % alignment_octets;
+        if (remainder > 0)
+        {
+            return unaligned_size + alignment_octets - remainder;
+        }
+    }
+
+    return unaligned_size;
+}

--- a/feeds/morse/utils/morsectrl/src/vendor_ie.c
+++ b/feeds/morse/utils/morsectrl/src/vendor_ie.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "portable_endian.h"
+#include "command.h"
+#include "utilities.h"
+
+#define MAX_VENDOR_IE_LENGTH                (255)
+#define NUM_OUI_BYTES                       (3)
+
+enum command_vendor_ie_opcode
+{
+    MORSE_VENDOR_IE_OP_ADD_ELEMENT = 0,
+    MORSE_VENDOR_IE_OP_CLEAR_ELEMENTS,
+    MORSE_VENDOR_IE_OP_ADD_FILTER,
+    MORSE_VENDOR_IE_OP_CLEAR_FILTERS,
+
+    MORSE_VENDOR_IE_OP_MAX = UINT16_MAX,
+    MORSE_VENDOR_IE_OP_INVALID = MORSE_VENDOR_IE_OP_MAX
+};
+
+enum vendor_ie_mgmt_type_flags {
+    MORSE_VENDOR_IE_TYPE_BEACON     = BIT(0),
+    MORSE_VENDOR_IE_TYPE_PROBE_REQ  = BIT(1),
+    MORSE_VENDOR_IE_TYPE_PROBE_RESP = BIT(2),
+    MORSE_VENDOR_IE_TYPE_ASSOC_REQ  = BIT(3),
+    MORSE_VENDOR_IE_TYPE_ASSOC_RESP = BIT(4),
+    /* ... etc. */
+
+    MORSE_VENDOR_IE_TYPE_ALL        = UINT16_MAX
+};
+
+struct PACKED command_vendor_ie_req
+{
+    uint16_t opcode;
+    uint16_t mgmt_type_mask;
+    uint8_t data[MAX_VENDOR_IE_LENGTH];
+};
+
+struct PACKED command_vendor_ie_cfm
+{
+    /* empty */
+};
+
+
+static void usage(struct morsectrl *mors)
+{
+    mctrl_print("\tvendor_ie [-a <bytes> | -c | -o <oui> | -r ] [ -b | -p ]\t");
+    mctrl_print("Manipulate vendor information elements\n");
+    mctrl_print("\t\t-a <bytes>\tadd a vendor element (hex string)\n");
+    mctrl_print("\t\t-c\tclear previously added vendor elements\n");
+    mctrl_print("\t\t-o <oui>\tadd an OUI to the vendor IE whitelist (hex string)\n");
+    mctrl_print("\t\t-r\treset configured OUI whitelist\n");
+    mctrl_print("\t\t-b\tapply to beacons\n");
+    mctrl_print("\t\t-p\tapply to probes\n");
+    mctrl_print("\t\t-s\tapply to assocs\n");
+}
+
+static int check_cmd_opcode_not_set(struct command_vendor_ie_req *cmd)
+{
+    if (cmd->opcode != MORSE_VENDOR_IE_OP_INVALID)
+    {
+        mctrl_err("Specify only one of [a,o,r,c]\n");
+        return -1;
+    }
+    return 0;
+}
+
+int vendor_ie(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = 0;
+    int option;
+    size_t length = 0;
+
+    struct command_vendor_ie_req *cmd_vie;
+    struct command_vendor_ie_cfm *rsp_vie;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc < 2)
+    {
+        mctrl_err("Invalid command parameters\n");
+        usage(mors);
+        return -1;
+    }
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd_vie));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*rsp_vie));
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    cmd_vie = TBUFF_TO_CMD(cmd_tbuff, struct command_vendor_ie_req);
+    rsp_vie = TBUFF_TO_RSP(rsp_tbuff, struct command_vendor_ie_cfm);
+
+    if (cmd_vie == NULL ||
+        rsp_vie == NULL)
+    {
+        ret = -1;
+        goto exit;
+    }
+
+    memset(cmd_vie, 0, sizeof(*cmd_vie));
+    cmd_vie->opcode = MORSE_VENDOR_IE_OP_INVALID;
+    cmd_vie->mgmt_type_mask = 0;
+
+    while ((option = getopt(argc, argv, "a:o:crhpsb")) != -1)
+    {
+        switch (option)
+        {
+            case 'a':
+            {
+                ret = check_cmd_opcode_not_set(cmd_vie);
+                if (ret)
+                    goto exit;
+
+                length = strlen(optarg);
+
+                if (length & 1)
+                {
+                    mctrl_err("Odd number of characters in data bytestring\n");
+                    ret = -1;
+                    goto exit;
+                }
+                length = length / 2;
+
+                if (length > sizeof(cmd_vie->data))
+                {
+                    mctrl_err("Vendor IE has too many bytes %zu\n", length);
+                    ret = -1;
+                    goto exit;
+                }
+
+                cmd_vie->opcode = MORSE_VENDOR_IE_OP_ADD_ELEMENT;
+                if (hexstr2bin(optarg, cmd_vie->data, length))
+                {
+                    mctrl_err("Invalid hex string\n");
+                    ret = -1;
+                    goto exit;
+                }
+                break;
+            }
+            case 'p':
+            {
+                cmd_vie->mgmt_type_mask |= (MORSE_VENDOR_IE_TYPE_PROBE_REQ |
+                                            MORSE_VENDOR_IE_TYPE_PROBE_RESP);
+                break;
+            }
+            case 's':
+            {
+                cmd_vie->mgmt_type_mask |= (MORSE_VENDOR_IE_TYPE_ASSOC_REQ |
+                                            MORSE_VENDOR_IE_TYPE_ASSOC_RESP);
+                break;
+            }
+            case 'b':
+            {
+                cmd_vie->mgmt_type_mask |= MORSE_VENDOR_IE_TYPE_BEACON;
+                break;
+            }
+            case 'c':
+            {
+                ret = check_cmd_opcode_not_set(cmd_vie);
+                if (ret)
+                    goto exit;
+
+
+                cmd_vie->opcode = MORSE_VENDOR_IE_OP_CLEAR_ELEMENTS;
+                break;
+            }
+            case 'o':
+            {
+                ret = check_cmd_opcode_not_set(cmd_vie);
+                if (ret)
+                    goto exit;
+
+
+                length = strlen(optarg) / 2;
+                if (length != NUM_OUI_BYTES)
+                {
+                    ret = -1;
+                    mctrl_err("invalid oui length\n");
+                    goto exit;
+                }
+                cmd_vie->opcode = MORSE_VENDOR_IE_OP_ADD_FILTER;
+                hexstr2bin(optarg, cmd_vie->data, length);
+                break;
+            }
+            case 'r':
+            {
+                ret = check_cmd_opcode_not_set(cmd_vie);
+                if (ret)
+                    goto exit;
+
+
+                cmd_vie->opcode = MORSE_VENDOR_IE_OP_CLEAR_FILTERS;
+                break;
+            }
+            case 'h':
+            {
+                ret = 0;
+                usage(mors);
+                goto exit;
+            }
+            default:
+                ret = -1;
+                mctrl_err("Unrecognised command parameters\n");
+                usage(mors);
+                goto exit;
+        }
+    }
+
+    /* set the length used in command */
+    morsectrl_transport_set_cmd_data_length(cmd_tbuff,
+                                length + sizeof(*cmd_vie) - sizeof(cmd_vie->data));
+
+    if (cmd_vie->opcode == MORSE_VENDOR_IE_OP_INVALID)
+    {
+        mctrl_err("No command specified\n");
+        usage(mors);
+        goto exit;
+    }
+
+    if (cmd_vie->mgmt_type_mask == 0)
+    {
+        mctrl_err("No frame type specified\n");
+        usage(mors);
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+                                 MORSE_COMMAND_VENDOR_IE_CONFIG,
+                                 cmd_tbuff,
+                                 rsp_tbuff);
+
+    if (ret < 0)
+    {
+        mctrl_err("Command error (%d)\n", ret);
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(vendor_ie, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/version.c
+++ b/feeds/morse/utils/morsectrl/src/version.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "portable_endian.h"
+
+#include "command.h"
+#include "mm_argtable3.h"
+
+/** Structure for a get version confirm */
+struct PACKED get_version_response
+{
+    /** Length of version */
+    int32_t length;
+    /** The version string */
+    uint8_t version[128];
+};
+
+int version_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Read the software versions");
+    return 0;
+}
+
+int version(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    uint32_t len;
+    struct get_version_response *version;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, 0);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, sizeof(*version));
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    version = TBUFF_TO_RSP(rsp_tbuff, struct get_version_response);
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_GET_VERSION,
+                                 cmd_tbuff, rsp_tbuff);
+exit:
+    if (ret < 0)
+    {
+        mctrl_err("Get firmware version failed (%d)\n", ret);
+    }
+    else
+    {
+        len = le32toh(version->length);
+        version->version[len] = '\0';
+        mctrl_print("FW Version: %s\n", version->version);
+    }
+
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+    return ret;
+}
+
+MM_CLI_HANDLER(version, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/wakeaction.c
+++ b/feeds/morse/utils/morsectrl/src/wakeaction.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Morse Micro
+ */
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "command.h"
+#include "utilities.h"
+
+struct PACKED command_send_wake_action_frame_req
+{
+    uint8_t dest_addr[6];
+    uint32_t payload_size;
+    uint8_t payload[0];
+};
+
+
+static void usage(struct morsectrl *mors) {
+    mctrl_print("\twakeaction <destination MAC address> <hex string payload>\n");
+    mctrl_print("\t\t\t\tsends a wake action frame with the given payload to a destination\n");
+    mctrl_print("\t\t\t\tmac address.\n");
+}
+
+int wakeaction(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct command_send_wake_action_frame_req* cmd = NULL;
+    struct morsectrl_transport_buff *cmd_tbuff = NULL;
+    struct morsectrl_transport_buff *rsp_tbuff = NULL;
+    int payload_size = 0;
+
+    if (argc == 0)
+    {
+        usage(mors);
+        return 0;
+    }
+
+    if (argc != 3)
+    {
+        usage(mors);
+        return -1;
+    }
+
+    payload_size = strlen(argv[2]);
+    if ((payload_size % 2) != 0)
+    {
+        mctrl_err("Invalid hex string, length must be a multiple of 2\n");
+        usage(mors);
+        return -1;
+    }
+
+    payload_size = (payload_size / 2);
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd) + payload_size);
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+        goto exit;
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_send_wake_action_frame_req);
+    if (!cmd)
+        goto exit;
+
+    cmd->payload_size = payload_size;
+
+    if (hexstr2bin(argv[2], cmd->payload, payload_size) < 0)
+    {
+        mctrl_err("Invalid hex string\n");
+        usage(mors);
+        goto exit;
+    }
+
+    if (str_to_mac_addr(cmd->dest_addr, argv[1]) < 0)
+    {
+        mctrl_err("Invalid MAC address - must be in the format aa:bb:cc:dd:ee:ff\n");
+        usage(mors);
+        goto exit;
+    }
+
+    ret = morsectrl_send_command(mors->transport,
+        MORSE_COMMAND_SEND_WAKE_ACTION_FRAME, cmd_tbuff, rsp_tbuff);
+
+exit:
+    if (ret)
+    {
+        mctrl_err("Failed to send wake action frame\n");
+    }
+    else
+    {
+        mctrl_print("Wake action frame scheduled for transmission\n");
+    }
+
+    if (cmd_tbuff)
+        morsectrl_transport_buff_free(cmd_tbuff);
+
+    if (rsp_tbuff)
+        morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(wakeaction, MM_INTF_REQUIRED, MM_DIRECT_CHIP_NOT_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/whitelist.c
+++ b/feeds/morse/utils/morsectrl/src/whitelist.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2024 Morse Micro
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "portable_endian.h"
+#if defined(__WINDOWS__)
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
+
+#include "command.h"
+#include "transport/transport.h"
+
+#define IPADDR_STR_LEN (16)
+
+#define WHITELIST_FLAGS_CLEAR BIT(0)
+
+#define WHITELIST_PARAM_PORT_MAX (65535)
+
+/** Whitelist config command */
+struct PACKED command_whitelist {
+    /** Flags */
+    uint8_t flags;
+
+    /** IP protocol */
+    uint8_t ip_protocol;
+
+    /** Link layer protocol */
+    be16_t llc_protocol;
+
+    /** Source IP address */
+    be32_t src_ip;
+
+    /** Destination IP address */
+    be32_t dest_ip;
+
+    /** Netmask */
+    be32_t netmask;
+
+    /** TCP or UDP source port */
+    be16_t src_port;
+
+    /** TCP or UDP destination port */
+    be16_t dest_port;
+};
+
+static struct
+{
+    struct arg_lit *clear;
+    struct arg_int *llc_protocol;
+    struct arg_int *ip_protocol;
+    struct arg_str *src_ip;
+    struct arg_str *dest_ip;
+    struct arg_str *netmask;
+    struct arg_int *src_port;
+    struct arg_int *dest_port;
+} args;
+
+int whitelist_init(struct morsectrl *mors, struct mm_argtable *mm_args)
+{
+    MM_INIT_ARGTABLE(mm_args, "Configure the packet whitelist filter",
+        args.llc_protocol = arg_int0("l", NULL, "<LLC proto>",
+            "Link layer protocol - e.g. 0x0800 for IPv4"),
+        args.ip_protocol = arg_int0("i", NULL, "<IPv4 proto>",
+            "IPv4 protocol - e.g. 6 for TCP or 17 for UDP"),
+        args.src_ip = arg_str0("s", NULL, "<src IP>",
+            "Source IP address in dotted decimal notation"),
+        args.dest_ip = arg_str0("d", NULL, "<dest IP>",
+            "Destination IP address in dotted decimal notation"),
+        args.netmask = arg_str0("n", NULL, "<dest IP>",
+            "Network mask for IP addresses in dotted decimal notation"),
+        args.src_port = arg_int0("S", NULL, "<src port>",
+            "UDP or TCP source port - range 1-65535"),
+        args.dest_port = arg_int0("D", NULL, "<dest port>",
+            "UDP or TCP destination port - range 1-65535"),
+        args.clear = arg_lit0("c", NULL,
+            "Clear all whitelist entries"));
+    return 0;
+}
+
+int whitelist(struct morsectrl *mors, int argc, char *argv[])
+{
+    int ret = -1;
+    struct morsectrl_transport_buff *cmd_tbuff;
+    struct morsectrl_transport_buff *rsp_tbuff;
+    struct command_whitelist *cmd;
+    int add_arg_count = 0;
+
+    cmd_tbuff = morsectrl_transport_cmd_alloc(mors->transport, sizeof(*cmd));
+    rsp_tbuff = morsectrl_transport_resp_alloc(mors->transport, 0);
+
+    if (!cmd_tbuff || !rsp_tbuff)
+    {
+        goto exit;
+    }
+
+    cmd = TBUFF_TO_CMD(cmd_tbuff, struct command_whitelist);
+    memset(cmd, 0, sizeof(*cmd));
+
+    add_arg_count = args.llc_protocol->count +
+            args.ip_protocol->count +
+            args.src_ip->count +
+            args.dest_ip->count +
+            args.netmask->count +
+            args.src_port->count +
+            args.dest_port->count;
+
+    if (args.clear->count == 1)
+    {
+        if (add_arg_count != 0)
+        {
+            mctrl_err("Invalid parameters specified for Clear operation\n");
+            goto exit;
+        }
+        cmd->flags |= WHITELIST_FLAGS_CLEAR;
+    }
+    else
+    {
+        if (add_arg_count == 0)
+        {
+            mctrl_err("No filter parameters specified\n");
+            goto exit;
+        }
+    }
+
+    if (args.llc_protocol->count)
+    {
+        cmd->llc_protocol = htobe16(args.llc_protocol->ival[0]);
+    }
+
+    if (args.ip_protocol->count)
+    {
+        cmd->ip_protocol = args.ip_protocol->ival[0];
+    }
+
+    if (args.src_ip->count)
+    {
+        if (inet_pton(AF_INET, args.src_ip->sval[0], &cmd->src_ip) != 1)
+        {
+            mctrl_err("Invalid source IP address %s\n", args.src_ip->sval[0]);
+            goto exit;
+        }
+    }
+
+    if (args.dest_ip->count)
+    {
+        if (inet_pton(AF_INET, args.dest_ip->sval[0], &cmd->dest_ip) != 1)
+        {
+            mctrl_err("Invalid destination IP address %s\n", args.dest_ip->sval[0]);
+            goto exit;
+        }
+    }
+
+    if (args.netmask->count)
+    {
+        if (inet_pton(AF_INET, args.netmask->sval[0], &cmd->netmask) != 1)
+        {
+            mctrl_err("Invalid netmask %s\n", args.netmask->sval[0]);
+            goto exit;
+        }
+        if (args.src_ip->count == 0 && args.dest_ip->count == 0)
+        {
+                mctrl_err("Netmask provided without source or destination IP address\n");
+                goto exit;
+        }
+        if (cmd->src_ip && ((cmd->src_ip & cmd->netmask) != cmd->src_ip))
+        {
+                mctrl_err("Netmask is invalid for source IP address\n");
+                goto exit;
+        }
+        if (cmd->dest_ip && ((cmd->dest_ip & cmd->netmask) != cmd->dest_ip))
+        {
+                mctrl_err("Netmask is invalid for destination IP address\n");
+                goto exit;
+        }
+    }
+
+    if (args.src_port->count)
+    {
+        if (args.src_port->ival[0] > WHITELIST_PARAM_PORT_MAX)
+        {
+            mctrl_err("Invalid source port %d\n", args.src_port->ival[0]);
+            goto exit;
+        }
+        cmd->src_port = htobe16(args.src_port->ival[0]);
+    }
+
+    if (args.dest_port->count)
+    {
+        if (args.dest_port->ival[0] > WHITELIST_PARAM_PORT_MAX)
+        {
+            mctrl_err("Invalid destination port %d\n", args.dest_port->ival[0]);
+            goto exit;
+        }
+        cmd->dest_port = htobe16(args.dest_port->ival[0]);
+    }
+
+    ret = morsectrl_send_command(mors->transport, MORSE_COMMAND_SET_WHITELIST,
+                                 cmd_tbuff, rsp_tbuff);
+    if (ret < 0)
+    {
+        mctrl_err("Whitelist command failed - error(%d)\n", ret);
+        goto exit;
+    }
+
+exit:
+    morsectrl_transport_buff_free(cmd_tbuff);
+    morsectrl_transport_buff_free(rsp_tbuff);
+
+    return ret;
+}
+
+MM_CLI_HANDLER(whitelist, MM_INTF_REQUIRED, MM_DIRECT_CHIP_SUPPORTED);

--- a/feeds/morse/utils/morsectrl/src/win/auxv.h
+++ b/feeds/morse/utils/morsectrl/src/win/auxv.h
@@ -1,0 +1,91 @@
+/* Copyright (C) 1995-2013 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+/* Legal values for a_type (entry type).  */
+
+#define AT_NULL		0		/* End of vector */
+#define AT_IGNORE	1		/* Entry should be ignored */
+#define AT_EXECFD	2		/* File descriptor of program */
+#define AT_PHDR		3		/* Program headers for program */
+#define AT_PHENT	4		/* Size of program header entry */
+#define AT_PHNUM	5		/* Number of program headers */
+#define AT_PAGESZ	6		/* System page size */
+#define AT_BASE		7		/* Base address of interpreter */
+#define AT_FLAGS	8		/* Flags */
+#define AT_ENTRY	9		/* Entry point of program */
+#define AT_NOTELF	10		/* Program is not ELF */
+#define AT_UID		11		/* Real uid */
+#define AT_EUID		12		/* Effective uid */
+#define AT_GID		13		/* Real gid */
+#define AT_EGID		14		/* Effective gid */
+#define AT_CLKTCK	17		/* Frequency of times() */
+
+/* Some more special a_type values describing the hardware.  */
+#define AT_PLATFORM	15		/* String identifying platform.  */
+#define AT_HWCAP	16		/* Machine-dependent hints about
+					   processor capabilities.  */
+
+/* This entry gives some information about the FPU initialization
+   performed by the kernel.  */
+#define AT_FPUCW	18		/* Used FPU control word.  */
+
+/* Cache block sizes.  */
+#define AT_DCACHEBSIZE	19		/* Data cache block size.  */
+#define AT_ICACHEBSIZE	20		/* Instruction cache block size.  */
+#define AT_UCACHEBSIZE	21		/* Unified cache block size.  */
+
+/* A special ignored value for PPC, used by the kernel to control the
+   interpretation of the AUXV. Must be > 16.  */
+#define AT_IGNOREPPC	22		/* Entry should be ignored.  */
+
+#define	AT_SECURE	23		/* Boolean, was exec setuid-like?  */
+
+#define AT_BASE_PLATFORM 24		/* String identifying real platforms.*/
+
+#define AT_RANDOM	25		/* Address of 16 random bytes.  */
+
+#define AT_HWCAP2	26		/* More machine-dependent hints about
+					   processor capabilities.  */
+
+#define AT_EXECFN	31		/* Filename of executable.  */
+
+/* Pointer to the global system page used for system calls and other
+   nice things.  */
+#define AT_SYSINFO	32
+#define AT_SYSINFO_EHDR	33
+
+/* Shapes of the caches.  Bits 0-3 contains associativity; bits 4-7 contains
+   log2 of line size; mask those to get cache size.  */
+#define AT_L1I_CACHESHAPE	34
+#define AT_L1D_CACHESHAPE	35
+#define AT_L2_CACHESHAPE	36
+#define AT_L3_CACHESHAPE	37
+
+/* Shapes of the caches, with more room to describe them.
+   *GEOMETRY are comprised of cache line size in bytes in the bottom 16 bits
+   and the cache associativity in the next 16 bits.  */
+#define AT_L1I_CACHESIZE	40
+#define AT_L1I_CACHEGEOMETRY	41
+#define AT_L1D_CACHESIZE	42
+#define AT_L1D_CACHEGEOMETRY	43
+#define AT_L2_CACHESIZE		44
+#define AT_L2_CACHEGEOMETRY	45
+#define AT_L3_CACHESIZE		46
+#define AT_L3_CACHEGEOMETRY	47
+
+#define AT_MINSIGSTKSZ		51 /* Stack needed for signal delivery
+				      (AArch64).  */

--- a/feeds/morse/utils/morsectrl/src/win/elf.h
+++ b/feeds/morse/utils/morsectrl/src/win/elf.h
@@ -1,0 +1,3940 @@
+/*
+ * This file defines standard ELF types, structures, and macros.
+ * Copyright (C) 1995-2020 Free Software Foundation, Inc.
+ * This file is part of the GNU C Library.
+ */
+
+#ifndef _ELF_H
+#define	_ELF_H 1
+
+/* Standard ELF types.  */
+
+#include <stdint.h>
+
+/* Type for a 16-bit quantity.  */
+typedef uint16_t Elf32_Half;
+typedef uint16_t Elf64_Half;
+
+/* Types for signed and unsigned 32-bit quantities.  */
+typedef uint32_t Elf32_Word;
+typedef	int32_t  Elf32_Sword;
+typedef uint32_t Elf64_Word;
+typedef	int32_t  Elf64_Sword;
+
+/* Types for signed and unsigned 64-bit quantities.  */
+typedef uint64_t Elf32_Xword;
+typedef	int64_t  Elf32_Sxword;
+typedef uint64_t Elf64_Xword;
+typedef	int64_t  Elf64_Sxword;
+
+/* Type of addresses.  */
+typedef uint32_t Elf32_Addr;
+typedef uint64_t Elf64_Addr;
+
+/* Type of file offsets.  */
+typedef uint32_t Elf32_Off;
+typedef uint64_t Elf64_Off;
+
+/* Type for section indices, which are 16-bit quantities.  */
+typedef uint16_t Elf32_Section;
+typedef uint16_t Elf64_Section;
+
+/* Type for version symbol information.  */
+typedef Elf32_Half Elf32_Versym;
+typedef Elf64_Half Elf64_Versym;
+
+
+/* The ELF file header.  This appears at the start of every ELF file.  */
+
+#define EI_NIDENT (16)
+
+typedef struct
+{
+  unsigned char	e_ident[EI_NIDENT];	/* Magic number and other info */
+  Elf32_Half	e_type;			/* Object file type */
+  Elf32_Half	e_machine;		/* Architecture */
+  Elf32_Word	e_version;		/* Object file version */
+  Elf32_Addr	e_entry;		/* Entry point virtual address */
+  Elf32_Off	e_phoff;		/* Program header table file offset */
+  Elf32_Off	e_shoff;		/* Section header table file offset */
+  Elf32_Word	e_flags;		/* Processor-specific flags */
+  Elf32_Half	e_ehsize;		/* ELF header size in bytes */
+  Elf32_Half	e_phentsize;		/* Program header table entry size */
+  Elf32_Half	e_phnum;		/* Program header table entry count */
+  Elf32_Half	e_shentsize;		/* Section header table entry size */
+  Elf32_Half	e_shnum;		/* Section header table entry count */
+  Elf32_Half	e_shstrndx;		/* Section header string table index */
+} Elf32_Ehdr;
+
+typedef struct
+{
+  unsigned char	e_ident[EI_NIDENT];	/* Magic number and other info */
+  Elf64_Half	e_type;			/* Object file type */
+  Elf64_Half	e_machine;		/* Architecture */
+  Elf64_Word	e_version;		/* Object file version */
+  Elf64_Addr	e_entry;		/* Entry point virtual address */
+  Elf64_Off	e_phoff;		/* Program header table file offset */
+  Elf64_Off	e_shoff;		/* Section header table file offset */
+  Elf64_Word	e_flags;		/* Processor-specific flags */
+  Elf64_Half	e_ehsize;		/* ELF header size in bytes */
+  Elf64_Half	e_phentsize;		/* Program header table entry size */
+  Elf64_Half	e_phnum;		/* Program header table entry count */
+  Elf64_Half	e_shentsize;		/* Section header table entry size */
+  Elf64_Half	e_shnum;		/* Section header table entry count */
+  Elf64_Half	e_shstrndx;		/* Section header string table index */
+} Elf64_Ehdr;
+
+/* Fields in the e_ident array.  The EI_* macros are indices into the
+   array.  The macros under each EI_* macro are the values the byte
+   may have.  */
+
+#define EI_MAG0		0		/* File identification byte 0 index */
+#define ELFMAG0		0x7f		/* Magic number byte 0 */
+
+#define EI_MAG1		1		/* File identification byte 1 index */
+#define ELFMAG1		'E'		/* Magic number byte 1 */
+
+#define EI_MAG2		2		/* File identification byte 2 index */
+#define ELFMAG2		'L'		/* Magic number byte 2 */
+
+#define EI_MAG3		3		/* File identification byte 3 index */
+#define ELFMAG3		'F'		/* Magic number byte 3 */
+
+/* Conglomeration of the identification bytes, for easy testing as a word.  */
+#define	ELFMAG		"\177ELF"
+#define	SELFMAG		4
+
+#define EI_CLASS	4		/* File class byte index */
+#define ELFCLASSNONE	0		/* Invalid class */
+#define ELFCLASS32	1		/* 32-bit objects */
+#define ELFCLASS64	2		/* 64-bit objects */
+#define ELFCLASSNUM	3
+
+#define EI_DATA		5		/* Data encoding byte index */
+#define ELFDATANONE	0		/* Invalid data encoding */
+#define ELFDATA2LSB	1		/* 2's complement, little endian */
+#define ELFDATA2MSB	2		/* 2's complement, big endian */
+#define ELFDATANUM	3
+
+#define EI_VERSION	6		/* File version byte index */
+					/* Value must be EV_CURRENT */
+
+#define EI_OSABI	7		/* OS ABI identification */
+#define ELFOSABI_NONE		0	/* UNIX System V ABI */
+#define ELFOSABI_SYSV		0	/* Alias.  */
+#define ELFOSABI_HPUX		1	/* HP-UX */
+#define ELFOSABI_NETBSD		2	/* NetBSD.  */
+#define ELFOSABI_GNU		3	/* Object uses GNU ELF extensions.  */
+#define ELFOSABI_LINUX		ELFOSABI_GNU /* Compatibility alias.  */
+#define ELFOSABI_SOLARIS	6	/* Sun Solaris.  */
+#define ELFOSABI_AIX		7	/* IBM AIX.  */
+#define ELFOSABI_IRIX		8	/* SGI Irix.  */
+#define ELFOSABI_FREEBSD	9	/* FreeBSD.  */
+#define ELFOSABI_TRU64		10	/* Compaq TRU64 UNIX.  */
+#define ELFOSABI_MODESTO	11	/* Novell Modesto.  */
+#define ELFOSABI_OPENBSD	12	/* OpenBSD.  */
+#define ELFOSABI_ARM_AEABI	64	/* ARM EABI */
+#define ELFOSABI_ARM		97	/* ARM */
+#define ELFOSABI_STANDALONE	255	/* Standalone (embedded) application */
+
+#define EI_ABIVERSION	8		/* ABI version */
+
+#define EI_PAD		9		/* Byte index of padding bytes */
+
+/* Legal values for e_type (object file type).  */
+
+#define ET_NONE		0		/* No file type */
+#define ET_REL		1		/* Relocatable file */
+#define ET_EXEC		2		/* Executable file */
+#define ET_DYN		3		/* Shared object file */
+#define ET_CORE		4		/* Core file */
+#define	ET_NUM		5		/* Number of defined types */
+#define ET_LOOS		0xfe00		/* OS-specific range start */
+#define ET_HIOS		0xfeff		/* OS-specific range end */
+#define ET_LOPROC	0xff00		/* Processor-specific range start */
+#define ET_HIPROC	0xffff		/* Processor-specific range end */
+
+/* Legal values for e_machine (architecture).  */
+
+#define EM_NONE		 0	/* No machine */
+#define EM_M32		 1	/* AT&T WE 32100 */
+#define EM_SPARC	 2	/* SUN SPARC */
+#define EM_386		 3	/* Intel 80386 */
+#define EM_68K		 4	/* Motorola m68k family */
+#define EM_88K		 5	/* Motorola m88k family */
+#define EM_IAMCU	 6	/* Intel MCU */
+#define EM_860		 7	/* Intel 80860 */
+#define EM_MIPS		 8	/* MIPS R3000 big-endian */
+#define EM_S370		 9	/* IBM System/370 */
+#define EM_MIPS_RS3_LE	10	/* MIPS R3000 little-endian */
+				/* reserved 11-14 */
+#define EM_PARISC	15	/* HPPA */
+				/* reserved 16 */
+#define EM_VPP500	17	/* Fujitsu VPP500 */
+#define EM_SPARC32PLUS	18	/* Sun's "v8plus" */
+#define EM_960		19	/* Intel 80960 */
+#define EM_PPC		20	/* PowerPC */
+#define EM_PPC64	21	/* PowerPC 64-bit */
+#define EM_S390		22	/* IBM S390 */
+#define EM_SPU		23	/* IBM SPU/SPC */
+				/* reserved 24-35 */
+#define EM_V800		36	/* NEC V800 series */
+#define EM_FR20		37	/* Fujitsu FR20 */
+#define EM_RH32		38	/* TRW RH-32 */
+#define EM_RCE		39	/* Motorola RCE */
+#define EM_ARM		40	/* ARM */
+#define EM_FAKE_ALPHA	41	/* Digital Alpha */
+#define EM_SH		42	/* Hitachi SH */
+#define EM_SPARCV9	43	/* SPARC v9 64-bit */
+#define EM_TRICORE	44	/* Siemens Tricore */
+#define EM_ARC		45	/* Argonaut RISC Core */
+#define EM_H8_300	46	/* Hitachi H8/300 */
+#define EM_H8_300H	47	/* Hitachi H8/300H */
+#define EM_H8S		48	/* Hitachi H8S */
+#define EM_H8_500	49	/* Hitachi H8/500 */
+#define EM_IA_64	50	/* Intel Merced */
+#define EM_MIPS_X	51	/* Stanford MIPS-X */
+#define EM_COLDFIRE	52	/* Motorola Coldfire */
+#define EM_68HC12	53	/* Motorola M68HC12 */
+#define EM_MMA		54	/* Fujitsu MMA Multimedia Accelerator */
+#define EM_PCP		55	/* Siemens PCP */
+#define EM_NCPU		56	/* Sony nCPU embeeded RISC */
+#define EM_NDR1		57	/* Denso NDR1 microprocessor */
+#define EM_STARCORE	58	/* Motorola Start*Core processor */
+#define EM_ME16		59	/* Toyota ME16 processor */
+#define EM_ST100	60	/* STMicroelectronic ST100 processor */
+#define EM_TINYJ	61	/* Advanced Logic Corp. Tinyj emb.fam */
+#define EM_X86_64	62	/* AMD x86-64 architecture */
+#define EM_PDSP		63	/* Sony DSP Processor */
+#define EM_PDP10	64	/* Digital PDP-10 */
+#define EM_PDP11	65	/* Digital PDP-11 */
+#define EM_FX66		66	/* Siemens FX66 microcontroller */
+#define EM_ST9PLUS	67	/* STMicroelectronics ST9+ 8/16 mc */
+#define EM_ST7		68	/* STmicroelectronics ST7 8 bit mc */
+#define EM_68HC16	69	/* Motorola MC68HC16 microcontroller */
+#define EM_68HC11	70	/* Motorola MC68HC11 microcontroller */
+#define EM_68HC08	71	/* Motorola MC68HC08 microcontroller */
+#define EM_68HC05	72	/* Motorola MC68HC05 microcontroller */
+#define EM_SVX		73	/* Silicon Graphics SVx */
+#define EM_ST19		74	/* STMicroelectronics ST19 8 bit mc */
+#define EM_VAX		75	/* Digital VAX */
+#define EM_CRIS		76	/* Axis Communications 32-bit emb.proc */
+#define EM_JAVELIN	77	/* Infineon Technologies 32-bit emb.proc */
+#define EM_FIREPATH	78	/* Element 14 64-bit DSP Processor */
+#define EM_ZSP		79	/* LSI Logic 16-bit DSP Processor */
+#define EM_MMIX		80	/* Donald Knuth's educational 64-bit proc */
+#define EM_HUANY	81	/* Harvard University machine-independent object files */
+#define EM_PRISM	82	/* SiTera Prism */
+#define EM_AVR		83	/* Atmel AVR 8-bit microcontroller */
+#define EM_FR30		84	/* Fujitsu FR30 */
+#define EM_D10V		85	/* Mitsubishi D10V */
+#define EM_D30V		86	/* Mitsubishi D30V */
+#define EM_V850		87	/* NEC v850 */
+#define EM_M32R		88	/* Mitsubishi M32R */
+#define EM_MN10300	89	/* Matsushita MN10300 */
+#define EM_MN10200	90	/* Matsushita MN10200 */
+#define EM_PJ		91	/* picoJava */
+#define EM_OPENRISC	92	/* OpenRISC 32-bit embedded processor */
+#define EM_ARC_COMPACT	93	/* ARC International ARCompact */
+#define EM_XTENSA	94	/* Tensilica Xtensa Architecture */
+#define EM_VIDEOCORE	95	/* Alphamosaic VideoCore */
+#define EM_TMM_GPP	96	/* Thompson Multimedia General Purpose Proc */
+#define EM_NS32K	97	/* National Semi. 32000 */
+#define EM_TPC		98	/* Tenor Network TPC */
+#define EM_SNP1K	99	/* Trebia SNP 1000 */
+#define EM_ST200	100	/* STMicroelectronics ST200 */
+#define EM_IP2K		101	/* Ubicom IP2xxx */
+#define EM_MAX		102	/* MAX processor */
+#define EM_CR		103	/* National Semi. CompactRISC */
+#define EM_F2MC16	104	/* Fujitsu F2MC16 */
+#define EM_MSP430	105	/* Texas Instruments msp430 */
+#define EM_BLACKFIN	106	/* Analog Devices Blackfin DSP */
+#define EM_SE_C33	107	/* Seiko Epson S1C33 family */
+#define EM_SEP		108	/* Sharp embedded microprocessor */
+#define EM_ARCA		109	/* Arca RISC */
+#define EM_UNICORE	110	/* PKU-Unity & MPRC Peking Uni. mc series */
+#define EM_EXCESS	111	/* eXcess configurable cpu */
+#define EM_DXP		112	/* Icera Semi. Deep Execution Processor */
+#define EM_ALTERA_NIOS2 113	/* Altera Nios II */
+#define EM_CRX		114	/* National Semi. CompactRISC CRX */
+#define EM_XGATE	115	/* Motorola XGATE */
+#define EM_C166		116	/* Infineon C16x/XC16x */
+#define EM_M16C		117	/* Renesas M16C */
+#define EM_DSPIC30F	118	/* Microchip Technology dsPIC30F */
+#define EM_CE		119	/* Freescale Communication Engine RISC */
+#define EM_M32C		120	/* Renesas M32C */
+				/* reserved 121-130 */
+#define EM_TSK3000	131	/* Altium TSK3000 */
+#define EM_RS08		132	/* Freescale RS08 */
+#define EM_SHARC	133	/* Analog Devices SHARC family */
+#define EM_ECOG2	134	/* Cyan Technology eCOG2 */
+#define EM_SCORE7	135	/* Sunplus S+core7 RISC */
+#define EM_DSP24	136	/* New Japan Radio (NJR) 24-bit DSP */
+#define EM_VIDEOCORE3	137	/* Broadcom VideoCore III */
+#define EM_LATTICEMICO32 138	/* RISC for Lattice FPGA */
+#define EM_SE_C17	139	/* Seiko Epson C17 */
+#define EM_TI_C6000	140	/* Texas Instruments TMS320C6000 DSP */
+#define EM_TI_C2000	141	/* Texas Instruments TMS320C2000 DSP */
+#define EM_TI_C5500	142	/* Texas Instruments TMS320C55x DSP */
+#define EM_TI_ARP32	143	/* Texas Instruments App. Specific RISC */
+#define EM_TI_PRU	144	/* Texas Instruments Prog. Realtime Unit */
+				/* reserved 145-159 */
+#define EM_MMDSP_PLUS	160	/* STMicroelectronics 64bit VLIW DSP */
+#define EM_CYPRESS_M8C	161	/* Cypress M8C */
+#define EM_R32C		162	/* Renesas R32C */
+#define EM_TRIMEDIA	163	/* NXP Semi. TriMedia */
+#define EM_QDSP6	164	/* QUALCOMM DSP6 */
+#define EM_8051		165	/* Intel 8051 and variants */
+#define EM_STXP7X	166	/* STMicroelectronics STxP7x */
+#define EM_NDS32	167	/* Andes Tech. compact code emb. RISC */
+#define EM_ECOG1X	168	/* Cyan Technology eCOG1X */
+#define EM_MAXQ30	169	/* Dallas Semi. MAXQ30 mc */
+#define EM_XIMO16	170	/* New Japan Radio (NJR) 16-bit DSP */
+#define EM_MANIK	171	/* M2000 Reconfigurable RISC */
+#define EM_CRAYNV2	172	/* Cray NV2 vector architecture */
+#define EM_RX		173	/* Renesas RX */
+#define EM_METAG	174	/* Imagination Tech. META */
+#define EM_MCST_ELBRUS	175	/* MCST Elbrus */
+#define EM_ECOG16	176	/* Cyan Technology eCOG16 */
+#define EM_CR16		177	/* National Semi. CompactRISC CR16 */
+#define EM_ETPU		178	/* Freescale Extended Time Processing Unit */
+#define EM_SLE9X	179	/* Infineon Tech. SLE9X */
+#define EM_L10M		180	/* Intel L10M */
+#define EM_K10M		181	/* Intel K10M */
+				/* reserved 182 */
+#define EM_AARCH64	183	/* ARM AARCH64 */
+				/* reserved 184 */
+#define EM_AVR32	185	/* Amtel 32-bit microprocessor */
+#define EM_STM8		186	/* STMicroelectronics STM8 */
+#define EM_TILE64	187	/* Tileta TILE64 */
+#define EM_TILEPRO	188	/* Tilera TILEPro */
+#define EM_MICROBLAZE	189	/* Xilinx MicroBlaze */
+#define EM_CUDA		190	/* NVIDIA CUDA */
+#define EM_TILEGX	191	/* Tilera TILE-Gx */
+#define EM_CLOUDSHIELD	192	/* CloudShield */
+#define EM_COREA_1ST	193	/* KIPO-KAIST Core-A 1st gen. */
+#define EM_COREA_2ND	194	/* KIPO-KAIST Core-A 2nd gen. */
+#define EM_ARC_COMPACT2	195	/* Synopsys ARCompact V2 */
+#define EM_OPEN8	196	/* Open8 RISC */
+#define EM_RL78		197	/* Renesas RL78 */
+#define EM_VIDEOCORE5	198	/* Broadcom VideoCore V */
+#define EM_78KOR	199	/* Renesas 78KOR */
+#define EM_56800EX	200	/* Freescale 56800EX DSC */
+#define EM_BA1		201	/* Beyond BA1 */
+#define EM_BA2		202	/* Beyond BA2 */
+#define EM_XCORE	203	/* XMOS xCORE */
+#define EM_MCHP_PIC	204	/* Microchip 8-bit PIC(r) */
+				/* reserved 205-209 */
+#define EM_KM32		210	/* KM211 KM32 */
+#define EM_KMX32	211	/* KM211 KMX32 */
+#define EM_EMX16	212	/* KM211 KMX16 */
+#define EM_EMX8		213	/* KM211 KMX8 */
+#define EM_KVARC	214	/* KM211 KVARC */
+#define EM_CDP		215	/* Paneve CDP */
+#define EM_COGE		216	/* Cognitive Smart Memory Processor */
+#define EM_COOL		217	/* Bluechip CoolEngine */
+#define EM_NORC		218	/* Nanoradio Optimized RISC */
+#define EM_CSR_KALIMBA	219	/* CSR Kalimba */
+#define EM_Z80		220	/* Zilog Z80 */
+#define EM_VISIUM	221	/* Controls and Data Services VISIUMcore */
+#define EM_FT32		222	/* FTDI Chip FT32 */
+#define EM_MOXIE	223	/* Moxie processor */
+#define EM_AMDGPU	224	/* AMD GPU */
+				/* reserved 225-242 */
+#define EM_RISCV	243	/* RISC-V */
+
+#define EM_BPF		247	/* Linux BPF -- in-kernel virtual machine */
+#define EM_CSKY		252     /* C-SKY */
+
+#define EM_NUM		253
+
+/* Old spellings/synonyms.  */
+
+#define EM_ARC_A5	EM_ARC_COMPACT
+
+/* If it is necessary to assign new unofficial EM_* values, please
+   pick large random numbers (0x8523, 0xa7f2, etc.) to minimize the
+   chances of collision with official or non-GNU unofficial values.  */
+
+#define EM_ALPHA	0x9026
+
+/* Legal values for e_version (version).  */
+
+#define EV_NONE		0		/* Invalid ELF version */
+#define EV_CURRENT	1		/* Current version */
+#define EV_NUM		2
+
+/* Section header.  */
+
+typedef struct
+{
+  Elf32_Word	sh_name;		/* Section name (string tbl index) */
+  Elf32_Word	sh_type;		/* Section type */
+  Elf32_Word	sh_flags;		/* Section flags */
+  Elf32_Addr	sh_addr;		/* Section virtual addr at execution */
+  Elf32_Off	sh_offset;		/* Section file offset */
+  Elf32_Word	sh_size;		/* Section size in bytes */
+  Elf32_Word	sh_link;		/* Link to another section */
+  Elf32_Word	sh_info;		/* Additional section information */
+  Elf32_Word	sh_addralign;		/* Section alignment */
+  Elf32_Word	sh_entsize;		/* Entry size if section holds table */
+} Elf32_Shdr;
+
+typedef struct
+{
+  Elf64_Word	sh_name;		/* Section name (string tbl index) */
+  Elf64_Word	sh_type;		/* Section type */
+  Elf64_Xword	sh_flags;		/* Section flags */
+  Elf64_Addr	sh_addr;		/* Section virtual addr at execution */
+  Elf64_Off	sh_offset;		/* Section file offset */
+  Elf64_Xword	sh_size;		/* Section size in bytes */
+  Elf64_Word	sh_link;		/* Link to another section */
+  Elf64_Word	sh_info;		/* Additional section information */
+  Elf64_Xword	sh_addralign;		/* Section alignment */
+  Elf64_Xword	sh_entsize;		/* Entry size if section holds table */
+} Elf64_Shdr;
+
+/* Special section indices.  */
+
+#define SHN_UNDEF	0		/* Undefined section */
+#define SHN_LORESERVE	0xff00		/* Start of reserved indices */
+#define SHN_LOPROC	0xff00		/* Start of processor-specific */
+#define SHN_BEFORE	0xff00		/* Order section before all others
+					   (Solaris).  */
+#define SHN_AFTER	0xff01		/* Order section after all others
+					   (Solaris).  */
+#define SHN_HIPROC	0xff1f		/* End of processor-specific */
+#define SHN_LOOS	0xff20		/* Start of OS-specific */
+#define SHN_HIOS	0xff3f		/* End of OS-specific */
+#define SHN_ABS		0xfff1		/* Associated symbol is absolute */
+#define SHN_COMMON	0xfff2		/* Associated symbol is common */
+#define SHN_XINDEX	0xffff		/* Index is in extra table.  */
+#define SHN_HIRESERVE	0xffff		/* End of reserved indices */
+
+/* Legal values for sh_type (section type).  */
+
+#define SHT_NULL	  0		/* Section header table entry unused */
+#define SHT_PROGBITS	  1		/* Program data */
+#define SHT_SYMTAB	  2		/* Symbol table */
+#define SHT_STRTAB	  3		/* String table */
+#define SHT_RELA	  4		/* Relocation entries with addends */
+#define SHT_HASH	  5		/* Symbol hash table */
+#define SHT_DYNAMIC	  6		/* Dynamic linking information */
+#define SHT_NOTE	  7		/* Notes */
+#define SHT_NOBITS	  8		/* Program space with no data (bss) */
+#define SHT_REL		  9		/* Relocation entries, no addends */
+#define SHT_SHLIB	  10		/* Reserved */
+#define SHT_DYNSYM	  11		/* Dynamic linker symbol table */
+#define SHT_INIT_ARRAY	  14		/* Array of constructors */
+#define SHT_FINI_ARRAY	  15		/* Array of destructors */
+#define SHT_PREINIT_ARRAY 16		/* Array of pre-constructors */
+#define SHT_GROUP	  17		/* Section group */
+#define SHT_SYMTAB_SHNDX  18		/* Extended section indeces */
+#define	SHT_NUM		  19		/* Number of defined types.  */
+#define SHT_LOOS	  0x60000000	/* Start OS-specific.  */
+#define SHT_GNU_ATTRIBUTES 0x6ffffff5	/* Object attributes.  */
+#define SHT_GNU_HASH	  0x6ffffff6	/* GNU-style hash table.  */
+#define SHT_GNU_LIBLIST	  0x6ffffff7	/* Prelink library list */
+#define SHT_CHECKSUM	  0x6ffffff8	/* Checksum for DSO content.  */
+#define SHT_LOSUNW	  0x6ffffffa	/* Sun-specific low bound.  */
+#define SHT_SUNW_move	  0x6ffffffa
+#define SHT_SUNW_COMDAT   0x6ffffffb
+#define SHT_SUNW_syminfo  0x6ffffffc
+#define SHT_GNU_verdef	  0x6ffffffd	/* Version definition section.  */
+#define SHT_GNU_verneed	  0x6ffffffe	/* Version needs section.  */
+#define SHT_GNU_versym	  0x6fffffff	/* Version symbol table.  */
+#define SHT_HISUNW	  0x6fffffff	/* Sun-specific high bound.  */
+#define SHT_HIOS	  0x6fffffff	/* End OS-specific type */
+#define SHT_LOPROC	  0x70000000	/* Start of processor-specific */
+#define SHT_HIPROC	  0x7fffffff	/* End of processor-specific */
+#define SHT_LOUSER	  0x80000000	/* Start of application-specific */
+#define SHT_HIUSER	  0x8fffffff	/* End of application-specific */
+
+/* Legal values for sh_flags (section flags).  */
+
+#define SHF_WRITE	     (1 << 0)	/* Writable */
+#define SHF_ALLOC	     (1 << 1)	/* Occupies memory during execution */
+#define SHF_EXECINSTR	     (1 << 2)	/* Executable */
+#define SHF_MERGE	     (1 << 4)	/* Might be merged */
+#define SHF_STRINGS	     (1 << 5)	/* Contains nul-terminated strings */
+#define SHF_INFO_LINK	     (1 << 6)	/* `sh_info' contains SHT index */
+#define SHF_LINK_ORDER	     (1 << 7)	/* Preserve order after combining */
+#define SHF_OS_NONCONFORMING (1 << 8)	/* Non-standard OS specific handling
+					   required */
+#define SHF_GROUP	     (1 << 9)	/* Section is member of a group.  */
+#define SHF_TLS		     (1 << 10)	/* Section hold thread-local data.  */
+#define SHF_COMPRESSED	     (1 << 11)	/* Section with compressed data. */
+#define SHF_MASKOS	     0x0ff00000	/* OS-specific.  */
+#define SHF_MASKPROC	     0xf0000000	/* Processor-specific */
+#define SHF_ORDERED	     (1 << 30)	/* Special ordering requirement
+					   (Solaris).  */
+#define SHF_EXCLUDE	     (1U << 31)	/* Section is excluded unless
+					   referenced or allocated (Solaris).*/
+
+/* Section compression header.  Used when SHF_COMPRESSED is set.  */
+
+typedef struct
+{
+  Elf32_Word	ch_type;	/* Compression format.  */
+  Elf32_Word	ch_size;	/* Uncompressed data size.  */
+  Elf32_Word	ch_addralign;	/* Uncompressed data alignment.  */
+} Elf32_Chdr;
+
+typedef struct
+{
+  Elf64_Word	ch_type;	/* Compression format.  */
+  Elf64_Word	ch_reserved;
+  Elf64_Xword	ch_size;	/* Uncompressed data size.  */
+  Elf64_Xword	ch_addralign;	/* Uncompressed data alignment.  */
+} Elf64_Chdr;
+
+/* Legal values for ch_type (compression algorithm).  */
+#define ELFCOMPRESS_ZLIB	1	   /* ZLIB/DEFLATE algorithm.  */
+#define ELFCOMPRESS_LOOS	0x60000000 /* Start of OS-specific.  */
+#define ELFCOMPRESS_HIOS	0x6fffffff /* End of OS-specific.  */
+#define ELFCOMPRESS_LOPROC	0x70000000 /* Start of processor-specific.  */
+#define ELFCOMPRESS_HIPROC	0x7fffffff /* End of processor-specific.  */
+
+/* Section group handling.  */
+#define GRP_COMDAT	0x1		/* Mark group as COMDAT.  */
+
+/* Symbol table entry.  */
+
+typedef struct
+{
+  Elf32_Word	st_name;		/* Symbol name (string tbl index) */
+  Elf32_Addr	st_value;		/* Symbol value */
+  Elf32_Word	st_size;		/* Symbol size */
+  unsigned char	st_info;		/* Symbol type and binding */
+  unsigned char	st_other;		/* Symbol visibility */
+  Elf32_Section	st_shndx;		/* Section index */
+} Elf32_Sym;
+
+typedef struct
+{
+  Elf64_Word	st_name;		/* Symbol name (string tbl index) */
+  unsigned char	st_info;		/* Symbol type and binding */
+  unsigned char st_other;		/* Symbol visibility */
+  Elf64_Section	st_shndx;		/* Section index */
+  Elf64_Addr	st_value;		/* Symbol value */
+  Elf64_Xword	st_size;		/* Symbol size */
+} Elf64_Sym;
+
+/* The syminfo section if available contains additional information about
+   every dynamic symbol.  */
+
+typedef struct
+{
+  Elf32_Half si_boundto;		/* Direct bindings, symbol bound to */
+  Elf32_Half si_flags;			/* Per symbol flags */
+} Elf32_Syminfo;
+
+typedef struct
+{
+  Elf64_Half si_boundto;		/* Direct bindings, symbol bound to */
+  Elf64_Half si_flags;			/* Per symbol flags */
+} Elf64_Syminfo;
+
+/* Possible values for si_boundto.  */
+#define SYMINFO_BT_SELF		0xffff	/* Symbol bound to self */
+#define SYMINFO_BT_PARENT	0xfffe	/* Symbol bound to parent */
+#define SYMINFO_BT_LOWRESERVE	0xff00	/* Beginning of reserved entries */
+
+/* Possible bitmasks for si_flags.  */
+#define SYMINFO_FLG_DIRECT	0x0001	/* Direct bound symbol */
+#define SYMINFO_FLG_PASSTHRU	0x0002	/* Pass-thru symbol for translator */
+#define SYMINFO_FLG_COPY	0x0004	/* Symbol is a copy-reloc */
+#define SYMINFO_FLG_LAZYLOAD	0x0008	/* Symbol bound to object to be lazy
+					   loaded */
+/* Syminfo version values.  */
+#define SYMINFO_NONE		0
+#define SYMINFO_CURRENT		1
+#define SYMINFO_NUM		2
+
+
+/* How to extract and insert information held in the st_info field.  */
+
+#define ELF32_ST_BIND(val)		(((unsigned char) (val)) >> 4)
+#define ELF32_ST_TYPE(val)		((val) & 0xf)
+#define ELF32_ST_INFO(bind, type)	(((bind) << 4) + ((type) & 0xf))
+
+/* Both Elf32_Sym and Elf64_Sym use the same one-byte st_info field.  */
+#define ELF64_ST_BIND(val)		ELF32_ST_BIND (val)
+#define ELF64_ST_TYPE(val)		ELF32_ST_TYPE (val)
+#define ELF64_ST_INFO(bind, type)	ELF32_ST_INFO ((bind), (type))
+
+/* Legal values for ST_BIND subfield of st_info (symbol binding).  */
+
+#define STB_LOCAL	0		/* Local symbol */
+#define STB_GLOBAL	1		/* Global symbol */
+#define STB_WEAK	2		/* Weak symbol */
+#define	STB_NUM		3		/* Number of defined types.  */
+#define STB_LOOS	10		/* Start of OS-specific */
+#define STB_GNU_UNIQUE	10		/* Unique symbol.  */
+#define STB_HIOS	12		/* End of OS-specific */
+#define STB_LOPROC	13		/* Start of processor-specific */
+#define STB_HIPROC	15		/* End of processor-specific */
+
+/* Legal values for ST_TYPE subfield of st_info (symbol type).  */
+
+#define STT_NOTYPE	0		/* Symbol type is unspecified */
+#define STT_OBJECT	1		/* Symbol is a data object */
+#define STT_FUNC	2		/* Symbol is a code object */
+#define STT_SECTION	3		/* Symbol associated with a section */
+#define STT_FILE	4		/* Symbol's name is file name */
+#define STT_COMMON	5		/* Symbol is a common data object */
+#define STT_TLS		6		/* Symbol is thread-local data object*/
+#define	STT_NUM		7		/* Number of defined types.  */
+#define STT_LOOS	10		/* Start of OS-specific */
+#define STT_GNU_IFUNC	10		/* Symbol is indirect code object */
+#define STT_HIOS	12		/* End of OS-specific */
+#define STT_LOPROC	13		/* Start of processor-specific */
+#define STT_HIPROC	15		/* End of processor-specific */
+
+
+/* Symbol table indices are found in the hash buckets and chain table
+   of a symbol hash table section.  This special index value indicates
+   the end of a chain, meaning no further symbols are found in that bucket.  */
+
+#define STN_UNDEF	0		/* End of a chain.  */
+
+
+/* How to extract and insert information held in the st_other field.  */
+
+#define ELF32_ST_VISIBILITY(o)	((o) & 0x03)
+
+/* For ELF64 the definitions are the same.  */
+#define ELF64_ST_VISIBILITY(o)	ELF32_ST_VISIBILITY (o)
+
+/* Symbol visibility specification encoded in the st_other field.  */
+#define STV_DEFAULT	0		/* Default symbol visibility rules */
+#define STV_INTERNAL	1		/* Processor specific hidden class */
+#define STV_HIDDEN	2		/* Sym unavailable in other modules */
+#define STV_PROTECTED	3		/* Not preemptible, not exported */
+
+
+/* Relocation table entry without addend (in section of type SHT_REL).  */
+
+typedef struct
+{
+  Elf32_Addr	r_offset;		/* Address */
+  Elf32_Word	r_info;			/* Relocation type and symbol index */
+} Elf32_Rel;
+
+/* I have seen two different definitions of the Elf64_Rel and
+   Elf64_Rela structures, so we'll leave them out until Novell (or
+   whoever) gets their act together.  */
+/* The following, at least, is used on Sparc v9, MIPS, and Alpha.  */
+
+typedef struct
+{
+  Elf64_Addr	r_offset;		/* Address */
+  Elf64_Xword	r_info;			/* Relocation type and symbol index */
+} Elf64_Rel;
+
+/* Relocation table entry with addend (in section of type SHT_RELA).  */
+
+typedef struct
+{
+  Elf32_Addr	r_offset;		/* Address */
+  Elf32_Word	r_info;			/* Relocation type and symbol index */
+  Elf32_Sword	r_addend;		/* Addend */
+} Elf32_Rela;
+
+typedef struct
+{
+  Elf64_Addr	r_offset;		/* Address */
+  Elf64_Xword	r_info;			/* Relocation type and symbol index */
+  Elf64_Sxword	r_addend;		/* Addend */
+} Elf64_Rela;
+
+/* How to extract and insert information held in the r_info field.  */
+
+#define ELF32_R_SYM(val)		((val) >> 8)
+#define ELF32_R_TYPE(val)		((val) & 0xff)
+#define ELF32_R_INFO(sym, type)		(((sym) << 8) + ((type) & 0xff))
+
+#define ELF64_R_SYM(i)			((i) >> 32)
+#define ELF64_R_TYPE(i)			((i) & 0xffffffff)
+#define ELF64_R_INFO(sym,type)		((((Elf64_Xword) (sym)) << 32) + (type))
+
+/* Program segment header.  */
+
+typedef struct
+{
+  Elf32_Word	p_type;			/* Segment type */
+  Elf32_Off	p_offset;		/* Segment file offset */
+  Elf32_Addr	p_vaddr;		/* Segment virtual address */
+  Elf32_Addr	p_paddr;		/* Segment physical address */
+  Elf32_Word	p_filesz;		/* Segment size in file */
+  Elf32_Word	p_memsz;		/* Segment size in memory */
+  Elf32_Word	p_flags;		/* Segment flags */
+  Elf32_Word	p_align;		/* Segment alignment */
+} Elf32_Phdr;
+
+typedef struct
+{
+  Elf64_Word	p_type;			/* Segment type */
+  Elf64_Word	p_flags;		/* Segment flags */
+  Elf64_Off	p_offset;		/* Segment file offset */
+  Elf64_Addr	p_vaddr;		/* Segment virtual address */
+  Elf64_Addr	p_paddr;		/* Segment physical address */
+  Elf64_Xword	p_filesz;		/* Segment size in file */
+  Elf64_Xword	p_memsz;		/* Segment size in memory */
+  Elf64_Xword	p_align;		/* Segment alignment */
+} Elf64_Phdr;
+
+/* Special value for e_phnum.  This indicates that the real number of
+   program headers is too large to fit into e_phnum.  Instead the real
+   value is in the field sh_info of section 0.  */
+
+#define PN_XNUM		0xffff
+
+/* Legal values for p_type (segment type).  */
+
+#define	PT_NULL		0		/* Program header table entry unused */
+#define PT_LOAD		1		/* Loadable program segment */
+#define PT_DYNAMIC	2		/* Dynamic linking information */
+#define PT_INTERP	3		/* Program interpreter */
+#define PT_NOTE		4		/* Auxiliary information */
+#define PT_SHLIB	5		/* Reserved */
+#define PT_PHDR		6		/* Entry for header table itself */
+#define PT_TLS		7		/* Thread-local storage segment */
+#define	PT_NUM		8		/* Number of defined types */
+#define PT_LOOS		0x60000000	/* Start of OS-specific */
+#define PT_GNU_EH_FRAME	0x6474e550	/* GCC .eh_frame_hdr segment */
+#define PT_GNU_STACK	0x6474e551	/* Indicates stack executability */
+#define PT_GNU_RELRO	0x6474e552	/* Read-only after relocation */
+#define PT_LOSUNW	0x6ffffffa
+#define PT_SUNWBSS	0x6ffffffa	/* Sun Specific segment */
+#define PT_SUNWSTACK	0x6ffffffb	/* Stack segment */
+#define PT_HISUNW	0x6fffffff
+#define PT_HIOS		0x6fffffff	/* End of OS-specific */
+#define PT_LOPROC	0x70000000	/* Start of processor-specific */
+#define PT_HIPROC	0x7fffffff	/* End of processor-specific */
+
+/* Legal values for p_flags (segment flags).  */
+
+#define PF_X		(1 << 0)	/* Segment is executable */
+#define PF_W		(1 << 1)	/* Segment is writable */
+#define PF_R		(1 << 2)	/* Segment is readable */
+#define PF_MASKOS	0x0ff00000	/* OS-specific */
+#define PF_MASKPROC	0xf0000000	/* Processor-specific */
+
+/* Legal values for note segment descriptor types for core files. */
+
+#define NT_PRSTATUS	1		/* Contains copy of prstatus struct */
+#define NT_PRFPREG	2		/* Contains copy of fpregset
+					   struct.  */
+#define NT_FPREGSET	2		/* Contains copy of fpregset struct */
+#define NT_PRPSINFO	3		/* Contains copy of prpsinfo struct */
+#define NT_PRXREG	4		/* Contains copy of prxregset struct */
+#define NT_TASKSTRUCT	4		/* Contains copy of task structure */
+#define NT_PLATFORM	5		/* String from sysinfo(SI_PLATFORM) */
+#define NT_AUXV		6		/* Contains copy of auxv array */
+#define NT_GWINDOWS	7		/* Contains copy of gwindows struct */
+#define NT_ASRS		8		/* Contains copy of asrset struct */
+#define NT_PSTATUS	10		/* Contains copy of pstatus struct */
+#define NT_PSINFO	13		/* Contains copy of psinfo struct */
+#define NT_PRCRED	14		/* Contains copy of prcred struct */
+#define NT_UTSNAME	15		/* Contains copy of utsname struct */
+#define NT_LWPSTATUS	16		/* Contains copy of lwpstatus struct */
+#define NT_LWPSINFO	17		/* Contains copy of lwpinfo struct */
+#define NT_PRFPXREG	20		/* Contains copy of fprxregset struct */
+#define NT_SIGINFO	0x53494749	/* Contains copy of siginfo_t,
+					   size might increase */
+#define NT_FILE		0x46494c45	/* Contains information about mapped
+					   files */
+#define NT_PRXFPREG	0x46e62b7f	/* Contains copy of user_fxsr_struct */
+#define NT_PPC_VMX	0x100		/* PowerPC Altivec/VMX registers */
+#define NT_PPC_SPE	0x101		/* PowerPC SPE/EVR registers */
+#define NT_PPC_VSX	0x102		/* PowerPC VSX registers */
+#define NT_PPC_TAR	0x103		/* Target Address Register */
+#define NT_PPC_PPR	0x104		/* Program Priority Register */
+#define NT_PPC_DSCR	0x105		/* Data Stream Control Register */
+#define NT_PPC_EBB	0x106		/* Event Based Branch Registers */
+#define NT_PPC_PMU	0x107		/* Performance Monitor Registers */
+#define NT_PPC_TM_CGPR	0x108		/* TM checkpointed GPR Registers */
+#define NT_PPC_TM_CFPR	0x109		/* TM checkpointed FPR Registers */
+#define NT_PPC_TM_CVMX	0x10a		/* TM checkpointed VMX Registers */
+#define NT_PPC_TM_CVSX	0x10b		/* TM checkpointed VSX Registers */
+#define NT_PPC_TM_SPR	0x10c		/* TM Special Purpose Registers */
+#define NT_PPC_TM_CTAR	0x10d		/* TM checkpointed Target Address
+					   Register */
+#define NT_PPC_TM_CPPR	0x10e		/* TM checkpointed Program Priority
+					   Register */
+#define NT_PPC_TM_CDSCR	0x10f		/* TM checkpointed Data Stream Control
+					   Register */
+#define NT_PPC_PKEY	0x110		/* Memory Protection Keys
+					   registers.  */
+#define NT_386_TLS	0x200		/* i386 TLS slots (struct user_desc) */
+#define NT_386_IOPERM	0x201		/* x86 io permission bitmap (1=deny) */
+#define NT_X86_XSTATE	0x202		/* x86 extended state using xsave */
+#define NT_S390_HIGH_GPRS	0x300	/* s390 upper register halves */
+#define NT_S390_TIMER	0x301		/* s390 timer register */
+#define NT_S390_TODCMP	0x302		/* s390 TOD clock comparator register */
+#define NT_S390_TODPREG	0x303		/* s390 TOD programmable register */
+#define NT_S390_CTRS	0x304		/* s390 control registers */
+#define NT_S390_PREFIX	0x305		/* s390 prefix register */
+#define NT_S390_LAST_BREAK	0x306	/* s390 breaking event address */
+#define NT_S390_SYSTEM_CALL	0x307	/* s390 system call restart data */
+#define NT_S390_TDB	0x308		/* s390 transaction diagnostic block */
+#define NT_S390_VXRS_LOW	0x309	/* s390 vector registers 0-15
+					   upper half.  */
+#define NT_S390_VXRS_HIGH	0x30a	/* s390 vector registers 16-31.  */
+#define NT_S390_GS_CB	0x30b		/* s390 guarded storage registers.  */
+#define NT_S390_GS_BC	0x30c		/* s390 guarded storage
+					   broadcast control block.  */
+#define NT_S390_RI_CB	0x30d		/* s390 runtime instrumentation.  */
+#define NT_ARM_VFP	0x400		/* ARM VFP/NEON registers */
+#define NT_ARM_TLS	0x401		/* ARM TLS register */
+#define NT_ARM_HW_BREAK	0x402		/* ARM hardware breakpoint registers */
+#define NT_ARM_HW_WATCH	0x403		/* ARM hardware watchpoint registers */
+#define NT_ARM_SYSTEM_CALL	0x404	/* ARM system call number */
+#define NT_ARM_SVE	0x405		/* ARM Scalable Vector Extension
+					   registers */
+#define NT_ARM_PAC_MASK	0x406		/* ARM pointer authentication
+					   code masks.  */
+#define NT_ARM_PACA_KEYS	0x407	/* ARM pointer authentication
+					   address keys.  */
+#define NT_ARM_PACG_KEYS	0x408	/* ARM pointer authentication
+					   generic key.  */
+#define NT_VMCOREDD	0x700		/* Vmcore Device Dump Note.  */
+#define NT_MIPS_DSP	0x800		/* MIPS DSP ASE registers.  */
+#define NT_MIPS_FP_MODE	0x801		/* MIPS floating-point mode.  */
+#define NT_MIPS_MSA	0x802		/* MIPS SIMD registers.  */
+
+/* Legal values for the note segment descriptor types for object files.  */
+
+#define NT_VERSION	1		/* Contains a version string.  */
+
+
+/* Dynamic section entry.  */
+
+typedef struct
+{
+  Elf32_Sword	d_tag;			/* Dynamic entry type */
+  union
+    {
+      Elf32_Word d_val;			/* Integer value */
+      Elf32_Addr d_ptr;			/* Address value */
+    } d_un;
+} Elf32_Dyn;
+
+typedef struct
+{
+  Elf64_Sxword	d_tag;			/* Dynamic entry type */
+  union
+    {
+      Elf64_Xword d_val;		/* Integer value */
+      Elf64_Addr d_ptr;			/* Address value */
+    } d_un;
+} Elf64_Dyn;
+
+/* Legal values for d_tag (dynamic entry type).  */
+
+#define DT_NULL		0		/* Marks end of dynamic section */
+#define DT_NEEDED	1		/* Name of needed library */
+#define DT_PLTRELSZ	2		/* Size in bytes of PLT relocs */
+#define DT_PLTGOT	3		/* Processor defined value */
+#define DT_HASH		4		/* Address of symbol hash table */
+#define DT_STRTAB	5		/* Address of string table */
+#define DT_SYMTAB	6		/* Address of symbol table */
+#define DT_RELA		7		/* Address of Rela relocs */
+#define DT_RELASZ	8		/* Total size of Rela relocs */
+#define DT_RELAENT	9		/* Size of one Rela reloc */
+#define DT_STRSZ	10		/* Size of string table */
+#define DT_SYMENT	11		/* Size of one symbol table entry */
+#define DT_INIT		12		/* Address of init function */
+#define DT_FINI		13		/* Address of termination function */
+#define DT_SONAME	14		/* Name of shared object */
+#define DT_RPATH	15		/* Library search path (deprecated) */
+#define DT_SYMBOLIC	16		/* Start symbol search here */
+#define DT_REL		17		/* Address of Rel relocs */
+#define DT_RELSZ	18		/* Total size of Rel relocs */
+#define DT_RELENT	19		/* Size of one Rel reloc */
+#define DT_PLTREL	20		/* Type of reloc in PLT */
+#define DT_DEBUG	21		/* For debugging; unspecified */
+#define DT_TEXTREL	22		/* Reloc might modify .text */
+#define DT_JMPREL	23		/* Address of PLT relocs */
+#define	DT_BIND_NOW	24		/* Process relocations of object */
+#define	DT_INIT_ARRAY	25		/* Array with addresses of init fct */
+#define	DT_FINI_ARRAY	26		/* Array with addresses of fini fct */
+#define	DT_INIT_ARRAYSZ	27		/* Size in bytes of DT_INIT_ARRAY */
+#define	DT_FINI_ARRAYSZ	28		/* Size in bytes of DT_FINI_ARRAY */
+#define DT_RUNPATH	29		/* Library search path */
+#define DT_FLAGS	30		/* Flags for the object being loaded */
+#define DT_ENCODING	32		/* Start of encoded range */
+#define DT_PREINIT_ARRAY 32		/* Array with addresses of preinit fct*/
+#define DT_PREINIT_ARRAYSZ 33		/* size in bytes of DT_PREINIT_ARRAY */
+#define DT_SYMTAB_SHNDX	34		/* Address of SYMTAB_SHNDX section */
+#define	DT_NUM		35		/* Number used */
+#define DT_LOOS		0x6000000d	/* Start of OS-specific */
+#define DT_HIOS		0x6ffff000	/* End of OS-specific */
+#define DT_LOPROC	0x70000000	/* Start of processor-specific */
+#define DT_HIPROC	0x7fffffff	/* End of processor-specific */
+#define	DT_PROCNUM	DT_MIPS_NUM	/* Most used by any processor */
+
+/* DT_* entries which fall between DT_VALRNGHI & DT_VALRNGLO use the
+   Dyn.d_un.d_val field of the Elf*_Dyn structure.  This follows Sun's
+   approach.  */
+#define DT_VALRNGLO	0x6ffffd00
+#define DT_GNU_PRELINKED 0x6ffffdf5	/* Prelinking timestamp */
+#define DT_GNU_CONFLICTSZ 0x6ffffdf6	/* Size of conflict section */
+#define DT_GNU_LIBLISTSZ 0x6ffffdf7	/* Size of library list */
+#define DT_CHECKSUM	0x6ffffdf8
+#define DT_PLTPADSZ	0x6ffffdf9
+#define DT_MOVEENT	0x6ffffdfa
+#define DT_MOVESZ	0x6ffffdfb
+#define DT_FEATURE_1	0x6ffffdfc	/* Feature selection (DTF_*).  */
+#define DT_POSFLAG_1	0x6ffffdfd	/* Flags for DT_* entries, effecting
+					   the following DT_* entry.  */
+#define DT_SYMINSZ	0x6ffffdfe	/* Size of syminfo table (in bytes) */
+#define DT_SYMINENT	0x6ffffdff	/* Entry size of syminfo */
+#define DT_VALRNGHI	0x6ffffdff
+#define DT_VALTAGIDX(tag)	(DT_VALRNGHI - (tag))	/* Reverse order! */
+#define DT_VALNUM 12
+
+/* DT_* entries which fall between DT_ADDRRNGHI & DT_ADDRRNGLO use the
+   Dyn.d_un.d_ptr field of the Elf*_Dyn structure.
+
+   If any adjustment is made to the ELF object after it has been
+   built these entries will need to be adjusted.  */
+#define DT_ADDRRNGLO	0x6ffffe00
+#define DT_GNU_HASH	0x6ffffef5	/* GNU-style hash table.  */
+#define DT_TLSDESC_PLT	0x6ffffef6
+#define DT_TLSDESC_GOT	0x6ffffef7
+#define DT_GNU_CONFLICT	0x6ffffef8	/* Start of conflict section */
+#define DT_GNU_LIBLIST	0x6ffffef9	/* Library list */
+#define DT_CONFIG	0x6ffffefa	/* Configuration information.  */
+#define DT_DEPAUDIT	0x6ffffefb	/* Dependency auditing.  */
+#define DT_AUDIT	0x6ffffefc	/* Object auditing.  */
+#define	DT_PLTPAD	0x6ffffefd	/* PLT padding.  */
+#define	DT_MOVETAB	0x6ffffefe	/* Move table.  */
+#define DT_SYMINFO	0x6ffffeff	/* Syminfo table.  */
+#define DT_ADDRRNGHI	0x6ffffeff
+#define DT_ADDRTAGIDX(tag)	(DT_ADDRRNGHI - (tag))	/* Reverse order! */
+#define DT_ADDRNUM 11
+
+/* The versioning entry types.  The next are defined as part of the
+   GNU extension.  */
+#define DT_VERSYM	0x6ffffff0
+
+#define DT_RELACOUNT	0x6ffffff9
+#define DT_RELCOUNT	0x6ffffffa
+
+/* These were chosen by Sun.  */
+#define DT_FLAGS_1	0x6ffffffb	/* State flags, see DF_1_* below.  */
+#define	DT_VERDEF	0x6ffffffc	/* Address of version definition
+					   table */
+#define	DT_VERDEFNUM	0x6ffffffd	/* Number of version definitions */
+#define	DT_VERNEED	0x6ffffffe	/* Address of table with needed
+					   versions */
+#define	DT_VERNEEDNUM	0x6fffffff	/* Number of needed versions */
+#define DT_VERSIONTAGIDX(tag)	(DT_VERNEEDNUM - (tag))	/* Reverse order! */
+#define DT_VERSIONTAGNUM 16
+
+/* Sun added these machine-independent extensions in the "processor-specific"
+   range.  Be compatible.  */
+#define DT_AUXILIARY    0x7ffffffd      /* Shared object to load before self */
+#define DT_FILTER       0x7fffffff      /* Shared object to get values from */
+#define DT_EXTRATAGIDX(tag)	((Elf32_Word)-((Elf32_Sword) (tag) <<1>>1)-1)
+#define DT_EXTRANUM	3
+
+/* Values of `d_un.d_val' in the DT_FLAGS entry.  */
+#define DF_ORIGIN	0x00000001	/* Object may use DF_ORIGIN */
+#define DF_SYMBOLIC	0x00000002	/* Symbol resolutions starts here */
+#define DF_TEXTREL	0x00000004	/* Object contains text relocations */
+#define DF_BIND_NOW	0x00000008	/* No lazy binding for this object */
+#define DF_STATIC_TLS	0x00000010	/* Module uses the static TLS model */
+
+/* State flags selectable in the `d_un.d_val' element of the DT_FLAGS_1
+   entry in the dynamic section.  */
+#define DF_1_NOW	0x00000001	/* Set RTLD_NOW for this object.  */
+#define DF_1_GLOBAL	0x00000002	/* Set RTLD_GLOBAL for this object.  */
+#define DF_1_GROUP	0x00000004	/* Set RTLD_GROUP for this object.  */
+#define DF_1_NODELETE	0x00000008	/* Set RTLD_NODELETE for this object.*/
+#define DF_1_LOADFLTR	0x00000010	/* Trigger filtee loading at runtime.*/
+#define DF_1_INITFIRST	0x00000020	/* Set RTLD_INITFIRST for this object*/
+#define DF_1_NOOPEN	0x00000040	/* Set RTLD_NOOPEN for this object.  */
+#define DF_1_ORIGIN	0x00000080	/* $ORIGIN must be handled.  */
+#define DF_1_DIRECT	0x00000100	/* Direct binding enabled.  */
+#define DF_1_TRANS	0x00000200
+#define DF_1_INTERPOSE	0x00000400	/* Object is used to interpose.  */
+#define DF_1_NODEFLIB	0x00000800	/* Ignore default lib search path.  */
+#define DF_1_NODUMP	0x00001000	/* Object can't be dldump'ed.  */
+#define DF_1_CONFALT	0x00002000	/* Configuration alternative created.*/
+#define DF_1_ENDFILTEE	0x00004000	/* Filtee terminates filters search. */
+#define	DF_1_DISPRELDNE	0x00008000	/* Disp reloc applied at build time. */
+#define	DF_1_DISPRELPND	0x00010000	/* Disp reloc applied at run-time.  */
+#define	DF_1_NODIRECT	0x00020000	/* Object has no-direct binding. */
+#define	DF_1_IGNMULDEF	0x00040000
+#define	DF_1_NOKSYMS	0x00080000
+#define	DF_1_NOHDR	0x00100000
+#define	DF_1_EDITED	0x00200000	/* Object is modified after built.  */
+#define	DF_1_NORELOC	0x00400000
+#define	DF_1_SYMINTPOSE	0x00800000	/* Object has individual interposers.  */
+#define	DF_1_GLOBAUDIT	0x01000000	/* Global auditing required.  */
+#define	DF_1_SINGLETON	0x02000000	/* Singleton symbols are used.  */
+#define	DF_1_STUB	0x04000000
+#define	DF_1_PIE	0x08000000
+#define	DF_1_KMOD       0x10000000
+#define	DF_1_WEAKFILTER 0x20000000
+#define	DF_1_NOCOMMON   0x40000000
+
+/* Flags for the feature selection in DT_FEATURE_1.  */
+#define DTF_1_PARINIT	0x00000001
+#define DTF_1_CONFEXP	0x00000002
+
+/* Flags in the DT_POSFLAG_1 entry effecting only the next DT_* entry.  */
+#define DF_P1_LAZYLOAD	0x00000001	/* Lazyload following object.  */
+#define DF_P1_GROUPPERM	0x00000002	/* Symbols from next object are not
+					   generally available.  */
+
+/* Version definition sections.  */
+
+typedef struct
+{
+  Elf32_Half	vd_version;		/* Version revision */
+  Elf32_Half	vd_flags;		/* Version information */
+  Elf32_Half	vd_ndx;			/* Version Index */
+  Elf32_Half	vd_cnt;			/* Number of associated aux entries */
+  Elf32_Word	vd_hash;		/* Version name hash value */
+  Elf32_Word	vd_aux;			/* Offset in bytes to verdaux array */
+  Elf32_Word	vd_next;		/* Offset in bytes to next verdef
+					   entry */
+} Elf32_Verdef;
+
+typedef struct
+{
+  Elf64_Half	vd_version;		/* Version revision */
+  Elf64_Half	vd_flags;		/* Version information */
+  Elf64_Half	vd_ndx;			/* Version Index */
+  Elf64_Half	vd_cnt;			/* Number of associated aux entries */
+  Elf64_Word	vd_hash;		/* Version name hash value */
+  Elf64_Word	vd_aux;			/* Offset in bytes to verdaux array */
+  Elf64_Word	vd_next;		/* Offset in bytes to next verdef
+					   entry */
+} Elf64_Verdef;
+
+
+/* Legal values for vd_version (version revision).  */
+#define VER_DEF_NONE	0		/* No version */
+#define VER_DEF_CURRENT	1		/* Current version */
+#define VER_DEF_NUM	2		/* Given version number */
+
+/* Legal values for vd_flags (version information flags).  */
+#define VER_FLG_BASE	0x1		/* Version definition of file itself */
+#define VER_FLG_WEAK	0x2		/* Weak version identifier */
+
+/* Versym symbol index values.  */
+#define	VER_NDX_LOCAL		0	/* Symbol is local.  */
+#define	VER_NDX_GLOBAL		1	/* Symbol is global.  */
+#define	VER_NDX_LORESERVE	0xff00	/* Beginning of reserved entries.  */
+#define	VER_NDX_ELIMINATE	0xff01	/* Symbol is to be eliminated.  */
+
+/* Auxialiary version information.  */
+
+typedef struct
+{
+  Elf32_Word	vda_name;		/* Version or dependency names */
+  Elf32_Word	vda_next;		/* Offset in bytes to next verdaux
+					   entry */
+} Elf32_Verdaux;
+
+typedef struct
+{
+  Elf64_Word	vda_name;		/* Version or dependency names */
+  Elf64_Word	vda_next;		/* Offset in bytes to next verdaux
+					   entry */
+} Elf64_Verdaux;
+
+
+/* Version dependency section.  */
+
+typedef struct
+{
+  Elf32_Half	vn_version;		/* Version of structure */
+  Elf32_Half	vn_cnt;			/* Number of associated aux entries */
+  Elf32_Word	vn_file;		/* Offset of filename for this
+					   dependency */
+  Elf32_Word	vn_aux;			/* Offset in bytes to vernaux array */
+  Elf32_Word	vn_next;		/* Offset in bytes to next verneed
+					   entry */
+} Elf32_Verneed;
+
+typedef struct
+{
+  Elf64_Half	vn_version;		/* Version of structure */
+  Elf64_Half	vn_cnt;			/* Number of associated aux entries */
+  Elf64_Word	vn_file;		/* Offset of filename for this
+					   dependency */
+  Elf64_Word	vn_aux;			/* Offset in bytes to vernaux array */
+  Elf64_Word	vn_next;		/* Offset in bytes to next verneed
+					   entry */
+} Elf64_Verneed;
+
+
+/* Legal values for vn_version (version revision).  */
+#define VER_NEED_NONE	 0		/* No version */
+#define VER_NEED_CURRENT 1		/* Current version */
+#define VER_NEED_NUM	 2		/* Given version number */
+
+/* Auxiliary needed version information.  */
+
+typedef struct
+{
+  Elf32_Word	vna_hash;		/* Hash value of dependency name */
+  Elf32_Half	vna_flags;		/* Dependency specific information */
+  Elf32_Half	vna_other;		/* Unused */
+  Elf32_Word	vna_name;		/* Dependency name string offset */
+  Elf32_Word	vna_next;		/* Offset in bytes to next vernaux
+					   entry */
+} Elf32_Vernaux;
+
+typedef struct
+{
+  Elf64_Word	vna_hash;		/* Hash value of dependency name */
+  Elf64_Half	vna_flags;		/* Dependency specific information */
+  Elf64_Half	vna_other;		/* Unused */
+  Elf64_Word	vna_name;		/* Dependency name string offset */
+  Elf64_Word	vna_next;		/* Offset in bytes to next vernaux
+					   entry */
+} Elf64_Vernaux;
+
+
+/* Legal values for vna_flags.  */
+#define VER_FLG_WEAK	0x2		/* Weak version identifier */
+
+
+/* Auxiliary vector.  */
+
+/* This vector is normally only used by the program interpreter.  The
+   usual definition in an ABI supplement uses the name auxv_t.  The
+   vector is not usually defined in a standard <elf.h> file, but it
+   can't hurt.  We rename it to avoid conflicts.  The sizes of these
+   types are an arrangement between the exec server and the program
+   interpreter, so we don't fully specify them here.  */
+
+typedef struct
+{
+  uint32_t a_type;		/* Entry type */
+  union
+    {
+      uint32_t a_val;		/* Integer value */
+      /* We use to have pointer elements added here.  We cannot do that,
+	 though, since it does not work when using 32-bit definitions
+	 on 64-bit platforms and vice versa.  */
+    } a_un;
+} Elf32_auxv_t;
+
+typedef struct
+{
+  uint64_t a_type;		/* Entry type */
+  union
+    {
+      uint64_t a_val;		/* Integer value */
+      /* We use to have pointer elements added here.  We cannot do that,
+	 though, since it does not work when using 32-bit definitions
+	 on 64-bit platforms and vice versa.  */
+    } a_un;
+} Elf64_auxv_t;
+
+#include "auxv.h"
+/* Note section contents.  Each entry in the note section begins with
+   a header of a fixed form.  */
+
+typedef struct
+{
+  Elf32_Word n_namesz;			/* Length of the note's name.  */
+  Elf32_Word n_descsz;			/* Length of the note's descriptor.  */
+  Elf32_Word n_type;			/* Type of the note.  */
+} Elf32_Nhdr;
+
+typedef struct
+{
+  Elf64_Word n_namesz;			/* Length of the note's name.  */
+  Elf64_Word n_descsz;			/* Length of the note's descriptor.  */
+  Elf64_Word n_type;			/* Type of the note.  */
+} Elf64_Nhdr;
+
+/* Known names of notes.  */
+
+/* Solaris entries in the note section have this name.  */
+#define ELF_NOTE_SOLARIS	"SUNW Solaris"
+
+/* Note entries for GNU systems have this name.  */
+#define ELF_NOTE_GNU		"GNU"
+
+
+/* Defined types of notes for Solaris.  */
+
+/* Value of descriptor (one word) is desired pagesize for the binary.  */
+#define ELF_NOTE_PAGESIZE_HINT	1
+
+
+/* Defined note types for GNU systems.  */
+
+/* ABI information.  The descriptor consists of words:
+   word 0: OS descriptor
+   word 1: major version of the ABI
+   word 2: minor version of the ABI
+   word 3: subminor version of the ABI
+*/
+#define NT_GNU_ABI_TAG	1
+#define ELF_NOTE_ABI	NT_GNU_ABI_TAG /* Old name.  */
+
+/* Known OSes.  These values can appear in word 0 of an
+   NT_GNU_ABI_TAG note section entry.  */
+#define ELF_NOTE_OS_LINUX	0
+#define ELF_NOTE_OS_GNU		1
+#define ELF_NOTE_OS_SOLARIS2	2
+#define ELF_NOTE_OS_FREEBSD	3
+
+/* Synthetic hwcap information.  The descriptor begins with two words:
+   word 0: number of entries
+   word 1: bitmask of enabled entries
+   Then follow variable-length entries, one byte followed by a
+   '\0'-terminated hwcap name string.  The byte gives the bit
+   number to test if enabled, (1U << bit) & bitmask.  */
+#define NT_GNU_HWCAP	2
+
+/* Build ID bits as generated by ld --build-id.
+   The descriptor consists of any nonzero number of bytes.  */
+#define NT_GNU_BUILD_ID	3
+
+/* Version note generated by GNU gold containing a version string.  */
+#define NT_GNU_GOLD_VERSION	4
+
+/* Program property.  */
+#define NT_GNU_PROPERTY_TYPE_0 5
+
+/* Note section name of program property.   */
+#define NOTE_GNU_PROPERTY_SECTION_NAME ".note.gnu.property"
+
+/* Values used in GNU .note.gnu.property notes (NT_GNU_PROPERTY_TYPE_0).  */
+
+/* Stack size.  */
+#define GNU_PROPERTY_STACK_SIZE			1
+/* No copy relocation on protected data symbol.  */
+#define GNU_PROPERTY_NO_COPY_ON_PROTECTED	2
+
+/* Processor-specific semantics, lo */
+#define GNU_PROPERTY_LOPROC			0xc0000000
+/* Processor-specific semantics, hi */
+#define GNU_PROPERTY_HIPROC			0xdfffffff
+/* Application-specific semantics, lo */
+#define GNU_PROPERTY_LOUSER			0xe0000000
+/* Application-specific semantics, hi */
+#define GNU_PROPERTY_HIUSER			0xffffffff
+
+/* The x86 instruction sets indicated by the corresponding bits are
+   used in program.  Their support in the hardware is optional.  */
+#define GNU_PROPERTY_X86_ISA_1_USED		0xc0000000
+/* The x86 instruction sets indicated by the corresponding bits are
+   used in program and they must be supported by the hardware.   */
+#define GNU_PROPERTY_X86_ISA_1_NEEDED		0xc0000001
+/* X86 processor-specific features used in program.  */
+#define GNU_PROPERTY_X86_FEATURE_1_AND		0xc0000002
+
+#define GNU_PROPERTY_X86_ISA_1_486		(1U << 0)
+#define GNU_PROPERTY_X86_ISA_1_586		(1U << 1)
+#define GNU_PROPERTY_X86_ISA_1_686		(1U << 2)
+#define GNU_PROPERTY_X86_ISA_1_SSE		(1U << 3)
+#define GNU_PROPERTY_X86_ISA_1_SSE2		(1U << 4)
+#define GNU_PROPERTY_X86_ISA_1_SSE3		(1U << 5)
+#define GNU_PROPERTY_X86_ISA_1_SSSE3		(1U << 6)
+#define GNU_PROPERTY_X86_ISA_1_SSE4_1		(1U << 7)
+#define GNU_PROPERTY_X86_ISA_1_SSE4_2		(1U << 8)
+#define GNU_PROPERTY_X86_ISA_1_AVX		(1U << 9)
+#define GNU_PROPERTY_X86_ISA_1_AVX2		(1U << 10)
+#define GNU_PROPERTY_X86_ISA_1_AVX512F		(1U << 11)
+#define GNU_PROPERTY_X86_ISA_1_AVX512CD		(1U << 12)
+#define GNU_PROPERTY_X86_ISA_1_AVX512ER		(1U << 13)
+#define GNU_PROPERTY_X86_ISA_1_AVX512PF		(1U << 14)
+#define GNU_PROPERTY_X86_ISA_1_AVX512VL		(1U << 15)
+#define GNU_PROPERTY_X86_ISA_1_AVX512DQ		(1U << 16)
+#define GNU_PROPERTY_X86_ISA_1_AVX512BW		(1U << 17)
+
+/* This indicates that all executable sections are compatible with
+   IBT.  */
+#define GNU_PROPERTY_X86_FEATURE_1_IBT		(1U << 0)
+/* This indicates that all executable sections are compatible with
+   SHSTK.  */
+#define GNU_PROPERTY_X86_FEATURE_1_SHSTK	(1U << 1)
+
+/* Move records.  */
+typedef struct
+{
+  Elf32_Xword m_value;		/* Symbol value.  */
+  Elf32_Word m_info;		/* Size and index.  */
+  Elf32_Word m_poffset;		/* Symbol offset.  */
+  Elf32_Half m_repeat;		/* Repeat count.  */
+  Elf32_Half m_stride;		/* Stride info.  */
+} Elf32_Move;
+
+typedef struct
+{
+  Elf64_Xword m_value;		/* Symbol value.  */
+  Elf64_Xword m_info;		/* Size and index.  */
+  Elf64_Xword m_poffset;	/* Symbol offset.  */
+  Elf64_Half m_repeat;		/* Repeat count.  */
+  Elf64_Half m_stride;		/* Stride info.  */
+} Elf64_Move;
+
+/* Macro to construct move records.  */
+#define ELF32_M_SYM(info)	((info) >> 8)
+#define ELF32_M_SIZE(info)	((unsigned char) (info))
+#define ELF32_M_INFO(sym, size)	(((sym) << 8) + (unsigned char) (size))
+
+#define ELF64_M_SYM(info)	ELF32_M_SYM (info)
+#define ELF64_M_SIZE(info)	ELF32_M_SIZE (info)
+#define ELF64_M_INFO(sym, size)	ELF32_M_INFO (sym, size)
+
+
+/* Motorola 68k specific definitions.  */
+
+/* Values for Elf32_Ehdr.e_flags.  */
+#define EF_CPU32	0x00810000
+
+/* m68k relocs.  */
+
+#define R_68K_NONE	0		/* No reloc */
+#define R_68K_32	1		/* Direct 32 bit  */
+#define R_68K_16	2		/* Direct 16 bit  */
+#define R_68K_8		3		/* Direct 8 bit  */
+#define R_68K_PC32	4		/* PC relative 32 bit */
+#define R_68K_PC16	5		/* PC relative 16 bit */
+#define R_68K_PC8	6		/* PC relative 8 bit */
+#define R_68K_GOT32	7		/* 32 bit PC relative GOT entry */
+#define R_68K_GOT16	8		/* 16 bit PC relative GOT entry */
+#define R_68K_GOT8	9		/* 8 bit PC relative GOT entry */
+#define R_68K_GOT32O	10		/* 32 bit GOT offset */
+#define R_68K_GOT16O	11		/* 16 bit GOT offset */
+#define R_68K_GOT8O	12		/* 8 bit GOT offset */
+#define R_68K_PLT32	13		/* 32 bit PC relative PLT address */
+#define R_68K_PLT16	14		/* 16 bit PC relative PLT address */
+#define R_68K_PLT8	15		/* 8 bit PC relative PLT address */
+#define R_68K_PLT32O	16		/* 32 bit PLT offset */
+#define R_68K_PLT16O	17		/* 16 bit PLT offset */
+#define R_68K_PLT8O	18		/* 8 bit PLT offset */
+#define R_68K_COPY	19		/* Copy symbol at runtime */
+#define R_68K_GLOB_DAT	20		/* Create GOT entry */
+#define R_68K_JMP_SLOT	21		/* Create PLT entry */
+#define R_68K_RELATIVE	22		/* Adjust by program base */
+#define R_68K_TLS_GD32      25          /* 32 bit GOT offset for GD */
+#define R_68K_TLS_GD16      26          /* 16 bit GOT offset for GD */
+#define R_68K_TLS_GD8       27          /* 8 bit GOT offset for GD */
+#define R_68K_TLS_LDM32     28          /* 32 bit GOT offset for LDM */
+#define R_68K_TLS_LDM16     29          /* 16 bit GOT offset for LDM */
+#define R_68K_TLS_LDM8      30          /* 8 bit GOT offset for LDM */
+#define R_68K_TLS_LDO32     31          /* 32 bit module-relative offset */
+#define R_68K_TLS_LDO16     32          /* 16 bit module-relative offset */
+#define R_68K_TLS_LDO8      33          /* 8 bit module-relative offset */
+#define R_68K_TLS_IE32      34          /* 32 bit GOT offset for IE */
+#define R_68K_TLS_IE16      35          /* 16 bit GOT offset for IE */
+#define R_68K_TLS_IE8       36          /* 8 bit GOT offset for IE */
+#define R_68K_TLS_LE32      37          /* 32 bit offset relative to
+					   static TLS block */
+#define R_68K_TLS_LE16      38          /* 16 bit offset relative to
+					   static TLS block */
+#define R_68K_TLS_LE8       39          /* 8 bit offset relative to
+					   static TLS block */
+#define R_68K_TLS_DTPMOD32  40          /* 32 bit module number */
+#define R_68K_TLS_DTPREL32  41          /* 32 bit module-relative offset */
+#define R_68K_TLS_TPREL32   42          /* 32 bit TP-relative offset */
+/* Keep this the last entry.  */
+#define R_68K_NUM	43
+
+/* Intel 80386 specific definitions.  */
+
+/* i386 relocs.  */
+
+#define R_386_NONE	   0		/* No reloc */
+#define R_386_32	   1		/* Direct 32 bit  */
+#define R_386_PC32	   2		/* PC relative 32 bit */
+#define R_386_GOT32	   3		/* 32 bit GOT entry */
+#define R_386_PLT32	   4		/* 32 bit PLT address */
+#define R_386_COPY	   5		/* Copy symbol at runtime */
+#define R_386_GLOB_DAT	   6		/* Create GOT entry */
+#define R_386_JMP_SLOT	   7		/* Create PLT entry */
+#define R_386_RELATIVE	   8		/* Adjust by program base */
+#define R_386_GOTOFF	   9		/* 32 bit offset to GOT */
+#define R_386_GOTPC	   10		/* 32 bit PC relative offset to GOT */
+#define R_386_32PLT	   11
+#define R_386_TLS_TPOFF	   14		/* Offset in static TLS block */
+#define R_386_TLS_IE	   15		/* Address of GOT entry for static TLS
+					   block offset */
+#define R_386_TLS_GOTIE	   16		/* GOT entry for static TLS block
+					   offset */
+#define R_386_TLS_LE	   17		/* Offset relative to static TLS
+					   block */
+#define R_386_TLS_GD	   18		/* Direct 32 bit for GNU version of
+					   general dynamic thread local data */
+#define R_386_TLS_LDM	   19		/* Direct 32 bit for GNU version of
+					   local dynamic thread local data
+					   in LE code */
+#define R_386_16	   20
+#define R_386_PC16	   21
+#define R_386_8		   22
+#define R_386_PC8	   23
+#define R_386_TLS_GD_32	   24		/* Direct 32 bit for general dynamic
+					   thread local data */
+#define R_386_TLS_GD_PUSH  25		/* Tag for pushl in GD TLS code */
+#define R_386_TLS_GD_CALL  26		/* Relocation for call to
+					   __tls_get_addr() */
+#define R_386_TLS_GD_POP   27		/* Tag for popl in GD TLS code */
+#define R_386_TLS_LDM_32   28		/* Direct 32 bit for local dynamic
+					   thread local data in LE code */
+#define R_386_TLS_LDM_PUSH 29		/* Tag for pushl in LDM TLS code */
+#define R_386_TLS_LDM_CALL 30		/* Relocation for call to
+					   __tls_get_addr() in LDM code */
+#define R_386_TLS_LDM_POP  31		/* Tag for popl in LDM TLS code */
+#define R_386_TLS_LDO_32   32		/* Offset relative to TLS block */
+#define R_386_TLS_IE_32	   33		/* GOT entry for negated static TLS
+					   block offset */
+#define R_386_TLS_LE_32	   34		/* Negated offset relative to static
+					   TLS block */
+#define R_386_TLS_DTPMOD32 35		/* ID of module containing symbol */
+#define R_386_TLS_DTPOFF32 36		/* Offset in TLS block */
+#define R_386_TLS_TPOFF32  37		/* Negated offset in static TLS block */
+#define R_386_SIZE32	   38 		/* 32-bit symbol size */
+#define R_386_TLS_GOTDESC  39		/* GOT offset for TLS descriptor.  */
+#define R_386_TLS_DESC_CALL 40		/* Marker of call through TLS
+					   descriptor for
+					   relaxation.  */
+#define R_386_TLS_DESC     41		/* TLS descriptor containing
+					   pointer to code and to
+					   argument, returning the TLS
+					   offset for the symbol.  */
+#define R_386_IRELATIVE	   42		/* Adjust indirectly by program base */
+#define R_386_GOT32X	   43		/* Load from 32 bit GOT entry,
+					   relaxable. */
+/* Keep this the last entry.  */
+#define R_386_NUM	   44
+
+/* SUN SPARC specific definitions.  */
+
+/* Legal values for ST_TYPE subfield of st_info (symbol type).  */
+
+#define STT_SPARC_REGISTER	13	/* Global register reserved to app. */
+
+/* Values for Elf64_Ehdr.e_flags.  */
+
+#define EF_SPARCV9_MM		3
+#define EF_SPARCV9_TSO		0
+#define EF_SPARCV9_PSO		1
+#define EF_SPARCV9_RMO		2
+#define EF_SPARC_LEDATA		0x800000 /* little endian data */
+#define EF_SPARC_EXT_MASK	0xFFFF00
+#define EF_SPARC_32PLUS		0x000100 /* generic V8+ features */
+#define EF_SPARC_SUN_US1	0x000200 /* Sun UltraSPARC1 extensions */
+#define EF_SPARC_HAL_R1		0x000400 /* HAL R1 extensions */
+#define EF_SPARC_SUN_US3	0x000800 /* Sun UltraSPARCIII extensions */
+
+/* SPARC relocs.  */
+
+#define R_SPARC_NONE		0	/* No reloc */
+#define R_SPARC_8		1	/* Direct 8 bit */
+#define R_SPARC_16		2	/* Direct 16 bit */
+#define R_SPARC_32		3	/* Direct 32 bit */
+#define R_SPARC_DISP8		4	/* PC relative 8 bit */
+#define R_SPARC_DISP16		5	/* PC relative 16 bit */
+#define R_SPARC_DISP32		6	/* PC relative 32 bit */
+#define R_SPARC_WDISP30		7	/* PC relative 30 bit shifted */
+#define R_SPARC_WDISP22		8	/* PC relative 22 bit shifted */
+#define R_SPARC_HI22		9	/* High 22 bit */
+#define R_SPARC_22		10	/* Direct 22 bit */
+#define R_SPARC_13		11	/* Direct 13 bit */
+#define R_SPARC_LO10		12	/* Truncated 10 bit */
+#define R_SPARC_GOT10		13	/* Truncated 10 bit GOT entry */
+#define R_SPARC_GOT13		14	/* 13 bit GOT entry */
+#define R_SPARC_GOT22		15	/* 22 bit GOT entry shifted */
+#define R_SPARC_PC10		16	/* PC relative 10 bit truncated */
+#define R_SPARC_PC22		17	/* PC relative 22 bit shifted */
+#define R_SPARC_WPLT30		18	/* 30 bit PC relative PLT address */
+#define R_SPARC_COPY		19	/* Copy symbol at runtime */
+#define R_SPARC_GLOB_DAT	20	/* Create GOT entry */
+#define R_SPARC_JMP_SLOT	21	/* Create PLT entry */
+#define R_SPARC_RELATIVE	22	/* Adjust by program base */
+#define R_SPARC_UA32		23	/* Direct 32 bit unaligned */
+
+/* Additional Sparc64 relocs.  */
+
+#define R_SPARC_PLT32		24	/* Direct 32 bit ref to PLT entry */
+#define R_SPARC_HIPLT22		25	/* High 22 bit PLT entry */
+#define R_SPARC_LOPLT10		26	/* Truncated 10 bit PLT entry */
+#define R_SPARC_PCPLT32		27	/* PC rel 32 bit ref to PLT entry */
+#define R_SPARC_PCPLT22		28	/* PC rel high 22 bit PLT entry */
+#define R_SPARC_PCPLT10		29	/* PC rel trunc 10 bit PLT entry */
+#define R_SPARC_10		30	/* Direct 10 bit */
+#define R_SPARC_11		31	/* Direct 11 bit */
+#define R_SPARC_64		32	/* Direct 64 bit */
+#define R_SPARC_OLO10		33	/* 10bit with secondary 13bit addend */
+#define R_SPARC_HH22		34	/* Top 22 bits of direct 64 bit */
+#define R_SPARC_HM10		35	/* High middle 10 bits of ... */
+#define R_SPARC_LM22		36	/* Low middle 22 bits of ... */
+#define R_SPARC_PC_HH22		37	/* Top 22 bits of pc rel 64 bit */
+#define R_SPARC_PC_HM10		38	/* High middle 10 bit of ... */
+#define R_SPARC_PC_LM22		39	/* Low miggle 22 bits of ... */
+#define R_SPARC_WDISP16		40	/* PC relative 16 bit shifted */
+#define R_SPARC_WDISP19		41	/* PC relative 19 bit shifted */
+#define R_SPARC_GLOB_JMP	42	/* was part of v9 ABI but was removed */
+#define R_SPARC_7		43	/* Direct 7 bit */
+#define R_SPARC_5		44	/* Direct 5 bit */
+#define R_SPARC_6		45	/* Direct 6 bit */
+#define R_SPARC_DISP64		46	/* PC relative 64 bit */
+#define R_SPARC_PLT64		47	/* Direct 64 bit ref to PLT entry */
+#define R_SPARC_HIX22		48	/* High 22 bit complemented */
+#define R_SPARC_LOX10		49	/* Truncated 11 bit complemented */
+#define R_SPARC_H44		50	/* Direct high 12 of 44 bit */
+#define R_SPARC_M44		51	/* Direct mid 22 of 44 bit */
+#define R_SPARC_L44		52	/* Direct low 10 of 44 bit */
+#define R_SPARC_REGISTER	53	/* Global register usage */
+#define R_SPARC_UA64		54	/* Direct 64 bit unaligned */
+#define R_SPARC_UA16		55	/* Direct 16 bit unaligned */
+#define R_SPARC_TLS_GD_HI22	56
+#define R_SPARC_TLS_GD_LO10	57
+#define R_SPARC_TLS_GD_ADD	58
+#define R_SPARC_TLS_GD_CALL	59
+#define R_SPARC_TLS_LDM_HI22	60
+#define R_SPARC_TLS_LDM_LO10	61
+#define R_SPARC_TLS_LDM_ADD	62
+#define R_SPARC_TLS_LDM_CALL	63
+#define R_SPARC_TLS_LDO_HIX22	64
+#define R_SPARC_TLS_LDO_LOX10	65
+#define R_SPARC_TLS_LDO_ADD	66
+#define R_SPARC_TLS_IE_HI22	67
+#define R_SPARC_TLS_IE_LO10	68
+#define R_SPARC_TLS_IE_LD	69
+#define R_SPARC_TLS_IE_LDX	70
+#define R_SPARC_TLS_IE_ADD	71
+#define R_SPARC_TLS_LE_HIX22	72
+#define R_SPARC_TLS_LE_LOX10	73
+#define R_SPARC_TLS_DTPMOD32	74
+#define R_SPARC_TLS_DTPMOD64	75
+#define R_SPARC_TLS_DTPOFF32	76
+#define R_SPARC_TLS_DTPOFF64	77
+#define R_SPARC_TLS_TPOFF32	78
+#define R_SPARC_TLS_TPOFF64	79
+#define R_SPARC_GOTDATA_HIX22	80
+#define R_SPARC_GOTDATA_LOX10	81
+#define R_SPARC_GOTDATA_OP_HIX22	82
+#define R_SPARC_GOTDATA_OP_LOX10	83
+#define R_SPARC_GOTDATA_OP	84
+#define R_SPARC_H34		85
+#define R_SPARC_SIZE32		86
+#define R_SPARC_SIZE64		87
+#define R_SPARC_WDISP10		88
+#define R_SPARC_JMP_IREL	248
+#define R_SPARC_IRELATIVE	249
+#define R_SPARC_GNU_VTINHERIT	250
+#define R_SPARC_GNU_VTENTRY	251
+#define R_SPARC_REV32		252
+/* Keep this the last entry.  */
+#define R_SPARC_NUM		253
+
+/* For Sparc64, legal values for d_tag of Elf64_Dyn.  */
+
+#define DT_SPARC_REGISTER	0x70000001
+#define DT_SPARC_NUM		2
+
+/* MIPS R3000 specific definitions.  */
+
+/* Legal values for e_flags field of Elf32_Ehdr.  */
+
+#define EF_MIPS_NOREORDER	1     /* A .noreorder directive was used.  */
+#define EF_MIPS_PIC		2     /* Contains PIC code.  */
+#define EF_MIPS_CPIC		4     /* Uses PIC calling sequence.  */
+#define EF_MIPS_XGOT		8
+#define EF_MIPS_64BIT_WHIRL	16
+#define EF_MIPS_ABI2		32
+#define EF_MIPS_ABI_ON32	64
+#define EF_MIPS_FP64		512  /* Uses FP64 (12 callee-saved).  */
+#define EF_MIPS_NAN2008	1024  /* Uses IEEE 754-2008 NaN encoding.  */
+#define EF_MIPS_ARCH		0xf0000000 /* MIPS architecture level.  */
+
+/* Legal values for MIPS architecture level.  */
+
+#define EF_MIPS_ARCH_1		0x00000000 /* -mips1 code.  */
+#define EF_MIPS_ARCH_2		0x10000000 /* -mips2 code.  */
+#define EF_MIPS_ARCH_3		0x20000000 /* -mips3 code.  */
+#define EF_MIPS_ARCH_4		0x30000000 /* -mips4 code.  */
+#define EF_MIPS_ARCH_5		0x40000000 /* -mips5 code.  */
+#define EF_MIPS_ARCH_32		0x50000000 /* MIPS32 code.  */
+#define EF_MIPS_ARCH_64		0x60000000 /* MIPS64 code.  */
+#define EF_MIPS_ARCH_32R2	0x70000000 /* MIPS32r2 code.  */
+#define EF_MIPS_ARCH_64R2	0x80000000 /* MIPS64r2 code.  */
+
+/* The following are unofficial names and should not be used.  */
+
+#define E_MIPS_ARCH_1		EF_MIPS_ARCH_1
+#define E_MIPS_ARCH_2		EF_MIPS_ARCH_2
+#define E_MIPS_ARCH_3		EF_MIPS_ARCH_3
+#define E_MIPS_ARCH_4		EF_MIPS_ARCH_4
+#define E_MIPS_ARCH_5		EF_MIPS_ARCH_5
+#define E_MIPS_ARCH_32		EF_MIPS_ARCH_32
+#define E_MIPS_ARCH_64		EF_MIPS_ARCH_64
+
+/* Special section indices.  */
+
+#define SHN_MIPS_ACOMMON	0xff00	/* Allocated common symbols.  */
+#define SHN_MIPS_TEXT		0xff01	/* Allocated test symbols.  */
+#define SHN_MIPS_DATA		0xff02	/* Allocated data symbols.  */
+#define SHN_MIPS_SCOMMON 	0xff03	/* Small common symbols.  */
+#define SHN_MIPS_SUNDEFINED	0xff04	/* Small undefined symbols.  */
+
+/* Legal values for sh_type field of Elf32_Shdr.  */
+
+#define SHT_MIPS_LIBLIST	0x70000000 /* Shared objects used in link.  */
+#define SHT_MIPS_MSYM		0x70000001
+#define SHT_MIPS_CONFLICT	0x70000002 /* Conflicting symbols.  */
+#define SHT_MIPS_GPTAB		0x70000003 /* Global data area sizes.  */
+#define SHT_MIPS_UCODE		0x70000004 /* Reserved for SGI/MIPS compilers */
+#define SHT_MIPS_DEBUG		0x70000005 /* MIPS ECOFF debugging info.  */
+#define SHT_MIPS_REGINFO	0x70000006 /* Register usage information.  */
+#define SHT_MIPS_PACKAGE	0x70000007
+#define SHT_MIPS_PACKSYM	0x70000008
+#define SHT_MIPS_RELD		0x70000009
+#define SHT_MIPS_IFACE		0x7000000b
+#define SHT_MIPS_CONTENT	0x7000000c
+#define SHT_MIPS_OPTIONS	0x7000000d /* Miscellaneous options.  */
+#define SHT_MIPS_SHDR		0x70000010
+#define SHT_MIPS_FDESC		0x70000011
+#define SHT_MIPS_EXTSYM		0x70000012
+#define SHT_MIPS_DENSE		0x70000013
+#define SHT_MIPS_PDESC		0x70000014
+#define SHT_MIPS_LOCSYM		0x70000015
+#define SHT_MIPS_AUXSYM		0x70000016
+#define SHT_MIPS_OPTSYM		0x70000017
+#define SHT_MIPS_LOCSTR		0x70000018
+#define SHT_MIPS_LINE		0x70000019
+#define SHT_MIPS_RFDESC		0x7000001a
+#define SHT_MIPS_DELTASYM	0x7000001b
+#define SHT_MIPS_DELTAINST	0x7000001c
+#define SHT_MIPS_DELTACLASS	0x7000001d
+#define SHT_MIPS_DWARF		0x7000001e /* DWARF debugging information.  */
+#define SHT_MIPS_DELTADECL	0x7000001f
+#define SHT_MIPS_SYMBOL_LIB	0x70000020
+#define SHT_MIPS_EVENTS		0x70000021 /* Event section.  */
+#define SHT_MIPS_TRANSLATE	0x70000022
+#define SHT_MIPS_PIXIE		0x70000023
+#define SHT_MIPS_XLATE		0x70000024
+#define SHT_MIPS_XLATE_DEBUG	0x70000025
+#define SHT_MIPS_WHIRL		0x70000026
+#define SHT_MIPS_EH_REGION	0x70000027
+#define SHT_MIPS_XLATE_OLD	0x70000028
+#define SHT_MIPS_PDR_EXCEPTION	0x70000029
+#define SHT_MIPS_XHASH		0x7000002b
+
+/* Legal values for sh_flags field of Elf32_Shdr.  */
+
+#define SHF_MIPS_GPREL		0x10000000 /* Must be in global data area.  */
+#define SHF_MIPS_MERGE		0x20000000
+#define SHF_MIPS_ADDR		0x40000000
+#define SHF_MIPS_STRINGS	0x80000000
+#define SHF_MIPS_NOSTRIP	0x08000000
+#define SHF_MIPS_LOCAL		0x04000000
+#define SHF_MIPS_NAMES		0x02000000
+#define SHF_MIPS_NODUPE		0x01000000
+
+
+/* Symbol tables.  */
+
+/* MIPS specific values for `st_other'.  */
+#define STO_MIPS_DEFAULT		0x0
+#define STO_MIPS_INTERNAL		0x1
+#define STO_MIPS_HIDDEN			0x2
+#define STO_MIPS_PROTECTED		0x3
+#define STO_MIPS_PLT			0x8
+#define STO_MIPS_SC_ALIGN_UNUSED	0xff
+
+/* MIPS specific values for `st_info'.  */
+#define STB_MIPS_SPLIT_COMMON		13
+
+/* Entries found in sections of type SHT_MIPS_GPTAB.  */
+
+typedef union
+{
+  struct
+    {
+      Elf32_Word gt_current_g_value;	/* -G value used for compilation.  */
+      Elf32_Word gt_unused;		/* Not used.  */
+    } gt_header;			/* First entry in section.  */
+  struct
+    {
+      Elf32_Word gt_g_value;		/* If this value were used for -G.  */
+      Elf32_Word gt_bytes;		/* This many bytes would be used.  */
+    } gt_entry;				/* Subsequent entries in section.  */
+} Elf32_gptab;
+
+/* Entry found in sections of type SHT_MIPS_REGINFO.  */
+
+typedef struct
+{
+  Elf32_Word ri_gprmask;		/* General registers used.  */
+  Elf32_Word ri_cprmask[4];		/* Coprocessor registers used.  */
+  Elf32_Sword ri_gp_value;		/* $gp register value.  */
+} Elf32_RegInfo;
+
+/* Entries found in sections of type SHT_MIPS_OPTIONS.  */
+
+typedef struct
+{
+  unsigned char kind;		/* Determines interpretation of the
+				   variable part of descriptor.  */
+  unsigned char size;		/* Size of descriptor, including header.  */
+  Elf32_Section section;	/* Section header index of section affected,
+				   0 for global options.  */
+  Elf32_Word info;		/* Kind-specific information.  */
+} Elf_Options;
+
+/* Values for `kind' field in Elf_Options.  */
+
+#define ODK_NULL	0	/* Undefined.  */
+#define ODK_REGINFO	1	/* Register usage information.  */
+#define ODK_EXCEPTIONS	2	/* Exception processing options.  */
+#define ODK_PAD		3	/* Section padding options.  */
+#define ODK_HWPATCH	4	/* Hardware workarounds performed */
+#define ODK_FILL	5	/* record the fill value used by the linker. */
+#define ODK_TAGS	6	/* reserve space for desktop tools to write. */
+#define ODK_HWAND	7	/* HW workarounds.  'AND' bits when merging. */
+#define ODK_HWOR	8	/* HW workarounds.  'OR' bits when merging.  */
+
+/* Values for `info' in Elf_Options for ODK_EXCEPTIONS entries.  */
+
+#define OEX_FPU_MIN	0x1f	/* FPE's which MUST be enabled.  */
+#define OEX_FPU_MAX	0x1f00	/* FPE's which MAY be enabled.  */
+#define OEX_PAGE0	0x10000	/* page zero must be mapped.  */
+#define OEX_SMM		0x20000	/* Force sequential memory mode?  */
+#define OEX_FPDBUG	0x40000	/* Force floating point debug mode?  */
+#define OEX_PRECISEFP	OEX_FPDBUG
+#define OEX_DISMISS	0x80000	/* Dismiss invalid address faults?  */
+
+#define OEX_FPU_INVAL	0x10
+#define OEX_FPU_DIV0	0x08
+#define OEX_FPU_OFLO	0x04
+#define OEX_FPU_UFLO	0x02
+#define OEX_FPU_INEX	0x01
+
+/* Masks for `info' in Elf_Options for an ODK_HWPATCH entry.  */
+
+#define OHW_R4KEOP	0x1	/* R4000 end-of-page patch.  */
+#define OHW_R8KPFETCH	0x2	/* may need R8000 prefetch patch.  */
+#define OHW_R5KEOP	0x4	/* R5000 end-of-page patch.  */
+#define OHW_R5KCVTL	0x8	/* R5000 cvt.[ds].l bug.  clean=1.  */
+
+#define OPAD_PREFIX	0x1
+#define OPAD_POSTFIX	0x2
+#define OPAD_SYMBOL	0x4
+
+/* Entry found in `.options' section.  */
+
+typedef struct
+{
+  Elf32_Word hwp_flags1;	/* Extra flags.  */
+  Elf32_Word hwp_flags2;	/* Extra flags.  */
+} Elf_Options_Hw;
+
+/* Masks for `info' in ElfOptions for ODK_HWAND and ODK_HWOR entries.  */
+
+#define OHWA0_R4KEOP_CHECKED	0x00000001
+#define OHWA1_R4KEOP_CLEAN	0x00000002
+
+/* MIPS relocs.  */
+
+#define R_MIPS_NONE		0	/* No reloc */
+#define R_MIPS_16		1	/* Direct 16 bit */
+#define R_MIPS_32		2	/* Direct 32 bit */
+#define R_MIPS_REL32		3	/* PC relative 32 bit */
+#define R_MIPS_26		4	/* Direct 26 bit shifted */
+#define R_MIPS_HI16		5	/* High 16 bit */
+#define R_MIPS_LO16		6	/* Low 16 bit */
+#define R_MIPS_GPREL16		7	/* GP relative 16 bit */
+#define R_MIPS_LITERAL		8	/* 16 bit literal entry */
+#define R_MIPS_GOT16		9	/* 16 bit GOT entry */
+#define R_MIPS_PC16		10	/* PC relative 16 bit */
+#define R_MIPS_CALL16		11	/* 16 bit GOT entry for function */
+#define R_MIPS_GPREL32		12	/* GP relative 32 bit */
+
+#define R_MIPS_SHIFT5		16
+#define R_MIPS_SHIFT6		17
+#define R_MIPS_64		18
+#define R_MIPS_GOT_DISP		19
+#define R_MIPS_GOT_PAGE		20
+#define R_MIPS_GOT_OFST		21
+#define R_MIPS_GOT_HI16		22
+#define R_MIPS_GOT_LO16		23
+#define R_MIPS_SUB		24
+#define R_MIPS_INSERT_A		25
+#define R_MIPS_INSERT_B		26
+#define R_MIPS_DELETE		27
+#define R_MIPS_HIGHER		28
+#define R_MIPS_HIGHEST		29
+#define R_MIPS_CALL_HI16	30
+#define R_MIPS_CALL_LO16	31
+#define R_MIPS_SCN_DISP		32
+#define R_MIPS_REL16		33
+#define R_MIPS_ADD_IMMEDIATE	34
+#define R_MIPS_PJUMP		35
+#define R_MIPS_RELGOT		36
+#define R_MIPS_JALR		37
+#define R_MIPS_TLS_DTPMOD32	38	/* Module number 32 bit */
+#define R_MIPS_TLS_DTPREL32	39	/* Module-relative offset 32 bit */
+#define R_MIPS_TLS_DTPMOD64	40	/* Module number 64 bit */
+#define R_MIPS_TLS_DTPREL64	41	/* Module-relative offset 64 bit */
+#define R_MIPS_TLS_GD		42	/* 16 bit GOT offset for GD */
+#define R_MIPS_TLS_LDM		43	/* 16 bit GOT offset for LDM */
+#define R_MIPS_TLS_DTPREL_HI16	44	/* Module-relative offset, high 16 bits */
+#define R_MIPS_TLS_DTPREL_LO16	45	/* Module-relative offset, low 16 bits */
+#define R_MIPS_TLS_GOTTPREL	46	/* 16 bit GOT offset for IE */
+#define R_MIPS_TLS_TPREL32	47	/* TP-relative offset, 32 bit */
+#define R_MIPS_TLS_TPREL64	48	/* TP-relative offset, 64 bit */
+#define R_MIPS_TLS_TPREL_HI16	49	/* TP-relative offset, high 16 bits */
+#define R_MIPS_TLS_TPREL_LO16	50	/* TP-relative offset, low 16 bits */
+#define R_MIPS_GLOB_DAT		51
+#define R_MIPS_COPY		126
+#define R_MIPS_JUMP_SLOT        127
+/* Keep this the last entry.  */
+#define R_MIPS_NUM		128
+
+/* Legal values for p_type field of Elf32_Phdr.  */
+
+#define PT_MIPS_REGINFO	  0x70000000	/* Register usage information. */
+#define PT_MIPS_RTPROC	  0x70000001	/* Runtime procedure table. */
+#define PT_MIPS_OPTIONS	  0x70000002
+#define PT_MIPS_ABIFLAGS  0x70000003	/* FP mode requirement. */
+
+/* Special program header types.  */
+
+#define PF_MIPS_LOCAL	0x10000000
+
+/* Legal values for d_tag field of Elf32_Dyn.  */
+
+#define DT_MIPS_RLD_VERSION  0x70000001	/* Runtime linker interface version */
+#define DT_MIPS_TIME_STAMP   0x70000002	/* Timestamp */
+#define DT_MIPS_ICHECKSUM    0x70000003	/* Checksum */
+#define DT_MIPS_IVERSION     0x70000004	/* Version string (string tbl index) */
+#define DT_MIPS_FLAGS	     0x70000005	/* Flags */
+#define DT_MIPS_BASE_ADDRESS 0x70000006	/* Base address */
+#define DT_MIPS_MSYM	     0x70000007
+#define DT_MIPS_CONFLICT     0x70000008	/* Address of CONFLICT section */
+#define DT_MIPS_LIBLIST	     0x70000009	/* Address of LIBLIST section */
+#define DT_MIPS_LOCAL_GOTNO  0x7000000a	/* Number of local GOT entries */
+#define DT_MIPS_CONFLICTNO   0x7000000b	/* Number of CONFLICT entries */
+#define DT_MIPS_LIBLISTNO    0x70000010	/* Number of LIBLIST entries */
+#define DT_MIPS_SYMTABNO     0x70000011	/* Number of DYNSYM entries */
+#define DT_MIPS_UNREFEXTNO   0x70000012	/* First external DYNSYM */
+#define DT_MIPS_GOTSYM	     0x70000013	/* First GOT entry in DYNSYM */
+#define DT_MIPS_HIPAGENO     0x70000014	/* Number of GOT page table entries */
+#define DT_MIPS_RLD_MAP	     0x70000016	/* Address of run time loader map.  */
+#define DT_MIPS_DELTA_CLASS  0x70000017	/* Delta C++ class definition.  */
+#define DT_MIPS_DELTA_CLASS_NO    0x70000018 /* Number of entries in
+						DT_MIPS_DELTA_CLASS.  */
+#define DT_MIPS_DELTA_INSTANCE    0x70000019 /* Delta C++ class instances.  */
+#define DT_MIPS_DELTA_INSTANCE_NO 0x7000001a /* Number of entries in
+						DT_MIPS_DELTA_INSTANCE.  */
+#define DT_MIPS_DELTA_RELOC  0x7000001b /* Delta relocations.  */
+#define DT_MIPS_DELTA_RELOC_NO 0x7000001c /* Number of entries in
+					     DT_MIPS_DELTA_RELOC.  */
+#define DT_MIPS_DELTA_SYM    0x7000001d /* Delta symbols that Delta
+					   relocations refer to.  */
+#define DT_MIPS_DELTA_SYM_NO 0x7000001e /* Number of entries in
+					   DT_MIPS_DELTA_SYM.  */
+#define DT_MIPS_DELTA_CLASSSYM 0x70000020 /* Delta symbols that hold the
+					     class declaration.  */
+#define DT_MIPS_DELTA_CLASSSYM_NO 0x70000021 /* Number of entries in
+						DT_MIPS_DELTA_CLASSSYM.  */
+#define DT_MIPS_CXX_FLAGS    0x70000022 /* Flags indicating for C++ flavor.  */
+#define DT_MIPS_PIXIE_INIT   0x70000023
+#define DT_MIPS_SYMBOL_LIB   0x70000024
+#define DT_MIPS_LOCALPAGE_GOTIDX 0x70000025
+#define DT_MIPS_LOCAL_GOTIDX 0x70000026
+#define DT_MIPS_HIDDEN_GOTIDX 0x70000027
+#define DT_MIPS_PROTECTED_GOTIDX 0x70000028
+#define DT_MIPS_OPTIONS	     0x70000029 /* Address of .options.  */
+#define DT_MIPS_INTERFACE    0x7000002a /* Address of .interface.  */
+#define DT_MIPS_DYNSTR_ALIGN 0x7000002b
+#define DT_MIPS_INTERFACE_SIZE 0x7000002c /* Size of the .interface section. */
+#define DT_MIPS_RLD_TEXT_RESOLVE_ADDR 0x7000002d /* Address of rld_text_rsolve
+						    function stored in GOT.  */
+#define DT_MIPS_PERF_SUFFIX  0x7000002e /* Default suffix of dso to be added
+					   by rld on dlopen() calls.  */
+#define DT_MIPS_COMPACT_SIZE 0x7000002f /* (O32)Size of compact rel section. */
+#define DT_MIPS_GP_VALUE     0x70000030 /* GP value for aux GOTs.  */
+#define DT_MIPS_AUX_DYNAMIC  0x70000031 /* Address of aux .dynamic.  */
+/* The address of .got.plt in an executable using the new non-PIC ABI.  */
+#define DT_MIPS_PLTGOT	     0x70000032
+/* The base of the PLT in an executable using the new non-PIC ABI if that
+   PLT is writable.  For a non-writable PLT, this is omitted or has a zero
+   value.  */
+#define DT_MIPS_RWPLT        0x70000034
+/* An alternative description of the classic MIPS RLD_MAP that is usable
+   in a PIE as it stores a relative offset from the address of the tag
+   rather than an absolute address.  */
+#define DT_MIPS_RLD_MAP_REL  0x70000035
+/* GNU-style hash table with xlat.  */
+#define DT_MIPS_XHASH	     0x70000036
+#define DT_MIPS_NUM	     0x37
+
+/* Legal values for DT_MIPS_FLAGS Elf32_Dyn entry.  */
+
+#define RHF_NONE		   0		/* No flags */
+#define RHF_QUICKSTART		   (1 << 0)	/* Use quickstart */
+#define RHF_NOTPOT		   (1 << 1)	/* Hash size not power of 2 */
+#define RHF_NO_LIBRARY_REPLACEMENT (1 << 2)	/* Ignore LD_LIBRARY_PATH */
+#define RHF_NO_MOVE		   (1 << 3)
+#define RHF_SGI_ONLY		   (1 << 4)
+#define RHF_GUARANTEE_INIT	   (1 << 5)
+#define RHF_DELTA_C_PLUS_PLUS	   (1 << 6)
+#define RHF_GUARANTEE_START_INIT   (1 << 7)
+#define RHF_PIXIE		   (1 << 8)
+#define RHF_DEFAULT_DELAY_LOAD	   (1 << 9)
+#define RHF_REQUICKSTART	   (1 << 10)
+#define RHF_REQUICKSTARTED	   (1 << 11)
+#define RHF_CORD		   (1 << 12)
+#define RHF_NO_UNRES_UNDEF	   (1 << 13)
+#define RHF_RLD_ORDER_SAFE	   (1 << 14)
+
+/* Entries found in sections of type SHT_MIPS_LIBLIST.  */
+
+typedef struct
+{
+  Elf32_Word l_name;		/* Name (string table index) */
+  Elf32_Word l_time_stamp;	/* Timestamp */
+  Elf32_Word l_checksum;	/* Checksum */
+  Elf32_Word l_version;		/* Interface version */
+  Elf32_Word l_flags;		/* Flags */
+} Elf32_Lib;
+
+typedef struct
+{
+  Elf64_Word l_name;		/* Name (string table index) */
+  Elf64_Word l_time_stamp;	/* Timestamp */
+  Elf64_Word l_checksum;	/* Checksum */
+  Elf64_Word l_version;		/* Interface version */
+  Elf64_Word l_flags;		/* Flags */
+} Elf64_Lib;
+
+
+/* Legal values for l_flags.  */
+
+#define LL_NONE		  0
+#define LL_EXACT_MATCH	  (1 << 0)	/* Require exact match */
+#define LL_IGNORE_INT_VER (1 << 1)	/* Ignore interface version */
+#define LL_REQUIRE_MINOR  (1 << 2)
+#define LL_EXPORTS	  (1 << 3)
+#define LL_DELAY_LOAD	  (1 << 4)
+#define LL_DELTA	  (1 << 5)
+
+/* Entries found in sections of type SHT_MIPS_CONFLICT.  */
+
+typedef Elf32_Addr Elf32_Conflict;
+
+typedef struct
+{
+  /* Version of flags structure.  */
+  Elf32_Half version;
+  /* The level of the ISA: 1-5, 32, 64.  */
+  unsigned char isa_level;
+  /* The revision of ISA: 0 for MIPS V and below, 1-n otherwise.  */
+  unsigned char isa_rev;
+  /* The size of general purpose registers.  */
+  unsigned char gpr_size;
+  /* The size of co-processor 1 registers.  */
+  unsigned char cpr1_size;
+  /* The size of co-processor 2 registers.  */
+  unsigned char cpr2_size;
+  /* The floating-point ABI.  */
+  unsigned char fp_abi;
+  /* Processor-specific extension.  */
+  Elf32_Word isa_ext;
+  /* Mask of ASEs used.  */
+  Elf32_Word ases;
+  /* Mask of general flags.  */
+  Elf32_Word flags1;
+  Elf32_Word flags2;
+} Elf_MIPS_ABIFlags_v0;
+
+/* Values for the register size bytes of an abi flags structure.  */
+
+#define MIPS_AFL_REG_NONE	0x00	 /* No registers.  */
+#define MIPS_AFL_REG_32		0x01	 /* 32-bit registers.  */
+#define MIPS_AFL_REG_64		0x02	 /* 64-bit registers.  */
+#define MIPS_AFL_REG_128	0x03	 /* 128-bit registers.  */
+
+/* Masks for the ases word of an ABI flags structure.  */
+
+#define MIPS_AFL_ASE_DSP	0x00000001 /* DSP ASE.  */
+#define MIPS_AFL_ASE_DSPR2	0x00000002 /* DSP R2 ASE.  */
+#define MIPS_AFL_ASE_EVA	0x00000004 /* Enhanced VA Scheme.  */
+#define MIPS_AFL_ASE_MCU	0x00000008 /* MCU (MicroController) ASE.  */
+#define MIPS_AFL_ASE_MDMX	0x00000010 /* MDMX ASE.  */
+#define MIPS_AFL_ASE_MIPS3D	0x00000020 /* MIPS-3D ASE.  */
+#define MIPS_AFL_ASE_MT		0x00000040 /* MT ASE.  */
+#define MIPS_AFL_ASE_SMARTMIPS	0x00000080 /* SmartMIPS ASE.  */
+#define MIPS_AFL_ASE_VIRT	0x00000100 /* VZ ASE.  */
+#define MIPS_AFL_ASE_MSA	0x00000200 /* MSA ASE.  */
+#define MIPS_AFL_ASE_MIPS16	0x00000400 /* MIPS16 ASE.  */
+#define MIPS_AFL_ASE_MICROMIPS	0x00000800 /* MICROMIPS ASE.  */
+#define MIPS_AFL_ASE_XPA	0x00001000 /* XPA ASE.  */
+#define MIPS_AFL_ASE_MASK	0x00001fff /* All ASEs.  */
+
+/* Values for the isa_ext word of an ABI flags structure.  */
+
+#define MIPS_AFL_EXT_XLR	  1   /* RMI Xlr instruction.  */
+#define MIPS_AFL_EXT_OCTEON2	  2   /* Cavium Networks Octeon2.  */
+#define MIPS_AFL_EXT_OCTEONP	  3   /* Cavium Networks OcteonP.  */
+#define MIPS_AFL_EXT_LOONGSON_3A  4   /* Loongson 3A.  */
+#define MIPS_AFL_EXT_OCTEON	  5   /* Cavium Networks Octeon.  */
+#define MIPS_AFL_EXT_5900	  6   /* MIPS R5900 instruction.  */
+#define MIPS_AFL_EXT_4650	  7   /* MIPS R4650 instruction.  */
+#define MIPS_AFL_EXT_4010	  8   /* LSI R4010 instruction.  */
+#define MIPS_AFL_EXT_4100	  9   /* NEC VR4100 instruction.  */
+#define MIPS_AFL_EXT_3900	  10  /* Toshiba R3900 instruction.  */
+#define MIPS_AFL_EXT_10000	  11  /* MIPS R10000 instruction.  */
+#define MIPS_AFL_EXT_SB1	  12  /* Broadcom SB-1 instruction.  */
+#define MIPS_AFL_EXT_4111	  13  /* NEC VR4111/VR4181 instruction.  */
+#define MIPS_AFL_EXT_4120	  14  /* NEC VR4120 instruction.  */
+#define MIPS_AFL_EXT_5400	  15  /* NEC VR5400 instruction.  */
+#define MIPS_AFL_EXT_5500	  16  /* NEC VR5500 instruction.  */
+#define MIPS_AFL_EXT_LOONGSON_2E  17  /* ST Microelectronics Loongson 2E.  */
+#define MIPS_AFL_EXT_LOONGSON_2F  18  /* ST Microelectronics Loongson 2F.  */
+
+/* Masks for the flags1 word of an ABI flags structure.  */
+#define MIPS_AFL_FLAGS1_ODDSPREG  1  /* Uses odd single-precision registers.  */
+
+/* Object attribute values.  */
+enum
+{
+  /* Not tagged or not using any ABIs affected by the differences.  */
+  Val_GNU_MIPS_ABI_FP_ANY = 0,
+  /* Using hard-float -mdouble-float.  */
+  Val_GNU_MIPS_ABI_FP_DOUBLE = 1,
+  /* Using hard-float -msingle-float.  */
+  Val_GNU_MIPS_ABI_FP_SINGLE = 2,
+  /* Using soft-float.  */
+  Val_GNU_MIPS_ABI_FP_SOFT = 3,
+  /* Using -mips32r2 -mfp64.  */
+  Val_GNU_MIPS_ABI_FP_OLD_64 = 4,
+  /* Using -mfpxx.  */
+  Val_GNU_MIPS_ABI_FP_XX = 5,
+  /* Using -mips32r2 -mfp64.  */
+  Val_GNU_MIPS_ABI_FP_64 = 6,
+  /* Using -mips32r2 -mfp64 -mno-odd-spreg.  */
+  Val_GNU_MIPS_ABI_FP_64A = 7,
+  /* Maximum allocated FP ABI value.  */
+  Val_GNU_MIPS_ABI_FP_MAX = 7
+};
+
+/* HPPA specific definitions.  */
+
+/* Legal values for e_flags field of Elf32_Ehdr.  */
+
+#define EF_PARISC_TRAPNIL	0x00010000 /* Trap nil pointer dereference.  */
+#define EF_PARISC_EXT		0x00020000 /* Program uses arch. extensions. */
+#define EF_PARISC_LSB		0x00040000 /* Program expects little endian. */
+#define EF_PARISC_WIDE		0x00080000 /* Program expects wide mode.  */
+#define EF_PARISC_NO_KABP	0x00100000 /* No kernel assisted branch
+					      prediction.  */
+#define EF_PARISC_LAZYSWAP	0x00400000 /* Allow lazy swapping.  */
+#define EF_PARISC_ARCH		0x0000ffff /* Architecture version.  */
+
+/* Defined values for `e_flags & EF_PARISC_ARCH' are:  */
+
+#define EFA_PARISC_1_0		    0x020b /* PA-RISC 1.0 big-endian.  */
+#define EFA_PARISC_1_1		    0x0210 /* PA-RISC 1.1 big-endian.  */
+#define EFA_PARISC_2_0		    0x0214 /* PA-RISC 2.0 big-endian.  */
+
+/* Additional section indeces.  */
+
+#define SHN_PARISC_ANSI_COMMON	0xff00	   /* Section for tenatively declared
+					      symbols in ANSI C.  */
+#define SHN_PARISC_HUGE_COMMON	0xff01	   /* Common blocks in huge model.  */
+
+/* Legal values for sh_type field of Elf32_Shdr.  */
+
+#define SHT_PARISC_EXT		0x70000000 /* Contains product specific ext. */
+#define SHT_PARISC_UNWIND	0x70000001 /* Unwind information.  */
+#define SHT_PARISC_DOC		0x70000002 /* Debug info for optimized code. */
+
+/* Legal values for sh_flags field of Elf32_Shdr.  */
+
+#define SHF_PARISC_SHORT	0x20000000 /* Section with short addressing. */
+#define SHF_PARISC_HUGE		0x40000000 /* Section far from gp.  */
+#define SHF_PARISC_SBP		0x80000000 /* Static branch prediction code. */
+
+/* Legal values for ST_TYPE subfield of st_info (symbol type).  */
+
+#define STT_PARISC_MILLICODE	13	/* Millicode function entry point.  */
+
+#define STT_HP_OPAQUE		(STT_LOOS + 0x1)
+#define STT_HP_STUB		(STT_LOOS + 0x2)
+
+/* HPPA relocs.  */
+
+#define R_PARISC_NONE		0	/* No reloc.  */
+#define R_PARISC_DIR32		1	/* Direct 32-bit reference.  */
+#define R_PARISC_DIR21L		2	/* Left 21 bits of eff. address.  */
+#define R_PARISC_DIR17R		3	/* Right 17 bits of eff. address.  */
+#define R_PARISC_DIR17F		4	/* 17 bits of eff. address.  */
+#define R_PARISC_DIR14R		6	/* Right 14 bits of eff. address.  */
+#define R_PARISC_PCREL32	9	/* 32-bit rel. address.  */
+#define R_PARISC_PCREL21L	10	/* Left 21 bits of rel. address.  */
+#define R_PARISC_PCREL17R	11	/* Right 17 bits of rel. address.  */
+#define R_PARISC_PCREL17F	12	/* 17 bits of rel. address.  */
+#define R_PARISC_PCREL14R	14	/* Right 14 bits of rel. address.  */
+#define R_PARISC_DPREL21L	18	/* Left 21 bits of rel. address.  */
+#define R_PARISC_DPREL14R	22	/* Right 14 bits of rel. address.  */
+#define R_PARISC_GPREL21L	26	/* GP-relative, left 21 bits.  */
+#define R_PARISC_GPREL14R	30	/* GP-relative, right 14 bits.  */
+#define R_PARISC_LTOFF21L	34	/* LT-relative, left 21 bits.  */
+#define R_PARISC_LTOFF14R	38	/* LT-relative, right 14 bits.  */
+#define R_PARISC_SECREL32	41	/* 32 bits section rel. address.  */
+#define R_PARISC_SEGBASE	48	/* No relocation, set segment base.  */
+#define R_PARISC_SEGREL32	49	/* 32 bits segment rel. address.  */
+#define R_PARISC_PLTOFF21L	50	/* PLT rel. address, left 21 bits.  */
+#define R_PARISC_PLTOFF14R	54	/* PLT rel. address, right 14 bits.  */
+#define R_PARISC_LTOFF_FPTR32	57	/* 32 bits LT-rel. function pointer. */
+#define R_PARISC_LTOFF_FPTR21L	58	/* LT-rel. fct ptr, left 21 bits. */
+#define R_PARISC_LTOFF_FPTR14R	62	/* LT-rel. fct ptr, right 14 bits. */
+#define R_PARISC_FPTR64		64	/* 64 bits function address.  */
+#define R_PARISC_PLABEL32	65	/* 32 bits function address.  */
+#define R_PARISC_PLABEL21L	66	/* Left 21 bits of fdesc address.  */
+#define R_PARISC_PLABEL14R	70	/* Right 14 bits of fdesc address.  */
+#define R_PARISC_PCREL64	72	/* 64 bits PC-rel. address.  */
+#define R_PARISC_PCREL22F	74	/* 22 bits PC-rel. address.  */
+#define R_PARISC_PCREL14WR	75	/* PC-rel. address, right 14 bits.  */
+#define R_PARISC_PCREL14DR	76	/* PC rel. address, right 14 bits.  */
+#define R_PARISC_PCREL16F	77	/* 16 bits PC-rel. address.  */
+#define R_PARISC_PCREL16WF	78	/* 16 bits PC-rel. address.  */
+#define R_PARISC_PCREL16DF	79	/* 16 bits PC-rel. address.  */
+#define R_PARISC_DIR64		80	/* 64 bits of eff. address.  */
+#define R_PARISC_DIR14WR	83	/* 14 bits of eff. address.  */
+#define R_PARISC_DIR14DR	84	/* 14 bits of eff. address.  */
+#define R_PARISC_DIR16F		85	/* 16 bits of eff. address.  */
+#define R_PARISC_DIR16WF	86	/* 16 bits of eff. address.  */
+#define R_PARISC_DIR16DF	87	/* 16 bits of eff. address.  */
+#define R_PARISC_GPREL64	88	/* 64 bits of GP-rel. address.  */
+#define R_PARISC_GPREL14WR	91	/* GP-rel. address, right 14 bits.  */
+#define R_PARISC_GPREL14DR	92	/* GP-rel. address, right 14 bits.  */
+#define R_PARISC_GPREL16F	93	/* 16 bits GP-rel. address.  */
+#define R_PARISC_GPREL16WF	94	/* 16 bits GP-rel. address.  */
+#define R_PARISC_GPREL16DF	95	/* 16 bits GP-rel. address.  */
+#define R_PARISC_LTOFF64	96	/* 64 bits LT-rel. address.  */
+#define R_PARISC_LTOFF14WR	99	/* LT-rel. address, right 14 bits.  */
+#define R_PARISC_LTOFF14DR	100	/* LT-rel. address, right 14 bits.  */
+#define R_PARISC_LTOFF16F	101	/* 16 bits LT-rel. address.  */
+#define R_PARISC_LTOFF16WF	102	/* 16 bits LT-rel. address.  */
+#define R_PARISC_LTOFF16DF	103	/* 16 bits LT-rel. address.  */
+#define R_PARISC_SECREL64	104	/* 64 bits section rel. address.  */
+#define R_PARISC_SEGREL64	112	/* 64 bits segment rel. address.  */
+#define R_PARISC_PLTOFF14WR	115	/* PLT-rel. address, right 14 bits.  */
+#define R_PARISC_PLTOFF14DR	116	/* PLT-rel. address, right 14 bits.  */
+#define R_PARISC_PLTOFF16F	117	/* 16 bits LT-rel. address.  */
+#define R_PARISC_PLTOFF16WF	118	/* 16 bits PLT-rel. address.  */
+#define R_PARISC_PLTOFF16DF	119	/* 16 bits PLT-rel. address.  */
+#define R_PARISC_LTOFF_FPTR64	120	/* 64 bits LT-rel. function ptr.  */
+#define R_PARISC_LTOFF_FPTR14WR	123	/* LT-rel. fct. ptr., right 14 bits. */
+#define R_PARISC_LTOFF_FPTR14DR	124	/* LT-rel. fct. ptr., right 14 bits. */
+#define R_PARISC_LTOFF_FPTR16F	125	/* 16 bits LT-rel. function ptr.  */
+#define R_PARISC_LTOFF_FPTR16WF	126	/* 16 bits LT-rel. function ptr.  */
+#define R_PARISC_LTOFF_FPTR16DF	127	/* 16 bits LT-rel. function ptr.  */
+#define R_PARISC_LORESERVE	128
+#define R_PARISC_COPY		128	/* Copy relocation.  */
+#define R_PARISC_IPLT		129	/* Dynamic reloc, imported PLT */
+#define R_PARISC_EPLT		130	/* Dynamic reloc, exported PLT */
+#define R_PARISC_TPREL32	153	/* 32 bits TP-rel. address.  */
+#define R_PARISC_TPREL21L	154	/* TP-rel. address, left 21 bits.  */
+#define R_PARISC_TPREL14R	158	/* TP-rel. address, right 14 bits.  */
+#define R_PARISC_LTOFF_TP21L	162	/* LT-TP-rel. address, left 21 bits. */
+#define R_PARISC_LTOFF_TP14R	166	/* LT-TP-rel. address, right 14 bits.*/
+#define R_PARISC_LTOFF_TP14F	167	/* 14 bits LT-TP-rel. address.  */
+#define R_PARISC_TPREL64	216	/* 64 bits TP-rel. address.  */
+#define R_PARISC_TPREL14WR	219	/* TP-rel. address, right 14 bits.  */
+#define R_PARISC_TPREL14DR	220	/* TP-rel. address, right 14 bits.  */
+#define R_PARISC_TPREL16F	221	/* 16 bits TP-rel. address.  */
+#define R_PARISC_TPREL16WF	222	/* 16 bits TP-rel. address.  */
+#define R_PARISC_TPREL16DF	223	/* 16 bits TP-rel. address.  */
+#define R_PARISC_LTOFF_TP64	224	/* 64 bits LT-TP-rel. address.  */
+#define R_PARISC_LTOFF_TP14WR	227	/* LT-TP-rel. address, right 14 bits.*/
+#define R_PARISC_LTOFF_TP14DR	228	/* LT-TP-rel. address, right 14 bits.*/
+#define R_PARISC_LTOFF_TP16F	229	/* 16 bits LT-TP-rel. address.  */
+#define R_PARISC_LTOFF_TP16WF	230	/* 16 bits LT-TP-rel. address.  */
+#define R_PARISC_LTOFF_TP16DF	231	/* 16 bits LT-TP-rel. address.  */
+#define R_PARISC_GNU_VTENTRY	232
+#define R_PARISC_GNU_VTINHERIT	233
+#define R_PARISC_TLS_GD21L	234	/* GD 21-bit left.  */
+#define R_PARISC_TLS_GD14R	235	/* GD 14-bit right.  */
+#define R_PARISC_TLS_GDCALL	236	/* GD call to __t_g_a.  */
+#define R_PARISC_TLS_LDM21L	237	/* LD module 21-bit left.  */
+#define R_PARISC_TLS_LDM14R	238	/* LD module 14-bit right.  */
+#define R_PARISC_TLS_LDMCALL	239	/* LD module call to __t_g_a.  */
+#define R_PARISC_TLS_LDO21L	240	/* LD offset 21-bit left.  */
+#define R_PARISC_TLS_LDO14R	241	/* LD offset 14-bit right.  */
+#define R_PARISC_TLS_DTPMOD32	242	/* DTP module 32-bit.  */
+#define R_PARISC_TLS_DTPMOD64	243	/* DTP module 64-bit.  */
+#define R_PARISC_TLS_DTPOFF32	244	/* DTP offset 32-bit.  */
+#define R_PARISC_TLS_DTPOFF64	245	/* DTP offset 32-bit.  */
+#define R_PARISC_TLS_LE21L	R_PARISC_TPREL21L
+#define R_PARISC_TLS_LE14R	R_PARISC_TPREL14R
+#define R_PARISC_TLS_IE21L	R_PARISC_LTOFF_TP21L
+#define R_PARISC_TLS_IE14R	R_PARISC_LTOFF_TP14R
+#define R_PARISC_TLS_TPREL32	R_PARISC_TPREL32
+#define R_PARISC_TLS_TPREL64	R_PARISC_TPREL64
+#define R_PARISC_HIRESERVE	255
+
+/* Legal values for p_type field of Elf32_Phdr/Elf64_Phdr.  */
+
+#define PT_HP_TLS		(PT_LOOS + 0x0)
+#define PT_HP_CORE_NONE		(PT_LOOS + 0x1)
+#define PT_HP_CORE_VERSION	(PT_LOOS + 0x2)
+#define PT_HP_CORE_KERNEL	(PT_LOOS + 0x3)
+#define PT_HP_CORE_COMM		(PT_LOOS + 0x4)
+#define PT_HP_CORE_PROC		(PT_LOOS + 0x5)
+#define PT_HP_CORE_LOADABLE	(PT_LOOS + 0x6)
+#define PT_HP_CORE_STACK	(PT_LOOS + 0x7)
+#define PT_HP_CORE_SHM		(PT_LOOS + 0x8)
+#define PT_HP_CORE_MMF		(PT_LOOS + 0x9)
+#define PT_HP_PARALLEL		(PT_LOOS + 0x10)
+#define PT_HP_FASTBIND		(PT_LOOS + 0x11)
+#define PT_HP_OPT_ANNOT		(PT_LOOS + 0x12)
+#define PT_HP_HSL_ANNOT		(PT_LOOS + 0x13)
+#define PT_HP_STACK		(PT_LOOS + 0x14)
+
+#define PT_PARISC_ARCHEXT	0x70000000
+#define PT_PARISC_UNWIND	0x70000001
+
+/* Legal values for p_flags field of Elf32_Phdr/Elf64_Phdr.  */
+
+#define PF_PARISC_SBP		0x08000000
+
+#define PF_HP_PAGE_SIZE		0x00100000
+#define PF_HP_FAR_SHARED	0x00200000
+#define PF_HP_NEAR_SHARED	0x00400000
+#define PF_HP_CODE		0x01000000
+#define PF_HP_MODIFY		0x02000000
+#define PF_HP_LAZYSWAP		0x04000000
+#define PF_HP_SBP		0x08000000
+
+
+/* Alpha specific definitions.  */
+
+/* Legal values for e_flags field of Elf64_Ehdr.  */
+
+#define EF_ALPHA_32BIT		1	/* All addresses must be < 2GB.  */
+#define EF_ALPHA_CANRELAX	2	/* Relocations for relaxing exist.  */
+
+/* Legal values for sh_type field of Elf64_Shdr.  */
+
+/* These two are primerily concerned with ECOFF debugging info.  */
+#define SHT_ALPHA_DEBUG		0x70000001
+#define SHT_ALPHA_REGINFO	0x70000002
+
+/* Legal values for sh_flags field of Elf64_Shdr.  */
+
+#define SHF_ALPHA_GPREL		0x10000000
+
+/* Legal values for st_other field of Elf64_Sym.  */
+#define STO_ALPHA_NOPV		0x80	/* No PV required.  */
+#define STO_ALPHA_STD_GPLOAD	0x88	/* PV only used for initial ldgp.  */
+
+/* Alpha relocs.  */
+
+#define R_ALPHA_NONE		0	/* No reloc */
+#define R_ALPHA_REFLONG		1	/* Direct 32 bit */
+#define R_ALPHA_REFQUAD		2	/* Direct 64 bit */
+#define R_ALPHA_GPREL32		3	/* GP relative 32 bit */
+#define R_ALPHA_LITERAL		4	/* GP relative 16 bit w/optimization */
+#define R_ALPHA_LITUSE		5	/* Optimization hint for LITERAL */
+#define R_ALPHA_GPDISP		6	/* Add displacement to GP */
+#define R_ALPHA_BRADDR		7	/* PC+4 relative 23 bit shifted */
+#define R_ALPHA_HINT		8	/* PC+4 relative 16 bit shifted */
+#define R_ALPHA_SREL16		9	/* PC relative 16 bit */
+#define R_ALPHA_SREL32		10	/* PC relative 32 bit */
+#define R_ALPHA_SREL64		11	/* PC relative 64 bit */
+#define R_ALPHA_GPRELHIGH	17	/* GP relative 32 bit, high 16 bits */
+#define R_ALPHA_GPRELLOW	18	/* GP relative 32 bit, low 16 bits */
+#define R_ALPHA_GPREL16		19	/* GP relative 16 bit */
+#define R_ALPHA_COPY		24	/* Copy symbol at runtime */
+#define R_ALPHA_GLOB_DAT	25	/* Create GOT entry */
+#define R_ALPHA_JMP_SLOT	26	/* Create PLT entry */
+#define R_ALPHA_RELATIVE	27	/* Adjust by program base */
+#define R_ALPHA_TLS_GD_HI	28
+#define R_ALPHA_TLSGD		29
+#define R_ALPHA_TLS_LDM		30
+#define R_ALPHA_DTPMOD64	31
+#define R_ALPHA_GOTDTPREL	32
+#define R_ALPHA_DTPREL64	33
+#define R_ALPHA_DTPRELHI	34
+#define R_ALPHA_DTPRELLO	35
+#define R_ALPHA_DTPREL16	36
+#define R_ALPHA_GOTTPREL	37
+#define R_ALPHA_TPREL64		38
+#define R_ALPHA_TPRELHI		39
+#define R_ALPHA_TPRELLO		40
+#define R_ALPHA_TPREL16		41
+/* Keep this the last entry.  */
+#define R_ALPHA_NUM		46
+
+/* Magic values of the LITUSE relocation addend.  */
+#define LITUSE_ALPHA_ADDR	0
+#define LITUSE_ALPHA_BASE	1
+#define LITUSE_ALPHA_BYTOFF	2
+#define LITUSE_ALPHA_JSR	3
+#define LITUSE_ALPHA_TLS_GD	4
+#define LITUSE_ALPHA_TLS_LDM	5
+
+/* Legal values for d_tag of Elf64_Dyn.  */
+#define DT_ALPHA_PLTRO		(DT_LOPROC + 0)
+#define DT_ALPHA_NUM		1
+
+/* PowerPC specific declarations */
+
+/* Values for Elf32/64_Ehdr.e_flags.  */
+#define EF_PPC_EMB		0x80000000	/* PowerPC embedded flag */
+
+/* Cygnus local bits below */
+#define EF_PPC_RELOCATABLE	0x00010000	/* PowerPC -mrelocatable flag*/
+#define EF_PPC_RELOCATABLE_LIB	0x00008000	/* PowerPC -mrelocatable-lib
+						   flag */
+
+/* PowerPC relocations defined by the ABIs */
+#define R_PPC_NONE		0
+#define R_PPC_ADDR32		1	/* 32bit absolute address */
+#define R_PPC_ADDR24		2	/* 26bit address, 2 bits ignored.  */
+#define R_PPC_ADDR16		3	/* 16bit absolute address */
+#define R_PPC_ADDR16_LO		4	/* lower 16bit of absolute address */
+#define R_PPC_ADDR16_HI		5	/* high 16bit of absolute address */
+#define R_PPC_ADDR16_HA		6	/* adjusted high 16bit */
+#define R_PPC_ADDR14		7	/* 16bit address, 2 bits ignored */
+#define R_PPC_ADDR14_BRTAKEN	8
+#define R_PPC_ADDR14_BRNTAKEN	9
+#define R_PPC_REL24		10	/* PC relative 26 bit */
+#define R_PPC_REL14		11	/* PC relative 16 bit */
+#define R_PPC_REL14_BRTAKEN	12
+#define R_PPC_REL14_BRNTAKEN	13
+#define R_PPC_GOT16		14
+#define R_PPC_GOT16_LO		15
+#define R_PPC_GOT16_HI		16
+#define R_PPC_GOT16_HA		17
+#define R_PPC_PLTREL24		18
+#define R_PPC_COPY		19
+#define R_PPC_GLOB_DAT		20
+#define R_PPC_JMP_SLOT		21
+#define R_PPC_RELATIVE		22
+#define R_PPC_LOCAL24PC		23
+#define R_PPC_UADDR32		24
+#define R_PPC_UADDR16		25
+#define R_PPC_REL32		26
+#define R_PPC_PLT32		27
+#define R_PPC_PLTREL32		28
+#define R_PPC_PLT16_LO		29
+#define R_PPC_PLT16_HI		30
+#define R_PPC_PLT16_HA		31
+#define R_PPC_SDAREL16		32
+#define R_PPC_SECTOFF		33
+#define R_PPC_SECTOFF_LO	34
+#define R_PPC_SECTOFF_HI	35
+#define R_PPC_SECTOFF_HA	36
+
+/* PowerPC relocations defined for the TLS access ABI.  */
+#define R_PPC_TLS		67 /* none	(sym+add)@tls */
+#define R_PPC_DTPMOD32		68 /* word32	(sym+add)@dtpmod */
+#define R_PPC_TPREL16		69 /* half16*	(sym+add)@tprel */
+#define R_PPC_TPREL16_LO	70 /* half16	(sym+add)@tprel@l */
+#define R_PPC_TPREL16_HI	71 /* half16	(sym+add)@tprel@h */
+#define R_PPC_TPREL16_HA	72 /* half16	(sym+add)@tprel@ha */
+#define R_PPC_TPREL32		73 /* word32	(sym+add)@tprel */
+#define R_PPC_DTPREL16		74 /* half16*	(sym+add)@dtprel */
+#define R_PPC_DTPREL16_LO	75 /* half16	(sym+add)@dtprel@l */
+#define R_PPC_DTPREL16_HI	76 /* half16	(sym+add)@dtprel@h */
+#define R_PPC_DTPREL16_HA	77 /* half16	(sym+add)@dtprel@ha */
+#define R_PPC_DTPREL32		78 /* word32	(sym+add)@dtprel */
+#define R_PPC_GOT_TLSGD16	79 /* half16*	(sym+add)@got@tlsgd */
+#define R_PPC_GOT_TLSGD16_LO	80 /* half16	(sym+add)@got@tlsgd@l */
+#define R_PPC_GOT_TLSGD16_HI	81 /* half16	(sym+add)@got@tlsgd@h */
+#define R_PPC_GOT_TLSGD16_HA	82 /* half16	(sym+add)@got@tlsgd@ha */
+#define R_PPC_GOT_TLSLD16	83 /* half16*	(sym+add)@got@tlsld */
+#define R_PPC_GOT_TLSLD16_LO	84 /* half16	(sym+add)@got@tlsld@l */
+#define R_PPC_GOT_TLSLD16_HI	85 /* half16	(sym+add)@got@tlsld@h */
+#define R_PPC_GOT_TLSLD16_HA	86 /* half16	(sym+add)@got@tlsld@ha */
+#define R_PPC_GOT_TPREL16	87 /* half16*	(sym+add)@got@tprel */
+#define R_PPC_GOT_TPREL16_LO	88 /* half16	(sym+add)@got@tprel@l */
+#define R_PPC_GOT_TPREL16_HI	89 /* half16	(sym+add)@got@tprel@h */
+#define R_PPC_GOT_TPREL16_HA	90 /* half16	(sym+add)@got@tprel@ha */
+#define R_PPC_GOT_DTPREL16	91 /* half16*	(sym+add)@got@dtprel */
+#define R_PPC_GOT_DTPREL16_LO	92 /* half16*	(sym+add)@got@dtprel@l */
+#define R_PPC_GOT_DTPREL16_HI	93 /* half16*	(sym+add)@got@dtprel@h */
+#define R_PPC_GOT_DTPREL16_HA	94 /* half16*	(sym+add)@got@dtprel@ha */
+#define R_PPC_TLSGD		95 /* none	(sym+add)@tlsgd */
+#define R_PPC_TLSLD		96 /* none	(sym+add)@tlsld */
+
+/* The remaining relocs are from the Embedded ELF ABI, and are not
+   in the SVR4 ELF ABI.  */
+#define R_PPC_EMB_NADDR32	101
+#define R_PPC_EMB_NADDR16	102
+#define R_PPC_EMB_NADDR16_LO	103
+#define R_PPC_EMB_NADDR16_HI	104
+#define R_PPC_EMB_NADDR16_HA	105
+#define R_PPC_EMB_SDAI16	106
+#define R_PPC_EMB_SDA2I16	107
+#define R_PPC_EMB_SDA2REL	108
+#define R_PPC_EMB_SDA21		109	/* 16 bit offset in SDA */
+#define R_PPC_EMB_MRKREF	110
+#define R_PPC_EMB_RELSEC16	111
+#define R_PPC_EMB_RELST_LO	112
+#define R_PPC_EMB_RELST_HI	113
+#define R_PPC_EMB_RELST_HA	114
+#define R_PPC_EMB_BIT_FLD	115
+#define R_PPC_EMB_RELSDA	116	/* 16 bit relative offset in SDA */
+
+/* Diab tool relocations.  */
+#define R_PPC_DIAB_SDA21_LO	180	/* like EMB_SDA21, but lower 16 bit */
+#define R_PPC_DIAB_SDA21_HI	181	/* like EMB_SDA21, but high 16 bit */
+#define R_PPC_DIAB_SDA21_HA	182	/* like EMB_SDA21, adjusted high 16 */
+#define R_PPC_DIAB_RELSDA_LO	183	/* like EMB_RELSDA, but lower 16 bit */
+#define R_PPC_DIAB_RELSDA_HI	184	/* like EMB_RELSDA, but high 16 bit */
+#define R_PPC_DIAB_RELSDA_HA	185	/* like EMB_RELSDA, adjusted high 16 */
+
+/* GNU extension to support local ifunc.  */
+#define R_PPC_IRELATIVE		248
+
+/* GNU relocs used in PIC code sequences.  */
+#define R_PPC_REL16		249	/* half16   (sym+add-.) */
+#define R_PPC_REL16_LO		250	/* half16   (sym+add-.)@l */
+#define R_PPC_REL16_HI		251	/* half16   (sym+add-.)@h */
+#define R_PPC_REL16_HA		252	/* half16   (sym+add-.)@ha */
+
+/* This is a phony reloc to handle any old fashioned TOC16 references
+   that may still be in object files.  */
+#define R_PPC_TOC16		255
+
+/* PowerPC specific values for the Dyn d_tag field.  */
+#define DT_PPC_GOT		(DT_LOPROC + 0)
+#define DT_PPC_OPT		(DT_LOPROC + 1)
+#define DT_PPC_NUM		2
+
+/* PowerPC specific values for the DT_PPC_OPT Dyn entry.  */
+#define PPC_OPT_TLS		1
+
+/* PowerPC64 relocations defined by the ABIs */
+#define R_PPC64_NONE		R_PPC_NONE
+#define R_PPC64_ADDR32		R_PPC_ADDR32 /* 32bit absolute address */
+#define R_PPC64_ADDR24		R_PPC_ADDR24 /* 26bit address, word aligned */
+#define R_PPC64_ADDR16		R_PPC_ADDR16 /* 16bit absolute address */
+#define R_PPC64_ADDR16_LO	R_PPC_ADDR16_LO	/* lower 16bits of address */
+#define R_PPC64_ADDR16_HI	R_PPC_ADDR16_HI	/* high 16bits of address. */
+#define R_PPC64_ADDR16_HA	R_PPC_ADDR16_HA /* adjusted high 16bits.  */
+#define R_PPC64_ADDR14		R_PPC_ADDR14 /* 16bit address, word aligned */
+#define R_PPC64_ADDR14_BRTAKEN	R_PPC_ADDR14_BRTAKEN
+#define R_PPC64_ADDR14_BRNTAKEN	R_PPC_ADDR14_BRNTAKEN
+#define R_PPC64_REL24		R_PPC_REL24 /* PC-rel. 26 bit, word aligned */
+#define R_PPC64_REL14		R_PPC_REL14 /* PC relative 16 bit */
+#define R_PPC64_REL14_BRTAKEN	R_PPC_REL14_BRTAKEN
+#define R_PPC64_REL14_BRNTAKEN	R_PPC_REL14_BRNTAKEN
+#define R_PPC64_GOT16		R_PPC_GOT16
+#define R_PPC64_GOT16_LO	R_PPC_GOT16_LO
+#define R_PPC64_GOT16_HI	R_PPC_GOT16_HI
+#define R_PPC64_GOT16_HA	R_PPC_GOT16_HA
+
+#define R_PPC64_COPY		R_PPC_COPY
+#define R_PPC64_GLOB_DAT	R_PPC_GLOB_DAT
+#define R_PPC64_JMP_SLOT	R_PPC_JMP_SLOT
+#define R_PPC64_RELATIVE	R_PPC_RELATIVE
+
+#define R_PPC64_UADDR32		R_PPC_UADDR32
+#define R_PPC64_UADDR16		R_PPC_UADDR16
+#define R_PPC64_REL32		R_PPC_REL32
+#define R_PPC64_PLT32		R_PPC_PLT32
+#define R_PPC64_PLTREL32	R_PPC_PLTREL32
+#define R_PPC64_PLT16_LO	R_PPC_PLT16_LO
+#define R_PPC64_PLT16_HI	R_PPC_PLT16_HI
+#define R_PPC64_PLT16_HA	R_PPC_PLT16_HA
+
+#define R_PPC64_SECTOFF		R_PPC_SECTOFF
+#define R_PPC64_SECTOFF_LO	R_PPC_SECTOFF_LO
+#define R_PPC64_SECTOFF_HI	R_PPC_SECTOFF_HI
+#define R_PPC64_SECTOFF_HA	R_PPC_SECTOFF_HA
+#define R_PPC64_ADDR30		37 /* word30 (S + A - P) >> 2 */
+#define R_PPC64_ADDR64		38 /* doubleword64 S + A */
+#define R_PPC64_ADDR16_HIGHER	39 /* half16 #higher(S + A) */
+#define R_PPC64_ADDR16_HIGHERA	40 /* half16 #highera(S + A) */
+#define R_PPC64_ADDR16_HIGHEST	41 /* half16 #highest(S + A) */
+#define R_PPC64_ADDR16_HIGHESTA	42 /* half16 #highesta(S + A) */
+#define R_PPC64_UADDR64		43 /* doubleword64 S + A */
+#define R_PPC64_REL64		44 /* doubleword64 S + A - P */
+#define R_PPC64_PLT64		45 /* doubleword64 L + A */
+#define R_PPC64_PLTREL64	46 /* doubleword64 L + A - P */
+#define R_PPC64_TOC16		47 /* half16* S + A - .TOC */
+#define R_PPC64_TOC16_LO	48 /* half16 #lo(S + A - .TOC.) */
+#define R_PPC64_TOC16_HI	49 /* half16 #hi(S + A - .TOC.) */
+#define R_PPC64_TOC16_HA	50 /* half16 #ha(S + A - .TOC.) */
+#define R_PPC64_TOC		51 /* doubleword64 .TOC */
+#define R_PPC64_PLTGOT16	52 /* half16* M + A */
+#define R_PPC64_PLTGOT16_LO	53 /* half16 #lo(M + A) */
+#define R_PPC64_PLTGOT16_HI	54 /* half16 #hi(M + A) */
+#define R_PPC64_PLTGOT16_HA	55 /* half16 #ha(M + A) */
+
+#define R_PPC64_ADDR16_DS	56 /* half16ds* (S + A) >> 2 */
+#define R_PPC64_ADDR16_LO_DS	57 /* half16ds  #lo(S + A) >> 2 */
+#define R_PPC64_GOT16_DS	58 /* half16ds* (G + A) >> 2 */
+#define R_PPC64_GOT16_LO_DS	59 /* half16ds  #lo(G + A) >> 2 */
+#define R_PPC64_PLT16_LO_DS	60 /* half16ds  #lo(L + A) >> 2 */
+#define R_PPC64_SECTOFF_DS	61 /* half16ds* (R + A) >> 2 */
+#define R_PPC64_SECTOFF_LO_DS	62 /* half16ds  #lo(R + A) >> 2 */
+#define R_PPC64_TOC16_DS	63 /* half16ds* (S + A - .TOC.) >> 2 */
+#define R_PPC64_TOC16_LO_DS	64 /* half16ds  #lo(S + A - .TOC.) >> 2 */
+#define R_PPC64_PLTGOT16_DS	65 /* half16ds* (M + A) >> 2 */
+#define R_PPC64_PLTGOT16_LO_DS	66 /* half16ds  #lo(M + A) >> 2 */
+
+/* PowerPC64 relocations defined for the TLS access ABI.  */
+#define R_PPC64_TLS		67 /* none	(sym+add)@tls */
+#define R_PPC64_DTPMOD64	68 /* doubleword64 (sym+add)@dtpmod */
+#define R_PPC64_TPREL16		69 /* half16*	(sym+add)@tprel */
+#define R_PPC64_TPREL16_LO	70 /* half16	(sym+add)@tprel@l */
+#define R_PPC64_TPREL16_HI	71 /* half16	(sym+add)@tprel@h */
+#define R_PPC64_TPREL16_HA	72 /* half16	(sym+add)@tprel@ha */
+#define R_PPC64_TPREL64		73 /* doubleword64 (sym+add)@tprel */
+#define R_PPC64_DTPREL16	74 /* half16*	(sym+add)@dtprel */
+#define R_PPC64_DTPREL16_LO	75 /* half16	(sym+add)@dtprel@l */
+#define R_PPC64_DTPREL16_HI	76 /* half16	(sym+add)@dtprel@h */
+#define R_PPC64_DTPREL16_HA	77 /* half16	(sym+add)@dtprel@ha */
+#define R_PPC64_DTPREL64	78 /* doubleword64 (sym+add)@dtprel */
+#define R_PPC64_GOT_TLSGD16	79 /* half16*	(sym+add)@got@tlsgd */
+#define R_PPC64_GOT_TLSGD16_LO	80 /* half16	(sym+add)@got@tlsgd@l */
+#define R_PPC64_GOT_TLSGD16_HI	81 /* half16	(sym+add)@got@tlsgd@h */
+#define R_PPC64_GOT_TLSGD16_HA	82 /* half16	(sym+add)@got@tlsgd@ha */
+#define R_PPC64_GOT_TLSLD16	83 /* half16*	(sym+add)@got@tlsld */
+#define R_PPC64_GOT_TLSLD16_LO	84 /* half16	(sym+add)@got@tlsld@l */
+#define R_PPC64_GOT_TLSLD16_HI	85 /* half16	(sym+add)@got@tlsld@h */
+#define R_PPC64_GOT_TLSLD16_HA	86 /* half16	(sym+add)@got@tlsld@ha */
+#define R_PPC64_GOT_TPREL16_DS	87 /* half16ds*	(sym+add)@got@tprel */
+#define R_PPC64_GOT_TPREL16_LO_DS 88 /* half16ds (sym+add)@got@tprel@l */
+#define R_PPC64_GOT_TPREL16_HI	89 /* half16	(sym+add)@got@tprel@h */
+#define R_PPC64_GOT_TPREL16_HA	90 /* half16	(sym+add)@got@tprel@ha */
+#define R_PPC64_GOT_DTPREL16_DS	91 /* half16ds*	(sym+add)@got@dtprel */
+#define R_PPC64_GOT_DTPREL16_LO_DS 92 /* half16ds (sym+add)@got@dtprel@l */
+#define R_PPC64_GOT_DTPREL16_HI	93 /* half16	(sym+add)@got@dtprel@h */
+#define R_PPC64_GOT_DTPREL16_HA	94 /* half16	(sym+add)@got@dtprel@ha */
+#define R_PPC64_TPREL16_DS	95 /* half16ds*	(sym+add)@tprel */
+#define R_PPC64_TPREL16_LO_DS	96 /* half16ds	(sym+add)@tprel@l */
+#define R_PPC64_TPREL16_HIGHER	97 /* half16	(sym+add)@tprel@higher */
+#define R_PPC64_TPREL16_HIGHERA	98 /* half16	(sym+add)@tprel@highera */
+#define R_PPC64_TPREL16_HIGHEST	99 /* half16	(sym+add)@tprel@highest */
+#define R_PPC64_TPREL16_HIGHESTA 100 /* half16	(sym+add)@tprel@highesta */
+#define R_PPC64_DTPREL16_DS	101 /* half16ds* (sym+add)@dtprel */
+#define R_PPC64_DTPREL16_LO_DS	102 /* half16ds	(sym+add)@dtprel@l */
+#define R_PPC64_DTPREL16_HIGHER	103 /* half16	(sym+add)@dtprel@higher */
+#define R_PPC64_DTPREL16_HIGHERA 104 /* half16	(sym+add)@dtprel@highera */
+#define R_PPC64_DTPREL16_HIGHEST 105 /* half16	(sym+add)@dtprel@highest */
+#define R_PPC64_DTPREL16_HIGHESTA 106 /* half16	(sym+add)@dtprel@highesta */
+#define R_PPC64_TLSGD		107 /* none	(sym+add)@tlsgd */
+#define R_PPC64_TLSLD		108 /* none	(sym+add)@tlsld */
+#define R_PPC64_TOCSAVE		109 /* none */
+
+/* Added when HA and HI relocs were changed to report overflows.  */
+#define R_PPC64_ADDR16_HIGH	110
+#define R_PPC64_ADDR16_HIGHA	111
+#define R_PPC64_TPREL16_HIGH	112
+#define R_PPC64_TPREL16_HIGHA	113
+#define R_PPC64_DTPREL16_HIGH	114
+#define R_PPC64_DTPREL16_HIGHA	115
+
+/* GNU extension to support local ifunc.  */
+#define R_PPC64_JMP_IREL	247
+#define R_PPC64_IRELATIVE	248
+#define R_PPC64_REL16		249	/* half16   (sym+add-.) */
+#define R_PPC64_REL16_LO	250	/* half16   (sym+add-.)@l */
+#define R_PPC64_REL16_HI	251	/* half16   (sym+add-.)@h */
+#define R_PPC64_REL16_HA	252	/* half16   (sym+add-.)@ha */
+
+/* e_flags bits specifying ABI.
+   1 for original function descriptor using ABI,
+   2 for revised ABI without function descriptors,
+   0 for unspecified or not using any features affected by the differences.  */
+#define EF_PPC64_ABI	3
+
+/* PowerPC64 specific values for the Dyn d_tag field.  */
+#define DT_PPC64_GLINK  (DT_LOPROC + 0)
+#define DT_PPC64_OPD	(DT_LOPROC + 1)
+#define DT_PPC64_OPDSZ	(DT_LOPROC + 2)
+#define DT_PPC64_OPT	(DT_LOPROC + 3)
+#define DT_PPC64_NUM    4
+
+/* PowerPC64 specific bits in the DT_PPC64_OPT Dyn entry.  */
+#define PPC64_OPT_TLS		1
+#define PPC64_OPT_MULTI_TOC	2
+#define PPC64_OPT_LOCALENTRY	4
+
+/* PowerPC64 specific values for the Elf64_Sym st_other field.  */
+#define STO_PPC64_LOCAL_BIT	5
+#define STO_PPC64_LOCAL_MASK	(7 << STO_PPC64_LOCAL_BIT)
+#define PPC64_LOCAL_ENTRY_OFFSET(other)				\
+ (((1 << (((other) & STO_PPC64_LOCAL_MASK) >> STO_PPC64_LOCAL_BIT)) >> 2) << 2)
+
+
+/* ARM specific declarations */
+
+/* Processor specific flags for the ELF header e_flags field.  */
+#define EF_ARM_RELEXEC		0x01
+#define EF_ARM_HASENTRY		0x02
+#define EF_ARM_INTERWORK	0x04
+#define EF_ARM_APCS_26		0x08
+#define EF_ARM_APCS_FLOAT	0x10
+#define EF_ARM_PIC		0x20
+#define EF_ARM_ALIGN8		0x40 /* 8-bit structure alignment is in use */
+#define EF_ARM_NEW_ABI		0x80
+#define EF_ARM_OLD_ABI		0x100
+#define EF_ARM_SOFT_FLOAT	0x200
+#define EF_ARM_VFP_FLOAT	0x400
+#define EF_ARM_MAVERICK_FLOAT	0x800
+
+#define EF_ARM_ABI_FLOAT_SOFT	0x200   /* NB conflicts with EF_ARM_SOFT_FLOAT */
+#define EF_ARM_ABI_FLOAT_HARD	0x400   /* NB conflicts with EF_ARM_VFP_FLOAT */
+
+
+/* Other constants defined in the ARM ELF spec. version B-01.  */
+/* NB. These conflict with values defined above.  */
+#define EF_ARM_SYMSARESORTED	0x04
+#define EF_ARM_DYNSYMSUSESEGIDX	0x08
+#define EF_ARM_MAPSYMSFIRST	0x10
+#define EF_ARM_EABIMASK		0XFF000000
+
+/* Constants defined in AAELF.  */
+#define EF_ARM_BE8	    0x00800000
+#define EF_ARM_LE8	    0x00400000
+
+#define EF_ARM_EABI_VERSION(flags)	((flags) & EF_ARM_EABIMASK)
+#define EF_ARM_EABI_UNKNOWN	0x00000000
+#define EF_ARM_EABI_VER1	0x01000000
+#define EF_ARM_EABI_VER2	0x02000000
+#define EF_ARM_EABI_VER3	0x03000000
+#define EF_ARM_EABI_VER4	0x04000000
+#define EF_ARM_EABI_VER5	0x05000000
+
+/* Additional symbol types for Thumb.  */
+#define STT_ARM_TFUNC		STT_LOPROC /* A Thumb function.  */
+#define STT_ARM_16BIT		STT_HIPROC /* A Thumb label.  */
+
+/* ARM-specific values for sh_flags */
+#define SHF_ARM_ENTRYSECT	0x10000000 /* Section contains an entry point */
+#define SHF_ARM_COMDEF		0x80000000 /* Section may be multiply defined
+					      in the input to a link step.  */
+
+/* ARM-specific program header flags */
+#define PF_ARM_SB		0x10000000 /* Segment contains the location
+					      addressed by the static base. */
+#define PF_ARM_PI		0x20000000 /* Position-independent segment.  */
+#define PF_ARM_ABS		0x40000000 /* Absolute segment.  */
+
+/* Processor specific values for the Phdr p_type field.  */
+#define PT_ARM_EXIDX		(PT_LOPROC + 1)	/* ARM unwind segment.  */
+
+/* Processor specific values for the Shdr sh_type field.  */
+#define SHT_ARM_EXIDX		(SHT_LOPROC + 1) /* ARM unwind section.  */
+#define SHT_ARM_PREEMPTMAP	(SHT_LOPROC + 2) /* Preemption details.  */
+#define SHT_ARM_ATTRIBUTES	(SHT_LOPROC + 3) /* ARM attributes section.  */
+
+
+/* AArch64 relocs.  */
+
+#define R_AARCH64_NONE            0	/* No relocation.  */
+
+/* ILP32 AArch64 relocs.  */
+#define R_AARCH64_P32_ABS32		  1	/* Direct 32 bit.  */
+#define R_AARCH64_P32_COPY		180	/* Copy symbol at runtime.  */
+#define R_AARCH64_P32_GLOB_DAT		181	/* Create GOT entry.  */
+#define R_AARCH64_P32_JUMP_SLOT		182	/* Create PLT entry.  */
+#define R_AARCH64_P32_RELATIVE		183	/* Adjust by program base.  */
+#define R_AARCH64_P32_TLS_DTPMOD	184	/* Module number, 32 bit.  */
+#define R_AARCH64_P32_TLS_DTPREL	185	/* Module-relative offset, 32 bit.  */
+#define R_AARCH64_P32_TLS_TPREL		186	/* TP-relative offset, 32 bit.  */
+#define R_AARCH64_P32_TLSDESC		187	/* TLS Descriptor.  */
+#define R_AARCH64_P32_IRELATIVE		188	/* STT_GNU_IFUNC relocation. */
+
+/* LP64 AArch64 relocs.  */
+#define R_AARCH64_ABS64         257	/* Direct 64 bit. */
+#define R_AARCH64_ABS32         258	/* Direct 32 bit.  */
+#define R_AARCH64_ABS16		259	/* Direct 16-bit.  */
+#define R_AARCH64_PREL64	260	/* PC-relative 64-bit.	*/
+#define R_AARCH64_PREL32	261	/* PC-relative 32-bit.	*/
+#define R_AARCH64_PREL16	262	/* PC-relative 16-bit.	*/
+#define R_AARCH64_MOVW_UABS_G0	263	/* Dir. MOVZ imm. from bits 15:0.  */
+#define R_AARCH64_MOVW_UABS_G0_NC 264	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_UABS_G1	265	/* Dir. MOVZ imm. from bits 31:16.  */
+#define R_AARCH64_MOVW_UABS_G1_NC 266	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_UABS_G2	267	/* Dir. MOVZ imm. from bits 47:32.  */
+#define R_AARCH64_MOVW_UABS_G2_NC 268	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_UABS_G3	269	/* Dir. MOV{K,Z} imm. from 63:48.  */
+#define R_AARCH64_MOVW_SABS_G0	270	/* Dir. MOV{N,Z} imm. from 15:0.  */
+#define R_AARCH64_MOVW_SABS_G1	271	/* Dir. MOV{N,Z} imm. from 31:16.  */
+#define R_AARCH64_MOVW_SABS_G2	272	/* Dir. MOV{N,Z} imm. from 47:32.  */
+#define R_AARCH64_LD_PREL_LO19	273	/* PC-rel. LD imm. from bits 20:2.  */
+#define R_AARCH64_ADR_PREL_LO21	274	/* PC-rel. ADR imm. from bits 20:0.  */
+#define R_AARCH64_ADR_PREL_PG_HI21 275	/* Page-rel. ADRP imm. from 32:12.  */
+#define R_AARCH64_ADR_PREL_PG_HI21_NC 276 /* Likewise; no overflow check.  */
+#define R_AARCH64_ADD_ABS_LO12_NC 277	/* Dir. ADD imm. from bits 11:0.  */
+#define R_AARCH64_LDST8_ABS_LO12_NC 278	/* Likewise for LD/ST; no check. */
+#define R_AARCH64_TSTBR14	279	/* PC-rel. TBZ/TBNZ imm. from 15:2.  */
+#define R_AARCH64_CONDBR19	280	/* PC-rel. cond. br. imm. from 20:2. */
+#define R_AARCH64_JUMP26	282	/* PC-rel. B imm. from bits 27:2.  */
+#define R_AARCH64_CALL26	283	/* Likewise for CALL.  */
+#define R_AARCH64_LDST16_ABS_LO12_NC 284 /* Dir. ADD imm. from bits 11:1.  */
+#define R_AARCH64_LDST32_ABS_LO12_NC 285 /* Likewise for bits 11:2.  */
+#define R_AARCH64_LDST64_ABS_LO12_NC 286 /* Likewise for bits 11:3.  */
+#define R_AARCH64_MOVW_PREL_G0	287	/* PC-rel. MOV{N,Z} imm. from 15:0.  */
+#define R_AARCH64_MOVW_PREL_G0_NC 288	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_PREL_G1	289	/* PC-rel. MOV{N,Z} imm. from 31:16. */
+#define R_AARCH64_MOVW_PREL_G1_NC 290	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_PREL_G2	291	/* PC-rel. MOV{N,Z} imm. from 47:32. */
+#define R_AARCH64_MOVW_PREL_G2_NC 292	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_PREL_G3	293	/* PC-rel. MOV{N,Z} imm. from 63:48. */
+#define R_AARCH64_LDST128_ABS_LO12_NC 299 /* Dir. ADD imm. from bits 11:4.  */
+#define R_AARCH64_MOVW_GOTOFF_G0 300	/* GOT-rel. off. MOV{N,Z} imm. 15:0. */
+#define R_AARCH64_MOVW_GOTOFF_G0_NC 301	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_GOTOFF_G1 302	/* GOT-rel. o. MOV{N,Z} imm. 31:16.  */
+#define R_AARCH64_MOVW_GOTOFF_G1_NC 303	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_GOTOFF_G2 304	/* GOT-rel. o. MOV{N,Z} imm. 47:32.  */
+#define R_AARCH64_MOVW_GOTOFF_G2_NC 305	/* Likewise for MOVK; no check.  */
+#define R_AARCH64_MOVW_GOTOFF_G3 306	/* GOT-rel. o. MOV{N,Z} imm. 63:48.  */
+#define R_AARCH64_GOTREL64	307	/* GOT-relative 64-bit.  */
+#define R_AARCH64_GOTREL32	308	/* GOT-relative 32-bit.  */
+#define R_AARCH64_GOT_LD_PREL19	309	/* PC-rel. GOT off. load imm. 20:2.  */
+#define R_AARCH64_LD64_GOTOFF_LO15 310	/* GOT-rel. off. LD/ST imm. 14:3.  */
+#define R_AARCH64_ADR_GOT_PAGE	311	/* P-page-rel. GOT off. ADRP 32:12.  */
+#define R_AARCH64_LD64_GOT_LO12_NC 312	/* Dir. GOT off. LD/ST imm. 11:3.  */
+#define R_AARCH64_LD64_GOTPAGE_LO15 313	/* GOT-page-rel. GOT off. LD/ST 14:3 */
+#define R_AARCH64_TLSGD_ADR_PREL21 512	/* PC-relative ADR imm. 20:0.  */
+#define R_AARCH64_TLSGD_ADR_PAGE21 513	/* page-rel. ADRP imm. 32:12.  */
+#define R_AARCH64_TLSGD_ADD_LO12_NC 514	/* direct ADD imm. from 11:0.  */
+#define R_AARCH64_TLSGD_MOVW_G1	515	/* GOT-rel. MOV{N,Z} 31:16.  */
+#define R_AARCH64_TLSGD_MOVW_G0_NC 516	/* GOT-rel. MOVK imm. 15:0.  */
+#define R_AARCH64_TLSLD_ADR_PREL21 517	/* Like 512; local dynamic model.  */
+#define R_AARCH64_TLSLD_ADR_PAGE21 518	/* Like 513; local dynamic model.  */
+#define R_AARCH64_TLSLD_ADD_LO12_NC 519	/* Like 514; local dynamic model.  */
+#define R_AARCH64_TLSLD_MOVW_G1	520	/* Like 515; local dynamic model.  */
+#define R_AARCH64_TLSLD_MOVW_G0_NC 521	/* Like 516; local dynamic model.  */
+#define R_AARCH64_TLSLD_LD_PREL19 522	/* TLS PC-rel. load imm. 20:2.  */
+#define R_AARCH64_TLSLD_MOVW_DTPREL_G2 523 /* TLS DTP-rel. MOV{N,Z} 47:32.  */
+#define R_AARCH64_TLSLD_MOVW_DTPREL_G1 524 /* TLS DTP-rel. MOV{N,Z} 31:16.  */
+#define R_AARCH64_TLSLD_MOVW_DTPREL_G1_NC 525 /* Likewise; MOVK; no check.  */
+#define R_AARCH64_TLSLD_MOVW_DTPREL_G0 526 /* TLS DTP-rel. MOV{N,Z} 15:0.  */
+#define R_AARCH64_TLSLD_MOVW_DTPREL_G0_NC 527 /* Likewise; MOVK; no check.  */
+#define R_AARCH64_TLSLD_ADD_DTPREL_HI12 528 /* DTP-rel. ADD imm. from 23:12. */
+#define R_AARCH64_TLSLD_ADD_DTPREL_LO12 529 /* DTP-rel. ADD imm. from 11:0.  */
+#define R_AARCH64_TLSLD_ADD_DTPREL_LO12_NC 530 /* Likewise; no ovfl. check.  */
+#define R_AARCH64_TLSLD_LDST8_DTPREL_LO12 531 /* DTP-rel. LD/ST imm. 11:0.  */
+#define R_AARCH64_TLSLD_LDST8_DTPREL_LO12_NC 532 /* Likewise; no check.  */
+#define R_AARCH64_TLSLD_LDST16_DTPREL_LO12 533 /* DTP-rel. LD/ST imm. 11:1.  */
+#define R_AARCH64_TLSLD_LDST16_DTPREL_LO12_NC 534 /* Likewise; no check.  */
+#define R_AARCH64_TLSLD_LDST32_DTPREL_LO12 535 /* DTP-rel. LD/ST imm. 11:2.  */
+#define R_AARCH64_TLSLD_LDST32_DTPREL_LO12_NC 536 /* Likewise; no check.  */
+#define R_AARCH64_TLSLD_LDST64_DTPREL_LO12 537 /* DTP-rel. LD/ST imm. 11:3.  */
+#define R_AARCH64_TLSLD_LDST64_DTPREL_LO12_NC 538 /* Likewise; no check.  */
+#define R_AARCH64_TLSIE_MOVW_GOTTPREL_G1 539 /* GOT-rel. MOV{N,Z} 31:16.  */
+#define R_AARCH64_TLSIE_MOVW_GOTTPREL_G0_NC 540 /* GOT-rel. MOVK 15:0.  */
+#define R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21 541 /* Page-rel. ADRP 32:12.  */
+#define R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC 542 /* Direct LD off. 11:3.  */
+#define R_AARCH64_TLSIE_LD_GOTTPREL_PREL19 543 /* PC-rel. load imm. 20:2.  */
+#define R_AARCH64_TLSLE_MOVW_TPREL_G2 544 /* TLS TP-rel. MOV{N,Z} 47:32.  */
+#define R_AARCH64_TLSLE_MOVW_TPREL_G1 545 /* TLS TP-rel. MOV{N,Z} 31:16.  */
+#define R_AARCH64_TLSLE_MOVW_TPREL_G1_NC 546 /* Likewise; MOVK; no check.  */
+#define R_AARCH64_TLSLE_MOVW_TPREL_G0 547 /* TLS TP-rel. MOV{N,Z} 15:0.  */
+#define R_AARCH64_TLSLE_MOVW_TPREL_G0_NC 548 /* Likewise; MOVK; no check.  */
+#define R_AARCH64_TLSLE_ADD_TPREL_HI12 549 /* TP-rel. ADD imm. 23:12.  */
+#define R_AARCH64_TLSLE_ADD_TPREL_LO12 550 /* TP-rel. ADD imm. 11:0.  */
+#define R_AARCH64_TLSLE_ADD_TPREL_LO12_NC 551 /* Likewise; no ovfl. check.  */
+#define R_AARCH64_TLSLE_LDST8_TPREL_LO12 552 /* TP-rel. LD/ST off. 11:0.  */
+#define R_AARCH64_TLSLE_LDST8_TPREL_LO12_NC 553 /* Likewise; no ovfl. check. */
+#define R_AARCH64_TLSLE_LDST16_TPREL_LO12 554 /* TP-rel. LD/ST off. 11:1.  */
+#define R_AARCH64_TLSLE_LDST16_TPREL_LO12_NC 555 /* Likewise; no check.  */
+#define R_AARCH64_TLSLE_LDST32_TPREL_LO12 556 /* TP-rel. LD/ST off. 11:2.  */
+#define R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC 557 /* Likewise; no check.  */
+#define R_AARCH64_TLSLE_LDST64_TPREL_LO12 558 /* TP-rel. LD/ST off. 11:3.  */
+#define R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC 559 /* Likewise; no check.  */
+#define R_AARCH64_TLSDESC_LD_PREL19 560	/* PC-rel. load immediate 20:2.  */
+#define R_AARCH64_TLSDESC_ADR_PREL21 561 /* PC-rel. ADR immediate 20:0.  */
+#define R_AARCH64_TLSDESC_ADR_PAGE21 562 /* Page-rel. ADRP imm. 32:12.  */
+#define R_AARCH64_TLSDESC_LD64_LO12 563	/* Direct LD off. from 11:3.  */
+#define R_AARCH64_TLSDESC_ADD_LO12 564	/* Direct ADD imm. from 11:0.  */
+#define R_AARCH64_TLSDESC_OFF_G1 565	/* GOT-rel. MOV{N,Z} imm. 31:16.  */
+#define R_AARCH64_TLSDESC_OFF_G0_NC 566	/* GOT-rel. MOVK imm. 15:0; no ck.  */
+#define R_AARCH64_TLSDESC_LDR	567	/* Relax LDR.  */
+#define R_AARCH64_TLSDESC_ADD	568	/* Relax ADD.  */
+#define R_AARCH64_TLSDESC_CALL	569	/* Relax BLR.  */
+#define R_AARCH64_TLSLE_LDST128_TPREL_LO12 570 /* TP-rel. LD/ST off. 11:4.  */
+#define R_AARCH64_TLSLE_LDST128_TPREL_LO12_NC 571 /* Likewise; no check.  */
+#define R_AARCH64_TLSLD_LDST128_DTPREL_LO12 572 /* DTP-rel. LD/ST imm. 11:4. */
+#define R_AARCH64_TLSLD_LDST128_DTPREL_LO12_NC 573 /* Likewise; no check.  */
+#define R_AARCH64_COPY         1024	/* Copy symbol at runtime.  */
+#define R_AARCH64_GLOB_DAT     1025	/* Create GOT entry.  */
+#define R_AARCH64_JUMP_SLOT    1026	/* Create PLT entry.  */
+#define R_AARCH64_RELATIVE     1027	/* Adjust by program base.  */
+#define R_AARCH64_TLS_DTPMOD   1028	/* Module number, 64 bit.  */
+#define R_AARCH64_TLS_DTPREL   1029	/* Module-relative offset, 64 bit.  */
+#define R_AARCH64_TLS_TPREL    1030	/* TP-relative offset, 64 bit.  */
+#define R_AARCH64_TLSDESC      1031	/* TLS Descriptor.  */
+#define R_AARCH64_IRELATIVE	1032	/* STT_GNU_IFUNC relocation.  */
+
+/* AArch64 specific values for the Dyn d_tag field.  */
+#define DT_AARCH64_VARIANT_PCS	(DT_LOPROC + 5)
+#define DT_AARCH64_NUM		6
+
+/* AArch64 specific values for the st_other field.  */
+#define STO_AARCH64_VARIANT_PCS 0x80
+
+/* ARM relocs.  */
+
+#define R_ARM_NONE		0	/* No reloc */
+#define R_ARM_PC24		1	/* Deprecated PC relative 26
+					   bit branch.  */
+#define R_ARM_ABS32		2	/* Direct 32 bit  */
+#define R_ARM_REL32		3	/* PC relative 32 bit */
+#define R_ARM_PC13		4
+#define R_ARM_ABS16		5	/* Direct 16 bit */
+#define R_ARM_ABS12		6	/* Direct 12 bit */
+#define R_ARM_THM_ABS5		7	/* Direct & 0x7C (LDR, STR).  */
+#define R_ARM_ABS8		8	/* Direct 8 bit */
+#define R_ARM_SBREL32		9
+#define R_ARM_THM_PC22		10	/* PC relative 24 bit (Thumb32 BL).  */
+#define R_ARM_THM_PC8		11	/* PC relative & 0x3FC
+					   (Thumb16 LDR, ADD, ADR).  */
+#define R_ARM_AMP_VCALL9	12
+#define R_ARM_SWI24		13	/* Obsolete static relocation.  */
+#define R_ARM_TLS_DESC		13      /* Dynamic relocation.  */
+#define R_ARM_THM_SWI8		14	/* Reserved.  */
+#define R_ARM_XPC25		15	/* Reserved.  */
+#define R_ARM_THM_XPC22		16	/* Reserved.  */
+#define R_ARM_TLS_DTPMOD32	17	/* ID of module containing symbol */
+#define R_ARM_TLS_DTPOFF32	18	/* Offset in TLS block */
+#define R_ARM_TLS_TPOFF32	19	/* Offset in static TLS block */
+#define R_ARM_COPY		20	/* Copy symbol at runtime */
+#define R_ARM_GLOB_DAT		21	/* Create GOT entry */
+#define R_ARM_JUMP_SLOT		22	/* Create PLT entry */
+#define R_ARM_RELATIVE		23	/* Adjust by program base */
+#define R_ARM_GOTOFF		24	/* 32 bit offset to GOT */
+#define R_ARM_GOTPC		25	/* 32 bit PC relative offset to GOT */
+#define R_ARM_GOT32		26	/* 32 bit GOT entry */
+#define R_ARM_PLT32		27	/* Deprecated, 32 bit PLT address.  */
+#define R_ARM_CALL		28	/* PC relative 24 bit (BL, BLX).  */
+#define R_ARM_JUMP24		29	/* PC relative 24 bit
+					   (B, BL<cond>).  */
+#define R_ARM_THM_JUMP24	30	/* PC relative 24 bit (Thumb32 B.W).  */
+#define R_ARM_BASE_ABS		31	/* Adjust by program base.  */
+#define R_ARM_ALU_PCREL_7_0	32	/* Obsolete.  */
+#define R_ARM_ALU_PCREL_15_8	33	/* Obsolete.  */
+#define R_ARM_ALU_PCREL_23_15	34	/* Obsolete.  */
+#define R_ARM_LDR_SBREL_11_0	35	/* Deprecated, prog. base relative.  */
+#define R_ARM_ALU_SBREL_19_12	36	/* Deprecated, prog. base relative.  */
+#define R_ARM_ALU_SBREL_27_20	37	/* Deprecated, prog. base relative.  */
+#define R_ARM_TARGET1		38
+#define R_ARM_SBREL31		39	/* Program base relative.  */
+#define R_ARM_V4BX		40
+#define R_ARM_TARGET2		41
+#define R_ARM_PREL31		42	/* 32 bit PC relative.  */
+#define R_ARM_MOVW_ABS_NC	43	/* Direct 16-bit (MOVW).  */
+#define R_ARM_MOVT_ABS		44	/* Direct high 16-bit (MOVT).  */
+#define R_ARM_MOVW_PREL_NC	45	/* PC relative 16-bit (MOVW).  */
+#define R_ARM_MOVT_PREL		46	/* PC relative (MOVT).  */
+#define R_ARM_THM_MOVW_ABS_NC	47	/* Direct 16 bit (Thumb32 MOVW).  */
+#define R_ARM_THM_MOVT_ABS	48	/* Direct high 16 bit
+					   (Thumb32 MOVT).  */
+#define R_ARM_THM_MOVW_PREL_NC	49	/* PC relative 16 bit
+					   (Thumb32 MOVW).  */
+#define R_ARM_THM_MOVT_PREL	50	/* PC relative high 16 bit
+					   (Thumb32 MOVT).  */
+#define R_ARM_THM_JUMP19	51	/* PC relative 20 bit
+					   (Thumb32 B<cond>.W).  */
+#define R_ARM_THM_JUMP6		52	/* PC relative X & 0x7E
+					   (Thumb16 CBZ, CBNZ).  */
+#define R_ARM_THM_ALU_PREL_11_0	53	/* PC relative 12 bit
+					   (Thumb32 ADR.W).  */
+#define R_ARM_THM_PC12		54	/* PC relative 12 bit
+					   (Thumb32 LDR{D,SB,H,SH}).  */
+#define R_ARM_ABS32_NOI		55	/* Direct 32-bit.  */
+#define R_ARM_REL32_NOI		56	/* PC relative 32-bit.  */
+#define R_ARM_ALU_PC_G0_NC	57	/* PC relative (ADD, SUB).  */
+#define R_ARM_ALU_PC_G0		58	/* PC relative (ADD, SUB).  */
+#define R_ARM_ALU_PC_G1_NC	59	/* PC relative (ADD, SUB).  */
+#define R_ARM_ALU_PC_G1		60	/* PC relative (ADD, SUB).  */
+#define R_ARM_ALU_PC_G2		61	/* PC relative (ADD, SUB).  */
+#define R_ARM_LDR_PC_G1		62	/* PC relative (LDR,STR,LDRB,STRB).  */
+#define R_ARM_LDR_PC_G2		63	/* PC relative (LDR,STR,LDRB,STRB).  */
+#define R_ARM_LDRS_PC_G0	64	/* PC relative (STR{D,H},
+					   LDR{D,SB,H,SH}).  */
+#define R_ARM_LDRS_PC_G1	65	/* PC relative (STR{D,H},
+					   LDR{D,SB,H,SH}).  */
+#define R_ARM_LDRS_PC_G2	66	/* PC relative (STR{D,H},
+					   LDR{D,SB,H,SH}).  */
+#define R_ARM_LDC_PC_G0		67	/* PC relative (LDC, STC).  */
+#define R_ARM_LDC_PC_G1		68	/* PC relative (LDC, STC).  */
+#define R_ARM_LDC_PC_G2		69	/* PC relative (LDC, STC).  */
+#define R_ARM_ALU_SB_G0_NC	70	/* Program base relative (ADD,SUB).  */
+#define R_ARM_ALU_SB_G0		71	/* Program base relative (ADD,SUB).  */
+#define R_ARM_ALU_SB_G1_NC	72	/* Program base relative (ADD,SUB).  */
+#define R_ARM_ALU_SB_G1		73	/* Program base relative (ADD,SUB).  */
+#define R_ARM_ALU_SB_G2		74	/* Program base relative (ADD,SUB).  */
+#define R_ARM_LDR_SB_G0		75	/* Program base relative (LDR,
+					   STR, LDRB, STRB).  */
+#define R_ARM_LDR_SB_G1		76	/* Program base relative
+					   (LDR, STR, LDRB, STRB).  */
+#define R_ARM_LDR_SB_G2		77	/* Program base relative
+					   (LDR, STR, LDRB, STRB).  */
+#define R_ARM_LDRS_SB_G0	78	/* Program base relative
+					   (LDR, STR, LDRB, STRB).  */
+#define R_ARM_LDRS_SB_G1	79	/* Program base relative
+					   (LDR, STR, LDRB, STRB).  */
+#define R_ARM_LDRS_SB_G2	80	/* Program base relative
+					   (LDR, STR, LDRB, STRB).  */
+#define R_ARM_LDC_SB_G0		81	/* Program base relative (LDC,STC).  */
+#define R_ARM_LDC_SB_G1		82	/* Program base relative (LDC,STC).  */
+#define R_ARM_LDC_SB_G2		83	/* Program base relative (LDC,STC).  */
+#define R_ARM_MOVW_BREL_NC	84	/* Program base relative 16
+					   bit (MOVW).  */
+#define R_ARM_MOVT_BREL		85	/* Program base relative high
+					   16 bit (MOVT).  */
+#define R_ARM_MOVW_BREL		86	/* Program base relative 16
+					   bit (MOVW).  */
+#define R_ARM_THM_MOVW_BREL_NC	87	/* Program base relative 16
+					   bit (Thumb32 MOVW).  */
+#define R_ARM_THM_MOVT_BREL	88	/* Program base relative high
+					   16 bit (Thumb32 MOVT).  */
+#define R_ARM_THM_MOVW_BREL	89	/* Program base relative 16
+					   bit (Thumb32 MOVW).  */
+#define R_ARM_TLS_GOTDESC	90
+#define R_ARM_TLS_CALL		91
+#define R_ARM_TLS_DESCSEQ	92	/* TLS relaxation.  */
+#define R_ARM_THM_TLS_CALL	93
+#define R_ARM_PLT32_ABS		94
+#define R_ARM_GOT_ABS		95	/* GOT entry.  */
+#define R_ARM_GOT_PREL		96	/* PC relative GOT entry.  */
+#define R_ARM_GOT_BREL12	97	/* GOT entry relative to GOT
+					   origin (LDR).  */
+#define R_ARM_GOTOFF12		98	/* 12 bit, GOT entry relative
+					   to GOT origin (LDR, STR).  */
+#define R_ARM_GOTRELAX		99
+#define R_ARM_GNU_VTENTRY	100
+#define R_ARM_GNU_VTINHERIT	101
+#define R_ARM_THM_PC11		102	/* PC relative & 0xFFE (Thumb16 B).  */
+#define R_ARM_THM_PC9		103	/* PC relative & 0x1FE
+					   (Thumb16 B/B<cond>).  */
+#define R_ARM_TLS_GD32		104	/* PC-rel 32 bit for global dynamic
+					   thread local data */
+#define R_ARM_TLS_LDM32		105	/* PC-rel 32 bit for local dynamic
+					   thread local data */
+#define R_ARM_TLS_LDO32		106	/* 32 bit offset relative to TLS
+					   block */
+#define R_ARM_TLS_IE32		107	/* PC-rel 32 bit for GOT entry of
+					   static TLS block offset */
+#define R_ARM_TLS_LE32		108	/* 32 bit offset relative to static
+					   TLS block */
+#define R_ARM_TLS_LDO12		109	/* 12 bit relative to TLS
+					   block (LDR, STR).  */
+#define R_ARM_TLS_LE12		110	/* 12 bit relative to static
+					   TLS block (LDR, STR).  */
+#define R_ARM_TLS_IE12GP	111	/* 12 bit GOT entry relative
+					   to GOT origin (LDR).  */
+#define R_ARM_ME_TOO		128	/* Obsolete.  */
+#define R_ARM_THM_TLS_DESCSEQ	129
+#define R_ARM_THM_TLS_DESCSEQ16	129
+#define R_ARM_THM_TLS_DESCSEQ32	130
+#define R_ARM_THM_GOT_BREL12	131	/* GOT entry relative to GOT
+					   origin, 12 bit (Thumb32 LDR).  */
+#define R_ARM_IRELATIVE		160
+#define R_ARM_RXPC25		249
+#define R_ARM_RSBREL32		250
+#define R_ARM_THM_RPC22		251
+#define R_ARM_RREL32		252
+#define R_ARM_RABS22		253
+#define R_ARM_RPC24		254
+#define R_ARM_RBASE		255
+/* Keep this the last entry.  */
+#define R_ARM_NUM		256
+
+/* C-SKY */
+#define R_CKCORE_NONE               0	/* no reloc */
+#define R_CKCORE_ADDR32             1	/* direct 32 bit (S + A) */
+#define R_CKCORE_PCRELIMM8BY4       2	/* disp ((S + A - P) >> 2) & 0xff   */
+#define R_CKCORE_PCRELIMM11BY2      3	/* disp ((S + A - P) >> 1) & 0x7ff  */
+#define R_CKCORE_PCREL32            5	/* 32-bit rel (S + A - P)           */
+#define R_CKCORE_PCRELJSR_IMM11BY2  6	/* disp ((S + A - P) >>1) & 0x7ff   */
+#define R_CKCORE_RELATIVE           9	/* 32 bit adjust program base(B + A)*/
+#define R_CKCORE_COPY               10	/* 32 bit adjust by program base    */
+#define R_CKCORE_GLOB_DAT           11	/* off between got and sym (S)      */
+#define R_CKCORE_JUMP_SLOT          12	/* PLT entry (S) */
+#define R_CKCORE_GOTOFF             13	/* offset to GOT (S + A - GOT)      */
+#define R_CKCORE_GOTPC              14	/* PC offset to GOT (GOT + A - P)   */
+#define R_CKCORE_GOT32              15	/* 32 bit GOT entry (G) */
+#define R_CKCORE_PLT32              16	/* 32 bit PLT entry (G) */
+#define R_CKCORE_ADDRGOT            17	/* GOT entry in GLOB_DAT (GOT + G)  */
+#define R_CKCORE_ADDRPLT            18	/* PLT entry in GLOB_DAT (GOT + G)  */
+#define R_CKCORE_PCREL_IMM26BY2     19	/* ((S + A - P) >> 1) & 0x3ffffff   */
+#define R_CKCORE_PCREL_IMM16BY2     20	/* disp ((S + A - P) >> 1) & 0xffff */
+#define R_CKCORE_PCREL_IMM16BY4     21	/* disp ((S + A - P) >> 2) & 0xffff */
+#define R_CKCORE_PCREL_IMM10BY2     22	/* disp ((S + A - P) >> 1) & 0x3ff  */
+#define R_CKCORE_PCREL_IMM10BY4     23	/* disp ((S + A - P) >> 2) & 0x3ff  */
+#define R_CKCORE_ADDR_HI16          24	/* high & low 16 bit ADDR */
+                                        /* ((S + A) >> 16) & 0xffff */
+#define R_CKCORE_ADDR_LO16          25	/* (S + A) & 0xffff */
+#define R_CKCORE_GOTPC_HI16         26	/* high & low 16 bit GOTPC */
+                                        /* ((GOT + A - P) >> 16) & 0xffff */
+#define R_CKCORE_GOTPC_LO16         27	/* (GOT + A - P) & 0xffff */
+#define R_CKCORE_GOTOFF_HI16        28	/* high & low 16 bit GOTOFF */
+                                        /* ((S + A - GOT) >> 16) & 0xffff */
+#define R_CKCORE_GOTOFF_LO16        29	/* (S + A - GOT) & 0xffff */
+#define R_CKCORE_GOT12              30	/* 12 bit disp GOT entry (G) */
+#define R_CKCORE_GOT_HI16           31	/* high & low 16 bit GOT */
+                                        /* (G >> 16) & 0xffff */
+#define R_CKCORE_GOT_LO16           32	/* (G & 0xffff) */
+#define R_CKCORE_PLT12              33	/* 12 bit disp PLT entry (G) */
+#define R_CKCORE_PLT_HI16           34	/* high & low 16 bit PLT */
+                                        /* (G >> 16) & 0xffff */
+#define R_CKCORE_PLT_LO16           35	/* G & 0xffff */
+#define R_CKCORE_ADDRGOT_HI16       36	/* high & low 16 bit ADDRGOT */
+                                        /* (GOT + G * 4) & 0xffff */
+#define R_CKCORE_ADDRGOT_LO16       37	/* (GOT + G * 4) & 0xffff */
+#define R_CKCORE_ADDRPLT_HI16       38	/* high & low 16 bit ADDRPLT */
+                                        /* ((GOT + G * 4) >> 16) & 0xFFFF */
+#define R_CKCORE_ADDRPLT_LO16       39	/* (GOT+G*4) & 0xffff */
+#define R_CKCORE_PCREL_JSR_IMM26BY2 40	/* disp ((S+A-P) >>1) & x3ffffff */
+#define R_CKCORE_TOFFSET_LO16       41	/* (S+A-BTEXT) & 0xffff */
+#define R_CKCORE_DOFFSET_LO16       42	/* (S+A-BTEXT) & 0xffff */
+#define R_CKCORE_PCREL_IMM18BY2     43	/* disp ((S+A-P) >>1) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18      44	/* disp (S+A-BDATA) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18BY2   45	/* disp ((S+A-BDATA)>>1) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18BY4   46	/* disp ((S+A-BDATA)>>2) & 0x3ffff */
+#define R_CKCORE_GOT_IMM18BY4       48	/* disp (G >> 2) */
+#define R_CKCORE_PLT_IMM18BY4       49	/* disp (G >> 2) */
+#define R_CKCORE_PCREL_IMM7BY4      50	/* disp ((S+A-P) >>2) & 0x7f */
+#define R_CKCORE_TLS_LE32           51	/* 32 bit offset to TLS block */
+#define R_CKCORE_TLS_IE32           52
+#define R_CKCORE_TLS_GD32           53
+#define R_CKCORE_TLS_LDM32          54
+#define R_CKCORE_TLS_LDO32          55
+#define R_CKCORE_TLS_DTPMOD32       56
+#define R_CKCORE_TLS_DTPOFF32       57
+#define R_CKCORE_TLS_TPOFF32        58
+
+/* C-SKY elf header definition.  */
+#define EF_CSKY_ABIMASK		    0XF0000000
+#define EF_CSKY_OTHER		    0X0FFF0000
+#define EF_CSKY_PROCESSOR	    0X0000FFFF
+
+#define EF_CSKY_ABIV1		    0X10000000
+#define EF_CSKY_ABIV2		    0X20000000
+
+/* C-SKY attributes section.  */
+#define SHT_CSKY_ATTRIBUTES	    (SHT_LOPROC + 1)
+
+/* IA-64 specific declarations.  */
+
+/* Processor specific flags for the Ehdr e_flags field.  */
+#define EF_IA_64_MASKOS		0x0000000f	/* os-specific flags */
+#define EF_IA_64_ABI64		0x00000010	/* 64-bit ABI */
+#define EF_IA_64_ARCH		0xff000000	/* arch. version mask */
+
+/* Processor specific values for the Phdr p_type field.  */
+#define PT_IA_64_ARCHEXT	(PT_LOPROC + 0)	/* arch extension bits */
+#define PT_IA_64_UNWIND		(PT_LOPROC + 1)	/* ia64 unwind bits */
+#define PT_IA_64_HP_OPT_ANOT	(PT_LOOS + 0x12)
+#define PT_IA_64_HP_HSL_ANOT	(PT_LOOS + 0x13)
+#define PT_IA_64_HP_STACK	(PT_LOOS + 0x14)
+
+/* Processor specific flags for the Phdr p_flags field.  */
+#define PF_IA_64_NORECOV	0x80000000	/* spec insns w/o recovery */
+
+/* Processor specific values for the Shdr sh_type field.  */
+#define SHT_IA_64_EXT		(SHT_LOPROC + 0) /* extension bits */
+#define SHT_IA_64_UNWIND	(SHT_LOPROC + 1) /* unwind bits */
+
+/* Processor specific flags for the Shdr sh_flags field.  */
+#define SHF_IA_64_SHORT		0x10000000	/* section near gp */
+#define SHF_IA_64_NORECOV	0x20000000	/* spec insns w/o recovery */
+
+/* Processor specific values for the Dyn d_tag field.  */
+#define DT_IA_64_PLT_RESERVE	(DT_LOPROC + 0)
+#define DT_IA_64_NUM		1
+
+/* IA-64 relocations.  */
+#define R_IA64_NONE		0x00	/* none */
+#define R_IA64_IMM14		0x21	/* symbol + addend, add imm14 */
+#define R_IA64_IMM22		0x22	/* symbol + addend, add imm22 */
+#define R_IA64_IMM64		0x23	/* symbol + addend, mov imm64 */
+#define R_IA64_DIR32MSB		0x24	/* symbol + addend, data4 MSB */
+#define R_IA64_DIR32LSB		0x25	/* symbol + addend, data4 LSB */
+#define R_IA64_DIR64MSB		0x26	/* symbol + addend, data8 MSB */
+#define R_IA64_DIR64LSB		0x27	/* symbol + addend, data8 LSB */
+#define R_IA64_GPREL22		0x2a	/* @gprel(sym + add), add imm22 */
+#define R_IA64_GPREL64I		0x2b	/* @gprel(sym + add), mov imm64 */
+#define R_IA64_GPREL32MSB	0x2c	/* @gprel(sym + add), data4 MSB */
+#define R_IA64_GPREL32LSB	0x2d	/* @gprel(sym + add), data4 LSB */
+#define R_IA64_GPREL64MSB	0x2e	/* @gprel(sym + add), data8 MSB */
+#define R_IA64_GPREL64LSB	0x2f	/* @gprel(sym + add), data8 LSB */
+#define R_IA64_LTOFF22		0x32	/* @ltoff(sym + add), add imm22 */
+#define R_IA64_LTOFF64I		0x33	/* @ltoff(sym + add), mov imm64 */
+#define R_IA64_PLTOFF22		0x3a	/* @pltoff(sym + add), add imm22 */
+#define R_IA64_PLTOFF64I	0x3b	/* @pltoff(sym + add), mov imm64 */
+#define R_IA64_PLTOFF64MSB	0x3e	/* @pltoff(sym + add), data8 MSB */
+#define R_IA64_PLTOFF64LSB	0x3f	/* @pltoff(sym + add), data8 LSB */
+#define R_IA64_FPTR64I		0x43	/* @fptr(sym + add), mov imm64 */
+#define R_IA64_FPTR32MSB	0x44	/* @fptr(sym + add), data4 MSB */
+#define R_IA64_FPTR32LSB	0x45	/* @fptr(sym + add), data4 LSB */
+#define R_IA64_FPTR64MSB	0x46	/* @fptr(sym + add), data8 MSB */
+#define R_IA64_FPTR64LSB	0x47	/* @fptr(sym + add), data8 LSB */
+#define R_IA64_PCREL60B		0x48	/* @pcrel(sym + add), brl */
+#define R_IA64_PCREL21B		0x49	/* @pcrel(sym + add), ptb, call */
+#define R_IA64_PCREL21M		0x4a	/* @pcrel(sym + add), chk.s */
+#define R_IA64_PCREL21F		0x4b	/* @pcrel(sym + add), fchkf */
+#define R_IA64_PCREL32MSB	0x4c	/* @pcrel(sym + add), data4 MSB */
+#define R_IA64_PCREL32LSB	0x4d	/* @pcrel(sym + add), data4 LSB */
+#define R_IA64_PCREL64MSB	0x4e	/* @pcrel(sym + add), data8 MSB */
+#define R_IA64_PCREL64LSB	0x4f	/* @pcrel(sym + add), data8 LSB */
+#define R_IA64_LTOFF_FPTR22	0x52	/* @ltoff(@fptr(s+a)), imm22 */
+#define R_IA64_LTOFF_FPTR64I	0x53	/* @ltoff(@fptr(s+a)), imm64 */
+#define R_IA64_LTOFF_FPTR32MSB	0x54	/* @ltoff(@fptr(s+a)), data4 MSB */
+#define R_IA64_LTOFF_FPTR32LSB	0x55	/* @ltoff(@fptr(s+a)), data4 LSB */
+#define R_IA64_LTOFF_FPTR64MSB	0x56	/* @ltoff(@fptr(s+a)), data8 MSB */
+#define R_IA64_LTOFF_FPTR64LSB	0x57	/* @ltoff(@fptr(s+a)), data8 LSB */
+#define R_IA64_SEGREL32MSB	0x5c	/* @segrel(sym + add), data4 MSB */
+#define R_IA64_SEGREL32LSB	0x5d	/* @segrel(sym + add), data4 LSB */
+#define R_IA64_SEGREL64MSB	0x5e	/* @segrel(sym + add), data8 MSB */
+#define R_IA64_SEGREL64LSB	0x5f	/* @segrel(sym + add), data8 LSB */
+#define R_IA64_SECREL32MSB	0x64	/* @secrel(sym + add), data4 MSB */
+#define R_IA64_SECREL32LSB	0x65	/* @secrel(sym + add), data4 LSB */
+#define R_IA64_SECREL64MSB	0x66	/* @secrel(sym + add), data8 MSB */
+#define R_IA64_SECREL64LSB	0x67	/* @secrel(sym + add), data8 LSB */
+#define R_IA64_REL32MSB		0x6c	/* data 4 + REL */
+#define R_IA64_REL32LSB		0x6d	/* data 4 + REL */
+#define R_IA64_REL64MSB		0x6e	/* data 8 + REL */
+#define R_IA64_REL64LSB		0x6f	/* data 8 + REL */
+#define R_IA64_LTV32MSB		0x74	/* symbol + addend, data4 MSB */
+#define R_IA64_LTV32LSB		0x75	/* symbol + addend, data4 LSB */
+#define R_IA64_LTV64MSB		0x76	/* symbol + addend, data8 MSB */
+#define R_IA64_LTV64LSB		0x77	/* symbol + addend, data8 LSB */
+#define R_IA64_PCREL21BI	0x79	/* @pcrel(sym + add), 21bit inst */
+#define R_IA64_PCREL22		0x7a	/* @pcrel(sym + add), 22bit inst */
+#define R_IA64_PCREL64I		0x7b	/* @pcrel(sym + add), 64bit inst */
+#define R_IA64_IPLTMSB		0x80	/* dynamic reloc, imported PLT, MSB */
+#define R_IA64_IPLTLSB		0x81	/* dynamic reloc, imported PLT, LSB */
+#define R_IA64_COPY		0x84	/* copy relocation */
+#define R_IA64_SUB		0x85	/* Addend and symbol difference */
+#define R_IA64_LTOFF22X		0x86	/* LTOFF22, relaxable.  */
+#define R_IA64_LDXMOV		0x87	/* Use of LTOFF22X.  */
+#define R_IA64_TPREL14		0x91	/* @tprel(sym + add), imm14 */
+#define R_IA64_TPREL22		0x92	/* @tprel(sym + add), imm22 */
+#define R_IA64_TPREL64I		0x93	/* @tprel(sym + add), imm64 */
+#define R_IA64_TPREL64MSB	0x96	/* @tprel(sym + add), data8 MSB */
+#define R_IA64_TPREL64LSB	0x97	/* @tprel(sym + add), data8 LSB */
+#define R_IA64_LTOFF_TPREL22	0x9a	/* @ltoff(@tprel(s+a)), imm2 */
+#define R_IA64_DTPMOD64MSB	0xa6	/* @dtpmod(sym + add), data8 MSB */
+#define R_IA64_DTPMOD64LSB	0xa7	/* @dtpmod(sym + add), data8 LSB */
+#define R_IA64_LTOFF_DTPMOD22	0xaa	/* @ltoff(@dtpmod(sym + add)), imm22 */
+#define R_IA64_DTPREL14		0xb1	/* @dtprel(sym + add), imm14 */
+#define R_IA64_DTPREL22		0xb2	/* @dtprel(sym + add), imm22 */
+#define R_IA64_DTPREL64I	0xb3	/* @dtprel(sym + add), imm64 */
+#define R_IA64_DTPREL32MSB	0xb4	/* @dtprel(sym + add), data4 MSB */
+#define R_IA64_DTPREL32LSB	0xb5	/* @dtprel(sym + add), data4 LSB */
+#define R_IA64_DTPREL64MSB	0xb6	/* @dtprel(sym + add), data8 MSB */
+#define R_IA64_DTPREL64LSB	0xb7	/* @dtprel(sym + add), data8 LSB */
+#define R_IA64_LTOFF_DTPREL22	0xba	/* @ltoff(@dtprel(s+a)), imm22 */
+
+/* SH specific declarations */
+
+/* Processor specific flags for the ELF header e_flags field.  */
+#define EF_SH_MACH_MASK		0x1f
+#define EF_SH_UNKNOWN		0x0
+#define EF_SH1			0x1
+#define EF_SH2			0x2
+#define EF_SH3			0x3
+#define EF_SH_DSP		0x4
+#define EF_SH3_DSP		0x5
+#define EF_SH4AL_DSP		0x6
+#define EF_SH3E			0x8
+#define EF_SH4			0x9
+#define EF_SH2E			0xb
+#define EF_SH4A			0xc
+#define EF_SH2A			0xd
+#define EF_SH4_NOFPU		0x10
+#define EF_SH4A_NOFPU		0x11
+#define EF_SH4_NOMMU_NOFPU	0x12
+#define EF_SH2A_NOFPU		0x13
+#define EF_SH3_NOMMU		0x14
+#define EF_SH2A_SH4_NOFPU	0x15
+#define EF_SH2A_SH3_NOFPU	0x16
+#define EF_SH2A_SH4		0x17
+#define EF_SH2A_SH3E		0x18
+
+/* SH relocs.  */
+#define	R_SH_NONE		0
+#define	R_SH_DIR32		1
+#define	R_SH_REL32		2
+#define	R_SH_DIR8WPN		3
+#define	R_SH_IND12W		4
+#define	R_SH_DIR8WPL		5
+#define	R_SH_DIR8WPZ		6
+#define	R_SH_DIR8BP		7
+#define	R_SH_DIR8W		8
+#define	R_SH_DIR8L		9
+#define	R_SH_SWITCH16		25
+#define	R_SH_SWITCH32		26
+#define	R_SH_USES		27
+#define	R_SH_COUNT		28
+#define	R_SH_ALIGN		29
+#define	R_SH_CODE		30
+#define	R_SH_DATA		31
+#define	R_SH_LABEL		32
+#define	R_SH_SWITCH8		33
+#define	R_SH_GNU_VTINHERIT	34
+#define	R_SH_GNU_VTENTRY	35
+#define	R_SH_TLS_GD_32		144
+#define	R_SH_TLS_LD_32		145
+#define	R_SH_TLS_LDO_32		146
+#define	R_SH_TLS_IE_32		147
+#define	R_SH_TLS_LE_32		148
+#define	R_SH_TLS_DTPMOD32	149
+#define	R_SH_TLS_DTPOFF32	150
+#define	R_SH_TLS_TPOFF32	151
+#define	R_SH_GOT32		160
+#define	R_SH_PLT32		161
+#define	R_SH_COPY		162
+#define	R_SH_GLOB_DAT		163
+#define	R_SH_JMP_SLOT		164
+#define	R_SH_RELATIVE		165
+#define	R_SH_GOTOFF		166
+#define	R_SH_GOTPC		167
+/* Keep this the last entry.  */
+#define	R_SH_NUM		256
+
+/* S/390 specific definitions.  */
+
+/* Valid values for the e_flags field.  */
+
+#define EF_S390_HIGH_GPRS    0x00000001  /* High GPRs kernel facility needed.  */
+
+/* Additional s390 relocs */
+
+#define R_390_NONE		0	/* No reloc.  */
+#define R_390_8			1	/* Direct 8 bit.  */
+#define R_390_12		2	/* Direct 12 bit.  */
+#define R_390_16		3	/* Direct 16 bit.  */
+#define R_390_32		4	/* Direct 32 bit.  */
+#define R_390_PC32		5	/* PC relative 32 bit.	*/
+#define R_390_GOT12		6	/* 12 bit GOT offset.  */
+#define R_390_GOT32		7	/* 32 bit GOT offset.  */
+#define R_390_PLT32		8	/* 32 bit PC relative PLT address.  */
+#define R_390_COPY		9	/* Copy symbol at runtime.  */
+#define R_390_GLOB_DAT		10	/* Create GOT entry.  */
+#define R_390_JMP_SLOT		11	/* Create PLT entry.  */
+#define R_390_RELATIVE		12	/* Adjust by program base.  */
+#define R_390_GOTOFF32		13	/* 32 bit offset to GOT.	 */
+#define R_390_GOTPC		14	/* 32 bit PC relative offset to GOT.  */
+#define R_390_GOT16		15	/* 16 bit GOT offset.  */
+#define R_390_PC16		16	/* PC relative 16 bit.	*/
+#define R_390_PC16DBL		17	/* PC relative 16 bit shifted by 1.  */
+#define R_390_PLT16DBL		18	/* 16 bit PC rel. PLT shifted by 1.  */
+#define R_390_PC32DBL		19	/* PC relative 32 bit shifted by 1.  */
+#define R_390_PLT32DBL		20	/* 32 bit PC rel. PLT shifted by 1.  */
+#define R_390_GOTPCDBL		21	/* 32 bit PC rel. GOT shifted by 1.  */
+#define R_390_64		22	/* Direct 64 bit.  */
+#define R_390_PC64		23	/* PC relative 64 bit.	*/
+#define R_390_GOT64		24	/* 64 bit GOT offset.  */
+#define R_390_PLT64		25	/* 64 bit PC relative PLT address.  */
+#define R_390_GOTENT		26	/* 32 bit PC rel. to GOT entry >> 1. */
+#define R_390_GOTOFF16		27	/* 16 bit offset to GOT. */
+#define R_390_GOTOFF64		28	/* 64 bit offset to GOT. */
+#define R_390_GOTPLT12		29	/* 12 bit offset to jump slot.	*/
+#define R_390_GOTPLT16		30	/* 16 bit offset to jump slot.	*/
+#define R_390_GOTPLT32		31	/* 32 bit offset to jump slot.	*/
+#define R_390_GOTPLT64		32	/* 64 bit offset to jump slot.	*/
+#define R_390_GOTPLTENT		33	/* 32 bit rel. offset to jump slot.  */
+#define R_390_PLTOFF16		34	/* 16 bit offset from GOT to PLT. */
+#define R_390_PLTOFF32		35	/* 32 bit offset from GOT to PLT. */
+#define R_390_PLTOFF64		36	/* 16 bit offset from GOT to PLT. */
+#define R_390_TLS_LOAD		37	/* Tag for load insn in TLS code.  */
+#define R_390_TLS_GDCALL	38	/* Tag for function call in general
+					   dynamic TLS code. */
+#define R_390_TLS_LDCALL	39	/* Tag for function call in local
+					   dynamic TLS code. */
+#define R_390_TLS_GD32		40	/* Direct 32 bit for general dynamic
+					   thread local data.  */
+#define R_390_TLS_GD64		41	/* Direct 64 bit for general dynamic
+					  thread local data.  */
+#define R_390_TLS_GOTIE12	42	/* 12 bit GOT offset for static TLS
+					   block offset.  */
+#define R_390_TLS_GOTIE32	43	/* 32 bit GOT offset for static TLS
+					   block offset.  */
+#define R_390_TLS_GOTIE64	44	/* 64 bit GOT offset for static TLS
+					   block offset. */
+#define R_390_TLS_LDM32		45	/* Direct 32 bit for local dynamic
+					   thread local data in LE code.  */
+#define R_390_TLS_LDM64		46	/* Direct 64 bit for local dynamic
+					   thread local data in LE code.  */
+#define R_390_TLS_IE32		47	/* 32 bit address of GOT entry for
+					   negated static TLS block offset.  */
+#define R_390_TLS_IE64		48	/* 64 bit address of GOT entry for
+					   negated static TLS block offset.  */
+#define R_390_TLS_IEENT		49	/* 32 bit rel. offset to GOT entry for
+					   negated static TLS block offset.  */
+#define R_390_TLS_LE32		50	/* 32 bit negated offset relative to
+					   static TLS block.  */
+#define R_390_TLS_LE64		51	/* 64 bit negated offset relative to
+					   static TLS block.  */
+#define R_390_TLS_LDO32		52	/* 32 bit offset relative to TLS
+					   block.  */
+#define R_390_TLS_LDO64		53	/* 64 bit offset relative to TLS
+					   block.  */
+#define R_390_TLS_DTPMOD	54	/* ID of module containing symbol.  */
+#define R_390_TLS_DTPOFF	55	/* Offset in TLS block.	 */
+#define R_390_TLS_TPOFF		56	/* Negated offset in static TLS
+					   block.  */
+#define R_390_20		57	/* Direct 20 bit.  */
+#define R_390_GOT20		58	/* 20 bit GOT offset.  */
+#define R_390_GOTPLT20		59	/* 20 bit offset to jump slot.  */
+#define R_390_TLS_GOTIE20	60	/* 20 bit GOT offset for static TLS
+					   block offset.  */
+#define R_390_IRELATIVE         61      /* STT_GNU_IFUNC relocation.  */
+/* Keep this the last entry.  */
+#define R_390_NUM		62
+
+
+/* CRIS relocations.  */
+#define R_CRIS_NONE		0
+#define R_CRIS_8		1
+#define R_CRIS_16		2
+#define R_CRIS_32		3
+#define R_CRIS_8_PCREL		4
+#define R_CRIS_16_PCREL		5
+#define R_CRIS_32_PCREL		6
+#define R_CRIS_GNU_VTINHERIT	7
+#define R_CRIS_GNU_VTENTRY	8
+#define R_CRIS_COPY		9
+#define R_CRIS_GLOB_DAT		10
+#define R_CRIS_JUMP_SLOT	11
+#define R_CRIS_RELATIVE		12
+#define R_CRIS_16_GOT		13
+#define R_CRIS_32_GOT		14
+#define R_CRIS_16_GOTPLT	15
+#define R_CRIS_32_GOTPLT	16
+#define R_CRIS_32_GOTREL	17
+#define R_CRIS_32_PLT_GOTREL	18
+#define R_CRIS_32_PLT_PCREL	19
+
+#define R_CRIS_NUM		20
+
+
+/* AMD x86-64 relocations.  */
+#define R_X86_64_NONE		0	/* No reloc */
+#define R_X86_64_64		1	/* Direct 64 bit  */
+#define R_X86_64_PC32		2	/* PC relative 32 bit signed */
+#define R_X86_64_GOT32		3	/* 32 bit GOT entry */
+#define R_X86_64_PLT32		4	/* 32 bit PLT address */
+#define R_X86_64_COPY		5	/* Copy symbol at runtime */
+#define R_X86_64_GLOB_DAT	6	/* Create GOT entry */
+#define R_X86_64_JUMP_SLOT	7	/* Create PLT entry */
+#define R_X86_64_RELATIVE	8	/* Adjust by program base */
+#define R_X86_64_GOTPCREL	9	/* 32 bit signed PC relative
+					   offset to GOT */
+#define R_X86_64_32		10	/* Direct 32 bit zero extended */
+#define R_X86_64_32S		11	/* Direct 32 bit sign extended */
+#define R_X86_64_16		12	/* Direct 16 bit zero extended */
+#define R_X86_64_PC16		13	/* 16 bit sign extended pc relative */
+#define R_X86_64_8		14	/* Direct 8 bit sign extended  */
+#define R_X86_64_PC8		15	/* 8 bit sign extended pc relative */
+#define R_X86_64_DTPMOD64	16	/* ID of module containing symbol */
+#define R_X86_64_DTPOFF64	17	/* Offset in module's TLS block */
+#define R_X86_64_TPOFF64	18	/* Offset in initial TLS block */
+#define R_X86_64_TLSGD		19	/* 32 bit signed PC relative offset
+					   to two GOT entries for GD symbol */
+#define R_X86_64_TLSLD		20	/* 32 bit signed PC relative offset
+					   to two GOT entries for LD symbol */
+#define R_X86_64_DTPOFF32	21	/* Offset in TLS block */
+#define R_X86_64_GOTTPOFF	22	/* 32 bit signed PC relative offset
+					   to GOT entry for IE symbol */
+#define R_X86_64_TPOFF32	23	/* Offset in initial TLS block */
+#define R_X86_64_PC64		24	/* PC relative 64 bit */
+#define R_X86_64_GOTOFF64	25	/* 64 bit offset to GOT */
+#define R_X86_64_GOTPC32	26	/* 32 bit signed pc relative
+					   offset to GOT */
+#define R_X86_64_GOT64		27	/* 64-bit GOT entry offset */
+#define R_X86_64_GOTPCREL64	28	/* 64-bit PC relative offset
+					   to GOT entry */
+#define R_X86_64_GOTPC64	29	/* 64-bit PC relative offset to GOT */
+#define R_X86_64_GOTPLT64	30 	/* like GOT64, says PLT entry needed */
+#define R_X86_64_PLTOFF64	31	/* 64-bit GOT relative offset
+					   to PLT entry */
+#define R_X86_64_SIZE32		32	/* Size of symbol plus 32-bit addend */
+#define R_X86_64_SIZE64		33	/* Size of symbol plus 64-bit addend */
+#define R_X86_64_GOTPC32_TLSDESC 34	/* GOT offset for TLS descriptor.  */
+#define R_X86_64_TLSDESC_CALL   35	/* Marker for call through TLS
+					   descriptor.  */
+#define R_X86_64_TLSDESC        36	/* TLS descriptor.  */
+#define R_X86_64_IRELATIVE	37	/* Adjust indirectly by program base */
+#define R_X86_64_RELATIVE64	38	/* 64-bit adjust by program base */
+					/* 39 Reserved was R_X86_64_PC32_BND */
+					/* 40 Reserved was R_X86_64_PLT32_BND */
+#define R_X86_64_GOTPCRELX	41	/* Load from 32 bit signed pc relative
+					   offset to GOT entry without REX
+					   prefix, relaxable.  */
+#define R_X86_64_REX_GOTPCRELX	42	/* Load from 32 bit signed pc relative
+					   offset to GOT entry with REX prefix,
+					   relaxable.  */
+#define R_X86_64_NUM		43
+
+/* x86-64 sh_type values.  */
+#define SHT_X86_64_UNWIND	0x70000001 /* Unwind information.  */
+
+
+/* AM33 relocations.  */
+#define R_MN10300_NONE		0	/* No reloc.  */
+#define R_MN10300_32		1	/* Direct 32 bit.  */
+#define R_MN10300_16		2	/* Direct 16 bit.  */
+#define R_MN10300_8		3	/* Direct 8 bit.  */
+#define R_MN10300_PCREL32	4	/* PC-relative 32-bit.  */
+#define R_MN10300_PCREL16	5	/* PC-relative 16-bit signed.  */
+#define R_MN10300_PCREL8	6	/* PC-relative 8-bit signed.  */
+#define R_MN10300_GNU_VTINHERIT	7	/* Ancient C++ vtable garbage... */
+#define R_MN10300_GNU_VTENTRY	8	/* ... collection annotation.  */
+#define R_MN10300_24		9	/* Direct 24 bit.  */
+#define R_MN10300_GOTPC32	10	/* 32-bit PCrel offset to GOT.  */
+#define R_MN10300_GOTPC16	11	/* 16-bit PCrel offset to GOT.  */
+#define R_MN10300_GOTOFF32	12	/* 32-bit offset from GOT.  */
+#define R_MN10300_GOTOFF24	13	/* 24-bit offset from GOT.  */
+#define R_MN10300_GOTOFF16	14	/* 16-bit offset from GOT.  */
+#define R_MN10300_PLT32		15	/* 32-bit PCrel to PLT entry.  */
+#define R_MN10300_PLT16		16	/* 16-bit PCrel to PLT entry.  */
+#define R_MN10300_GOT32		17	/* 32-bit offset to GOT entry.  */
+#define R_MN10300_GOT24		18	/* 24-bit offset to GOT entry.  */
+#define R_MN10300_GOT16		19	/* 16-bit offset to GOT entry.  */
+#define R_MN10300_COPY		20	/* Copy symbol at runtime.  */
+#define R_MN10300_GLOB_DAT	21	/* Create GOT entry.  */
+#define R_MN10300_JMP_SLOT	22	/* Create PLT entry.  */
+#define R_MN10300_RELATIVE	23	/* Adjust by program base.  */
+#define R_MN10300_TLS_GD	24	/* 32-bit offset for global dynamic.  */
+#define R_MN10300_TLS_LD	25	/* 32-bit offset for local dynamic.  */
+#define R_MN10300_TLS_LDO	26	/* Module-relative offset.  */
+#define R_MN10300_TLS_GOTIE	27	/* GOT offset for static TLS block
+					   offset.  */
+#define R_MN10300_TLS_IE	28	/* GOT address for static TLS block
+					   offset.  */
+#define R_MN10300_TLS_LE	29	/* Offset relative to static TLS
+					   block.  */
+#define R_MN10300_TLS_DTPMOD	30	/* ID of module containing symbol.  */
+#define R_MN10300_TLS_DTPOFF	31	/* Offset in module TLS block.  */
+#define R_MN10300_TLS_TPOFF	32	/* Offset in static TLS block.  */
+#define R_MN10300_SYM_DIFF	33	/* Adjustment for next reloc as needed
+					   by linker relaxation.  */
+#define R_MN10300_ALIGN		34	/* Alignment requirement for linker
+					   relaxation.  */
+#define R_MN10300_NUM		35
+
+
+/* M32R relocs.  */
+#define R_M32R_NONE		0	/* No reloc. */
+#define R_M32R_16		1	/* Direct 16 bit. */
+#define R_M32R_32		2	/* Direct 32 bit. */
+#define R_M32R_24		3	/* Direct 24 bit. */
+#define R_M32R_10_PCREL		4	/* PC relative 10 bit shifted. */
+#define R_M32R_18_PCREL		5	/* PC relative 18 bit shifted. */
+#define R_M32R_26_PCREL		6	/* PC relative 26 bit shifted. */
+#define R_M32R_HI16_ULO		7	/* High 16 bit with unsigned low. */
+#define R_M32R_HI16_SLO		8	/* High 16 bit with signed low. */
+#define R_M32R_LO16		9	/* Low 16 bit. */
+#define R_M32R_SDA16		10	/* 16 bit offset in SDA. */
+#define R_M32R_GNU_VTINHERIT	11
+#define R_M32R_GNU_VTENTRY	12
+/* M32R relocs use SHT_RELA.  */
+#define R_M32R_16_RELA		33	/* Direct 16 bit. */
+#define R_M32R_32_RELA		34	/* Direct 32 bit. */
+#define R_M32R_24_RELA		35	/* Direct 24 bit. */
+#define R_M32R_10_PCREL_RELA	36	/* PC relative 10 bit shifted. */
+#define R_M32R_18_PCREL_RELA	37	/* PC relative 18 bit shifted. */
+#define R_M32R_26_PCREL_RELA	38	/* PC relative 26 bit shifted. */
+#define R_M32R_HI16_ULO_RELA	39	/* High 16 bit with unsigned low */
+#define R_M32R_HI16_SLO_RELA	40	/* High 16 bit with signed low */
+#define R_M32R_LO16_RELA	41	/* Low 16 bit */
+#define R_M32R_SDA16_RELA	42	/* 16 bit offset in SDA */
+#define R_M32R_RELA_GNU_VTINHERIT	43
+#define R_M32R_RELA_GNU_VTENTRY	44
+#define R_M32R_REL32		45	/* PC relative 32 bit.  */
+
+#define R_M32R_GOT24		48	/* 24 bit GOT entry */
+#define R_M32R_26_PLTREL	49	/* 26 bit PC relative to PLT shifted */
+#define R_M32R_COPY		50	/* Copy symbol at runtime */
+#define R_M32R_GLOB_DAT		51	/* Create GOT entry */
+#define R_M32R_JMP_SLOT		52	/* Create PLT entry */
+#define R_M32R_RELATIVE		53	/* Adjust by program base */
+#define R_M32R_GOTOFF		54	/* 24 bit offset to GOT */
+#define R_M32R_GOTPC24		55	/* 24 bit PC relative offset to GOT */
+#define R_M32R_GOT16_HI_ULO	56	/* High 16 bit GOT entry with unsigned
+					   low */
+#define R_M32R_GOT16_HI_SLO	57	/* High 16 bit GOT entry with signed
+					   low */
+#define R_M32R_GOT16_LO		58	/* Low 16 bit GOT entry */
+#define R_M32R_GOTPC_HI_ULO	59	/* High 16 bit PC relative offset to
+					   GOT with unsigned low */
+#define R_M32R_GOTPC_HI_SLO	60	/* High 16 bit PC relative offset to
+					   GOT with signed low */
+#define R_M32R_GOTPC_LO		61	/* Low 16 bit PC relative offset to
+					   GOT */
+#define R_M32R_GOTOFF_HI_ULO	62	/* High 16 bit offset to GOT
+					   with unsigned low */
+#define R_M32R_GOTOFF_HI_SLO	63	/* High 16 bit offset to GOT
+					   with signed low */
+#define R_M32R_GOTOFF_LO	64	/* Low 16 bit offset to GOT */
+#define R_M32R_NUM		256	/* Keep this the last entry. */
+
+/* MicroBlaze relocations */
+#define R_MICROBLAZE_NONE		0	/* No reloc. */
+#define R_MICROBLAZE_32 		1	/* Direct 32 bit. */
+#define R_MICROBLAZE_32_PCREL		2	/* PC relative 32 bit. */
+#define R_MICROBLAZE_64_PCREL		3	/* PC relative 64 bit. */
+#define R_MICROBLAZE_32_PCREL_LO	4	/* Low 16 bits of PCREL32. */
+#define R_MICROBLAZE_64 		5	/* Direct 64 bit. */
+#define R_MICROBLAZE_32_LO		6	/* Low 16 bit. */
+#define R_MICROBLAZE_SRO32		7	/* Read-only small data area. */
+#define R_MICROBLAZE_SRW32		8	/* Read-write small data area. */
+#define R_MICROBLAZE_64_NONE		9	/* No reloc. */
+#define R_MICROBLAZE_32_SYM_OP_SYM	10	/* Symbol Op Symbol relocation. */
+#define R_MICROBLAZE_GNU_VTINHERIT	11	/* GNU C++ vtable hierarchy. */
+#define R_MICROBLAZE_GNU_VTENTRY	12	/* GNU C++ vtable member usage. */
+#define R_MICROBLAZE_GOTPC_64		13	/* PC-relative GOT offset.  */
+#define R_MICROBLAZE_GOT_64		14	/* GOT entry offset.  */
+#define R_MICROBLAZE_PLT_64		15	/* PLT offset (PC-relative).  */
+#define R_MICROBLAZE_REL		16	/* Adjust by program base.  */
+#define R_MICROBLAZE_JUMP_SLOT		17	/* Create PLT entry.  */
+#define R_MICROBLAZE_GLOB_DAT		18	/* Create GOT entry.  */
+#define R_MICROBLAZE_GOTOFF_64		19	/* 64 bit offset to GOT. */
+#define R_MICROBLAZE_GOTOFF_32		20	/* 32 bit offset to GOT. */
+#define R_MICROBLAZE_COPY		21	/* Runtime copy.  */
+#define R_MICROBLAZE_TLS		22	/* TLS Reloc. */
+#define R_MICROBLAZE_TLSGD		23	/* TLS General Dynamic. */
+#define R_MICROBLAZE_TLSLD		24	/* TLS Local Dynamic. */
+#define R_MICROBLAZE_TLSDTPMOD32	25	/* TLS Module ID. */
+#define R_MICROBLAZE_TLSDTPREL32	26	/* TLS Offset Within TLS Block. */
+#define R_MICROBLAZE_TLSDTPREL64	27	/* TLS Offset Within TLS Block. */
+#define R_MICROBLAZE_TLSGOTTPREL32	28	/* TLS Offset From Thread Pointer. */
+#define R_MICROBLAZE_TLSTPREL32 	29	/* TLS Offset From Thread Pointer. */
+
+/* Legal values for d_tag (dynamic entry type).  */
+#define DT_NIOS2_GP             0x70000002 /* Address of _gp.  */
+
+/* Nios II relocations.  */
+#define R_NIOS2_NONE		0	/* No reloc.  */
+#define R_NIOS2_S16		1	/* Direct signed 16 bit.  */
+#define R_NIOS2_U16		2	/* Direct unsigned 16 bit.  */
+#define R_NIOS2_PCREL16		3	/* PC relative 16 bit.  */
+#define R_NIOS2_CALL26		4	/* Direct call.  */
+#define R_NIOS2_IMM5		5	/* 5 bit constant expression.  */
+#define R_NIOS2_CACHE_OPX	6	/* 5 bit expression, shift 22.  */
+#define R_NIOS2_IMM6		7	/* 6 bit constant expression.  */
+#define R_NIOS2_IMM8		8	/* 8 bit constant expression.  */
+#define R_NIOS2_HI16		9	/* High 16 bit.  */
+#define R_NIOS2_LO16		10	/* Low 16 bit.  */
+#define R_NIOS2_HIADJ16		11	/* High 16 bit, adjusted.  */
+#define R_NIOS2_BFD_RELOC_32	12	/* 32 bit symbol value + addend.  */
+#define R_NIOS2_BFD_RELOC_16	13	/* 16 bit symbol value + addend.  */
+#define R_NIOS2_BFD_RELOC_8	14	/* 8 bit symbol value + addend.  */
+#define R_NIOS2_GPREL		15	/* 16 bit GP pointer offset.  */
+#define R_NIOS2_GNU_VTINHERIT	16	/* GNU C++ vtable hierarchy.  */
+#define R_NIOS2_GNU_VTENTRY	17	/* GNU C++ vtable member usage.  */
+#define R_NIOS2_UJMP		18	/* Unconditional branch.  */
+#define R_NIOS2_CJMP		19	/* Conditional branch.  */
+#define R_NIOS2_CALLR		20	/* Indirect call through register.  */
+#define R_NIOS2_ALIGN		21	/* Alignment requirement for
+					   linker relaxation.  */
+#define R_NIOS2_GOT16		22	/* 16 bit GOT entry.  */
+#define R_NIOS2_CALL16		23	/* 16 bit GOT entry for function.  */
+#define R_NIOS2_GOTOFF_LO	24	/* %lo of offset to GOT pointer.  */
+#define R_NIOS2_GOTOFF_HA	25	/* %hiadj of offset to GOT pointer.  */
+#define R_NIOS2_PCREL_LO	26	/* %lo of PC relative offset.  */
+#define R_NIOS2_PCREL_HA	27	/* %hiadj of PC relative offset.  */
+#define R_NIOS2_TLS_GD16	28	/* 16 bit GOT offset for TLS GD.  */
+#define R_NIOS2_TLS_LDM16	29	/* 16 bit GOT offset for TLS LDM.  */
+#define R_NIOS2_TLS_LDO16	30	/* 16 bit module relative offset.  */
+#define R_NIOS2_TLS_IE16	31	/* 16 bit GOT offset for TLS IE.  */
+#define R_NIOS2_TLS_LE16	32	/* 16 bit LE TP-relative offset.  */
+#define R_NIOS2_TLS_DTPMOD	33	/* Module number.  */
+#define R_NIOS2_TLS_DTPREL	34	/* Module-relative offset.  */
+#define R_NIOS2_TLS_TPREL	35	/* TP-relative offset.  */
+#define R_NIOS2_COPY		36	/* Copy symbol at runtime.  */
+#define R_NIOS2_GLOB_DAT	37	/* Create GOT entry.  */
+#define R_NIOS2_JUMP_SLOT	38	/* Create PLT entry.  */
+#define R_NIOS2_RELATIVE	39	/* Adjust by program base.  */
+#define R_NIOS2_GOTOFF		40	/* 16 bit offset to GOT pointer.  */
+#define R_NIOS2_CALL26_NOAT	41	/* Direct call in .noat section.  */
+#define R_NIOS2_GOT_LO		42	/* %lo() of GOT entry.  */
+#define R_NIOS2_GOT_HA		43	/* %hiadj() of GOT entry.  */
+#define R_NIOS2_CALL_LO		44	/* %lo() of function GOT entry.  */
+#define R_NIOS2_CALL_HA		45	/* %hiadj() of function GOT entry.  */
+
+/* TILEPro relocations.  */
+#define R_TILEPRO_NONE		0	/* No reloc */
+#define R_TILEPRO_32		1	/* Direct 32 bit */
+#define R_TILEPRO_16		2	/* Direct 16 bit */
+#define R_TILEPRO_8		3	/* Direct 8 bit */
+#define R_TILEPRO_32_PCREL	4	/* PC relative 32 bit */
+#define R_TILEPRO_16_PCREL	5	/* PC relative 16 bit */
+#define R_TILEPRO_8_PCREL	6	/* PC relative 8 bit */
+#define R_TILEPRO_LO16		7	/* Low 16 bit */
+#define R_TILEPRO_HI16		8	/* High 16 bit */
+#define R_TILEPRO_HA16		9	/* High 16 bit, adjusted */
+#define R_TILEPRO_COPY		10	/* Copy relocation */
+#define R_TILEPRO_GLOB_DAT	11	/* Create GOT entry */
+#define R_TILEPRO_JMP_SLOT	12	/* Create PLT entry */
+#define R_TILEPRO_RELATIVE	13	/* Adjust by program base */
+#define R_TILEPRO_BROFF_X1	14	/* X1 pipe branch offset */
+#define R_TILEPRO_JOFFLONG_X1	15	/* X1 pipe jump offset */
+#define R_TILEPRO_JOFFLONG_X1_PLT 16	/* X1 pipe jump offset to PLT */
+#define R_TILEPRO_IMM8_X0	17	/* X0 pipe 8-bit */
+#define R_TILEPRO_IMM8_Y0	18	/* Y0 pipe 8-bit */
+#define R_TILEPRO_IMM8_X1	19	/* X1 pipe 8-bit */
+#define R_TILEPRO_IMM8_Y1	20	/* Y1 pipe 8-bit */
+#define R_TILEPRO_MT_IMM15_X1	21	/* X1 pipe mtspr */
+#define R_TILEPRO_MF_IMM15_X1	22	/* X1 pipe mfspr */
+#define R_TILEPRO_IMM16_X0	23	/* X0 pipe 16-bit */
+#define R_TILEPRO_IMM16_X1	24	/* X1 pipe 16-bit */
+#define R_TILEPRO_IMM16_X0_LO	25	/* X0 pipe low 16-bit */
+#define R_TILEPRO_IMM16_X1_LO	26	/* X1 pipe low 16-bit */
+#define R_TILEPRO_IMM16_X0_HI	27	/* X0 pipe high 16-bit */
+#define R_TILEPRO_IMM16_X1_HI	28	/* X1 pipe high 16-bit */
+#define R_TILEPRO_IMM16_X0_HA	29	/* X0 pipe high 16-bit, adjusted */
+#define R_TILEPRO_IMM16_X1_HA	30	/* X1 pipe high 16-bit, adjusted */
+#define R_TILEPRO_IMM16_X0_PCREL 31	/* X0 pipe PC relative 16 bit */
+#define R_TILEPRO_IMM16_X1_PCREL 32	/* X1 pipe PC relative 16 bit */
+#define R_TILEPRO_IMM16_X0_LO_PCREL 33	/* X0 pipe PC relative low 16 bit */
+#define R_TILEPRO_IMM16_X1_LO_PCREL 34	/* X1 pipe PC relative low 16 bit */
+#define R_TILEPRO_IMM16_X0_HI_PCREL 35	/* X0 pipe PC relative high 16 bit */
+#define R_TILEPRO_IMM16_X1_HI_PCREL 36	/* X1 pipe PC relative high 16 bit */
+#define R_TILEPRO_IMM16_X0_HA_PCREL 37	/* X0 pipe PC relative ha() 16 bit */
+#define R_TILEPRO_IMM16_X1_HA_PCREL 38	/* X1 pipe PC relative ha() 16 bit */
+#define R_TILEPRO_IMM16_X0_GOT	39	/* X0 pipe 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X1_GOT	40	/* X1 pipe 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X0_GOT_LO 41	/* X0 pipe low 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X1_GOT_LO 42	/* X1 pipe low 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X0_GOT_HI 43	/* X0 pipe high 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X1_GOT_HI 44	/* X1 pipe high 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X0_GOT_HA 45	/* X0 pipe ha() 16-bit GOT offset */
+#define R_TILEPRO_IMM16_X1_GOT_HA 46	/* X1 pipe ha() 16-bit GOT offset */
+#define R_TILEPRO_MMSTART_X0	47	/* X0 pipe mm "start" */
+#define R_TILEPRO_MMEND_X0	48	/* X0 pipe mm "end" */
+#define R_TILEPRO_MMSTART_X1	49	/* X1 pipe mm "start" */
+#define R_TILEPRO_MMEND_X1	50	/* X1 pipe mm "end" */
+#define R_TILEPRO_SHAMT_X0	51	/* X0 pipe shift amount */
+#define R_TILEPRO_SHAMT_X1	52	/* X1 pipe shift amount */
+#define R_TILEPRO_SHAMT_Y0	53	/* Y0 pipe shift amount */
+#define R_TILEPRO_SHAMT_Y1	54	/* Y1 pipe shift amount */
+#define R_TILEPRO_DEST_IMM8_X1	55	/* X1 pipe destination 8-bit */
+/* Relocs 56-59 are currently not defined.  */
+#define R_TILEPRO_TLS_GD_CALL	60	/* "jal" for TLS GD */
+#define R_TILEPRO_IMM8_X0_TLS_GD_ADD 61	/* X0 pipe "addi" for TLS GD */
+#define R_TILEPRO_IMM8_X1_TLS_GD_ADD 62	/* X1 pipe "addi" for TLS GD */
+#define R_TILEPRO_IMM8_Y0_TLS_GD_ADD 63	/* Y0 pipe "addi" for TLS GD */
+#define R_TILEPRO_IMM8_Y1_TLS_GD_ADD 64	/* Y1 pipe "addi" for TLS GD */
+#define R_TILEPRO_TLS_IE_LOAD	65	/* "lw_tls" for TLS IE */
+#define R_TILEPRO_IMM16_X0_TLS_GD 66	/* X0 pipe 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X1_TLS_GD 67	/* X1 pipe 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X0_TLS_GD_LO 68	/* X0 pipe low 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X1_TLS_GD_LO 69	/* X1 pipe low 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X0_TLS_GD_HI 70	/* X0 pipe high 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X1_TLS_GD_HI 71	/* X1 pipe high 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X0_TLS_GD_HA 72	/* X0 pipe ha() 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X1_TLS_GD_HA 73	/* X1 pipe ha() 16-bit TLS GD offset */
+#define R_TILEPRO_IMM16_X0_TLS_IE 74	/* X0 pipe 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X1_TLS_IE 75	/* X1 pipe 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X0_TLS_IE_LO 76	/* X0 pipe low 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X1_TLS_IE_LO 77	/* X1 pipe low 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X0_TLS_IE_HI 78	/* X0 pipe high 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X1_TLS_IE_HI 79	/* X1 pipe high 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X0_TLS_IE_HA 80	/* X0 pipe ha() 16-bit TLS IE offset */
+#define R_TILEPRO_IMM16_X1_TLS_IE_HA 81	/* X1 pipe ha() 16-bit TLS IE offset */
+#define R_TILEPRO_TLS_DTPMOD32	82	/* ID of module containing symbol */
+#define R_TILEPRO_TLS_DTPOFF32	83	/* Offset in TLS block */
+#define R_TILEPRO_TLS_TPOFF32	84	/* Offset in static TLS block */
+#define R_TILEPRO_IMM16_X0_TLS_LE 85	/* X0 pipe 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X1_TLS_LE 86	/* X1 pipe 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X0_TLS_LE_LO 87	/* X0 pipe low 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X1_TLS_LE_LO 88	/* X1 pipe low 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X0_TLS_LE_HI 89	/* X0 pipe high 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X1_TLS_LE_HI 90	/* X1 pipe high 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X0_TLS_LE_HA 91	/* X0 pipe ha() 16-bit TLS LE offset */
+#define R_TILEPRO_IMM16_X1_TLS_LE_HA 92	/* X1 pipe ha() 16-bit TLS LE offset */
+
+#define R_TILEPRO_GNU_VTINHERIT	128	/* GNU C++ vtable hierarchy */
+#define R_TILEPRO_GNU_VTENTRY	129	/* GNU C++ vtable member usage */
+
+#define R_TILEPRO_NUM		130
+
+
+/* TILE-Gx relocations.  */
+#define R_TILEGX_NONE		0	/* No reloc */
+#define R_TILEGX_64		1	/* Direct 64 bit */
+#define R_TILEGX_32		2	/* Direct 32 bit */
+#define R_TILEGX_16		3	/* Direct 16 bit */
+#define R_TILEGX_8		4	/* Direct 8 bit */
+#define R_TILEGX_64_PCREL	5	/* PC relative 64 bit */
+#define R_TILEGX_32_PCREL	6	/* PC relative 32 bit */
+#define R_TILEGX_16_PCREL	7	/* PC relative 16 bit */
+#define R_TILEGX_8_PCREL	8	/* PC relative 8 bit */
+#define R_TILEGX_HW0		9	/* hword 0 16-bit */
+#define R_TILEGX_HW1		10	/* hword 1 16-bit */
+#define R_TILEGX_HW2		11	/* hword 2 16-bit */
+#define R_TILEGX_HW3		12	/* hword 3 16-bit */
+#define R_TILEGX_HW0_LAST	13	/* last hword 0 16-bit */
+#define R_TILEGX_HW1_LAST	14	/* last hword 1 16-bit */
+#define R_TILEGX_HW2_LAST	15	/* last hword 2 16-bit */
+#define R_TILEGX_COPY		16	/* Copy relocation */
+#define R_TILEGX_GLOB_DAT	17	/* Create GOT entry */
+#define R_TILEGX_JMP_SLOT	18	/* Create PLT entry */
+#define R_TILEGX_RELATIVE	19	/* Adjust by program base */
+#define R_TILEGX_BROFF_X1	20	/* X1 pipe branch offset */
+#define R_TILEGX_JUMPOFF_X1	21	/* X1 pipe jump offset */
+#define R_TILEGX_JUMPOFF_X1_PLT	22	/* X1 pipe jump offset to PLT */
+#define R_TILEGX_IMM8_X0	23	/* X0 pipe 8-bit */
+#define R_TILEGX_IMM8_Y0	24	/* Y0 pipe 8-bit */
+#define R_TILEGX_IMM8_X1	25	/* X1 pipe 8-bit */
+#define R_TILEGX_IMM8_Y1	26	/* Y1 pipe 8-bit */
+#define R_TILEGX_DEST_IMM8_X1	27	/* X1 pipe destination 8-bit */
+#define R_TILEGX_MT_IMM14_X1	28	/* X1 pipe mtspr */
+#define R_TILEGX_MF_IMM14_X1	29	/* X1 pipe mfspr */
+#define R_TILEGX_MMSTART_X0	30	/* X0 pipe mm "start" */
+#define R_TILEGX_MMEND_X0	31	/* X0 pipe mm "end" */
+#define R_TILEGX_SHAMT_X0	32	/* X0 pipe shift amount */
+#define R_TILEGX_SHAMT_X1	33	/* X1 pipe shift amount */
+#define R_TILEGX_SHAMT_Y0	34	/* Y0 pipe shift amount */
+#define R_TILEGX_SHAMT_Y1	35	/* Y1 pipe shift amount */
+#define R_TILEGX_IMM16_X0_HW0	36	/* X0 pipe hword 0 */
+#define R_TILEGX_IMM16_X1_HW0	37	/* X1 pipe hword 0 */
+#define R_TILEGX_IMM16_X0_HW1	38	/* X0 pipe hword 1 */
+#define R_TILEGX_IMM16_X1_HW1	39	/* X1 pipe hword 1 */
+#define R_TILEGX_IMM16_X0_HW2	40	/* X0 pipe hword 2 */
+#define R_TILEGX_IMM16_X1_HW2	41	/* X1 pipe hword 2 */
+#define R_TILEGX_IMM16_X0_HW3	42	/* X0 pipe hword 3 */
+#define R_TILEGX_IMM16_X1_HW3	43	/* X1 pipe hword 3 */
+#define R_TILEGX_IMM16_X0_HW0_LAST 44	/* X0 pipe last hword 0 */
+#define R_TILEGX_IMM16_X1_HW0_LAST 45	/* X1 pipe last hword 0 */
+#define R_TILEGX_IMM16_X0_HW1_LAST 46	/* X0 pipe last hword 1 */
+#define R_TILEGX_IMM16_X1_HW1_LAST 47	/* X1 pipe last hword 1 */
+#define R_TILEGX_IMM16_X0_HW2_LAST 48	/* X0 pipe last hword 2 */
+#define R_TILEGX_IMM16_X1_HW2_LAST 49	/* X1 pipe last hword 2 */
+#define R_TILEGX_IMM16_X0_HW0_PCREL 50	/* X0 pipe PC relative hword 0 */
+#define R_TILEGX_IMM16_X1_HW0_PCREL 51	/* X1 pipe PC relative hword 0 */
+#define R_TILEGX_IMM16_X0_HW1_PCREL 52	/* X0 pipe PC relative hword 1 */
+#define R_TILEGX_IMM16_X1_HW1_PCREL 53	/* X1 pipe PC relative hword 1 */
+#define R_TILEGX_IMM16_X0_HW2_PCREL 54	/* X0 pipe PC relative hword 2 */
+#define R_TILEGX_IMM16_X1_HW2_PCREL 55	/* X1 pipe PC relative hword 2 */
+#define R_TILEGX_IMM16_X0_HW3_PCREL 56	/* X0 pipe PC relative hword 3 */
+#define R_TILEGX_IMM16_X1_HW3_PCREL 57	/* X1 pipe PC relative hword 3 */
+#define R_TILEGX_IMM16_X0_HW0_LAST_PCREL 58 /* X0 pipe PC-rel last hword 0 */
+#define R_TILEGX_IMM16_X1_HW0_LAST_PCREL 59 /* X1 pipe PC-rel last hword 0 */
+#define R_TILEGX_IMM16_X0_HW1_LAST_PCREL 60 /* X0 pipe PC-rel last hword 1 */
+#define R_TILEGX_IMM16_X1_HW1_LAST_PCREL 61 /* X1 pipe PC-rel last hword 1 */
+#define R_TILEGX_IMM16_X0_HW2_LAST_PCREL 62 /* X0 pipe PC-rel last hword 2 */
+#define R_TILEGX_IMM16_X1_HW2_LAST_PCREL 63 /* X1 pipe PC-rel last hword 2 */
+#define R_TILEGX_IMM16_X0_HW0_GOT 64	/* X0 pipe hword 0 GOT offset */
+#define R_TILEGX_IMM16_X1_HW0_GOT 65	/* X1 pipe hword 0 GOT offset */
+#define R_TILEGX_IMM16_X0_HW0_PLT_PCREL 66 /* X0 pipe PC-rel PLT hword 0 */
+#define R_TILEGX_IMM16_X1_HW0_PLT_PCREL 67 /* X1 pipe PC-rel PLT hword 0 */
+#define R_TILEGX_IMM16_X0_HW1_PLT_PCREL 68 /* X0 pipe PC-rel PLT hword 1 */
+#define R_TILEGX_IMM16_X1_HW1_PLT_PCREL 69 /* X1 pipe PC-rel PLT hword 1 */
+#define R_TILEGX_IMM16_X0_HW2_PLT_PCREL 70 /* X0 pipe PC-rel PLT hword 2 */
+#define R_TILEGX_IMM16_X1_HW2_PLT_PCREL 71 /* X1 pipe PC-rel PLT hword 2 */
+#define R_TILEGX_IMM16_X0_HW0_LAST_GOT 72 /* X0 pipe last hword 0 GOT offset */
+#define R_TILEGX_IMM16_X1_HW0_LAST_GOT 73 /* X1 pipe last hword 0 GOT offset */
+#define R_TILEGX_IMM16_X0_HW1_LAST_GOT 74 /* X0 pipe last hword 1 GOT offset */
+#define R_TILEGX_IMM16_X1_HW1_LAST_GOT 75 /* X1 pipe last hword 1 GOT offset */
+#define R_TILEGX_IMM16_X0_HW3_PLT_PCREL 76 /* X0 pipe PC-rel PLT hword 3 */
+#define R_TILEGX_IMM16_X1_HW3_PLT_PCREL 77 /* X1 pipe PC-rel PLT hword 3 */
+#define R_TILEGX_IMM16_X0_HW0_TLS_GD 78	/* X0 pipe hword 0 TLS GD offset */
+#define R_TILEGX_IMM16_X1_HW0_TLS_GD 79	/* X1 pipe hword 0 TLS GD offset */
+#define R_TILEGX_IMM16_X0_HW0_TLS_LE 80	/* X0 pipe hword 0 TLS LE offset */
+#define R_TILEGX_IMM16_X1_HW0_TLS_LE 81	/* X1 pipe hword 0 TLS LE offset */
+#define R_TILEGX_IMM16_X0_HW0_LAST_TLS_LE 82 /* X0 pipe last hword 0 LE off */
+#define R_TILEGX_IMM16_X1_HW0_LAST_TLS_LE 83 /* X1 pipe last hword 0 LE off */
+#define R_TILEGX_IMM16_X0_HW1_LAST_TLS_LE 84 /* X0 pipe last hword 1 LE off */
+#define R_TILEGX_IMM16_X1_HW1_LAST_TLS_LE 85 /* X1 pipe last hword 1 LE off */
+#define R_TILEGX_IMM16_X0_HW0_LAST_TLS_GD 86 /* X0 pipe last hword 0 GD off */
+#define R_TILEGX_IMM16_X1_HW0_LAST_TLS_GD 87 /* X1 pipe last hword 0 GD off */
+#define R_TILEGX_IMM16_X0_HW1_LAST_TLS_GD 88 /* X0 pipe last hword 1 GD off */
+#define R_TILEGX_IMM16_X1_HW1_LAST_TLS_GD 89 /* X1 pipe last hword 1 GD off */
+/* Relocs 90-91 are currently not defined.  */
+#define R_TILEGX_IMM16_X0_HW0_TLS_IE 92	/* X0 pipe hword 0 TLS IE offset */
+#define R_TILEGX_IMM16_X1_HW0_TLS_IE 93	/* X1 pipe hword 0 TLS IE offset */
+#define R_TILEGX_IMM16_X0_HW0_LAST_PLT_PCREL 94 /* X0 pipe PC-rel PLT last hword 0 */
+#define R_TILEGX_IMM16_X1_HW0_LAST_PLT_PCREL 95 /* X1 pipe PC-rel PLT last hword 0 */
+#define R_TILEGX_IMM16_X0_HW1_LAST_PLT_PCREL 96 /* X0 pipe PC-rel PLT last hword 1 */
+#define R_TILEGX_IMM16_X1_HW1_LAST_PLT_PCREL 97 /* X1 pipe PC-rel PLT last hword 1 */
+#define R_TILEGX_IMM16_X0_HW2_LAST_PLT_PCREL 98 /* X0 pipe PC-rel PLT last hword 2 */
+#define R_TILEGX_IMM16_X1_HW2_LAST_PLT_PCREL 99 /* X1 pipe PC-rel PLT last hword 2 */
+#define R_TILEGX_IMM16_X0_HW0_LAST_TLS_IE 100 /* X0 pipe last hword 0 IE off */
+#define R_TILEGX_IMM16_X1_HW0_LAST_TLS_IE 101 /* X1 pipe last hword 0 IE off */
+#define R_TILEGX_IMM16_X0_HW1_LAST_TLS_IE 102 /* X0 pipe last hword 1 IE off */
+#define R_TILEGX_IMM16_X1_HW1_LAST_TLS_IE 103 /* X1 pipe last hword 1 IE off */
+/* Relocs 104-105 are currently not defined.  */
+#define R_TILEGX_TLS_DTPMOD64	106	/* 64-bit ID of symbol's module */
+#define R_TILEGX_TLS_DTPOFF64	107	/* 64-bit offset in TLS block */
+#define R_TILEGX_TLS_TPOFF64	108	/* 64-bit offset in static TLS block */
+#define R_TILEGX_TLS_DTPMOD32	109	/* 32-bit ID of symbol's module */
+#define R_TILEGX_TLS_DTPOFF32	110	/* 32-bit offset in TLS block */
+#define R_TILEGX_TLS_TPOFF32	111	/* 32-bit offset in static TLS block */
+#define R_TILEGX_TLS_GD_CALL	112	/* "jal" for TLS GD */
+#define R_TILEGX_IMM8_X0_TLS_GD_ADD 113	/* X0 pipe "addi" for TLS GD */
+#define R_TILEGX_IMM8_X1_TLS_GD_ADD 114	/* X1 pipe "addi" for TLS GD */
+#define R_TILEGX_IMM8_Y0_TLS_GD_ADD 115	/* Y0 pipe "addi" for TLS GD */
+#define R_TILEGX_IMM8_Y1_TLS_GD_ADD 116	/* Y1 pipe "addi" for TLS GD */
+#define R_TILEGX_TLS_IE_LOAD	117	/* "ld_tls" for TLS IE */
+#define R_TILEGX_IMM8_X0_TLS_ADD 118	/* X0 pipe "addi" for TLS GD/IE */
+#define R_TILEGX_IMM8_X1_TLS_ADD 119	/* X1 pipe "addi" for TLS GD/IE */
+#define R_TILEGX_IMM8_Y0_TLS_ADD 120	/* Y0 pipe "addi" for TLS GD/IE */
+#define R_TILEGX_IMM8_Y1_TLS_ADD 121	/* Y1 pipe "addi" for TLS GD/IE */
+
+#define R_TILEGX_GNU_VTINHERIT	128	/* GNU C++ vtable hierarchy */
+#define R_TILEGX_GNU_VTENTRY	129	/* GNU C++ vtable member usage */
+
+#define R_TILEGX_NUM		130
+
+/* RISC-V ELF Flags */
+#define EF_RISCV_RVC 			0x0001
+#define EF_RISCV_FLOAT_ABI 		0x0006
+#define EF_RISCV_FLOAT_ABI_SOFT 	0x0000
+#define EF_RISCV_FLOAT_ABI_SINGLE 	0x0002
+#define EF_RISCV_FLOAT_ABI_DOUBLE 	0x0004
+#define EF_RISCV_FLOAT_ABI_QUAD 	0x0006
+
+/* RISC-V relocations.  */
+#define R_RISCV_NONE		 0
+#define R_RISCV_32		 1
+#define R_RISCV_64		 2
+#define R_RISCV_RELATIVE	 3
+#define R_RISCV_COPY		 4
+#define R_RISCV_JUMP_SLOT	 5
+#define R_RISCV_TLS_DTPMOD32	 6
+#define R_RISCV_TLS_DTPMOD64	 7
+#define R_RISCV_TLS_DTPREL32	 8
+#define R_RISCV_TLS_DTPREL64	 9
+#define R_RISCV_TLS_TPREL32	10
+#define R_RISCV_TLS_TPREL64	11
+#define R_RISCV_BRANCH		16
+#define R_RISCV_JAL		17
+#define R_RISCV_CALL		18
+#define R_RISCV_CALL_PLT	19
+#define R_RISCV_GOT_HI20	20
+#define R_RISCV_TLS_GOT_HI20	21
+#define R_RISCV_TLS_GD_HI20	22
+#define R_RISCV_PCREL_HI20	23
+#define R_RISCV_PCREL_LO12_I	24
+#define R_RISCV_PCREL_LO12_S	25
+#define R_RISCV_HI20		26
+#define R_RISCV_LO12_I		27
+#define R_RISCV_LO12_S		28
+#define R_RISCV_TPREL_HI20	29
+#define R_RISCV_TPREL_LO12_I	30
+#define R_RISCV_TPREL_LO12_S	31
+#define R_RISCV_TPREL_ADD	32
+#define R_RISCV_ADD8		33
+#define R_RISCV_ADD16		34
+#define R_RISCV_ADD32		35
+#define R_RISCV_ADD64		36
+#define R_RISCV_SUB8		37
+#define R_RISCV_SUB16		38
+#define R_RISCV_SUB32		39
+#define R_RISCV_SUB64		40
+#define R_RISCV_GNU_VTINHERIT	41
+#define R_RISCV_GNU_VTENTRY	42
+#define R_RISCV_ALIGN		43
+#define R_RISCV_RVC_BRANCH	44
+#define R_RISCV_RVC_JUMP	45
+#define R_RISCV_RVC_LUI		46
+#define R_RISCV_GPREL_I		47
+#define R_RISCV_GPREL_S		48
+#define R_RISCV_TPREL_I		49
+#define R_RISCV_TPREL_S		50
+#define R_RISCV_RELAX		51
+#define R_RISCV_SUB6		52
+#define R_RISCV_SET6		53
+#define R_RISCV_SET8		54
+#define R_RISCV_SET16		55
+#define R_RISCV_SET32		56
+#define R_RISCV_32_PCREL	57
+
+#define R_RISCV_NUM		58
+
+/* BPF specific declarations.  */
+
+#define R_BPF_NONE		0	/* No reloc */
+#define R_BPF_64_64		1
+#define R_BPF_64_32		10
+
+/* Imagination Meta specific relocations. */
+
+#define R_METAG_HIADDR16	0
+#define R_METAG_LOADDR16	1
+#define R_METAG_ADDR32		2	/* 32bit absolute address */
+#define R_METAG_NONE		3	/* No reloc */
+#define R_METAG_RELBRANCH	4
+#define R_METAG_GETSETOFF	5
+
+/* Backward compatability */
+#define R_METAG_REG32OP1	6
+#define R_METAG_REG32OP2	7
+#define R_METAG_REG32OP3	8
+#define R_METAG_REG16OP1	9
+#define R_METAG_REG16OP2	10
+#define R_METAG_REG16OP3	11
+#define R_METAG_REG32OP4	12
+
+#define R_METAG_HIOG		13
+#define R_METAG_LOOG		14
+
+#define R_METAG_REL8		15
+#define R_METAG_REL16		16
+
+/* GNU */
+#define R_METAG_GNU_VTINHERIT	30
+#define R_METAG_GNU_VTENTRY	31
+
+/* PIC relocations */
+#define R_METAG_HI16_GOTOFF	32
+#define R_METAG_LO16_GOTOFF	33
+#define R_METAG_GETSET_GOTOFF	34
+#define R_METAG_GETSET_GOT	35
+#define R_METAG_HI16_GOTPC	36
+#define R_METAG_LO16_GOTPC	37
+#define R_METAG_HI16_PLT	38
+#define R_METAG_LO16_PLT	39
+#define R_METAG_RELBRANCH_PLT	40
+#define R_METAG_GOTOFF		41
+#define R_METAG_PLT		42
+#define R_METAG_COPY		43
+#define R_METAG_JMP_SLOT	44
+#define R_METAG_RELATIVE	45
+#define R_METAG_GLOB_DAT	46
+
+/* TLS relocations */
+#define R_METAG_TLS_GD		47
+#define R_METAG_TLS_LDM		48
+#define R_METAG_TLS_LDO_HI16	49
+#define R_METAG_TLS_LDO_LO16	50
+#define R_METAG_TLS_LDO		51
+#define R_METAG_TLS_IE		52
+#define R_METAG_TLS_IENONPIC	53
+#define R_METAG_TLS_IENONPIC_HI16 54
+#define R_METAG_TLS_IENONPIC_LO16 55
+#define R_METAG_TLS_TPOFF	56
+#define R_METAG_TLS_DTPMOD	57
+#define R_METAG_TLS_DTPOFF	58
+#define R_METAG_TLS_LE		59
+#define R_METAG_TLS_LE_HI16	60
+#define R_METAG_TLS_LE_LO16	61
+
+/* NDS32 relocations.  */
+#define R_NDS32_NONE		0
+#define R_NDS32_32_RELA 	20
+#define R_NDS32_COPY		39
+#define R_NDS32_GLOB_DAT	40
+#define R_NDS32_JMP_SLOT	41
+#define R_NDS32_RELATIVE	42
+#define R_NDS32_TLS_TPOFF	102
+#define R_NDS32_TLS_DESC	119
+
+#endif	/* elf.h */

--- a/feeds/morse/utils/morsectrl/src/win/strsep.c
+++ b/feeds/morse/utils/morsectrl/src/win/strsep.c
@@ -1,0 +1,72 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <string.h>
+
+#undef strsep
+
+/*
+ * Get next token from string *stringp, where tokens are possibly-empty
+ * strings separated by characters from delim.
+ *
+ * Writes NULs into the string at *stringp to end tokens.
+ * delim need not remain constant from call to call.
+ * On return, *stringp points past the last NUL written (if there might
+ * be further tokens), or is NULL (if there are definitely no more tokens).
+ *
+ * If *stringp is NULL, strsep returns NULL.
+ */
+char *
+strsep(char **stringp, const char *delim)
+{
+    char *s;
+    const char *spanp;
+    int c, sc;
+    char *tok;
+
+    if ((s = *stringp) == NULL)
+        return (NULL);
+    for (tok = s;;) {
+        c = *s++;
+        spanp = delim;
+        do {
+            if ((sc = *spanp++) == c) {
+                if (c == 0)
+                    s = NULL;
+                else
+                    s[-1] = 0;
+                *stringp = s;
+                return (tok);
+            }
+        } while (sc != 0);
+    }
+    /* NOTREACHED */
+}

--- a/feeds/morse/utils/morsectrl/src/win/strsep.h
+++ b/feeds/morse/utils/morsectrl/src/win/strsep.h
@@ -1,0 +1,10 @@
+/* $Id: strsep.h,v 1.2 2001/02/09 01:55:36 djm Exp $ */
+
+#ifndef _BSD_STRSEP_H
+#define _BSD_STRSEP_H
+
+#ifndef HAVE_STRSEP
+char *strsep(char **stringp, const char *delim);
+#endif /* HAVE_STRSEP */
+
+#endif /* _BSD_STRSEP_H */

--- a/profiles/edgecore_eap112.yml
+++ b/profiles/edgecore_eap112.yml
@@ -36,6 +36,7 @@ packages:
   - kmod-morse
   - morse-fw
   - morsecli
+  - morsectrl
   - hostapd_s1g
   - wpa_supplicant_s1g
   - netifd-morse


### PR DESCRIPTION
Disable energy-detect CCA on HaLow interface bring-up by
invoking 'morsectrl edconfig energy ignore' in drv_morse_setup.

new package "morsectrl"

Fixes: WIFI-15483
