### PR TITLE
ath12k: pass the correct value of each TID during a stop AMPDU session

### DIFF
--- a/feeds/qca-wifi-7/mac80211/patches-tip/pending/a-101-ath12k-fix-ampdu-stop-tid.patch
+++ b/feeds/qca-wifi-7/mac80211/patches-tip/pending/a-101-ath12k-fix-ampdu-stop-tid.patch
@@ -1,0 +1,44 @@
+From: Reshma Immaculate Rajkumar <reshma.rajkumar@oss.qualcomm.com>
+Date: Fri, 27 Feb 2026 16:31:23 +0530
+Subject: [PATCH] wifi: ath12k: Pass the correct value of each TID during a stop AMPDU session
+
+With traffic ongoing for data TID [TID 0], an DELBA request to
+stop AMPDU for the BA session was received on management TID [TID 4].
+The corresponding TID number was incorrectly passed to stop the BA session,
+resulting in the BA session for data TIDs being stopped and the BA size
+being reduced to 1, causing an overall dip in TCP throughput.
+
+Fix this issue by passing the correct argument from
+ath12k_dp_rx_ampdu_stop() to ath12k_dp_arch_peer_rx_tid_reo_update()
+during an AMPDU stop session. Instead of passing peer->dp_peer->rx_tid,
+which is the base address of the array, corresponding to TID 0, pass
+the value of &peer->dp_peer->rx_tid[params->tid]. With this, the
+different TID numbers are accounted for.
+
+Tested-on: QCN9274 hw2.0 PCI WLAN.WBE.1.5-01651-QCAHKSWPL_SILICONZ-1
+
+Fixes: d889913205cf ("wifi: ath12k: driver for Qualcomm Wi-Fi 7 devices")
+Signed-off-by: Reshma Immaculate Rajkumar <reshma.rajkumar@oss.qualcomm.com>
+---
+--- a/drivers/net/wireless/ath/ath12k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath12k/dp_rx.c
+@@ -1280,6 +1280,7 @@ int ath12k_dp_rx_ampdu_stop(struct ath12
+ 	struct ath12k_base *ab = ar->ab;
+ 	struct ath12k_peer *peer;
+ 	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(params->sta);
++	struct ath12k_dp_rx_tid *rx_tid;
+ 	struct ath12k_link_sta *arsta;
+ 	int vdev_id;
+ 	bool active;
+@@ -1307,7 +1308,8 @@ int ath12k_dp_rx_ampdu_stop(struct ath12
+ 		return 0;
+ 	}
+
+-	ret = ath12k_peer_rx_tid_reo_update(ab, peer, peer->rx_tid, 1, 0, false);
++	rx_tid = &peer->rx_tid[params->tid];
++	ret = ath12k_peer_rx_tid_reo_update(ab, peer, rx_tid, 1, 0, false);
+ 	spin_unlock_bh(&ab->base_lock);
+ 	if (ret) {
+ 		ath12k_warn(ab, "failed to update reo for rx tid %d: %d\n",
+--
+2.34.1


### PR DESCRIPTION
backport:
https://lore.kernel.org/all/20260227110123.3726354-1-reshma.rajkumar@oss.qualcomm.com/

With traffic ongoing for data TID [TID 0], an DELBA request to stop AMPDU for the BA session was received on management TID [TID 4]. The corresponding TID number was incorrectly passed to stop the BA session, resulting in the BA session for data TIDs being stopped and the BA size being reduced to 1, causing an overall dip in TCP throughput.

Fix this issue by passing the correct argument from ath12k_dp_rx_ampdu_stop() to ath12k_dp_arch_peer_rx_tid_reo_update() during an AMPDU stop session. Instead of passing peer->dp_peer->rx_tid, which is the base address of the array, corresponding to TID 0, pass the value of &peer->dp_peer->rx_tid[params->tid]. With this, the different TID numbers are accounted for.