### PR TITLE
qca-wifi-7: fix WAN/LAN port assignment for AP7330

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/etc/board.d/02_network
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/etc/board.d/02_network
@@ -48,9 +48,9 @@ ipq53xx_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	asterfusion,AP7330)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_lan "eth0"
 		ucidef_add_switch "switch1" \
-			"0u@eth1" "3:lan" "4:lan"
+			"0u@eth1" "3:lan" "4:wan"
 		;;
 	esac
 }


### PR DESCRIPTION
Change eth0 from WAN to LAN interface, and reassign switch port 4 as the WAN port.

Fixes: WIFI-15490