### PR TITLE
WIFI-15495-ipq54xx-target-enhancements

### DIFF
--- a/feeds/qca-wifi-7/ath12k-firmware/files/IPQ5424/Data.msc
+++ b/feeds/qca-wifi-7/ath12k-firmware/files/IPQ5424/Data.msc
@@ -1,0 +1,9427 @@
+VERSION:369394907
+0,ii,[ parseBinCmdStream_v2.c : 202 ] parmIdx %d more than expected maxParmnum %d 
+1,,[ LMRxInitProcessing.c : 29 ] Failed to allocate memory for lm_rxStats is NULL 
+2,,[ cmdProcessTlv2.c : 336 ] ftm_temp_timer: MAC in sleep state 
+3,iii,[ cmdProcessTlv2.c : 607 ] ftmTsDebugHandler cmdId %d phyId %d status %d 
+4,i,[ cmdProcessTlv2.c : 625 ] Invalid phyId %d 
+5,i,[ cmdProcessTlv2.c : 636 ] pHandle NULL/Inactive phyId %d 
+6,i,[ cmdProcessTlv2.c : 758 ] pktgen_complete_timer: Invalid phyId %d 
+7,ii,[ cmdProcessTlv2.c : 773 ] pktgen_complete_timer: phyId %d pktgen_done_fail_cnt %d 
+8,iiiiiiiI,[ cmdProcessTlv2.c : 1052 ] FTM txHandler: phyId %d txMode %d freq %d freq2 %d wlanMode %d chainMask %d wifiStandard %d timestamp =%ld 
+9,III,[ cmdProcessTlv2.c : 1083 ] FTM txHandler: Invalid Parms. chainMask 0x%x, txChainMask_translate 0x%x BDF txChainMask 0x%x 
+10,i,[ cmdProcessTlv2.c : 1124 ] FTM txHandler: TX operation not allowed on phyID %d 
+11,i,[ cmdProcessTlv2.c : 1259 ] FTM: OFDMA Tone Plan BW %d 
+12,,[ cmdProcessTlv2.c : 1272 ] FTM: AGILE SCAN NOT SUPPORTED IN TX 
+13,ii,[ cmdProcessTlv2.c : 1337 ] FTM txHandler: dev running state=%d iterations_taken_to_flush=%d 
+14,iI,[ cmdProcessTlv2.c : 1373 ] FTM txHandler: Sent response to host with status =%d, timestamp =%ld 
+15,iiiI,[ cmdProcessTlv2.c : 1452 ] txStatusHandler: phyId %d needReport %d stopTx %d timestamp %u ms 
+16,iiiiiIi,[ cmdProcessTlv2.c : 1648 ] rxAuxHandler: phyId %d rxMode %d wlanMode %d freq %d freq2 %d chainMask 0x%x wifiStandard %d 
+17,iiiiiIi,[ cmdProcessTlv2.c : 1819 ] rxHandler: phyId %d rxMode %d wlanMode %d freq %d freq2 %d chainMask 0x%x wifiStandard %d 
+18,i,[ cmdProcessTlv2.c : 1832 ] RX operation not allowed on phyID %d 
+19,iiiiiII,[ cmdProcessTlv2.c : 2082 ] BCF1 %d, BCF2 %d, PHYRF_BW_IDX %d phy_mode %d num_20_bw %d rx_CM 0x%x, tx_CM 0x%x 
+20,ii,[ cmdProcessTlv2.c : 2662 ] UTFCMD: phyId %d cmdId %d 
+21,,[ cmdProcessTlv2.c : 2689 ] Failed Rx Stop 
+22,i,[ cmdProcessTlv2.c : 2729 ] UTFCMD: MMSeqID %d  
+23,i,[ cmdProcessTlv2.c : 2858 ] UTFCMD: InValid CmdID %d 
+24,,[ cmdProcessTlv2.c : 2946 ] Compressed mode ADC capture not possible when both channels selected 
+25,,[ cmdProcessTlv2.c : 2969 ] adcCapture : command param error 
+26,IiI,[ cmdProcessTlv2.c : 3151 ] data_ptr %p size %d status 0x%x 
+27,Ii,[ cmdProcessTlv2.c : 3160 ] data_ptr %p stream_cnt %d 
+28,,[ cmdProcessTlv2.c : 3203 ] DacPlayback2: Invalid playback count. ExceededMax(512) 
+29,,[ cmdProcessTlv2.c : 3208 ] DacPlayback2: Invalid playback count. ExceedsMax(256) 
+30,i,[ cmdProcessTlv2.c : 3540 ] PHYDBGdump: No.of Segments %d 
+31,Ii,[ cmdProcessTlv2.c : 3545 ] PHYDBGdump: data_ptr %p stream_cnt %d 
+32,IiI,[ cmdProcessTlv2.c : 3562 ] data_ptr %p size %d status 0x%x 
+33,Ii,[ cmdProcessTlv2.c : 3571 ] data_ptr %p stream_cnt %d 
+34,iI,[ cmdProcessTlv2.c : 3898 ] PhyRfMode: DBS/SBS is not supported. phyRfMode %d status 0x%x  
+35,,[ cmdProcessTlv2.c : 3945 ] DACPlybck: Invalid playback count.ExceedsMax(512) 
+36,,[ cmdProcessTlv2.c : 3950 ] DACPlybck: Invalid playback count.ExceedsMax(256) 
+37,I,[ cmdProcessTlv2.c : 4235 ] bdRead: checksum failed. bdSize %u  
+38,i,[ cmdProcessTlv2.c : 4293 ] error in bdReadHandler: status %d 
+39,iii,[ cmdProcessTlv2.c : 4601 ] NF_CAL FTM: freq=%d chainmask=%d cWlanMode =%d 
+40,ii,[ cmdProcessTlv2.c : 4608 ] NF_CAL FTM: PrevChan=%d currentChan=%d 
+41,iiiii,[ cmdProcessTlv2.c : 4654 ] NF_CAL FTM: iChain=%d ChainIdx=%d i20MhzSegment=%d 20MhzSegmentIdx=%d NFvalue=%d 
+42,i,[ cmdProcessTlv2.c : 4757 ] NF_CAL FTM: nfCalSave Invalid phyId %d 
+43,i,[ cmdProcessTlv2.c : 4937 ] dfs_ftm_handler: band_center_freq1=%d  
+44,,[ cmdProcessTlv2.c : 5117 ] OFDMA TonePlan
+ 
+45,,[ cmdProcessTlv2.c : 5150 ] OFDMA TonePlan is NULL 
+46,IIIIIIII,[ cmdProcessTlv2.c : 5184 ] FTM_DBG: allocIndxEHT: 0-7: %lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu 
+47,IIIIIIII,[ cmdProcessTlv2.c : 5195 ] FTM_DBG: allocIndxEHT: 8-15: %lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu 
+48,i,[ cmdProcessTlv2.c : 5576 ] Channel idx out of bounds %d 
+49,i,[ cmdProcessTlv2.c : 5584 ] Power offset Idx out of bounds %d 
+50,i,[ cmdProcessTlv2.c : 5664 ] Channel idx out of bounds %d 
+51,i,[ cmdProcessTlv2.c : 5745 ] Channel idx out of bounds %d 
+52,i,[ cmdProcessTlv2.c : 5760 ] TargetPwr idx out of bounds %d 
+53,i,[ cmdProcessTlv2.c : 5775 ] GainIdx out of bounds %d 
+54,,[ cmdProcessTlv2.c : 5851 ] TpcSetCalFreq: Invalid Freq 
+55,,[ cmdProcessTlv2.c : 5871 ] TpcSetCalFreq: Freq Range is not within any bands 
+56,,[ cmdProcessTlv2.c : 5879 ] TpcSetCalFreqHandler - ChannelIdx out of bounds 
+57,I,[ cmdProcessTlv2.c : 5941 ] calDbRegen: Total Calibration completed in %u uSec 
+58,,[ cmdProcessTlv2.c : 5979 ] modifyBDFOTPFlags: pCmdStream is NULL 
+59,iii,[ cmdProcessTlv2.c : 6109 ] CTL_ENGINE: CtlExceptionTableSize status %d valid_Exception_entries %d exceptionTableFlag(sorted/unsorted) %d  
+60,iiiiii,[ cmdProcessTlv2.c : 6155 ] CTL_ENGINE: CtlExceptionValue status %d ctlExceptionValue %d freq %d,numChain %d,nss %d,beamForming %d 
+61,iiiii,[ cmdProcessTlv2.c : 6226 ] CTL_ENGINE setCtlExceptionValueHandler Exception value %d ctl grp %d %d %d, status %d 
+62,i,[ cmdProcessTlv2.c : 6252 ] CTL_ENGINE setCtlInfoHandler: status %d  
+63,ii,[ cmdProcessTlv2.c : 6294 ] CTL_ENGINE: getCtlInfo status %d ctlEngineVersion %d 
+64,iii,[ cmdProcessTlv2.c : 6339 ] CTL_ENGINE getCtlSupportedInfo: ctlNumTXChain %d supportMaxBW %d status %d 
+65,iii,[ cmdProcessTlv2.c : 6383 ] CTL_ENGINE getCtlSupportedChanns: status %d supportMaxMcs %d numFreq %d 
+66,ii,[ cmdProcessTlv2.c : 6708 ] CTL_ENGINE: setCtlTpcTestScreen status %d powerSetIndex %d 
+67,iiiiii,[ cmdProcessTlv2.c : 7441 ] CTL_ENGINE pktType %d bw %d rix %d  mcsRate %d beamForming %d txMode %d 
+68,iiiiiii,[ cmdProcessTlv2.c : 7478 ] CTL_ENGINE rateIndex %d tgtPwrMode %d phy_mode %d CTL Group %d freq %d ctlNonOfdmaType %d tgtpwr %d 
+69,iii,[ cmdProcessTlv2.c : 7580 ] Powertype %d wds %d ctlgrp %d 
+70,iiii,[ cmdProcessTlv2.c : 7860 ] CtlEngine ctlPerChainPower=%d, ctlExceptionValue=%d, ctlFinalTotalPower=%d, r2pPower=%d 
+71,I,[ cmdProcessTlv2.c : 8146 ] OTP Write status, 0x%x 
+72,I,[ cmdProcessTlv2.c : 8362 ] eepromRead: finalCheckSum=0x%x 
+73,,[ cmdProcessTlv2.c : 8583 ] Failed Rx Stop 
+74,iiii,[ cmdProcessTlv2.c : 8636 ] ftmTsDebugHandler opt %d phyId %d print_mask %d print_cnt %d 
+75,,[ cmdProcessTlv2.c : 8653 ] ftmTsDebugHandler globals reset 
+76,i,[ cmdProcessTlv2.c : 8657 ] ftmTsDebugHandler ts_FPC %d 
+77,i,[ cmdProcessTlv2.c : 8658 ] ftmTsDebugHandler ts_OPC %d 
+78,i,[ cmdProcessTlv2.c : 8659 ] ftmTsDebugHandler ts_xtalcal %d 
+79,i,[ cmdProcessTlv2.c : 8660 ] ftmTsDebugHandler ts_rxgaincal %d 
+80,i,[ cmdProcessTlv2.c : 8661 ] ftmTsDebugHandler ts_nfcal %d 
+81,i,[ cmdProcessTlv2.c : 8662 ] ftmTsDebugHandler ts_tx_ver %d 
+82,i,[ cmdProcessTlv2.c : 8663 ] ftmTsDebugHandler ts_rx_ver %d 
+83,i,[ cmdProcessTlv2.c : 8664 ] ftmTsDebugHandler ts_index %d 
+84,iiii,[ cmdProcessTlv2.c : 8670 ] ftmTsDebugHandler idx %d cmd entry %d ts %d type %d 
+85,i,[ cmdProcessTlv2.c : 8672 ] ftmTsDebugHandler ts_index %d 
+86,i,[ cmdProcessTlv2.c : 8832 ] ftmTsDebugCmdExit Invalid/unhandled Exit point %d 
+87,iii,[ cmdProcessTlv2.c : 8977 ] FTM_MLO Ping Initiate failed. Destination link %d hw_link_id %d num_hw_links %d 
+88,,[ cmdProcessTlv2.c : 9000 ] ANI_FTM: Null pointer 
+89,,[ cmdProcessTlv2.c : 9007 ] ANI_FTM: Invalid phyId 
+90,i,[ cmdProcessTlv2.c : 9020 ] ANI_FTM : ani_mode %d  
+91,i,[ cmdProcessTlv2.c : 9038 ] ANI_FTM: Invalid ANI timerPeriod %d  
+92,i,[ cmdProcessTlv2.c : 9051 ] ANI_FTM: Invalid ANI mode %d  
+93,,[ cmdProcessTlv2.c : 9163 ]  TsDebug : pTSDEBUGParms is NULL 
+94,ii,[ cmdProcessTlv2.c : 9178 ]  TsDebug : Invalid phyId=%d & option=%d 
+95,II,[ cmdProcessing.c : 284 ] FTM_DEBUG :: txCmdProcessor, TxMiscFlags : 0x%x txParms->aifsn=0x%x 
+96,iiiii,[ cmdProcessing.c : 393 ] FTM :: txCmdProcessor channel=%d txPwr=%d dataRrate=%d numPkt=%d txChain=%d
+ 
+97,iIi,[ dpdTuning.c : 272 ] GetDpdLoopbackInfoHandler phyId %d chainMask 0x%x GlutIdx %d 
+98,ii,[ dpdTuning.c : 301 ] GetDpdLoopbackInfoHandler nmse %d, nmse_nondpd %d 
+99,,[ getTgtPwr.c : 527 ] getTgtPwr: Failed to get phy handle 
+100,,[ getTgtPwr.c : 592 ] getTgtPwr: ratesArray is NULL 
+101,,[ getTgtPwr.c : 601 ] getTgtPwr: Failed to create command response 
+102,i,[ getTgtPwr.c : 358 ] Unsupported rateBW %d 
+103,,[ tcmd.c : 1509 ] tcmd_tx_complete tcmd_tx_irq: spurious tx irq 
+104,i,[ tcmd.c : 1685 ] tcmd_config: Invalid phyMode. wlanMode = %d 
+105,i,[ tcmd.c : 1851 ] ERROR: tcmd_get_channel: Unknown WLAN mode %d 
+106,i,[ tcmd.c : 1900 ] ERROR: tcmd_get_channel: 2.4G: Unknown WLAN mode %d 
+107,i,[ tcmd.c : 1938 ] ERROR: tcmd_get_channel: Invalid frequency %d 
+108,i,[ tcmd.c : 2505 ] tcmd_get_channel_newNode: Invalid frequency %d 
+109,iii,[ tcmd.c : 2530 ] tcmd_get_channel_newNode: 160MHz BW disabled in BDF. Set phy_mode=MODE_UNKNOWN. chan_mhz = %d, phy_mode = %d, is_chan_160Mhz = %d 
+110,iIiiiiII,[ tcmd.c : 2536 ] tcmd_get_channel_newNode: wlanMode %d miscFlags 0x%x chan params: mhz %d freq1 %d freq2 %d phy_mode %d flags 0x%x ext_flags 0x%x 
+111,,[ tcmd.c : 2962 ] tcmd_cont_tx_cmd: contTx = NUL 
+112,iIi,[ tcmd.c : 3121 ] tcmd_cont_tx_cmd: phyId %d miscFlags 0x%x tcmdTxGo %d ... stop Tx 
+113,Ii,[ tcmd.c : 3141 ] tcmd_cont_tx_cmd: Restricted chainmask %u to supported chainMask in BDF %d 
+114,iiiiii,[ tcmd.c : 3270 ] TCMD: mode %d pkt type %d, Pkt size %d, PPDU duration %d, max PPDU duration %d contTx->tpcm %d 
+115,iiii,[ tcmd.c : 3344 ] TCMD: Setup chan failed: freq %d, freq2 %d, wlanMd %d, bw %d 
+116,,[ tcmd.c : 3705 ] Error tcmd_cont_tx unsupport mode 
+117,Ii,[ tcmd.c : 3794 ] tcmd_cont_rx_cmd: miscFlags 0x%x, act %d 
+118,,[ tcmd.c : 3808 ] Could not find valid aID in tone plan 
+119,i,[ tcmd.c : 4366 ] cont_rx_begin: phyId=%d, chain mask 0 
+120,i,[ tcmd.c : 4434 ] cont_rx_begin: phyId=%d, setup_channel failure 
+121,iiii,[ tcmd.c : 5722 ] ftm_txq_update : ftm_tx_params %d, aifs %d cw_min %d cw_max %d 
+122,iiii,[ tcmd.c : 5764 ] ftm_txq_update_ofdma_dpd : ftm_tx_params %d, aifs %d cw_min %d cw_max %d 
+123,,[ tcmd.c : 5826 ] Could not find valid ruIdx in tone plan 
+124,I,[ tcmd.c : 6686 ] Invalid pdev %lu 
+125,iii,[ tcmd.c : 6929 ] TCMD: Invalid Config, overriding agg to %d for pktType=%d and bandwidth=%d 
+126,,[ tcmd.c : 1267 ] Out of Bound Access 
+127,,[ tcmd.c : 1278 ] Out of Bound Access 
+128,,[ tcmd.c : 1289 ] Out of Bound Access 
+129,,[ tcmd.c : 2859 ] ERROR: payloadLenEHT is NULL 
+130,,[ tcmd.c : 2871 ] ERROR: payloadLen is NULL 
+131,iiiiI,[ tcmd.c : 2881 ] [UL-OFDMA]ruIdx=%d, dataRate=%d, NSS=%d, pktSz=%d, miscFlags=0x%x 
+132,iIIII,[ tcmd.c : 4979 ] setup_channel_real: phyId=%d, Failure: phy_mode UNKNOWN, pktType = 0x%x (Tx) / 0x%x (Rx), miscFlags=0x%x (Tx) / 0x%x (Rx) 
+133,II,[ tcmd.c : 5109 ] tcmd() Before override: GI 0x%x LTF 0x%x 
+134,II,[ tcmd.c : 5144 ] tcmd()  After override: GI 0x%x LTF 0x%x 
+135,i,[ tcmd.c : 5194 ] tcmd_setup_channel_real: VHT 160/80P80/165: wlanMode %d, same channel. no need to do set channel 
+136,iii,[ tcmd.c : 5260 ] maxHomeChannels:%d gMaxHomeChanUserInput[%d]:%d 
+137,iiii,[ tcmd.c : 5679 ] FTM TCMD: ftm_txoff_dur_calc: txtime_us:%d, target_txoff_duration_us = %d, pkt_len :%d, Correction_Enabled: %d 
+138,Iii,[ tcmd.c : 6128 ] tcmd() RC flag 0x%x GI %d LTF %d 
+139,iiii,[ tcmd.c : 6276 ] FTM TCMD : ftm mode: %d, bursting_mode: %d, ofdma = %d, misFlags = %d 
+140,ii,[ tcmd.c : 6375 ] [UL-OFDMA]gi=%d, ltf=%d 
+141,ii,[ tcmd.c : 6553 ] CW enable %d, gain idx %d 
+142,,[ tcmd_rx.c : 360 ] RX_TCMD: da_addr or bss_addr is NULL 
+143,,[ tcmd_rx.c : 380 ] RX_TCMD:  page fault. All vdev is null 
+144,,[ tcmd_rx.c : 391 ] RX WAL PEER A_ASSERT_UNEXPECTED 
+145,ii,[ tcmd_rx.c : 409 ] RX_TCMD: vdev_attach vdevId[%d]=%d 
+146,ii,[ tcmd_tx.c : 445 ] TX_TCMD: ftm_tid_create_handler: phyId %d, tid %d 
+147,ii,[ tcmd_tx.c : 926 ] TX_TCMD: rc %d invalid for freq %d 
+148,iiI,[ tcmd_tx.c : 1089 ] TX_TCMD: A: g_bss_peer[%d]=%d g_ftm_bss_peer[phyId]= %08x 
+149,iIII,[ tcmd_tx.c : 1114 ] TX_TCMD: phyId %d, peer=0x%x, da_addr=0x%x, bss_addr=0x%x 
+150,,[ tcmd_tx.c : 1156 ] peer allocation failed 
+151,,[ tcmd_tx.c : 1172 ] bss_peer allocation failed 
+152,,[ tcmd_tx.c : 1177 ] nonqos data tid allocation failed 
+153,II,[ tcmd_tx.c : 1380 ] TX_TCMD: Tx failed. Duplicate AST entry available for MAC: %x%x 
+154,,[ tcmd_tx.c : 1402 ] TX_TCMD: A: dcache_peer NULL 
+155,ii,[ tcmd_tx.c : 1408 ] TX_TCMD: A: dcache_peer DL %d %d 
+156,i,[ tcmd_tx.c : 1413 ] TX_TCMD: A: dcache_peer UL %d 
+157,ii,[ tcmd_tx.c : 1431 ] TX_TCMD: [MU] sched_algo_mu_tx_peer_assoc() peer[%d] AID %d 
+158,,[ tcmd_tx.c : 1601 ] TX_TCMD: bss_addr or da_addr is NULL 
+159,,[ tcmd_tx.c : 1607 ] TX_TCMD: vdev is NULL 
+160,,[ tcmd_tx.c : 1610 ] TX_TCMD: bss_peer or peer is NULL 
+161,,[ tcmd_tx.c : 1615 ] TX_TCMD: bss_track_peer or ctxt_track_peer is not NULL 
+162,ii,[ rxGainCal.c : 311 ] rxGainCal: 2G chan[%d]=%d 
+163,ii,[ rxGainCal.c : 313 ] rxGainCal: 5G chan[%d]=%d 
+164,i,[ rxGainCal.c : 423 ] rxGainCal: Error on chainIdx %d 
+165,i,[ rxGainCal.c : 453 ] rxGainCal: Error on chainIdx %d 
+166,ii,[ rxGainCal.c : 508 ] rxGainCal:: Host error: phyId %d,  veryFirstRxGainCal %d 
+167,iiiiii,[ rxGainCal.c : 521 ] rxGainCal: HostErr: phyId %d, chainIdx %d, ChanIdx %d, Expected Pkt Cnt %d, Actual Pkt Cnt %d,  rxGainCalState.status %d 
+168,iiiiii,[ rxGainCal.c : 577 ] rxGainCal: Saving Results for phyId %d, chainIdx %d, ChanIdx %d, Expected Pkt Cnt %d, Actual Pkt Cnt %d totalPkt %d 
+169,i,[ rxGainCal.c : 977 ]  cust_rxGainCal_dbg: %d 
+170,i,[ rxGainCal.c : 1027 ] cust_rxGainCal_dbg: Cleared Rxgain Caldata for band %d 
+171,iiiiiiii,[ rxGainCal.c : 1082 ] cust_rxGainCal_dbg: Saving Results for rssiDB %d phyId %d, chainIdx %d, PNFdBr %d PNFdBm %d, Expected Pkt Cnt %d, Actual Pkt Cnt %d minCcaThreshold %d 
+172,i,[ rxGainCal.c : 1114 ] cust_rxGainCal_dbg: Caldata Saved with status %d 
+173,iii,[ rxGainCal.c : 1120 ] cust_rxGainCal_dbg: RxGainCal result Save Failure for phyId %d,Invalid Channel %d chainIdx %d 
+174,iiii,[ rxGainCal.c : 1150 ] cust_rxGainCal_dbg: Sent to Host status %d NFdbr %d NFdbm %d minccaThreshold %d 
+175,iiiiiii,[ rxGainCal.c : 1239 ] RXGAINCALRSP: i=%d, freq[i]=%d , rxNFCalPowerDBmResult[i]=%d ,rxNFCalPowerDBrResult[i]=%d , minCcaThresholdResult[i]=%d, totalPkt[i]=%d, goodPkt[i]=%d  
+176,i,[ rxGainCal.c : 1267 ] RXGAINCALRSP: Response sent to HOST with status %d 
+177,ii,[ rxGainCal.c : 661 ] rxGainCal: inc chan %d nextaction %d 
+178,iii,[ rxGainCal.c : 666 ] rxGainCal: curLoop: numBand %d numChan %d numChain %d 
+179,iiiIi,[ rxGainCal.c : 805 ] rxGainCal: rxParm band=%d freq=%d chain=%d chainM=0x%x refISS=%d 
+180,iiI,[ rxGainCal.c : 870 ] rxGainCal: CMD_RXGAINCALRSP_DONE phyId=%d rxGainCalState.calband=%d, status:%u 
+181,iiIi,[ rxGainCal.c : 902 ] rxGainCal: nextlooprxcal band=%d idxChan=%d rxGainCalCfgChans=%u isFbin=%d 
+182,iii,[ tpcCal.c : 678 ] tpccal:PowerSave: Mode %d gainIdxSwitch %d gainIdxSel %d 
+183,,[ tpcCal.c : 2023 ] FTM_REGEN_CALDB: Initiating cold boot calibration in FTM 
+184,,[ tpcCal.c : 2036 ] FTM_REGEN_CALDB: CalDb Cleared due to SkipCalDb 
+185,iii,[ tpcCal.c : 2228 ] regionId Selected %d, StartIdx %d, HighPwrIdx %d 
+186,i,[ tpcCal.c : 2271 ] tpcCal: Fail TPC GLUT non-Linearity. No.of Gluts filled %d 
+187,I,[ tpcCal.c : 2582 ] tpccal:CalFail Exceeded %u Cal Attempts 
+188,,[ tpcCal.c : 2588 ] tpccal:CalFail All GLUTs not filled 
+189,,[ tpcCal.c : 2594 ] tpccal:CalFail PLUT Non-linear 
+190,ii,[ tpcCal.c : 3122 ] tpccal:CalFail Mid range power check failed cur %d, prev %d 
+191,ii,[ tpcCal.c : 3127 ]  tpccal: PowerSave: enabled %d ignore non-linearity at Gainidx switch %d 
+192,iiii,[ tpcCal.c : 3137 ]  tpccal: PowerSave: enabled paBias mode ignore non-linearity at Gainidx switch %d min %d gainidx %d max %d 
+193,,[ tpcCal.c : 3164 ] tpccal:CalFail pdadc being read as 0 
+194,ii,[ tpcCal.c : 3196 ] tpccal:CalFail: Received identical power meas:%d prevMeas:%d.Failing calloop 
+195,,[ tpcCal.c : 3245 ] tpccal:Out of sync power measurement report 
+196,iIIIII,[ tpcCal.c : 3311 ] tpccal: latestThermValue %d for Band %u tpcChan %u opcChan[%u] %u  Chain %u 
+197,iIIIII,[ tpcCal.c : 3331 ] tpccal: latestThermValue %d for Band %u tpcChan %u opcChan[%u] %u  Chain %u 
+198,iiiii,[ tpcCal.c : 3364 ] Got Power from host Chain %d Chan %d ,  GainIdx %d , MeasPwr  %d , Read pdadc %d  
+199,iiiii,[ tpcCal.c : 3372 ] Got Power from host Chan %d ,  GainIdx %d , MeasPwr  %d , Read pdadc %d curChain %d 
+200,i,[ tpcCal.c : 3396 ] tpccal:CalFail: Poor measured power %d 
+201,i,[ tpcCal.c : 3403 ] tpccal::CalFail: Poor measured power %d 
+202,,[ tpcCal.c : 3664 ] ERR: BAD CAL TARGETs CONFIGURED for:  
+203,,[ tpcCal.c : 3702 ] BAD CAL TARGETs CONFIGURED for 
+204,,[ tpcCal.c : 3713 ] Invalid pick_glut_entry condition 
+205,iii,[ tpcCal.c : 3807 ] gtx Invalid TPC_GLUT_PWR_MAP_GRP Id from Band:%d Chain:%d tgtpwridx:%d 
+206,III,[ tpcCal.c : 1778 ] tpccal:CalFail:getNextLoop fail curLoop->idxCalPt %u, Chain %u, Gain %u 
+207,I,[ tpcCal.c : 1791 ] tpccal:CalFail: CalAttempts(%u) Exceeded limit 
+208,iiii,[ tpcCal.c : 1840 ] tpccal band %d gainidx %d region %d max %d 
+209,IIIIiiiII,[ tpcCal.c : 1719 ] tpccal:Sending to host to look for measurements in Chan2G %u, Chan5G %u, ChainMask(User) %u, Gain %u, pwr %d numChain %d numCalpt %d nxtLoop_idxChain %u chainMaskTransApplied %u 
+210,iii,[ tpcCal.c : 2497 ] tpccal: PowerSave: Switch Gainindex %d switchpwrIndex %d iRegion %d 
+211,i,[ tpcCal.c : 2503 ] tpccal: PowerSave last region %d 
+212,iii,[ tpcCal.c : 2755 ] tpcCal: PLUT non-linearity: iGainidx %d current pdadc %d, previous pdadc %d 
+213,iii,[ tpcCal.c : 2888 ] tpcCal: PLUT non-linearity iGainidx %d current pdadc %d, previous pdadc %d 
+214,i,[ tpcOnepointCal.c : 155 ] tpcOnepointCal: chan_2g %d 
+215,i,[ tpcOnepointCal.c : 166 ] tpcOnepointCal:chan_5g %d 
+216,ii,[ tpcOnepointCal.c : 203 ] tpcOnepointCal TPC_DBG numChain: 5G %d 2G %d 
+217,ii,[ tpcOnepointCal.c : 402 ] tpcOnepointCal: idxChain %d band %d 
+218,IIII,[ tpcOnepointCal.c : 604 ] tpcOnepointCal: Requesting pwr measurement for phy %u, freq %u, chainMask %u,tgtPwr_db8 %u 
+219,IIIiiI,[ tpcOnepointCal.c : 1035 ] tpcOnepointCal:Pwr measurement for phy %u, freq %u, chainMask %u, glutOffset %d, thermOffset %d, measPwr_db8 is %u 
+220,IIIiiI,[ tpcOnepointCal.c : 1042 ] tpcOnepointCal:Pwr measurement for phy %u, freq %u, chainMask %u, glutOffset %d, thermOffset %d, measPwr_db8 is %u 
+221,ii,[ tpcOnepointCal.c : 1107 ] tpcOnepointCal: pGlutOffset %d chain %d 
+222,i,[ tpcOnepointCal.c : 1116 ] tpcOnepointCal: pGlutOffset %d  
+223,i,[ tpcOnepointCal.c : 1166 ] cust_OPC_dbg: opcCtrl %d 
+224,,[ tpcOnepointCal.c : 1178 ] cust_OPC_dbg: Invalid OPC Argument 
+225,i,[ tpcOnepointCal.c : 1248 ] cust_OPC_dbg: OPC Caldata Saved with status %d 
+226,i,[ tpcOnepointCal.c : 1251 ] cust_OPC_dbg: Invalid Frequency:%d 
+227,I,[ tpcOnepointCal.c : 1293 ] cust_OPC_dbg: Sent to Host pCmdStream=%p 
+228,iii,[ tpcOnepointCal.c : 671 ] tpcOnepointCal: Failure at BandIdx:%d chanIdx:%d chainIdx:%d 
+229,I,[ tpcOnepointCal.c : 843 ] tpcOnepointCal: Translated chainMask 0x%x 
+230,iiiiiii,[ xtalCal.c : 184 ] FTM: XTAL newCapIn=%d newCapOut=%d ctrlFlag=%d phyId=%d band=%d ppmOffset=%d hsVal = %d 
+231,ii,[ xtalCal.c : 208 ] FTM: XTAL xtalCmd %d errCode %d 
+232,iiii,[ xtalCal.c : 220 ] FTM: XTAL xtalCmd %d capIn=%d capOut=%d ppmOffset=%d 
+233,iiii,[ xtalCal.c : 235 ] FTM: XTAL xtalCmd %d capIn=%d capOut=%d ppmOffset=%d 
+234,,[ xtalCal.c : 281 ] FTM: XTAL OTP already fused 
+235,iiiiii,[ xtalCal.c : 288 ] FTM: XTAL xtalCmd %d capIn=%d capOut=%d ppmOffset=%d errCode=%d OtpSupported=%d 
+236,,[ xtalCal.c : 296 ] FTM: XTAL [ERR]OTP feature is not supported 
+237,iii,[ xtalCal.c : 338 ] FTM: XTAL [ERR] Failure Loop: hsVal %d xtalSts %d errCode %d 
+238,iii,[ xtalCal.c : 342 ] FTM: XTAL [ERR][TLV2_CTRL_W_OTP]OTP has data %d, %d err_reason %d 
+239,iiiiii,[ xtalCal.c : 345 ] FTM: XTAL xtalCmd %d capIn=%d capOut=%d ppmOffset=%d errCode=%d OtpSupported=%d 
+240,,[ xtalCal.c : 353 ] [ERROR] OTP feature is not supported 
+241,iiiii,[ xtalCal.c : 364 ] FTM: XTAL xtalCmd %d Read OTP capIn=%d capOut=%d ppmOffset=%d errCode=%d 
+242,,[ xtalCal.c : 439 ] FTM: Invalid xtalCmd 
+243,iiiiii,[ xtalCal.c : 484 ] FTM: XTAL send2HostXtalParms capInMin=%d capInMax=%d capOutMin=%d capOutMax=%d capIn=%d capOut=%d 
+244,ii,[ wmi_ftm_attach.c : 229 ] ERR ftm_parse_unifiedcmd: dataLen %d < segHdrInfo_size %d 
+245,ii,[ wmi_ftm_attach.c : 252 ] Mismatch: expected Seq %d curr_seq %d 
+246,ii,[ wmi_ftm_attach.c : 267 ] All segs rcvd. total len mismatch. len %d total len %d 
+247,ii,[ wmi_ftm_attach.c : 293 ] Length exceeded Max. Max %d len %d 
+248,,[ wmi_ftm_attach.c : 388 ] UTF_WMI No Data in TLV 
+249,i,[ whal_coex.c : 1354 ] En Soft Abort %d 
+250,IIii,[ whal_coex.c : 1371 ] Flex Req Param                                                          FlushBmap 0x%x                                                          TidBmap   0x%x                                                          CCATimeout%d                                                          MaxReqLim %d 
+251,iii,[ whal_coex.c : 1446 ] WHAL_COEX_TPC: [update] set:%d, band:%d, module:%d 
+252,IIII,[ whal_coex.c : 1470 ] WHAL_COEX_TPC: [Set] 2G tpc=0x%x, 5G tpc=0x%x, 6G tpc=0x%x, status_6G_5G_2G=0x%x 
+253,III,[ whal_coex.c : 1530 ] BTCOEX_DBG_MCI_2: PTC freeze, phy_handler= 0x%x, enable= %u, status= %u 
+254,Iii,[ whal_mci.c : 515 ] COEX_GENERIC_ERROR: MCI_BT_IntfTimeout(%u), TX_MCI_GPM:%d, TRANSFER_PWRDOWN_ERR:%d  
+255,IIIIiIIII,[ whal_mci.c : 1031 ] WAL_COEX_CONT_INFO: INFO|NACK|RST|TX[0x%x]: Prio(%u), LinkId(%u) Ch(%u) Rssi_pwr(%d) btClock|priIdx[0x%x] nack_wght(%u) PT|JO|FRAB|POT[0x%x] po_bm(0x%x)  
+256,IIIIiII,[ whal_mci.c : 1044 ] WAL_COEX_CONT_INFO_V1: INFO|NACK|RST|TX[0x%x]: ChInUse(%u), WlanPhyInd(%u), Duration(%u), Rssi_pwr1(%d), Ch1(%u), DualLayer(%u) 
+257,iI,[ whal_mci.c : 1128 ] COEX_SYS_INDICATION: SYS_INDICATION type(%d) at time(0x%x) 
+258,iiii,[ whal_pta.c : 54 ] COEX_PTA_INT_STATS: Pta1BtStomped(%d) Pta1WlanStomped(%d) Pta1BtHighPriFaling(%d) Pta1BtHighPriRising(%d) 
+259,iiii,[ whal_pta.c : 61 ] COEX_PTA_INT_STATS: Pta1BtLowPriFalling(%d) Pta1BtLowPriRising(%d) Pta1BtActiveFalling(%d) Pta1BtActiveRising(%d) 
+260,iiii,[ whal_pta.c : 69 ] COEX_PTA_INT_STATS: Pta2BtStomped(%d) Pta2WlanStomped(%d) Pta2BtHighPriFaling(%d) Pta2BtHighPriRising(%d) 
+261,iiii,[ whal_pta.c : 76 ] COEX_PTA_INT_STATS: Pta2BtLowPriFalling(%d) Pta2BtLowPriRising(%d) Pta2BtActiveFalling(%d) Pta2BtActiveRising(%d) 
+262,I,[ whal_coex_gpm.c : 74 ] ERROR_COEX_MCI_GPM: ERROR - MCI Init is NOT complete ! Dropping GPM - 0x%x 
+263,IIIIIIII,[ whal_coex_gpm.c : 77 ] ERROR_COEX_MCI_GPM: AnyMacPowerUp (%u) IsMCIBusPaused (%u), whal_mci_get_sleep_state(%u), SleepOverride(%u), IsMciHWBusy(%u) IsMciInitComplete(%u) MCIBasicSyncError(%u) whal_mci_get_wsi_state(%u)
+ 
+264,II,[ whal_coex_gpm.c : 162 ] ERROR_COEX_MCI_GPM: Drop GPM, Recovery in progress: SWGpmIndex(%u) NumGPM(%u) 
+265,II,[ whal_coex_gpm.c : 281 ] ERROR_COEX_MCI_GPM: Drop GPM, Recovery in progress: SWGpmIndex(%u) NumGPM(%u) 
+266,I,[ whal_coex_smh.c : 101 ] WHAL_COEX_SMH_ISR: Error(0x%x) 
+267,,[ whal_coex_smh.c : 116 ] NULL: Buffers not allocated 
+268,I,[ whal_coex_smh.c : 194 ] WHAL_COEX_SMH_HNDLR: Error(0x%x) 
+269,,[ whal_coex_bmh.c : 208 ] WHAL_COEX_TLV_CONTROL: PRINTING COEX TLV CONTROL REG VALUES 
+270,II,[ whal_coex_bmh.c : 209 ] WHAL_COEX_TLV_CONTROL: COEX_TLV_MASTER_DISABLE_ARB1(0x%X) COEX_TLV_MASTER_DISABLE_ARB2(0x%X) 
+271,II,[ whal_coex_bmh.c : 210 ] WHAL_COEX_TLV_CONTROL: COEX_PHY_CTRL_TLV_TRIG_DIS_ARB1(0x%X) COEX_PHY_CTRL_TLV_TRIG_DIS_ARB2(0x%X) 
+272,II,[ whal_coex_bmh.c : 211 ] WHAL_COEX_TLV_CONTROL: COEX_STATUS_BROADCAST_TLV_TRIG_DIS_ARB1(0x%X) COEX_STATUS_BROADCAST_TLV_TRIG_DIS_ARB2(0x%X) 
+273,II,[ whal_coex_bmh.c : 212 ] WHAL_COEX_TLV_CONTROL: COEX_TX_STOP_CTRL_TLV_TRIG_DIS_ARB1(0x%X) COEX_TX_STOP_CTRL_TLV_TRIG_DIS_ARB2(0x%X) 
+274,II,[ whal_coex_bmh.c : 213 ] WHAL_COEX_TLV_CONTROL: TX_FLUSH_RESEND_BT_WAN_PHY_CTRL_TLV_EN_ARB1(0x%X) TX_FLUSH_RESEND_BT_WAN_PHY_CTRL_TLV_EN_ARB2(0x%X) 
+275,I,[ whal_coex_bmh.c : 214 ] WHAL_COEX_TLV_CONTROL: LISTEN_MODE_EXIT_RESEND_TLV_EN_ARB1(0x%X) 
+276,,[ whal_coex_bmh.c : 311 ] COEX_MCI_ISR_IntRaw: BMH ISR overflow 
+277,I,[ whal_coex_bmh.c : 555 ] WHAL_COEX_BMH_HNDLR: Error(0x%x) 
+278,III,[ whal_coex_bmh.c : 651 ] WAL_COEX_SCHED_INFO: sched_info start 0x%x, stop 0x%x wbts 0x%x 
+279,IIIIiII,[ whal_coex_bmh.c : 661 ] WAL_COEX_SCHED_INFO: i=%u Prio(%u) Tag(%u) tx(%u) Txp(%d) Link(%u) Dur(%u) 
+280,IIi,[ whal_coex_lmh.c : 58 ] COEX_LNA_LOCK_INFO: gain_idx=0x%x, lna_in_use=0x%x, lna_bt_lock=%d 
+281,,[ whal_coex_lmh.c : 64 ] COEX_MCI_ISR_IntRaw: LMH ISR overflow 
+282,I,[ whal_coex_lmh.c : 120 ] WHAL_COEX_LMH_HNDLR: Error(0x%x) 
+283,IIi,[ whal_coex_lmh.c : 160 ] COEX_LNA_LOCK_INFO: gain_idx=0x%x, lna_in_use=0x%x, lna_bt_lock_early=%d 
+284,I,[ whal_coex_mcim.c : 68 ] COEX_MCIM_ISR: Error(0x%x) 
+285,I,[ whal_coex_mcim.c : 210 ] WHAL_COEX_MCIM_HNDLR: Error(0x%x) 
+286,,[ whal_coex_pmh.c : 89 ] BTCOEX_DBG_MCI_1: No CONT_INFO/RST msg received after sending BT SYS_WAKE message 
+287,,[ whal_coex_pmh.c : 98 ] COEX_MCI_ISR_IntRaw: PMH ISR overflow 
+288,I,[ whal_coex_pmh.c : 149 ] WHAL_COEX_PMH_ERR: err(0x%x) 
+289,,[ whal_coex_pmh.c : 466 ] BTCOEX_DBG_MCI_2: Trying to power up. due to POWERUP_FAILURE, return 
+ 
+290,I,[ whal_coex_pmh.c : 879 ] COEX_LPM_ERROR: LPM RESP Timeout status 0x%x 
+291,,[ whal_coex_recipes.c : 40 ] BTCOEX_DBG_MCI_2: Calling cxc power down
+ 
+292,iiiIIII,[ whal_coex_recipes.c : 698 ] WLAN_COEX_CXC_TLV: PAUSE:%d, WMAC1_DIS:%d, WMAC2_DIS:%d, R0_CTRL:0x%x, TLV_M1:0x%x, TLV_M2:0x%x, Time:0x%x 
+293,IIIIIIII,[ whal_beacon.c : 538 ] MLO_SWBA_DBG mlo_timestamp_msb = %llu  mlo_timestamp_lsb = %llu generic_timer_msb = %llu  generic_timer_lsb = %llu n0_msb = %llu n0_lsb = %llu n1_msb = %llu n1_lsb = %llu  
+294,IIIIIIII,[ whal_beacon.c : 552 ] MLO_SWBA_DBGn2_msb = %llu n2_lsb = %llu n3_msb = %llu n3_lsb = %llu n4_msb =%llu n4_lsb =%llu mlo_ts_msb = %llu mlo_ts_lsb = %llu 
+295,II,[ whal_beacon.c : 2155 ] qtimer_unit_test tsf2_timer64 value from register is 0x%x and from qtimer is 0x%x 
+296,II,[ whal_beacon.c : 2160 ] qtimer_unit_test tsf2_timer32 value from register is 0x%x and from qtimer is 0x%x 
+297,II,[ whal_beacon.c : 2165 ] qtimer_unit_test global_count64 value from register is 0x%x and from qtimer is 0x%x 
+298,ii,[ whal_debug.c : 273 ] config_reg_dump: Entries exceeded MAX REG DUMP ENTRY :%d! :%d 
+ 
+299,I,[ whal_debug.c : 278 ] config_reg_dump: Invalid register physical address! :0x%x 
+ 
+300,IIIIIII,[ whal_debug.c : 301 ] DMAC_IDLE 0x%x, TLV_READY 0x%x, ISR_S7 0x%x, ISR_S8 0x%x, TXOLE_CONFIG 0x%x, TXOLE SM_STATES: MO_R1 0x%x, M1_R1 0x%x 
+ 
+301,IIIIIIII,[ whal_debug.c : 344 ] TXPCU_R1_DEBUG registers : DEBUG_STATE 0x%x TX_FES_0 0x%x TX_FES_1 0x%x TX_FES_2 0x%x INT_OR_ERR_STATUS 0x%x LAST_INT_OR_ERR_STATUS_MASK 0x%x LAST_INT_OR_ERR_STATUS 0x%x TRACE_BUS_UPPER 0x%x 
+ 
+302,iIII,[ whal_debug.c : 358 ] CRYPTO Debug Reg: %d. TLV_READY = 0x%x, IDLE_STATUS = 0x%x, TLV_INTF_STATE = 0x%x 
+303,IIIIIII,[ whal_hwsch_control.c : 138 ] hwsch cca_wdog: status=0x%x, IX_0=0x%x, IX_1=0x%x status_cfg(h=0x%x ph=0x%x t=0x%x ht=0x%x) 
+304,iii,[ whal_hwsch_control.c : 1010 ] PM_STATE_DBG: sw_peer_id=%d, pmfilter=%d, twtfilter=%d 
+305,i,[ whal_hwsch_control.c : 1333 ]  HW_ERR_REINJECTION : PDG Latency Error : ENABLE_LATENCY_MITIGATION : %d 
+306,I,[ whal_hwsch_control.c : 1717 ] SFM empty check timeout. Curr SFM dwords used: %u 
+307,iI,[ whal_mac_cmn.c : 616 ] DSS is disabled p_whal_phy_handle:%d dss_disable_vote:0x%x 
+308,iiIIii,[ whal_mac_cmn.c : 629 ] whalEnableDSS enable=%d client=%d phy_handle:0x%x disable_vote:0x%x isDSSEnabled:%d dev_id:%d 
+309,iiII,[ whal_mac_cmn.c : 653 ] DSS is disabled client:%d enable:%d phy_handle:0x%x disable_vote:0x%x 
+310,,[ whal_interrupt.c : 840 ] whalGetPendingDmcmnInterrupts DMAC is in power down state 
+311,iIi,[ whal_interrupt.c : 2016 ] whalGetTIMBit: lmac_id=%d, isr_s5=0x%x(RX_TIM[9:8], RX_NOTIM[7:6]), tsf_id=%d 
+312,II,[ whal_interrupt.c : 2157 ] Clear false RXPCU WDOG, status %x, limit %x 
+313,I,[ whal_interrupt.c : 2751 ] GetPendingInterrupts-whalPending:0x%x 
+314,II,[ whal_interrupt.c : 2961 ] Before clearing the isr mask, isr_p_wsi : 0x%x, PMAC_PMCMN_R0_MCMN_ISR_S20 : 0x%x 
+315,III,[ whal_interrupt.c : 2998 ] After clearing the isr mask, isr_s1_wsi : 0x%x, isr_p_wsi : 0x%x, PMAC_PMCMN_R0_MCMN_ISR_S20 : 0x%x 
+316,ii,[ whal_interrupt.c : 5533 ] hwsch_fes_low_wm_cnt:%d, pdev_id:%d 
+317,II,[ whal_error_handler.c : 279 ] DMCMN APB0 error interrupt on  mask 0x%x, total count 0x%x
+ 
+318,II,[ whal_error_handler.c : 291 ] DMCMN APB1 error interrupt on  mask 0x%x, total count 0x%x
+ 
+319,II,[ whal_error_handler.c : 303 ] DMCMN DMXI error interrupt on  mask 0x%x, total count 0x%x
+ 
+320,II,[ whal_error_handler.c : 316 ] DMCMN DSFM error interrupt on  mask 0x%x, total count 0x%x
+ 
+321,II,[ whal_error_handler.c : 328 ] DMCMN DMCMN error interrupt on  mask 0x%x, total count 0x%x
+ 
+322,II,[ whal_error_handler.c : 340 ] DMCMN AGGR WDOG error interrupt on  mask 0x%x, total count 0x%x
+ 
+323,II,[ whal_error_handler.c : 352 ] DMCMN AGGR WDOG WARN interrupt on  mask 0x%x, total count 0x%x
+ 
+324,II,[ whal_error_handler.c : 364 ] DMCMN TXDMA error interrupt on  mask 0x%x, total count 0x%x
+ 
+325,II,[ whal_error_handler.c : 376 ] DMCMN TXOLE error interrupt on  mask 0x%x, total count 0x%x
+ 
+326,II,[ whal_error_handler.c : 388 ] DMCMN CRYPTO error interrupt on  mask 0x%x, total count 0x%x
+ 
+327,II,[ whal_error_handler.c : 400 ] DMCMN RXOLE error interrupt on  mask 0x%x, total count 0x%x
+ 
+328,II,[ whal_error_handler.c : 413 ] DMCMN RXDMA error interrupt on  mask 0x%x, total count 0x%x
+ 
+329,II,[ whal_error_handler.c : 431 ] DMCMN RXDMA_SRC_RING error interrupt on  mask 0x%x, total count 0x%x
+ 
+330,II,[ whal_error_handler.c : 443 ] DMCMN RXDMA_DEST_RING error interrupt on  mask 0x%x, total count 0x%x
+ 
+331,II,[ whal_error_handler.c : 455 ] DMCMN TXMON error interrupt on  mask 0x%x, total count 0x%x
+ 
+332,II,[ whal_error_handler.c : 468 ] DMCMN RXMON error interrupt on  mask 0x%x, total count 0x%x
+ 
+333,iII,[ whal_error_handler.c : 482 ] RXPCU WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+334,iII,[ whal_error_handler.c : 501 ] RXPCU1 WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+335,iIII,[ whal_error_handler.c : 542 ] TXPCU WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x, PhyErr 0x%x 
+336,iII,[ whal_error_handler.c : 586 ] TXDMA WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+337,iII,[ whal_error_handler.c : 639 ] RXOLE WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+338,iII,[ whal_error_handler.c : 655 ] TXOLE WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+339,iII,[ whal_error_handler.c : 668 ] CRYPTO WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+340,iII,[ whal_error_handler.c : 692 ] RXDMA WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+341,iII,[ whal_error_handler.c : 708 ] PDG WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+342,iIII,[ whal_error_handler.c : 765 ] HWSCH WDOG error interrupt on PDEV ID-%d, mask 0x%x, reset 0x%x, total count 0x%x
+ 
+343,iII,[ whal_error_handler.c : 857 ] MXI WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+344,iII,[ whal_error_handler.c : 873 ] AMPI WDOG error interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+345,II,[ whal_error_handler.c : 956 ] whalRxpcuWdogInterruptWar rxpcu_fsm_status_0: 0x%x rxpcu_fsm_status_1: 0x%x 
+346,iII,[ whal_error_handler.c : 1035 ] CRYPTO panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+347,iII,[ whal_error_handler.c : 1198 ] TXPCU0 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+348,iII,[ whal_error_handler.c : 1299 ] TXDMA panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+349,iII,[ whal_error_handler.c : 1380 ] RXDMA panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+350,iII,[ whal_error_handler.c : 1395 ] RXPCU0 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+351,iII,[ whal_error_handler.c : 1423 ] RXPCU1 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+352,Ii,[ whal_error_handler.c : 1429 ] RXPCU_R1_PMI_ERROR_STATUS 0x%x RXPCU_R1_AMPI_ERR_BIT %d
+ 
+353,iIIIII,[ whal_error_handler.c : 1494 ] PDG panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x, fes status 0x%x, cmd status 0x%x, wdog warn 0x%x 
+354,iIII,[ whal_error_handler.c : 1520 ] PDG panic interrupt on PDEV ID-%d pdg_testbus_lower:0x%x pdg_fsm_state0:0x%x pdg_fsm_state1:0x%x 
+355,iII,[ whal_error_handler.c : 1658 ] HWSCH panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+356,iIIII,[ whal_error_handler.c : 1673 ] HWSCH status ring panic interrupt on PDEV ID-%d, HP=0x%x TP=0x%x, avail=0x%x,left=0x%x 
+357,iII,[ whal_error_handler.c : 1694 ] HWMLO panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+358,iII,[ whal_error_handler.c : 1741 ] MXI panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+359,iII,[ whal_error_handler.c : 1756 ] AMPI panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+360,iII,[ whal_error_handler.c : 1771 ] APB0 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+361,iII,[ whal_error_handler.c : 1786 ] APB1 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+362,iII,[ whal_error_handler.c : 1936 ] TXOLE panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+363,iII,[ whal_error_handler.c : 1977 ] RXOLE panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+364,I,[ whal_error_handler.c : 2022 ] RXOLE_R1_SM_STATES : 0x%x
+ 
+365,,[ whal_error_handler.c : 2063 ] SFM_dbg: whal_check_sfm_idle: sfm/fsm is identified to be non idle 
+366,iII,[ whal_error_handler.c : 2084 ] SFM panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+367,ii,[ whal_error_handler.c : 2125 ] SFM panic interrupt ready timeout %d fsm_status %d
+ 
+368,iII,[ whal_error_handler.c : 2177 ] RXDMA1 panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+369,iII,[ whal_error_handler.c : 2191 ] RXDMA1_SRC_RNG panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+370,iII,[ whal_error_handler.c : 2205 ] RXDMA_SRC_RNG panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+371,iII,[ whal_error_handler.c : 2221 ] RXDMA_DST_RNG panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+372,iII,[ whal_error_handler.c : 2238 ] RXDMA1_DST_RNG panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+373,iII,[ whal_error_handler.c : 2251 ] MCMN panic interrupt on PDEV ID-%d, mask 0x%x, total count 0x%x
+ 
+374,II,[ whal_error_handler.c : 2268 ] DMCMN APB0 panic interrupt mask 0x%x, total count 0x%x
+ 
+375,II,[ whal_error_handler.c : 2285 ] DMCMN APB1 panic interrupt mask 0x%x, total count 0x%x
+ 
+376,II,[ whal_error_handler.c : 2302 ] DMCMN DMXI panic interrupt mask 0x%x, total count 0x%x
+ 
+377,II,[ whal_error_handler.c : 2344 ] DMCMN DSFM panic interrupt mask 0x%x, total count 0x%x
+ 
+378,II,[ whal_error_handler.c : 2379 ] DMCMN DMCMN panic interrupt mask 0x%x, total count 0x%x
+ 
+379,III,[ whal_error_handler.c : 2402 ] DMCMN AGGR WDOG ERR panic interrupt rxole err count 0x%x dmcmn_idle_wlan0  0x%x dmcmn_idle_wlan1 0x%x
+ 
+380,II,[ whal_error_handler.c : 2416 ] DMCMN AGGR WDOG ERR panic interrupt mask 0x%x, total count 0x%x
+ 
+381,II,[ whal_error_handler.c : 2434 ] DMCMN AGGR WDOG WARN panic interrupt mask 0x%x, total count 0x%x
+ 
+382,II,[ whal_error_handler.c : 2451 ] DMCMN TXDMA panic interrupt mask 0x%x, total count 0x%x
+ 
+383,II,[ whal_error_handler.c : 2468 ] DMCMN TXOLE panic interrupt mask 0x%x, total count 0x%x
+ 
+384,II,[ whal_error_handler.c : 2485 ] DMCMN CRYPTO panic interrupt mask 0x%x, total count 0x%x
+ 
+385,II,[ whal_error_handler.c : 2510 ] DMCMN RXOLE panic interrupt mask 0x%x, total count 0x%x
+ 
+386,II,[ whal_error_handler.c : 2533 ] DMCMN RXDMA panic interrupt mask 0x%x, total count 0x%x
+ 
+387,II,[ whal_error_handler.c : 2550 ] DMCMN RXDMA SRC RING panic interrupt mask 0x%x, total count 0x%x
+ 
+388,II,[ whal_error_handler.c : 2568 ] DMCMN RXDMA DEST RING panic interrupt mask 0x%x, total count 0x%x
+ 
+389,II,[ whal_error_handler.c : 2585 ] DMCMN TXMON panic interrupt mask 0x%x, total count 0x%x
+ 
+390,II,[ whal_error_handler.c : 2603 ] DMCMN RXMON panic interrupt mask 0x%x, total count 0x%x
+ 
+391,ii,[ whal_mlo.c : 193 ] whal_mlo_get_pending_doorbell_interrupts() WSI corruption detected in data from src_link_id : %d, counter is %d 
+392,,[ whal_mlo_ssr.c : 62 ] MLO_SSR WSIB Reset done & Master sync high 
+393,I,[ whal_mlo_ssr.c : 93 ] MLO_SSR WSIB-idle:%u & Master sync low 
+394,I,[ whal_mlo_ssr.c : 103 ] MLO_SSR WSIB-pause:%u done 
+395,iII,[ whal_cce.c : 327 ] whal_cce_set_rule_config: rule no=%d cce_rule_lsb:0x%x, cce_rule_msb:0x%x
+ 
+396,ii,[ whal_cce.c : 715 ] whal_program_rule_valid: rule no=%d action:%d 
+397,i,[ whal_cce.c : 1754 ] whal_cce_stop_ppdu_recipe :PDDU_END_INT Not received RXOLE_IDLE post %d Check for RXDMA/RXOLE Backpressure 
+398,,[ whal_recv_recipes.c : 489 ]  Host Source Buffers Empty  
+399,,[ whal_recv_recipes.c : 501 ]  Failed [pmac0_idle]  to put RXMON Idle!! 
+400,,[ whal_recv_recipes.c : 513 ]  Failed [pmac1_idle] to put RXMON Idle!! 
+401,,[ whal_recv_recipes.c : 1425 ] whalStopPcuReceive: PHY OFF Timemout 
+402,,[ whal_recv_recipes.c : 1518 ] whalStopPcuReceive: pmac not idle and no back pressure seen 
+403,I,[ whal_recv_recipes.c : 1598 ] whalStopPcuReceive: RX flush failure  status: 0x%x  
+404,Ii,[ whal_recv_recipes.c : 2247 ] %s: invalid lmac id %d
+ 
+405,i,[ whal_recv_recipes.c : 2895 ] RXPCU_BA_DBG: HALT_RX: Failed, stop_status: %d 
+406,iiii,[ whal_recv_recipes.c : 2904 ] RXPCU_BA_DBG: ret: %d, end_time-start_time: %dus, TA/TID READ : ta_tid_cnt: %d, bmap_last_reg_idx: %d 
+407,ii,[ whal_recv_recipes.c : 2922 ] RXPCU_BA_DBG: Reading Bitmap from %d - %d 
+408,iIIIIIIII,[ whal_recv_recipes.c : 2942 ] RXPCU_BA_DBG: ta_tid_idx: %d, sw_peer_id: %u, tid: %u, ssn_32: %u, ssn_64: %u, ssn_128: %u, ssn_256: %u, ssn_512: %u, ssn_1024: %u, 
+409,iIIIIIIII,[ whal_recv_recipes.c : 2952 ] RXPCU_BA_DBG: ssn_valid = %d, TA: %012llX, ack_policy: %u, is_qos: %u, most_recent_is_aggr: %u, user_index: %u, use_256_ba_bitmap: %u, use_255_ba_bitmap_valid: %u, use_1024_512_ba_bitmap: %u 
+410,iIIIIIIII,[ whal_recv_recipes.c : 2964 ] RXPCU_BA_DBG: ssn_valid: %d,       seqnum_bitmap_31_0  -> 255_224:  0x%08X %08X %08X %08X %08X %08X %08X %08X,  
+411,IIIIIIII,[ whal_recv_recipes.c : 2976 ] RXPCU_BA_DBG:                     seqnum_bitmap_287_256 -> 511_480:  0x%08X %08X %08X %08X %08X %08X %08X %08X,  
+412,IIIIIIII,[ whal_recv_recipes.c : 2988 ] RXPCU_BA_DBG:                     seqnum_bitmap_543_512 -> 767_736:  0x%08X %08X %08X %08X %08X %08X %08X %08X,  
+413,IIIIIIII,[ whal_recv_recipes.c : 2998 ] RXPCU_BA_DBG:                     seqnum_bitmap_799_768 -> 1023_992: 0x%08X %08X %08X %08X %08X %08X %08X %08X,  
+414,,[ whal_recv_recovery.c : 150 ] FW2RXDMA_STATBUF ring empty 
+415,,[ whal_recv_recovery.c : 157 ] FW2RXDMA_STATBUF ring empty 
+416,IIIIII,[ whal_recv_recovery.c : 201 ] ring type [0x%x] empty error ts-0x%x, pre hp:0x%x, ts 0x%x, hp 0x%x, tp 0x%x 
+417,,[ whal_recv_recovery.c : 258 ] SW2RXDMA_BUF ring empty 
+418,,[ whal_recv_recovery.c : 265 ] SW2RXDMA_BUF ring empty 
+419,,[ whal_recv_recovery.c : 309 ] FW2RXDMA_BUF ring empty 
+420,,[ whal_recv_recovery.c : 316 ] FW2RXDMA_BUF ring empty 
+421,,[ whal_recv_recovery.c : 344 ] RX_RING_FW_BUF ring empty caused by RX_RING_WMI_EVT 
+422,,[ whal_recv_recovery.c : 369 ] WBM2RXDMA_LINK ring empty 
+423,,[ whal_recv_recovery.c : 376 ] WBM2RXDMA_LINK ring empty 
+424,,[ whal_recv_recovery.c : 419 ] FW2RXDMA_LINK ring empty 
+425,,[ whal_recv_recovery.c : 426 ] FW2RXDMA_LINK ring empty 
+426,IIIIII,[ whal_recv_recovery.c : 569 ] ring type [0x%x] empty error ts-0x%x, pre hp:0x%x, ts 0x%x, hp 0x%x, tp 0x%x 
+427,IiI,[ whal_recv_recovery.c : 580 ] ring type [0x%x] wmi pending:%d, empty %x 
+428,IIIIIIII,[ whal_recv_recovery.c : 723 ] ring [0x%x] full ts-0x%x, hp 0x%x, tp 0x%x, reo2sw1: 0x%x, reo2sw4:0x%x, reo2tcl:0x%x, rxdma2sw:0x%x 
+429,IIIII,[ whal_recv_recovery.c : 1814 ] whal_recv_capture_rxpcu_fsm_data ppdu_id 0x%x fsm_status_0 0x%x fsm_status_1 0x%x fsm_status_2 0x%x fsm_status_3 0x%x 
+430,II,[ whal_recv_recovery.c : 1854 ] whalIsRxpcuGseWdogWar testbus_lower 0x%x testbus_upper 0x%x 
+431,I,[ whal_recv_recovery.c : 1882 ] whalRecvPcu0HangHandler WDOG ERR : issued rx flush fsm_stuck_count 0x%x 
+432,I,[ whal_recv_recovery.c : 1954 ] RXPCU WDOG ERR long dur set , status of S6_RXPCU1 mask 0x%x 
+433,i,[ whal_recv_recovery.c : 2059 ] whalRecvPcu0HangHandler Issue rxpcu_fsm_idle_war hit count %d 
+434,II,[ whal_recv_recovery.c : 2295 ] WAIKIKIONE#131 - Ignore RXDMA destination ring backpressure: [%x] [%x] 
+435,iIIII,[ whal_recv_config.c : 650 ] mac=%d, filter_type=%x frame_type=%x rx_filter:0x%x,0x%x 
+436,III,[ whal_recv_config.c : 3290 ] ProgRxMonSrcRing:%lx, ring_cfg[0x%p] p_cfg[0x%p]
+ 
+437,IIIIIII,[ whal_recv_config.c : 4728 ] RXPEER Status ring upload cfg: %lx, flag0: %lx, flag1: %lx, flags2: %lx, flags3: %lx, flags4: %lx, tlv_flags: %lx
+ 
+438,III,[ whal_recv_config.c : 7429 ] whalProgRxMonCfg - cfg_len_data:%x pTEML:%x dma_mpdu_data:%x 
+439,III,[ whal_recv_config.c : 7557 ] whalProgRxMonCfg - cfg_len_mgmt:%x pTEML:%x dma_mpdu_mgmt:%x 
+440,III,[ whal_recv_config.c : 7685 ] whalProgRxMonCfg - cfg_len_ctrl:%x pTEML:%x dma_mpdu_ctrl:%x 
+441,III,[ whal_recv_config.c : 9683 ] whalSetBssColor: parameters bsscolor|en|bss_id = %08x, caller = 0x%x:0x%x 
+442,iii,[ whal_recv_config.c : 10800 ] ring switch: src ring drop thr mac_id %d ring_idx %d drop_th %d  
+443,ii,[ whal_recv_config.c : 10823 ] ring switch: disable src ring drop thr macid: %d mask %d  
+444,IIIII,[ whal_reo_offloads_ext.c : 114 ] local_link_desc buffer_addr_31_0:%x, buffer_addr_39_32:%x, link_desc:%x, reo_ind desc_base:%x, cur_idx:%x 
+445,III,[ whal_reo_offloads_ext.c : 127 ] whal_reo_remote_data_ind local:%x, flags:%x valid:%x 
+446,IIII,[ whal_reo_offloads_ext.c : 159 ] whal_reo_remote_data_ind addr:0x%x:0x%x, reo_destination_indication:%u, caller:%x 
+447,IIIII,[ whal_reo_offloads.c : 103 ] RXDMA_MC_SM_STATUS0 %x RXDMA_MC_STAUS1 %x RXDMA_MC_R1_RXDMA_RCV_DBG_0 %x RXMDA_M0_RCV_DBG %x RXDMA_M1_RCV_DBG %x 
+448,IIII,[ whal_reo_offloads.c : 127 ] RXDMA_SFM_R0_BUSY_BUFFERS_0 %x RXDMA_SFM_R0_BUSY_BUFFERS_1 %x DMAC_M0_R1_TLV_READY %x DMAC_M1_R1_TLV_READY %x  
+449,II,[ whal_reset.c : 518 ] whalDmacReset reset_cause=0x%x reset_flags = 0x%x 
+450,i,[ whal_reset.c : 643 ] DYNAMIC : Current MAC Clk settings %d 
+451,,[ whal_reset.c : 666 ] DYNAMIC : Invalid MAC Clock frequency !!!  
+452,i,[ whal_reset.c : 669 ] DYNAMIC : MAC Clk Changed to ==> %d 
+453,I,[ whal_reset.c : 769 ] whalSetMACNAVOverrideCfg: 0x%x  
+454,ii,[ whal_reset.c : 1065 ] whalSetHalphyAssocid  p_whal_mac_struct->dev_id %d, assoc_id %d 
+455,IIIIIIIIi,[ whal_reset.c : 1125 ] VBSS whalWriteBssidAssocid, mac=%u,BSS_ID=%u,bssid=%02X:%02X:%02X:%02X:%02X:%02X,enable=%d 
+456,IIIIIIIII,[ whal_reset.c : 1248 ] whalWriteBssidAssocid, mac=%u,BSS_ID=%u,bssid=%02X:%02X:%02X:%02X:%02X:%02X,assoc_id=%u 
+457,iiii,[ whal_reset.c : 1446 ] EMLSR_BCN_PROT SET_AID_INVALID pdev %d assoc_id %d bssid %d id %d
+ 
+458,iiii,[ whal_reset.c : 1450 ] EMLSR_BCN_PROT SET_AID_VALID  pdev %d assoc_id %d bssid %d id %d
+ 
+459,iii,[ whal_reset.c : 1575 ] VBSS whal_config_proxy_sta_snoop_bssid ad1_match %d , no_ack : %d , snoop : %d  
+460,i,[ whal_reset.c : 1777 ] whalConfigProxyStaParams Unhandled BSS_ID :%d  
+461,iiiii,[ whal_reset.c : 2871 ] channelSwitch: HalphyChannelSwitchTime(in us) = %d whalXmitReset(in us) = %d TotalChannelSwitchTime(in us) = %d HalPhy_PF = %d Total_PF = %d 
+462,iiiii,[ whal_reset.c : 2898 ] Homechan = %d channelSwitch: Mac = %d HALPHY_CLK_RESET= %d MAC_MTU = %d ApplyDSS_MUTEX_UNLOCK = %d 
+463,i,[ whal_reset.c : 3252 ]  whalGetCCACounters Counter are 0xFFFFFFFF, itr=%d 
+464,,[ whal_reset.c : 3374 ]  whalGetCCACounters Counter are 0xFFFFFFFF 
+465,IIIIIII,[ whal_reset.c : 3392 ] RX_FRAME_ADJ: Before mac_id %ld rx_frame_adj[ucode]: %ld rx_clear_adj[ucode]: %ld rxFrameCnt[MAC]: %ld rxClearCnt[MAC]: %ld txFrameCnt[MAC]: %ld myRxFrameCnt[MAC]: %ld 
+466,III,[ whal_reset.c : 3403 ] RX_FRAME_ADJ Resetting due to negative Vreg mac_id %ld [ucode]: %ld rxFrameCnt[MAC]: %ld 
+467,III,[ whal_reset.c : 3427 ] RX_FRAME_CLEAR Resetting due to negative Vreg mac_id %ld [ucode]: %ld rxClearCnt[MAC]: %ld 
+468,,[ whal_reset.c : 3445 ] RX_FRAME_ADJ Previous rx_frame Count error 
+469,,[ whal_reset.c : 3452 ] RX_FRAME_ADJ Previous rx_clear Count error 
+470,IIIIIII,[ whal_reset.c : 3469 ] RX_FRAME_ADJ: After mac_id %ld rx_frame_adj[ucode]: %ld rx_clear_adj[ucode]: %ld rxFrameCnt[MAC]: %ld rxClearCnt[MAC]: %ld txFrameCnt[MAC]: %ld myRxFrameCnt[MAC]: %ld 
+471,I,[ whal_reset.c : 3691 ] whalSetMACNAVOverrideCfg: 0x%x  
+472,IIIIIIIII,[ whal_hwmlo_reset.c : 56 ] hwmlo_reset  USED_CLIENT6_PMAC_INI mlo_ts :0x%x  0:0x%x, 1:0x%x 2:0x%x 3:0x%x wsib_r1_idle:0x%x, wsib_r1_sm_states:0x%x, sfm_clr:0x%x, sfm_wr_ovflow:0x%x
+ 
+473,I,[ whal_hwmlo_reset.c : 58 ] hwmlo_reset q6_ts : 0x%x 
+474,IIi,[ whal_hwmlo_reset.c : 907 ] hwmlo_logging whal_hwmlo_fast_recovery_recipe  mlo_ts:%u, g_dbg_mlo_fast_recovery_entry_ts : 0x%x, g_whal_wsib_intr_reset_cnt:%d
+ 
+475,IIi,[ whal_hwmlo_reset.c : 925 ] hwmlo_logging whal_hwmlo_fast_recovery_recipe  mlo_ts:%u, g_dbg_mlo_fast_recovery_exit_ts : 0x%x g_whal_wsib_intr_reset_cnt:%d
+ 
+476,,[ whal_rtt.c : 359 ] whal_rtt_frame_recover() HW was not configured for RTT!!! return 
+477,IIIIIIIII,[ whal_rtt.c : 593 ] %cXLocInf1 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+478,IIIIIIIII,[ whal_rtt.c : 597 ] %cXLocInf2 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+479,IIIIIIIII,[ whal_rtt.c : 601 ] %cXLocInf3 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+480,IIIIII,[ whal_rtt.c : 605 ] %cXLocInf4 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+481,IIII,[ whal_rtt.c : 609 ] fac_0:0x%08d fac_1:0x%08d, fac_2:0x%08d, fac_3:0x%08d 
+482,III,[ whal_rtt.c : 618 ] 11AZ: RAW_TOA: (T2/T4 in clock cycle): start_ts: 0x%x%08x, end_ts:0x%x 
+483,IIII,[ whal_rtt.c : 626 ] 11AZ: RAW_TOD: (T3 in clock cycle): start_ts: 0x%x%04x, end_ts:0x%x%04x 
+484,IIIIIII,[ whal_rtt.c : 642 ] %cX-IntegrityData 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+485,IiIiiiII,[ whal_rtt.c : 1518 ] rtt_get_toda: txrx_msg_buf=%p toda_type=%d toda_phy_clk=%u ppdu_id=%d txrx_delay=%d status=%d, tx_group_delay:%u, rx_gim_delay:%u 
+486,iiIIII,[ whal_rtt.c : 1760 ] whal_rtt_11az_selfgen_resp_report: gen_resp:%d, ranging:%d, location_info:%p, tx_start_ts:%u, end_ts:%u, tx_bw:%u 
+487,,[ whal_rtt.c : 1865 ] ar_wal_rtt_tx_ppdu_completion_handler: excess zero values in receive_rssi_info 
+488,ii,[ whal_rtt.c : 2198 ] whal_cfir_setup_fixed_rx_rtt_chain: mode %d rtt_rx_chain_idx%d 
+489,iiIIiIi,[ whal_rtt.c : 189 ] whal_rtt_recv_sta_txrx_chain_handle_event: mode %d event %d tx_mask 0x%02x rx_mask 0x%02x tx_dirty %d rtt_selfgen_tx_chain_idx %u rtt_rx_chain_idx %d 
+490,,[ whal_rtt.c : 237 ] whal_rtt_frame_prepare() HW is already prepared for RTT return !!! 
+491,iiiii,[ whal_cfir.c : 275 ] whal_cfir_configure: rtt %d capture_cfr %d capture_cir %d capture_rcc %d capture_11bCir %d 
+492,iiII,[ whal_cfir.c : 193 ] whal_cfir_enable: enaRttPerBurst %d enaFixedStrChain %d fixedStrChainIdx 0x%02x, enableCfr | enableCir | enableRcc :0x%x 
+493,II,[ whal_tx_mon.c : 331 ] TX_MON ProgTxMonRing:%lx, buf_size[%lx]
+ 
+494,III,[ whal_tx_mon.c : 349 ] TX_MON ProgTxMonSrcRing:%lx, ring_cfg[0x%p] p_cfg[0x%p]
+ 
+495,I,[ whal_tx_mon.c : 422 ] TX_MON ProgTxMonDestRing:%lx
+ 
+496,IIIIIII,[ whal_tx_mon.c : 1037 ] TX_MON whalProgTxMonUploadCfg function cfgLenMgmt: %lx, cfgLenCtrl: %lx, cfgLenData: %lx, pktSwap: %lx, stSwap: %lx, ptEF: %lx, ptMsMp: %lx
+ 
+497,IIIII,[ whal_tx_mon.c : 1045 ] TX_MON whalProgTxMonUploadCfg function MGMT dma: %lx, mpdu_start: %lx, msdu_start: %lx, mpdu_end: %lx, msdu_end: %lx
+ 
+498,IIIII,[ whal_tx_mon.c : 1052 ] TX_MON whalProgTxMonUploadCfg function CTRL dma: %lx, mpdu_start: %lx, msdu_start: %lx, mpdu_end: %lx, msdu_end: %lx
+ 
+499,IIIII,[ whal_tx_mon.c : 1059 ] TX_MON whalProgTxMonUploadCfg function DATA dma: %lx, mpdu_start: %lx, msdu_start: %lx, mpdu_end: %lx, msdu_end: %lx
+ 
+500,IIIII,[ whal_tx_mon.c : 1159 ] TX_MON whalProgTxMonUploadCfg function dnCtrl0: %lx, dnCtrl3:%lx, upCtrl0: %lx, upCtrl1: %lx, upCtrl2: %lx
+ 
+501,i,[ whal_tx_mon.c : 1182 ] TX_MON whalProgTxMonUploadCfg function pkt_tlv_sel->word_mask_compaction_enable: %d
+ 
+502,I,[ whal_tx_mon.c : 1400 ] TX_MON TXPCU setting MISC_MODE : [%x] 
+503,I,[ whal_tx_mon.c : 1430 ] TX_MON RXPCU setting ACK_REPORT_CTRL : [%x] 
+504,III,[ whal_tx_mon.c : 1442 ] TX_MON TXPCU/RXPCU setting reset[%x][%x][%x] 
+505,IIIII,[ whal_wbm_control.c : 936 ] IDLE_STATUS:%08X IDLE_SEQUENCE:%08X MSDU_PARSER_STATUS:%08X SM_STATES_IX_0:%08X SM_STATES_IX_1:%08X 
+506,ii,[ whal_wbm_control.c : 948 ] wbm drain: %d, %d 
+507,IIIII,[ whal_wbm_control.c : 963 ] IDLE_STATUS:%08X IDLE_SEQUENCE:%08X MSDU_PARSER_STATUS:%08X SM_STATES_IX_0:%08X SM_STATES_IX_1:%08X 
+508,,[ whal_xmit_control.c : 635 ]  DMAC : FLUSH REQ ACK received for PMAC0 
+509,,[ whal_xmit_control.c : 646 ]  DMAC : FLUSH REQ Failed for PMAC0 
+510,,[ whal_xmit_control.c : 663 ]  DMAC : FLUSH REQ ACK received for PMAC1 
+511,,[ whal_xmit_control.c : 675 ]  DMAC : FLUSH REQ Failed for PMAC1 
+512,iiii,[ whal_xmit_control.c : 2083 ] whalXmitReset: HomeChan = %d Init_ResetTxQueue = %d HEMisConfig_Inits = %d InitPowerCtrlTbl_GenRespChainMask = %d 
+513,iiii,[ whal_xmit_control.c : 2091 ] whalXmitReset: Mhz = %d Home = %d bkoff_cca_mask = %d Total = %d 
+514,ii,[ whal_xmit_control.c : 4190 ] WhalEmlsrConfig: dev_id %d, enable %d 
+515,II,[ whal_xmit_control.c : 4620 ] FIPS hp %x tp %x 
+516,I,[ whal_xmit_control.c : 4655 ] FIPS nxt_p %x 
+517,,[ whal_xmit_control.c : 4696 ] FIPS hp null 
+518,I,[ whal_xmit_control.c : 4731 ] FIPS %x 
+519,,[ whal_xmit_control.c : 4742 ] FIPS nxt_p null 
+520,I,[ whal_xmit_control.c : 4775 ] FIPS %x 
+521,I,[ whal_xmit_control.c : 4843 ] FIPS %x 
+522,iiIII,[ whal_xmit_control.c : 5043 ] TPCDBG: selfGen: tpc=%d,%d cm=%x c=%08x:%08x 
+523,IIIIIII,[ whal_xmit_control.c : 5273 ] Invalid resp_frm_param, pkt_type=%x, rc=%x, bw=%x, cm=%x, nss=%x, i=%u, j=%u 
+524,iiIII,[ whal_xmit_control.c : 5393 ] TPCDBG: New power by pkt type: tpc=%d,%d cm=%x c=%x:%x 
+525,,[ whal_xmit_control.c : 6078 ] NAN disable CCA profiling 
+526,IIIIIII,[ whal_hwsch.c : 551 ] _whal_hwsch_post_cmd id 0x%X, ring_index (%lu): HW head/tail=%lu/%lu, WHAL head/tail=%lu/%lu TSF %lu
+ 
+527,III,[ whal_hwsch.c : 1972 ] whal_hwsch_check_sch_cmd_ring_empty : head 0x%x tail 0x%x queue 0x%x 
+528,IIIIIII,[ whal_hwsch.c : 2167 ] MAC-%u cur_hw_tstamp=%x latency_cnt=%x fes_ring_th=%x latency_migtigation=%x, cca_hist=%x %x 
+529,IIIIIIIII,[ whal_hwsch.c : 2174 ] FES hw_head=%x hw_head_mem=%x hw_tail=%x sw_tail=%x reg_read_mode=%x CMD_STATUS head=%x tail=%x head_mem=%x tail_mem=%x 
+530,IIIIIIIII,[ whal_hwsch.c : 2189 ] CMD_STATUS(%u): schedule_id=%x cmd_result=%x flush_req_reason=%x eval_tstamp=%x %x dbg_info=%x fes_offset=%x %x 
+531,II,[ whal_hwsch.c : 2191 ] CMD_STATUS(%u): tag=%x 
+532,I,[ whal_hwsch.c : 2202 ] FES offset=%x invalid 
+533,III,[ whal_hwsch.c : 2211 ] FES offset=%x length=%x FES_START id=%x 
+534,II,[ whal_hwsch.c : 2213 ] FES offset=%x length=%x FES_END 
+535,III,[ whal_hwsch.c : 2215 ] FES offset=%x length=%x tag=%x 
+536,i,[ whal_hwsch.c : 2327 ] HWSCH WDOG %d times due to HWSCH2TQM SM stuck 
+537,i,[ whal_recv_fast.c : 1390 ] RTT: WIFIPHYRX_LOCATION_E: location_info_valid:%d 
+538,ii,[ whal_recv.c : 161 ] WDS_OFFLOAD: 4 addr packet received sw_frame_group_id %d, pkt_type %d 
+539,III,[ whal_sring.c : 1885 ] DMXI err=%u, DMAC_IDLE_CMN=0x%x, SRNG=0x%x 
+540,I,[ whal_tqm.c : 85 ] link_Desc_tshd register value:%02x 
+541,I,[ whal_tqm.c : 95 ] link_Desc_tshd register value:%02x 
+542,ii,[ whal_tqm_dbg.c : 156 ] TQM: TLV 32: Length: %d, Tag: %d
+ 
+543,iii,[ whal_tqm_dbg.c : 163 ] TQM: TLV 32: Length: %d, Tag: %d, Usr: %d
+ 
+544,I,[ whal_tqm_dbg.c : 169 ] TQM: tqm_cmd_number: 0x%08X 
+545,i,[ whal_tqm_dbg.c : 170 ] TQM: tqm_status_required: %d 
+546,i,[ whal_tqm_dbg.c : 171 ] TQM: tqm_status_ring: %d 
+547,i,[ whal_tqm_dbg.c : 172 ] TQM: pass_on_to_tqm: %d 
+548,i,[ whal_tqm_dbg.c : 173 ] TQM: sch_sifs_burst_cmd_drop: %d 
+549,i,[ whal_tqm_dbg.c : 174 ] TQM: sch_backoff_cmd_drop: %d 
+550,IIii,[ whal_tqm_dbg.c : 182 ] TQM: Buffer Addr Info: 0x%02x%08x, Return Mgr: %d, SW Cookie: %d
+ 
+551,I,[ whal_tqm_dbg.c : 188 ] TQM: tqm_status_number: 0x%08X 
+552,I,[ whal_tqm_dbg.c : 189 ] TQM: cmd_execution_time: 0x%08X 
+553,i,[ whal_tqm_dbg.c : 190 ] TQM: cmd_execution_code: %d 
+554,i,[ whal_tqm_dbg.c : 191 ] TQM: tqm_cmd_execution_status: %d 
+555,i,[ whal_tqm_dbg.c : 192 ] TQM: cmd_execution_was_paused: %d 
+556,I,[ whal_tqm_dbg.c : 196 ] TQM: timestamp: 0x%08X 
+557,,[ whal_tqm_dbg.c : 203 ] TQM: TQM STATUS: Acked MPDU 
+558,i,[ whal_tqm_dbg.c : 207 ] TQM: removed_mpdu_count: %d
+ 
+559,i,[ whal_tqm_dbg.c : 208 ] TQM: removed_msdu_count: %d
+ 
+560,i,[ whal_tqm_dbg.c : 210 ] TQM: removed_mpdu_byte_count: %d
+ 
+561,i,[ whal_tqm_dbg.c : 212 ] TQM: remaining_mpdu_queue_byte_count: %d
+ 
+562,i,[ whal_tqm_dbg.c : 213 ] TQM: remaining_mpdu_count: %d
+ 
+563,i,[ whal_tqm_dbg.c : 214 ] TQM: prev_mpdu_start_sequence_number: %d
+ 
+564,i,[ whal_tqm_dbg.c : 215 ] TQM: tx_mpdu_queue_number: %d
+ 
+565,i,[ whal_tqm_dbg.c : 216 ] TQM: new_mpdu_start_sequence_number: %d
+ 
+566,i,[ whal_tqm_dbg.c : 217 ] TQM: looping_count: %d
+ 
+567,,[ whal_tqm_dbg.c : 223 ] TQM: TQM CMD: Acked MPDU 
+568,I,[ whal_tqm_dbg.c : 227 ] TQM: mpdu_queue_desc_addr_31_0: 0x%08X 
+569,I,[ whal_tqm_dbg.c : 228 ] TQM: mpdu_queue_desc_addr_39_32: 0x%08X 
+570,i,[ whal_tqm_dbg.c : 229 ] TQM: remove_acked_cmd_type: %d 
+571,i,[ whal_tqm_dbg.c : 230 ] TQM: gen_mpdu_list_control: %d 
+572,i,[ whal_tqm_dbg.c : 231 ] TQM: ssn: %d 
+573,i,[ whal_tqm_dbg.c : 232 ] TQM: ack_frame_rssi: %d 
+574,I,[ whal_tqm_dbg.c : 239 ] TQM: ba_bitmap_31_0: 0x%08X 
+575,I,[ whal_tqm_dbg.c : 240 ] TQM: ba_bitmap_63_32: 0x%08X 
+576,I,[ whal_tqm_dbg.c : 241 ] TQM: ba_bitmap_95_64: 0x%08X 
+577,I,[ whal_tqm_dbg.c : 242 ] TQM: ba_bitmap_127_96: 0x%08X 
+578,I,[ whal_tqm_dbg.c : 243 ] TQM: ba_bitmap_159_128: 0x%08X 
+579,I,[ whal_tqm_dbg.c : 244 ] TQM: ba_bitmap_191_160: 0x%08X 
+580,I,[ whal_tqm_dbg.c : 245 ] TQM: ba_bitmap_223_192: 0x%08X 
+581,I,[ whal_tqm_dbg.c : 246 ] TQM: ba_bitmap_255_224: 0x%08X 
+582,IIIIIIIII,[ whal_tqm_dbg.c : 1232 ] tqm_dbg: list_status status_num:0x%x ts=%u, exec_time=%u, peer:%u, mpdu_cnt=%u, byte_cnt=%u, end_reason=%u, ssn=%u, lsn=%u 
+583,IIIIIIIII,[ whal_tqm_dbg.c : 1290 ] tqm_dbg: gen_mpdu_status status_num:0x%x, ts=%u, sw_peer_id_exec_time=%x, q_mpdu_cnt=%u, gen_mpdu_cnt=%u, used_msdu_cnt=%u, end_reason=%u, ssn=%u, lsn=%u 
+584,IIII,[ whal_xmit.c : 890 ] tqm_dbg: list_command cmd_num:0x%x, max_mpdu_cnt=%u, window_size=%u, stop_byte_cnt=%u 
+585,iiiii,[ whal_xmit.c : 3609 ] EARLY_RX_TERM: num_user/resp: [%d/%d], cmd_result/abort: %d/%d fes_dur: %d 
+ 
+586,II,[ whal_xmit.c : 6279 ] whalSetupCbfRateParams: rate code %x, flags %x 
+587,ii,[ whal_xmit.c : 6342 ] PF4: change to force PERM=%d, rate MCS=%d 
+588,ii,[ whal_xmit.c : 7433 ] InfoTPC: Max TPC = %d Min TPC = %d
+ 
+589,ii,[ whal_xmit.c : 12964 ] EARLY_RX_TERM: good/bad: [%d/%d] 
+ 
+590,IIiiii,[ whal_xmit.c : 13349 ] WHAL_TPC: rix: 0x%08x, rc_flags: 0x%08x, tpc 0,1,2,3: %d, %d, %d, %d 
+591,iiiiIII,[ whal_xmit.c : 13369 ] TPCDBG: Coex TPC is lower than BDF: bdf_tpc=%d,%d coes_tpc= %d,%d cm=%x c=%08x:%08x 
+592,iiIII,[ whal_xmit.c : 13392 ] TPCDBG: HWAdjust: tpc=%d,%d cm=%x c=%08x:%08x 
+593,iiiiIIIII,[ whal_xmit.c : 14307 ] TPCDBG: override: tpc=%d p_tpc[0]:0x%d p_tpc[1]:0x%d fw_tpc %d ppdu_flags: 0x%x rix = 0x%x rc_flags = 0x%x rc_series = 0x%x type = 0x%x  
+594,II,[ whal_xmit.c : 15435 ]  wifiradar: Rx chainmask 0x%x, txCM 0x%x 
+595,IIII,[ whal_xmit.c : 15503 ] Info: TPCDBG = %u, %u ppdu_ftype = 0x%x flags = 0x%x
+ 
+596,iIiI,[ whal_xmit.c : 19341 ] whalUpdatePdgTxNotifyParams pdev_id %d rate_code: %x index: %d, rc_flags: 0x%x 
+597,IIIIIIII,[ whal_xmit.c : 19351 ] whalUpdatePdgTxNotifyParams Notify rate params: %x %x %x %x %x %x %x %x  
+598,,[ whal_xmit.c : 19442 ] wal_sw_peer_key allocation failed...!!! 
+599,,[ whal_xmit.c : 19445 ] wal_sw_peer_key allocation SUCCESS 
+600,ii,[ whal_xmit.c : 22275 ] pcu data threshold step %d %d 
+601,,[ whal_wmac_recipes.c : 306 ] enable_gpio_profiling:BT is ON, Turnoff BT to have this feature
+ 
+602,iII,[ whal_wmac_recipes.c : 312 ] enable_gpio_profiling MAC:%d pmm_cx_mask:0x%x pmm_wlan_mask:0x%x
+ 
+603,,[ whal_wmac_recipes.c : 315 ] enable_gpio_profiling USE_COEX_WSI_DATA_EN not set
+ 
+604,I,[ whal_wmac_recipes.c : 328 ] enable_gpio_profiling PMM_TOP_WLANk_GPIO_PWR_MSK:0x%x
+ 
+605,I,[ whal_wmac_recipes.c : 332 ] enable_gpio_profiling PMM_TOP_GPIO_PWR_CSR:0x%x
+ 
+606,iiII,[ whal_wmac_recipes.c : 2494 ] mac%d: tlv:%d timeout pre_tlv_cnt:%x post_tlv_cnt:%x 
+607,II,[ whal_wmac_recipes.c : 2496 ] pre_tlv_ack_cnt:%x post_tlv_ack_cnt:%x 
+608,i,[ whal_wmac_recipes.c : 2625 ] set bcn timeout: %d 
+609,i,[ whal_wmac_recipes.c : 2670 ] dmac_idle: reg %d
+ 
+610,IIiI,[ lputils.c : 46 ] poll reg:0x%x for 0x%x timeout, line:%d, regval 0x%x 
+611,II,[ lputils.c : 48 ] caller:%s, reg_name:%s 
+612,i,[ whal_txbf_mimo_cv_image_api.c : 767 ] Invalid ru26_idx %d 
+ 
+613,i,[ whal_txbf_mimo_cv_image_api.c : 802 ] Invalid ru26_idx %d 
+ 
+614,i,[ whal_txbf_mimo_cv_image_api.c : 837 ] Invalid _20_band_index %d 
+ 
+615,i,[ whal_txbf_mimo_cv_image_api.c : 873 ] Invalid _20_band_index %d 
+ 
+616,III,[ phyDevLib.c : 287 ] PDL_CAL_FUNC: func=phyRxDCOCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+617,II,[ phyDevLib.c : 287 ] PDL_CAL_FUNC: func=phyRxDCOCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+618,III,[ phyDevLib.c : 305 ] PDL_CAL_FUNC: func=phyCombinedCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+619,II,[ phyDevLib.c : 305 ] PDL_CAL_FUNC: func=phyCombinedCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+620,III,[ phyDevLib.c : 323 ] PDL_CAL_FUNC: func=phyPDCCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+621,II,[ phyDevLib.c : 323 ] PDL_CAL_FUNC: func=phyPDCCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+622,III,[ phyDevLib.c : 350 ] PDL_CAL_FUNC: func=phyPkDetCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+623,II,[ phyDevLib.c : 350 ] PDL_CAL_FUNC: func=phyPkDetCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+624,III,[ phyDevLib.c : 593 ] PDL_CAL_FUNC: func=phyRxBBFCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+625,II,[ phyDevLib.c : 593 ] PDL_CAL_FUNC: func=phyRxBBFCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+626,III,[ phyDevLib.c : 602 ] PDL_CAL_FUNC: func=phyTxBBFCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+627,II,[ phyDevLib.c : 602 ] PDL_CAL_FUNC: func=phyTxBBFCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+628,III,[ phyDevLib.c : 638 ] PDL_CAL_FUNC: func=phyDACCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+629,II,[ phyDevLib.c : 638 ] PDL_CAL_FUNC: func=phyDACCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+630,III,[ phyDevLib.c : 647 ] PDL_CAL_FUNC: func=phyIM2Cal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+631,II,[ phyDevLib.c : 647 ] PDL_CAL_FUNC: func=phyIM2Cal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+632,III,[ phyDevLib.c : 755 ] PDL_CAL_FUNC: func=phyADCCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+633,II,[ phyDevLib.c : 755 ] PDL_CAL_FUNC: func=phyADCCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+634,III,[ phyDevLib.c : 764 ] PDL_CAL_FUNC: func=phyDisablePerActCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+635,II,[ phyDevLib.c : 764 ] PDL_CAL_FUNC: func=phyDisablePerActCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+636,III,[ phyDevLib.c : 773 ] PDL_CAL_FUNC: func=phyTIAdcCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+637,II,[ phyDevLib.c : 773 ] PDL_CAL_FUNC: func=phyTIAdcCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+638,III,[ phyDevLib.c : 791 ] PDL_CAL_FUNC: func=phyPALCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+639,II,[ phyDevLib.c : 791 ] PDL_CAL_FUNC: func=phyPALCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+640,III,[ phyDevLib.c : 800 ] PDL_CAL_FUNC: func=phySetTPC phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+641,II,[ phyDevLib.c : 800 ] PDL_CAL_FUNC: func=phySetTPC phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+642,III,[ phyDevLib.c : 872 ] PDL_CAL_FUNC: func=phyAdcCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+643,II,[ phyDevLib.c : 872 ] PDL_CAL_FUNC: func=phyAdcCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+644,III,[ phyDevLib.c : 2879 ] PDL_CAL_FUNC: func=phyRSTCal phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+645,II,[ phyDevLib.c : 2879 ] PDL_CAL_FUNC: func=phyRSTCal phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+646,III,[ phyDevLib.c : 4286 ] PDL_CAL_FUNC: func=phyGetCurrentTempInDegC phyId=0x%x calCmdId=0x%x RC=0x%x
+ 
+647,II,[ phyDevLib.c : 4286 ] PDL_CAL_FUNC: func=phyGetCurrentTempInDegC phyId=0x%x calCmdId=NULL RC=0x%x
+ 
+648,,[ phyDevLibCommon.c : 36 ] register polling disabled 
+649,i,[ phyDevLibCommon.c : 61 ] Error: Invalid PHY ID [=%d] 
+650,I,[ phyDevLibCommon.c : 82 ] Switch WCSS ENV to %s 
+651,II,[ phyDevLibCommon.c : 119 ] Dumping PDMEM: [0x%08lx : 0x%08lx] 
+652,,[ phyDevLibCommon.c : 124 ] Dumping PDMEM Done 
+653,,[ phyDevLibCommon.c : 168 ] Error: cmdInput is NULL 
+654,i,[ phyDevLibCommon.c : 175 ] num_args: %d 
+655,,[ phyDevLibCommon.c : 178 ] Error: num_args is 0 
+656,i,[ phyDevLibCommon.c : 184 ] cmdId (%d) unhandled 
+657,,[ phyIniAg.c : 423 ] Error: cannot commit NULL table! 
+658,iI,[ phyIniAg.c : 450 ] Note: table filtered out. table[%d].filter = %c 
+659,I,[ phy_dev_init.c : 78 ] wlan base: 0x%x 
+660,III,[ phy_dev_init.c : 88 ] CHIP: %s ENV: %s VER: %s 
+661,i,[ phy_dev_init.c : 104 ] ERROR: set parameter ID %d not yet implemented 
+662,i,[ phy_dev_init.c : 171 ] ERROR: get parameter ID %d not yet implemented 
+663,i,[ configFtpg.c : 71 ] Error: Maximum of %d users supported in SBS Mode! 
+664,II,[ configFtpg.c : 95 ] Writing 0x%08x to addr 0x%08x 
+665,III,[ configFtpg.c : 101 ] TxPPM = %hhd fc_pri_mhz = %u delta_sfo = %u 
+666,,[ configFtpg.c : 114 ] Error: lastTxTime=0us! Nothing to re-transmit 
+667,I,[ configFtpg.c : 121 ] [TxTime=%uus] 
+668,i,[ configFtpg.c : 128 ] waiting for Trigger[%d] ... 
+669,iI,[ configFtpg.c : 131 ] TBPPDU = Trigger + %d cycles [%fus] 
+670,iII,[ configFtpg.c : 177 ] Session[%d]: [pktDur_us=%uus TotalTxTime=%uus] 
+671,I,[ configFtpg.c : 186 ] [IFS=%uus] 
+672,I,[ configFtpg.c : 189 ] [multiSessionRptCount=%u] 
+673,I,[ configFtpg.c : 190 ] [pktsPerSession=%u] 
+674,I,[ configFtpg.c : 194 ] [numPkts=%u] 
+675,I,[ configFtpg.c : 195 ] [pktdur=%uus] 
+676,I,[ configFtpg.c : 198 ] [TotalTxTime=%uus] 
+677,i,[ configFtpg.c : 203 ] TBPPDU Rx Prep: PMI FCS for USER%d 
+678,i,[ configFtpg.c : 232 ] Waiting %dus for ISR Completion 
+679,i,[ configFtpg.c : 250 ] Waiting for Rx Node to be enabled. Delaying FTPG by %dus 
+680,,[ configFtpg.c : 296 ] Resetting FTPG Block ... 
+681,i,[ configFtpg.c : 298 ] Detected CBW = %d 
+682,I,[ ftpgCompute.c : 749 ] %s: Error: Invalid input! 
+683,I,[ ftpgCompute.c : 809 ] crc_chk = 0x%lx 
+684,I,[ ftpgCompute.c : 950 ] Error: Invalid 11b Rate Code [=%u] 
+685,i,[ ftpgCompute.c : 1020 ] ifs_cycles = %d 
+686,I,[ ftpgCompute.c : 1759 ] Error: Unsupported RU Size [=%u] 
+687,I,[ ftpgCompute.c : 1787 ] Error: Unsupported 11ax ltf_size_index [=%u] 
+688,I,[ ftpgCompute.c : 1801 ] Error: Unsupported 11ax GI Index [=%u] 
+689,I,[ ftpgCompute.c : 1815 ] Error: Unsupported 11ax GI Index [=%u] 
+690,,[ ftpgCompute.c : 2339 ] Error: Attempt to puncture Pri20!! 
+691,Ii,[ ftpgCompute.c : 2340 ] puncPattern=0x%hhx pri20SubBand=%d 
+692,Iii,[ ftpgCompute.c : 2389 ] EHT SU PUNC: puncPattern=0x%x lowerMostPuncIdx=%d splitPuncIdx=%d 
+693,ii,[ ftpgCompute.c : 2469 ] Error: Invalid puncturing configuration. bw=%d puncBands=%d 
+694,,[ ftpgCompute.c : 2677 ] E: FTPG_COMPUTE_SM in unexpected state! 
+695,ii,[ ftpgCompute.c : 2685 ] ftpgComputeSmState(%d) = %d 
+696,i,[ ftpgCompute.c : 2686 ] payLoadSize = %d 
+697,i,[ ftpgCompute.c : 2687 ] nsym = %d 
+698,,[ ftpgCompute.c : 2702 ] E: FTPG_COMPUTE_SM did not converge! 
+699,I,[ ftpgCompute.c : 2707 ] payLoadSize converged to %u 
+700,III,[ ftpgCompute.c : 2719 ] %-30s| %-10s| %-8s 
+701,I,[ ftpgCompute.c : 2302 ] Error: Invalid BW Code [%u] 
+702,,[ ftpgCompute.c : 337 ] Error: EHT Duplicate or MCS14 is not supported for BW < 80MHz 
+703,,[ ftpgCompute.c : 353 ] Error: Could not compute Nsc! [check input parameters] 
+704,I,[ ftpgCompute.c : 365 ] Error: Unsupported RU Size [=%u] 
+705,,[ ftpgCompute.c : 382 ] Error: Could not compute Nsc! [check input parameters] 
+706,I,[ ftpgCompute.c : 389 ] Error: Unsupported pktSubTypeIdx[=%u] 
+707,,[ ftpgCompute.c : 622 ] Error: DCM is not supported for MCS > 0 
+708,,[ ftpgCompute.c : 634 ] Error: DCM is not supported for MCS > 0 
+709,I,[ ftpgCompute.c : 641 ] %s: Error: Could not compute Nbpscs! [check input parameters] 
+710,i,[ ftpgCompute.c : 713 ] Error: %d is not a valid 11a Modulation Index. Valid=[8, 15]. 
+711,I,[ ftpgCompute.c : 576 ] %s: Error: Could not compute Coding Rate! [check input parameters] 
+712,I,[ ftpgCompute.c : 587 ] %s: Error: Could not compute Coding Rate! [check input parameters] 
+713,,[ ftpgCompute.c : 490 ] Fatal Error: Could not compute Ncbps! 
+714,I,[ ftpgCompute.c : 520 ] Fatal Error: Could not compute Ncbps for user %u! 
+715,I,[ ftpgCompute.c : 535 ] Fatal Error: Could not compute Ncbps for user %u! 
+716,I,[ ftpgCompute.c : 542 ] Error: Unsupported pktSubTypeIdx[=%u] 
+717,,[ ftpgCompute.c : 420 ] Fatal Error: Could not compute Ndbps! 
+718,I,[ ftpgCompute.c : 445 ] Fatal Error: Could not compute Ndbps for user %u! 
+719,I,[ ftpgCompute.c : 464 ] Fatal Error: Could not compute Ndbps for user %u! 
+720,I,[ ftpgCompute.c : 471 ] Error: Unsupported pktSubTypeIdx[=%u] 
+721,II,[ ftpgCompute.c : 1276 ] Error: Unsupported [pktTypeIdx, pktSubTypeIdx] = [%u, %u] 
+722,I,[ ftpgCompute.c : 1282 ] Error: Unsupported pktSubTypeIdx[=%u] 
+723,i,[ ftpgCompute.c : 672 ] Error: %d is not a valid 11b Rate Code! 
+724,I,[ ftpgCompute.c : 696 ] Error: Unsupported pktSubTypeIdx[=%u] 
+725,I,[ ftpgCompute.c : 1882 ] Error: Unsupported pktSubTypeIdx[=%u] 
+726,I,[ ftpgCompute.c : 1996 ] Error: Unsupported pktSubTypeIdx[=%u] 
+727,,[ ftpgCompute.c : 1296 ] Error: HE_SU/STBC+DCM is not supported 
+728,,[ ftpgCompute.c : 1321 ] Error: Invalid pktSubType for given cpLtfSize! 
+729,,[ ftpgCompute.c : 1358 ] Error: STBC and DCM are not support for HE_SUxHE_LTF+0.8GI 
+730,,[ ftpgCompute.c : 1370 ] Error: Invalid GI Input for NON-HE-SU packet 
+731,,[ ftpgCompute.c : 1381 ] Error: DCM is not support for HE_SUxHE_LTF+0.4GI 
+732,,[ ftpgCompute.c : 1394 ] Error: Invalid mcs for QC Proprietary GI+LTF! 
+733,,[ ftpgCompute.c : 1400 ] Error: Invalid GI Input for NON-HE-SU packet! 
+734,,[ ftpgCompute.c : 1411 ] Error: DCM is not support for HE_SUxHE_LTF+0.4GI 
+735,,[ ftpgCompute.c : 1424 ] Error: Invalid mcs for QC Proprietary GI+LTF! 
+736,,[ ftpgCompute.c : 1430 ] Error: Invalid GI Input for NON-HE-SU packet! 
+737,,[ ftpgCompute.c : 1437 ] Error: Invalid cp_ltf_size! 
+738,i,[ ftpgCompute.c : 1469 ] Error: Nsym cannot accomodate payload for user %d [ldpc] 
+739,ii,[ ftpgCompute.c : 1470 ] nsym = %d total bits = %d 
+740,i,[ ftpgCompute.c : 1483 ] Error: Nsym cannot accomodate payload for user %d [bcc] 
+741,i,[ ftpgCompute.c : 1484 ] total bits = %d 
+742,II,[ ftpgCompute.c : 1631 ] Error: Unsupported [pktTypeIdx, pktSubTypeIdx] = [%u, %u] 
+743,I,[ ftpgCompute.c : 1637 ] Error: Unsupported pktSubTypeIdx[=%u] 
+744,I,[ ftpgCompute.c : 1172 ] Error: Unsupported pktSubTypeIdx[=%u] 
+745,Ii,[ ftpgCompute.c : 2147 ] %s: iter%d 
+746,iii,[ ftpgCompute.c : 2148 ] numSigBSymCh0=%d numSigBSymCh1=%d mcsHeSigB=%d 
+747,I,[ ftpgCompute.c : 2160 ] %s: Fatal Error in HeSigBSymCalc Calc 
+748,I,[ ftpgCompute.c : 224 ] %s: Error: Invalid Packet Type! 
+749,I,[ ftpgCompute.c : 270 ] %s: Error: Invalid dot11ax_gi! 
+750,I,[ ftpgCompute.c : 289 ] Fatal Error: L-SIGA LENGTH must be divisible by 3 for Non-HE packet. Got %u ! 
+751,iI,[ ftpgCompute.c : 2247 ] Warning: Nss[=%d] should be < than Total Tx Chains [=%u] 
+752,I,[ ftpgCompute.c : 2291 ] %s: Fatal Error in SGI Disamb Calc 
+753,i,[ ftpgInitTlv.c : 118 ] Session located at memory index %d 
+754,iI,[ ftpgRuAllocation.c : 141 ] Error: Invalid band offset (%d) for MRU %s 
+755,iiiiIi,[ ftpgRuAllocation.c : 201 ] user=%d ruStartIdx=%d ruSize=%d ruCC=%d ruBandMask=0x%x ruOrder=%d 
+756,i,[ ftpgSingleTlv.c : 41 ] Sending tlvType=%d 
+757,,[ ftpgTlvFieldProgStruct.c : 160 ] Error: Payload CRC is Invalid!! 
+758,II,[ ftpgTlvFieldProgStruct.c : 259 ] USIG1=0x%lx USIG2=0x%lx 
+759,II,[ ftpgTlvFieldProgStruct.c : 277 ] Corrupting LSig: %u->%u 
+760,II,[ ftpgTlvFieldProgStruct.c : 287 ] Corrupting Rate: %u->%u 
+761,II,[ ftpgTlvFieldProgStruct.c : 298 ] Corrupting LSigParity: %u->%u 
+762,II,[ ftpgTlvFieldProgStruct.c : 309 ] Corrupting CRC: %u->%u 
+763,III,[ ftpgTlvout.c : 75 ] %-30s| %-40s| 0x%08x 
+764,III,[ ftpgTlvout.c : 76 ] %-30s| %-40s| 0x%08x 
+765,III,[ ftpgTlvout.c : 77 ] %-30s| %-40s| 0x%08x 
+766,III,[ ftpgTlvout.c : 78 ] %-30s| %-40s| 0x%08x 
+767,III,[ ftpgTlvout.c : 82 ] %-30s| %-40s| 0x%08x 
+768,III,[ ftpgTlvout.c : 83 ] %-30s| %-40s| 0x%08x 
+769,III,[ ftpgTlvout.c : 84 ] %-30s| %-40s| 0x%08x 
+770,III,[ ftpgTlvout.c : 85 ] %-30s| %-40s| 0x%08x 
+771,III,[ ftpgTlvout.c : 90 ] %-30s| %-40s| 0x%08x 
+772,III,[ ftpgTlvout.c : 91 ] %-30s| %-40s| 0x%08x 
+773,III,[ ftpgTlvout.c : 92 ] %-30s| %-40s| 0x%08x 
+774,IIII,[ ftpgTlvout.c : 94 ] %-30s| %-40s| [61:32]0x%08x | [31:0]0x%08x 
+775,I,[ ftpgTlvSeq.c : 65 ] Error: Invalid Argument [pktSubType = %u]. 
+776,I,[ ftpgTlvSeq.c : 95 ] Error: Invalid Argument [pktSubType = %u]. 
+777,I,[ ftpgTlvSeq.c : 117 ] Error: Invalid Argument [pktType = %u]. 
+778,,[ ftpgTlvWrapper.c : 66 ] Error: TLVFIELD array points to NULL! 
+779,II,[ ftpgTlvWrapper.c : 78 ] Error: Field %s of TLV %s is read only! 
+780,III,[ ftpgTlvWrapper.c : 92 ] Error: Max TLV Field Value = %u has been exceeded for field [%s] of [%s]! 
+781,II,[ ftpgTlvWrapper.c : 102 ] Error: Field %s was not found in the TLV %s! 
+782,,[ ftpgTlvWrapper.c : 115 ] Error: TLVFIELD array points to NULL! 
+783,III,[ ftpgTlvWrapper.c : 134 ] Error: Max TLV Field Value = %u has been exceeded for field [%s] of [%s]! 
+784,II,[ ftpgTlvWrapper.c : 144 ] Error: Field %s was not found in the TLV %s! 
+785,,[ ftpgTlvWrapper.c : 157 ] Error: TLVFIELD array points to NULL! 
+786,II,[ ftpgTlvWrapper.c : 172 ] Error: Field %s not found in the TLV %s! 
+787,i,[ ftpgTlvWrapper.c : 260 ] Error: FTPGWORDs has reached Max supported FTPGWORDs of %d 
+788,I,[ ftpgTlvWrapper.c : 338 ] Error: invalid input to function %s. Exiting ... 
+789,i,[ ftpgTlvWrapper.c : 453 ] nextSessionAddr = %d 
+790,i,[ ftpgToolBox.c : 149 ] Error: Invalid phyid [=%d] 
+791,I,[ ftpgToolBox.c : 177 ] Error: PHYDBG BANK OVERFLOW! [bank_size=%u] 
+792,I,[ ftpgToolBox.c : 198 ] Error: Invalid memidx. [bank_size=%u] 
+793,III,[ ftpgToolBox.c : 240 ] %-30s| 0x%08x| %08d 
+794,I,[ phyvi_ftpgTx.c : 122 ] puncPattern=0x%x 
+795,,[ phyvi_ftpgTx.c : 141 ] FTPG Tx: Stopping Transmit ... 
+796,,[ phyvi_ftpgTx.c : 148 ] FTPG Tx: Re-Transmitting ... 
+797,I,[ phyvi_ftpgTx.c : 156 ] E: Some input parameters were invalid [err_mask=0x%X]! 
+798,,[ phyvi_ftpgTx.c : 157 ] Aborting FTPG TX 
+799,I,[ phyvi_ftpgTx.c : 183 ] %s: Recipe Failed! 
+800,I,[ phyvi_ftpgTx.c : 188 ] %s: Recipe Completed 
+801,,[ phyAni.c : 463 ] ERROR: GTC_GAIN_TABLE_HOLD_MODE is NOT PROGRAMMED in INI ! 
+802,ii,[ phyDbg.c : 1104 ] phyDbgCmdStructTotalBits %d, phyDbgCmdStructTotalBitsFromPhyDbgCmdStruct %d do not match. Exiting ... 
+803,ii,[ phyDbg.c : 1109 ] phyDbgCmdStructTotalBits %d, phyDbgCmdStructTotalBitsFromPhyDbgCmdStruct %d match.Version check success 
+804,i,[ phyDbg.c : 1113 ] phyDbgCmdStruct expects 6 args. Got only %d. Exiting ... 
+805,ii,[ phyDbg.c : 1126 ] phyDbgCmdStruct Invalid dword. Got %d, but only support upto %d. Exiting ... 
+806,ii,[ phyDbg.c : 1134 ] phyDbgCmdStruct Invalid phyId. Got %d, but only support upto %d. Exiting ... 
+807,iiiiIiiI,[ phyDbg.c : 1145 ] phyDbgCmdStruct numArgs %d, phyDbgCmdId %d, phyId %d, dWordId %d, Mask 0x%08x, Shift %d, Value %d, dwordFinal 0x%08x 
+808,III,[ phyDbg.c : 1267 ] phyUnitTestApi phyGetTpcPowersFromGlut txChainMask 0x%x, bufferLen %u, numGluts %u 
+809,IIIiii,[ phyDbg.c : 1278 ] phyUnitTestApi phyGetTpcPowersFromGlut chainIdx %u, glutIdx %u, txGainIdx %u, minTxPwr %d, txPower %d, maxTxPower %d 
+810,III,[ phyDbg.c : 1304 ] phyUnitTestApi  chainIdx %u, pdadc %u, latestAccumulatedCLPCError %u 
+811,II,[ phyDbg.c : 1314 ] phyUnitTestApi phyProgClpcErrorDup retVal %u, dword0_phy_prog_clpc_err_dup_retries %u 
+812,IIIi,[ phyDbg.c : 1329 ] phyUnitTestApi phy_paprd_get_glut_idx_for_dpd_table[%02u][%02u] = %03u, regulatoryBackoffdB4 %d 
+813,I,[ phyDbg.c : 1339 ] phyUnitTestApi phyIsRf360 rc %u 
+814,I,[ phyDbg.c : 1341 ] phyUnitTestApi phyProgRf360Mipi rc %u 
+815,Iiiii,[ phyDbg.c : 1371 ] phyUnitTestApi phyForcedGainMode rc %u, force_target_power %d, force_glut_idx %d, force_tx_gain_idx %d, force_dac_gain %d 
+816,iiiii,[ phyDbg.c : 1468 ] phyUnitTestApi TSENS_RUNTIME_TEMP_PER_CHAIN %d, %d, %d, %d, avg %d 
+817,iiiii,[ phyDbg.c : 1479 ] phyUnitTestApi RUNTIME_TEMP_PER_CHAIN %d, %d, %d, %d, avg %d 
+818,iiiiiiiii,[ phyDbg.c : 1503 ] phyUnitTestApi TSENS_PAPRD_TEMP_PER_CHAIN[%d][%d], %d, %d, %d, %d, avg %d, nmsex10 %d, dpdTrainingDac %d 
+819,iiiiiiiii,[ phyDbg.c : 1514 ] phyUnitTestApi PAPRD_TEMP_PER_CHAIN[%d][%d], %d, %d, %d, %d, avg %d, sq_val %d, dpdTrainRxGain %d 
+820,iiIIIII,[ phyDbg.c : 1530 ] phyUnitTestApi TPC_STATS_FOR_DPD_TRAINING[%d][%d], tpcDpdLatAccClpcErr %05d, tpcDpdLatClpcErr %05d, tpcDpdLatGlut %05d, tpcDpdClpcErrGlut %05d, tpcDpdClpcPktCntGlut %05d 
+821,ii,[ phyDbg.c : 1555 ] phyUnitTestApi daGainPassed[%d] = %d 
+822,ii,[ phyDbg.c : 1564 ] phyUnitTestApi dacGainPassed[%d] = %d 
+823,i,[ phyDbg.c : 1572 ] phyUnitTestApi iqNumBlocksMalaga = %d 
+824,i,[ phyDbg.c : 1583 ] phyUnitTestApi heaterRecipeTxGain = %d 
+825,I,[ phyDbg.c : 1594 ] phyUnitTestApi iqHeaterTxGainOvd = 0x%08x 
+826,i,[ phyDbg.c : 1604 ] phyUnitTestApi ftpgHeaterEnable = %d 
+827,i,[ phyDbg.c : 1614 ] phyUnitTestApi iqHeaterEnable = %d 
+828,i,[ phyDbg.c : 1624 ] phyUnitTestApi dpdHeaterEnable = %d 
+829,iiiii,[ phyDbg.c : 1682 ] HEATER_PRE_TEMP_PER_CHAIN: %d, %d, %d, %d, avg %d 
+830,iii,[ phyDbg.c : 1721 ] FTPG Tx called with mpdulen %d,ftpg_ifs_5g %d, ftpgCount %d 
+831,iiiii,[ phyDbg.c : 1731 ] HEATER_POST_TEMP_PER_CHAIN: %d, %d, %d, %d, avg %d 
+832,ii,[ phyPcss.c : 201 ] ANI_CCA: supported_ucode_feature=%d, vReg=%d 
+833,i,[ phyPcss.c : 365 ] IU_SSR::CheckIfPhyIsOff CF_active: %d 
+834,,[ phyPcss.c : 371 ] IU_SSR::CheckIfPhyIsOff:: Forcing CF_ACTIVE LOW 
+835,ii,[ phyPcss.c : 376 ] IU_SSR::CheckIfPhyIsOff CF_active: %d readStatus: %d  
+836,,[ phyPcss.c : 387 ] CheckIfPhyIsOff::phyOff was not received by uCode, to force phyOff via Interrupt
+ 
+837,,[ phyPcss.c : 392 ] CheckIfPhyIsOff::phyOff was received by uCode via TLV
+ 
+838,i,[ phyPcss.c : 407 ] phyPcssSpatialReuse_ipq5424 type: %d 
+839,,[ phySetRxDeaf.c : 50 ] rxDeaf done! 
+840,,[ phySetRxDeaf.c : 71 ] rxDeaf cleared! 
+841,I,[ phyComputeOfdma.c : 24 ] Error: Unsupported RU Size [=%u] 
+842,iiii,[ phyComputeOfdma.c : 496 ] bw=%d numUsersr=%d pktType=%d MPRFlag=%d 
+843,II,[ phyComputeOfdma.c : 497 ] unAllocatedRuMask = (%x, %x) 
+844,II,[ phyComputeOfdma.c : 498 ] useCenterRu = (%x, %x) 
+845,ii,[ phyComputeOfdma.c : 500 ] ruStartIdx[%d] = %d 
+846,ii,[ phyComputeOfdma.c : 502 ] ruAllocation[%d] = %d 
+847,i,[ phyComputeOfdma.c : 531 ] totalRuNum = %d 
+848,i,[ phyComputeOfdma.c : 553 ] processing ruIdx=%d 
+849,iiIii,[ phyComputeOfdma.c : 565 ] ruIdx=%d  realUserIdx=%d bandMask=0x%x unAllocatedRUMaskLower=%d unAllocatedRUMaskUpper=%d 
+850,,[ phyComputeOfdma.c : 433 ] Error: Invalid EHT RU Allocation! 
+851,iIiI,[ phyComputeOfdma.c : 451 ] band_idx=%d, ruAlloc=0x%x, shft=%d final_band_mask=0x%x 
+852,I,[ phyComputeOfdma.c : 342 ] Error: Invalid ruAllocation [=%hhx] 
+853,,[ phyComputeOfdma.c : 230 ] Fatal Error during MRU Allocation! 
+854,,[ phyComputeOfdma.c : 266 ] Error: Invalid band_idx for RU996x2+484. Expected band_idx <=7 
+855,,[ phyComputeOfdma.c : 274 ] Fatal Error: Invalid RU Allocation! 
+856,iiI,[ phyEhtTbl.c : 146 ] sbw=%d, decimation_factor = %d, phyBase=0x%x 
+857,iI,[ phyEhtTbl.c : 195 ] DC_MEM[%d]=0x%llx 
+858,I,[ phyEhtTbl.c : 215 ] DC_MEM[LAST]=0x%08x 
+859,iI,[ dynPriChn.c : 41 ] sbw=%dMHz pri20=%+dMHz 
+860,Iii,[ m3_init.c : 82 ] m3ctrl: %x boot done/fail: %d/%d 
+861,i,[ m3_init.c : 111 ] phyM3Boot: phyId = %d 
+862,,[ m3_init.c : 114 ] M3 is already Running. Asserting Reset 
+863,,[ m3_init.c : 123 ] M3 Reset de-asserted [Running @640MHz] 
+864,i,[ m3_init.c : 124 ] Polling for boot completion ... [max_poll_count = %d] 
+865,,[ m3_init.c : 141 ] Warning: Max Poll Count Exceeded 
+866,,[ m3_init.c : 148 ] M3 is idle 
+867,,[ m3_init.c : 153 ] Alert: M3 has reported boot failure 
+868,,[ m3_init.c : 158 ] Error: Could not detect M3 Boot completion 
+869,,[ m3_init.c : 170 ] Using Direct IO!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
+870,,[ m3_init.c : 260 ] invalid phym3 binary, skip loading 
+871,,[ m3_init.c : 264 ] Loading PDMEM (may take few minutes)... 
+872,iIIII,[ m3_init.c : 271 ] seg%d: buf: %p dsize: %x msize: %x offset: %x 
+873,I,[ m3_init.c : 286 ] Loading PDMEM %s 
+874,III,[ m3_init.c : 198 ] dma: virt: %p phys: 0x%08x size: %x 
+875,i,[ m3Config.c : 112 ] Fatal Error: Invalid PHYID[=%d] 
+876,iiii,[ m3Config.c : 236 ] CBF info: nc - %d , ng value - %d , codebook - %d , nr - %d 
+877,,[ m3Config.c : 444 ] M3 DFS INI programmed 
+878,ii,[ m3Config.c : 523 ] BRANCH = %d BUILD = %d 
+879,iiiii,[ m3Config.c : 560 ] phySetTempCompensation PHYID[=%d], channel[=%d], temp[=%d], ppmOffset[=%d], delta_sfo[=%d] 
+880,I,[ m3Config.c : 675 ] forceCrashMask=0x%0.08x 
+881,i,[ phy_dev_setChainMask.c : 148 ] phySetChainMask: setting chain mask for phyId = %d ... 
+882,iiI,[ phy_dev_setChainMask.c : 151 ] Warning: [PHYID=%d isSBS=%d RXCHMASK=0x%X] is not supported. 
+883,,[ phy_dev_setChainMask.c : 152 ]          RXCHMASK will be forced to 0x1 
+884,i,[ phy_dev_setChainMask.c : 188 ] phySetChainMask: chain mask for phyId = %d completed 
+885,i,[ phy_dev_setXbar.c : 68 ] phySetXbar: setting xbar for phyId = %d ... 
+886,i,[ phy_dev_setXbar.c : 100 ] phySetXbar: xbar for phyId = %d completed 
+887,,[ phyHeavyClip.c : 331 ] CFR: Enabled 
+888,IIII,[ phyHeavyClip.c : 274 ] dword20_override_hcEn %u, heavyClipBdfParam.heavyClipPerMcs %u, heavyClipBdfParam.heavyClipEnablePktType %u, heavyClipBdfParam.heavyClipNssThreshold %u 
+889,iii,[ phyHeavyClip.c : 277 ] heavyClipPerMcs:%d, heavyClipEnablePktType:%d, heavyClipNssThreshold:%d 
+890,IIIII,[ phyHeavyClip.c : 78 ] dword20_override_hcPacked %u, hcFactorsPacked[0] 0x%08x, hcFactorsPacked[1] 0x%08x, hcFactorsPacked[2] 0x%08x, hcFactorsPacked[3] 0x%08x 
+891,IIiI,[ phyInitCfoCsr.c : 72 ] coefMan=0x%x coefExp=0x%x fcPri20=%d phyBase=%08x 
+892,iii,[ phyInitCfoCsr.c : 101 ] regVal=%d freqOffset=%d fcPri20=%d 
+893,iiii,[ phyInitCfoCsr.c : 119 ] fcRF=%d fcPri20=%d dpc_idx=%d bwCode=%d  
+894,iiii,[ phyInitCfoCsr.c : 207 ] fcPri20=%dMHz band_center_freq1(fcRF)=%d  phyInput->dynPriChan=%d dpc_idx=%d 
+895,iii,[ phyRegIni.c : 95 ] phy_mode = %d: adc_freq = %d, timestamp_inc = %d 
+896,i,[ phyRegIni.c : 377 ] phyAdfsMask:  %d 
+897,,[ phyRegIni.c : 436 ] DFS INI programmed 
+898,i,[ phyRegIni.c : 457 ] phyAdfsMask: %d 
+899,,[ phyRegIni.c : 512 ] Sscan INI programmed 
+900,i,[ phyReset.c : 73 ] [phyId=%d] 
+901,I,[ phyReset.c : 74 ] [phyBase=0x%0.08x] 
+902,i,[ phyReset.c : 75 ] [bwCode=%d] 
+903,i,[ phyReset.c : 76 ] [bandCode=%d] 
+904,I,[ phyReset.c : 77 ] [rxChMask=0x%x] 
+905,i,[ phyReset.c : 78 ] [dynPriChn=%d] 
+906,i,[ phyReset.c : 79 ] [band_center_freq1=%dMHz] 
+907,i,[ phyReset.c : 80 ] [band_center_freq2=%dMHz] 
+908,I,[ phyReset.c : 81 ] [loadIniMask=0x%x] 
+909,,[ phyReset.c : 126 ] phyRegAccessPass 
+910,,[ phyReset.c : 176 ] Enable the REFCLK from MSIP 
+911,I,[ phyReset.c : 179 ] BootstrapRefClkSel is 0x%x
+ 
+912,,[ phyReset.c : 193 ] Take rfa out of reset 
+913,,[ phyReset.c : 201 ] [REFCLK CONFIG FATAL ERROR]. phyRegAccess Failed 
+914,I,[ phyReset.c : 202 ] Skipping refclkConfig for [phyBase = 0x%0.08X] 
+915,I,[ phyReset.c : 206 ] Running refclkConfig for [phyBase=0x%0.08X] 
+916,,[ phyReset.c : 216 ] phyRefClkConfig_ipq5424 Recipe Complete 
+917,,[ phyReset.c : 236 ] (Start) 
+918,,[ phyReset.c : 253 ] (End) 
+919,,[ phyReset.c : 299 ] phyPdcCal_ipq5424 done 
+920,,[ phyReset.c : 1028 ] Error: Skipping phyReset since reset_input is NULL!!  
+921,I,[ phyReset.c : 1036 ] [phyResetCtrl=0x%x] 
+922,,[ phyReset.c : 1047 ] Error: phyRegAccess Failed 
+923,I,[ phyReset.c : 1048 ] Skipping phyReset for [phyBase = 0x%0.08X] 
+924,,[ phyReset.c : 1105 ] Recipe Complete 
+925,,[ phyReset.c : 1154 ] Recipe Complete 
+926,,[ phyReset.c : 1193 ] Recipe Complete 
+927,,[ phyReset.c : 1212 ] RxDco Cal complete.
+ 
+928,,[ phyRetention.c : 35 ] Enter retention save 
+929,,[ phyRetention.c : 44 ] Enter retention restore 
+930,i,[ phySetRx11bDetThr.c : 66 ] phySetRx11bDetCorrThr: Warning: numRxChain = %d was unexpected! 
+931,,[ phySetRx11bDetThr.c : 92 ] Recipe Complete 
+932,I,[ phySetRxfePerNrx.c : 161 ] numChains = %lu 
+933,I,[ wsiconfig.c : 42 ] rfa_test_reg = 0x%x 
+934,i,[ phyCfrCirCap.c : 26 ] Enable CFR ini programming phyId=%d 
+935,i,[ phyCfrCirCap.c : 43 ] Restoring Enable CFR ini programed phyId=%d 
+936,i,[ phyCfrCirCap.c : 59 ] Enable CIR ini programming phyId=%d 
+937,i,[ phyCfrCirCap.c : 76 ] Restoring Enable CIR ini programed phyId=%d 
+938,iI,[ phyRtt.c : 24 ] RTT per busrt ini programming phyId=%d phyBase=0x%08x 
+939,i,[ phyRtt.c : 42 ] Restoring RTT per burst ini programed phyId=%d 
+940,i,[ phyRtt.c : 55 ] Setting RTT_CHAN_CAPTURE RTT per frame ini programming phyId=%d 
+941,i,[ phyRtt.c : 71 ] Restoring RTT_CHAN_CAPTURE RTT per frame ini programming phyId=%d 
+942,,[ phyRtt.c : 83 ] RTT_11AZ: Set integrity Thresholds 
+943,ii,[ phyRtt.c : 135 ] phyRttSetVreg: illegal vregindex %d, should be in range 0..%d 
+944,iiiiIIIi,[ phyRtt.c : 143 ] phyRttSetVreg: peerId:%d lmrEnc:%d isAssoc:%d aid or Rsid:%d wrote %x read back %x, vregindex %x isLMRDelayedFeedback %d 
+945,i,[ phyRtt.c : 153 ] phyRtt_ipq5424: setVreg:%d 
+946,,[ phyRtt.c : 335 ] phyRttGetDlyCalSta_ipq5424 default case entered! 
+947,iI,[ phyRtt.c : 340 ] phyRttGetDlyCalSta_ipq5424 dlyCalMods = %d output = 0x%x 
+948,iii,[ phyRtt.c : 554 ] RTT - BASE Delays phy%d txRxIdx: %d, dynBw: %d 
+949,iii,[ phyRtt.c : 558 ] RTT - FINAL Delays phy%d txRxIdx: %d, dynBw: %d 
+950,iiii,[ phyRtt.c : 564 ] RTT - delay 11az NTB non-secure PBW[20 40 80 160]=[%d %d %d %d] 
+951,iiii,[ phyRtt.c : 567 ] RTT - delay 11az NTB secure PBW[20 40 80 160]=[%d %d %d %d] 
+952,iiii,[ phyRtt.c : 570 ] RTT - delay 11az TB non-secure PBW[20 40 80 160]=[%d %d %d %d] 
+953,iiii,[ phyRtt.c : 573 ] RTT - delay 11az TB secure PBW[20 40 80 160]=[%d %d %d %d] 
+954,iii,[ phyRtt.c : 576 ] RTT - Other chains delay 11az %d %d %d 
+955,iiii,[ phyRtt.c : 581 ] RTT - delay 11az NTB non-secure PBW[20 40 80 160]=[%d %d %d %d] 
+956,iiii,[ phyRtt.c : 584 ] RTT - delay 11az NTB secure PBW[20 40 80 160]=[%d %d %d %d] 
+957,iiii,[ phyRtt.c : 587 ] RTT - delay 11az TB non-secure PBW[20 40 80 160]=[%d %d %d %d] 
+958,iiii,[ phyRtt.c : 590 ] RTT - delay 11az TB secure PBW[20 40 80 160]=[%d %d %d %d] 
+959,iii,[ phyRtt.c : 593 ] RTT - Other chains delay 11az %d %d %d 
+960,,[ phyRtt.c : 649 ] phyRttSetBaseFinalDelayInStats invalid rtt mode 
+961,i,[ phyRttBdf.c : 293 ] Invalid bwCode %d 
+962,i,[ phyRttBdf.c : 372 ] phyBdfGetRttbwIdx In default case bwCode %d 
+963,i,[ phyRttBdf.c : 463 ] ChainNum of 0 was passed %d 
+964,ii,[ phyRttBdf.c : 517 ] bw Match not found bwCode %d is2G %d 
+965,i,[ phyRttBdf.c : 588 ] phyBdfGetRttPerPktBW In default case bwCode %d 
+966,,[ phyRttBdf.c : 639 ] RTT - Error: Null passed for chanIndex and array of channels 
+967,,[ phyRttBdf.c : 651 ] RTT - Error: unmatched chanIndex and array of channel list 
+968,iiiii,[ phyRttBdf.c : 700 ] RTT - dynamicBw: %d, center Freq: %d, index: %d, txRxIdx: %d delaydelta: %d
+ 
+969,ii,[ phyRttBdf.c : 736 ] RTT - pri20 %d is not valid in dynamicBw %d 
+970,iiii,[ phyRttBdf.c : 802 ] RTT - pri20, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+971,i,[ phyRttBdf.c : 830 ] phyBdfGetRttPerPktBWFromPktType In 2G default case bwCode %d 
+972,i,[ phyRttBdf.c : 921 ] phyBdfGet11azDeltaDelayValues_ipq5424 dlyCalMods=%d 
+973,iiii,[ phyRttBdf.c : 942 ] RTT - Tx IQ Cor, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+974,iiii,[ phyRttBdf.c : 963 ] RTT - Preemp FIR, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+975,iiii,[ phyRttBdf.c : 984 ] RTT - Tx Lpc off, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+976,iiii,[ phyRttBdf.c : 1017 ] RTT - PA Droop, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+977,iiii,[ phyRttBdf.c : 1041 ] RTT - eDpd Cond2, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+978,iiii,[ phyRttBdf.c : 1057 ] RTT - eDpd Cond2, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+979,iiii,[ phyRttBdf.c : 1073 ] RTT - eDpd Cond2, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+980,iiii,[ phyRttBdf.c : 1100 ] RTT - Rx IQ Cor, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+981,iiii,[ phyRttBdf.c : 1121 ] RTT - Rx Lpc off, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+982,iiii,[ phyRttBdf.c : 1164 ] RTT - vsrc filter, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+983,iiii,[ phyRttBdf.c : 1233 ] RTT - DC Noth filter, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+984,iiii,[ phyRttBdf.c : 1256 ] RTT - DC Noth detect, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+985,iiii,[ phyRttBdf.c : 1281 ] RTT - adc dc, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+986,iiii,[ phyRttBdf.c : 1300 ] RTT - adc gain, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+987,iiiii,[ phyRttBdf.c : 1339 ] RTT -  spur filter det %d, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+988,iiiii,[ phyRttBdf.c : 1368 ] RTT - spur filter %d, delta=PBW[20 40 80 160]=[%d,%d,%d,%d] 
+989,i,[ phyRttBdf.c : 1377 ] default: Bad rtt_dly_cal_mods %d 
+990,,[ phySpurMitigation.c : 40 ] Invalid Spur Flag!!!. Enabling common notch if there is a spur!!! 
+991,iiii,[ phySpurMitigation.c : 60 ] RxFD %d spurmit: CHE - %d, BW - %d, PTC - %d 
+992,Iiiiii,[ phySpurMitigation.c : 94 ] spur_tone_index 0x%x, d'%d spur1Offset_Mhz_x10 %d whichSegment80 %d nSegment80ToWrite %d sbwCode %d 
+993,iiII,[ phySpurMitigation.c : 107 ] write %d of %d fullAddr 0x%x reg32 0x%x 
+994,,[ phySpurMitigation.c : 139 ] Enabling DC subtraction 
+995,,[ phySpurMitigation.c : 155 ] Enabling DC compensation and disabling DC subtraction 
+996,ii,[ phySpurMitigation.c : 177 ] Enabling RxTD dynamic spurmit - %d, MCS threshold - %d 
+997,,[ phySpurMitigation.c : 185 ] Disabling dyn spurmit 
+998,iiiiii,[ phySpurMitigation.c : 222 ] Chain=%d, AdcRate=%d, BwCode=%d, numberOfSpurs = %d, spur1Offset = %dMhz, spur2Offset = %dMhz 
+999,i,[ phySpurMitigation.c : 226 ] RxTD %d spurmit case - Common and detection notch 
+1000,i,[ phySpurMitigation.c : 265 ] Enabling RxTD %d spurmit case - Common notch 
+1001,i,[ phySpurMitigation.c : 302 ] Enabling RxTD %d spurmit case - Detection notch 
+1002,i,[ phySpurMitigation.c : 336 ] Enabling RxTD %d spurmit case - DCSUB/DCN - Common/Detection notch, Spur - Detection notch 
+1003,,[ phySpurMitigation.c : 380 ] Programming POR values 
+1004,iiiii,[ phySpurMitigation.c : 471 ] numberOfSpurs = %d spur1Offset_Mhz_x10 = %d spur2Offset_Mhz_x10 = %d spur1Flag = %d spur2Flag = %d 
+1005,IIIIIIi,[ phyWarmRst.c : 43 ] phyWarmResetDebugRegDump 0x%X : 0x%X : 0x%X : 0x%X : 0x%X : 0x%X : Time = %d 
+1006,,[ phyWarmRst.c : 53 ] Executing Warm Reset 
+1007,,[ phyWarmRst.c : 99 ] RECIPE COMPLETE 
+1008,iI,[ phyVersion.c : 17 ] HDL Version %d.%02d 
+1009,,[ phydbg_utils.c : 50 ] AccquirePhydbgMuxtex 
+1010,,[ phydbg_utils.c : 67 ] ConfigurePhydbgTrigger 
+1011,,[ phydbg_utils.c : 80 ] ConfigureEventCapture 
+1012,,[ phydbg_utils.c : 90 ] ConfigureMPImoduleEventMask 
+1013,,[ phydbg_utils.c : 109 ] StopCapture 
+1014,,[ phydbg_utils.c : 117 ] EnableCapture 
+1015,,[ phydbg_utils.c : 125 ] ResetCaptureBankMask 
+1016,,[ phydbg_utils.c : 135 ] ReleasePhydbgMutex 
+1017,i,[ phydbg_utils.c : 178 ] Clearing phyDbg bank: %d 
+1018,,[ phydbg_utils.c : 249 ] DumpPhydbgMemoryBank 
+1019,,[ phydbg_utils.c : 281 ] ConfigureAdcCapture 
+1020,,[ phydbg_utils.c : 317 ] DumpPhydbgMemoryBankADC 
+1021,,[ phydbg_utils.c : 318 ] ADC capture details: 
+1022,,[ phydbg_utils.c : 326 ] Capture mode : 4 chain capture 
+1023,,[ phydbg_utils.c : 334 ] ADC-IQ[2nd bank, 1st bank, mem_count, 2nd bank U32, 2nd bank L32, 1st bank U32, 1st bank L32], Chn3_I, Chn3_Q, Chn2_I, Chn2_Q, Chn1_I, Chn1_Q, Chn0_I, Chn0_Q 
+1024,iiIIIII,[ phydbg_utils.c : 369 ] DEBUG>> ADC-IQ[%d, %d, %4d, 0x%08x, 0x%08x, 0x%08x, 0x%08x] 
+1025,IIIIIIII,[ phydbg_utils.c : 370 ] DEBUG>> ADC-IQ %4d, %4d, %4d, %4d, %4d, %4d, %4d, %4d 
+1026,,[ phydbg_utils.c : 376 ] Invalid CSR_CAPTURE_BANK 
+1027,,[ phydbg_utils.c : 377 ] Valid values: 0x3, 0xC, 0xF 
+1028,,[ phydbg_utils.c : 384 ] Capture mode : 1 chain capture 
+1029,i,[ phydbg_utils.c : 385 ] ADC-IQ for Chain %d 
+1030,,[ phydbg_utils.c : 391 ] ADC-IQ[bank, mem_count, U32, L32], I, Q 
+1031,iIIIII,[ phydbg_utils.c : 433 ] ADC-IQ[%d, %4d, 0x%08x, 0x%08x], %4d, %4d 
+1032,iIIIII,[ phydbg_utils.c : 434 ] ADC-IQ[%d, %4d, 0x%08x, 0x%08x], %4d, %4d 
+1033,,[ phydbg_utils.c : 441 ] Invalid CSR_ADC_CHAIN_MASK 
+1034,,[ phydbg_utils.c : 442 ] Valid values: 1 chain capture mode = 0x1, 0x2, 0x4, 0x8 
+1035,,[ phydbg_utils.c : 443 ] Valid values: 4 chain capture mode = 0xF 
+1036,,[ phydbg_utils.c : 695 ] LoadPhydbgMemoryBank 
+1037,i,[ phydbg_utils.c : 708 ] LoadPhydbgMemoryBank for Freq = %dMHz 
+1038,ii,[ phydbg_utils.c : 721 ] Freq scaling factor = %d, Scaled Freq = %dMHz 
+1039,,[ phydbg_utils.c : 748 ] ConfigureDacPlayback, Manyuan recipe 
+1040,,[ phydbg_utils.c : 828 ] StopDacPlayback 
+1041,,[ phydbg_utils.c : 836 ] Register dump - Start 
+1042,,[ phydbg_utils.c : 837 ] Addr, Val, Register 
+1043,II,[ phydbg_utils.c : 840 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_MODE_L  
+1044,II,[ phydbg_utils.c : 843 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_MODE_U  
+1045,II,[ phydbg_utils.c : 846 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_0_L  
+1046,II,[ phydbg_utils.c : 849 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_0_U  
+1047,II,[ phydbg_utils.c : 852 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_1_L  
+1048,II,[ phydbg_utils.c : 855 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_1_U  
+1049,II,[ phydbg_utils.c : 858 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_2_L  
+1050,II,[ phydbg_utils.c : 861 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_TRIGGER_2_U  
+1051,II,[ phydbg_utils.c : 864 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_PLAYBACK_L  
+1052,II,[ phydbg_utils.c : 867 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_PLAYBACK_U  
+1053,II,[ phydbg_utils.c : 870 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_CAPTURE_0_L  
+1054,II,[ phydbg_utils.c : 873 ] 0x%08x, 0x%08x, PHYRF_PHYDBG_CAPTURE_0_U  
+1055,II,[ phydbg_utils.c : 876 ] 0x%08x, 0x%08x, TXFD_PHYDBG_MPI_0_L  
+1056,II,[ phydbg_utils.c : 879 ] 0x%08x, 0x%08x, TXFD_PHYDBG_MPI_1_U  
+1057,II,[ phydbg_utils.c : 882 ] 0x%08x, 0x%08x, TXFD_PHYDBG_MPI_4_L  
+1058,II,[ phydbg_utils.c : 885 ] 0x%08x, 0x%08x, ROBE_PMI_PMI_PHYDBG_CONFIG_0_L  
+1059,II,[ phydbg_utils.c : 888 ] 0x%08x, 0x%08x, ROBE_PMI_PMI_PHYDBG_CONFIG_2_L  
+1060,II,[ phydbg_utils.c : 891 ] 0x%08x, 0x%08x, RXTD_PHYDBG_CTRL_L  
+1061,,[ phydbg_utils.c : 892 ] Register dump - End 
+1062,,[ phydbg_utils.c : 898 ] Starting SysSim playback 
+1063,,[ phydbg_utils.c : 957 ] Stopping SysSim playback 
+1064,I,[ phydbg_utils.c : 1002 ] Current MPDU_CHK_COUNT is 0x%x 
+1065,I,[ phydbg_utils.c : 1012 ] Waiting for Trigger..! MPDU_CHK_COUNT is 0x%x 
+1066,I,[ phydbg_utils.c : 1031 ] Waiting for %1.2f uS 
+1067,,[ phydbg_utils.c : 1034 ] Playing packet 
+1068,I,[ phydbg_utils.c : 1038 ] Waiting for %1.2f uS 
+1069,I,[ phydbg_utils.c : 1044 ] Waiting for %1.2f uS 
+1070,I,[ phydbg_utils.c : 1054 ] Waiting for %1.2f uS 
+1071,i,[ phydbg_utils.c : 1057 ] Playing packet #%d 
+1072,I,[ phydbg_utils.c : 1061 ] Waiting for %1.2f uS 
+1073,I,[ phydbg_utils.c : 1072 ] Waiting for %1.2f uS 
+1074,i,[ phydbg_utils.c : 1075 ] Playing packet #%d 
+1075,I,[ phydbg_utils.c : 1079 ] Waiting for %1.2f uS 
+1076,,[ phydbg_utils.c : 1089 ] ConfigurePMImoduleEventMask 
+1077,,[ phydbg_utils.c : 1111 ] PollForCsrCaptureEn 
+1078,I,[ phydbg_utils.c : 1123 ] CSR_CAPTURE_EN = 0x%x, Waiting for Trigger..! 
+1079,I,[ phydbg_utils.c : 1127 ] CSR_CAPTURE_EN = 0x%x, Triggered..! 
+1080,,[ phydbg_utils.c : 1133 ] ConfigureRXTDmoduleEventMask 
+1081,,[ phydbg_utils.c : 1148 ] ConfigureTxFDmoduleEvents 
+1082,,[ phydbg_utils.c : 1158 ] ConfigurePcssModuleEvents 
+1083,,[ phydbg_utils.c : 1175 ] ConfigureFFTmoduleEvents 
+1084,,[ phydbg_utils.c : 1186 ] ConfigureTxTDmoduleEvents 
+1085,,[ phydbg_utils.c : 1194 ] ConfigureRobeModuleEvents 
+1086,,[ phydbg_utils.c : 1206 ] ConfigureWSImoduleEvents 
+1087,,[ phydbg_utils.c : 1213 ] ConfigureRfCntlmoduleEvents 
+1088,,[ phydbg_utils.c : 1220 ] ConfigureTPCmoduleEvents 
+1089,ii,[ phydbg_utils.c : 1236 ] Current_timer_count is %d and new_timer_count is %d 
+1090,i,[ phydbg_utils.c : 1243 ] Hit..! current_timer_count is %d 
+1091,ii,[ phydbg_utils.c : 1256 ] Current_timer_count is %d and new_timer_count is %d 
+1092,i,[ phydbg_utils.c : 1263 ] Hit..! current_timer_count is %d 
+1093,,[ phydbg_utils.c : 1269 ] ConfigureDemfrontModuleEventMask 
+1094,,[ phydbg_utils.c : 1308 ] PHYDBG MEMORY CONTENTS 
+1095,iII,[ phydbg_utils.c : 1322 ] %d,0x%x,0x%x 
+1096,,[ phydbg_utils.c : 1334 ] PHYDBG MEMORY CONTENTS 
+1097,I,[ phydbg_utils.c : 1355 ] DEBUG>> Programming PHYRF_PHYDBG_MEM_DATA_L_0 with 0x%08x 
+1098,I,[ phydbg_utils.c : 1367 ] DEBUG>> Programming PHYRF_PHYDBG_MEM_DATA_U_0 with 0x%08x 
+1099,i,[ phydbg_utils.c : 1389 ] DEBUG>> Programming PHYRF_PHYDBG_MEM_ADDR_L_0  with %d 
+1100,,[ phydbg_utils.c : 1584 ] RxDcoSweep:Chain,RxDcoOn,RxGainIndex,ResDcI(mV),ResDcQ(mV) 
+1101,iiii,[ phydbg_utils.c : 1596 ] RxDcoSweep: Converged values: rangeIOvd %d, rangeQOvd %d, resIOvd %d, resQOvd %d 
+1102,iiiII,[ phydbg_utils.c : 1621 ] RxDcoSweep:%d,%d,%d,%5.2f,%5.2f 
+1103,,[ phydbg_event_capture.c : 86 ] Configure phyDbg event capture : START 
+1104,,[ phydbg_event_capture.c : 184 ] Configure phyDbg event capture : END 
+1105,,[ phydbg_adc_capture.c : 67 ] Configuring phyDbg ADC capture 
+1106,,[ phydbg_adc_capture.c : 187 ] Configuring MemSS ADC capture 
+1107,,[ phydbg_mem_dump.c : 32 ] DEBUG>> Capture mode : 4 chain capture 
+1108,,[ phydbg_mem_dump.c : 39 ] DEBUG>> ADC-IQ[2nd bank, 1st bank, mem_count, 2nd bank U32, 2nd bank L32, 1st bank U32, 1st bank L32], Chn3_I, Chn3_Q, Chn2_I, Chn2_Q, Chn1_I, Chn1_Q, Chn0_I, Chn0_Q 
+1109,,[ phydbg_mem_dump.c : 95 ] DEBUG>> Invalid CSR_CAPTURE_BANK 
+1110,,[ phydbg_mem_dump.c : 96 ] DEBUG>> Valid values: 0x3, 0xC, 0xF 
+1111,,[ phydbg_mem_dump.c : 101 ] DEBUG>> Capture mode : 1 chain capture 
+1112,i,[ phydbg_mem_dump.c : 102 ] DEBUG>> ADC-IQ for Chain %d 
+1113,,[ phydbg_mem_dump.c : 108 ] DEBUG>> ADC-IQ[bank, mem_count, U32, L32], I, Q 
+1114,,[ phydbg_mem_dump.c : 157 ] DEBUG>> Invalid CSR_ADC_CHAIN_MASK 
+1115,,[ phydbg_mem_dump.c : 158 ] DEBUG>> Valid values: 1 chain capture mode = 0x1, 0x2, 0x4, 0x8 
+1116,,[ phydbg_mem_dump.c : 159 ] DEBUG>> Valid values: 4 chain capture mode = 0xF 
+1117,,[ phydbg_mem_dump.c : 306 ] DEBUG>> ~~~~~~~~~~~~~~~~~~~~~~ DUMP PHYDBG MEM ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+1118,,[ phydbg_mem_dump.c : 360 ] DEBUG>> ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+1119,,[ phydbg_dac_playback.c : 47 ] Configuring phyDbg DacPlayback 
+1120,,[ phydbg_dac_playback.c : 63 ] Stopping phyDbg DacPlayback 
+1121,iI,[ phy_dev_calUtils.c : 169 ] calSavedParams[%d].rxChainMask = 0x%08x 
+1122,iI,[ phy_dev_calUtils.c : 184 ] calSavedParams[%d].rxChainMask = 0x%08x 
+1123,i,[ phy_dev_calUtils.c : 300 ] Invalid OTP_WORD[=%d]. 
+1124,i,[ phy_dev_calUtils.c : 372 ] TriggerCal failure for phyId: %d 
+1125,IIII,[ phy_dev_calUtils.c : 698 ] phyFem set_func_select phyId 0x%x, numGpioPerChain 0x%x, chainMask 0x%x, forceValue 0x%x 
+1126,IIIIIII,[ phy_dev_calUtils.c : 700 ] phyFem set_func_select phyId 0x%x, gpio_config_mask1 0x%x, gpio_config_value1 0x%x, gpio_config_mask2 0x%x, gpio_config_value2 0x%x, gpio_config_mask3 0x%x, gpio_config_value3 0x%x 
+1127,I,[ phy_dev_calUtils.c : 885 ] CAL CHAIN MASK Deduced - 0x%x 
+1128,i,[ phy_dev_calUtils.c : 967 ] TriggerCal failure for phyId: %d 
+1129,i,[ phy_dev_calUtils.c : 1024 ] Invalid gainTableIdx %d passed 
+1130,ii,[ phy_dev_calUtils.c : 1032 ] Invalid rxGainIdx %d passed for gainTableIdx %d 
+1131,iiiiiIi,[ phy_dev_calUtils.c : 1055 ] isXlnaOn mode_sel %d , mode_offset %d, chainidx %d, gainTableIdx %d, rxGainIdx %d, RxGain Address 0x%x, XlnaState %d 
+1132,iii,[ phy_dev_calUtils.c : 1172 ] rfaOtpParam chain = %d, ko = %d, kg = %d 
+1133,i,[ phy_dev_calUtils.c : 1189 ] rfaOtpParam ambient_temp_cal = %d 
+1134,iii,[ phy_dev_calUtils.c : 1228 ] rfaOtpParam chain = %d, temp_code_cal_tmp = %d, temp_code_cal = %d 
+1135,ii,[ phy_dev_calUtils.c : 1281 ] Temp Read valid for iteration %d, Chain - %d 
+1136,iiiii,[ phy_dev_calUtils.c : 1308 ] Temp Valid for RF Chain - %d, Measured Temp - %d, Temp_code - %d, Current Sum - %d, Num_valid_chains - %d 
+1137,I,[ phy_dev_calUtils.c : 1317 ] Invalid Temperature Read across all the chains valid in TxChain Mask - 0x%x 
+1138,iI,[ phy_dev_calUtils.c : 1321 ] Temperature Sensor Read success for %d number of chains valid in TxChain Mask - 0x%x 
+1139,ii,[ phy_dev_calUtils.c : 1345 ] Final Temperature Value sent to upper layer - Chain - %d, Temperature - %d 
+1140,i,[ phy_dev_fdmtCombCal.c : 218 ] FDMT: TXDCOC: CHAIN%d-PRI-PRISYN: 
+1141,iI,[ phy_dev_fdmtCombCal.c : 223 ] FDMT: index: %d VAL: 0x%08x 
+1142,i,[ phy_dev_fdmtCombCal.c : 226 ] FDMT: TXDCOC: CHAIN%d-FCS-PRISYN: 
+1143,iI,[ phy_dev_fdmtCombCal.c : 231 ] FDMT: index: %d VAL: 0x%08x 
+1144,ii,[ phy_dev_fdmtCombCal.c : 260 ] FDMT: TXCL: PHYID%d CHAIN%d-PRI: 
+1145,iI,[ phy_dev_fdmtCombCal.c : 264 ] FDMT: index: %d VAL: 0x%08x 
+1146,ii,[ phy_dev_fdmtCombCal.c : 267 ] FDMT: TXCL: PHYID%d CHAIN%d-FCS: 
+1147,iI,[ phy_dev_fdmtCombCal.c : 271 ] FDMT: index: %d VAL: 0x%08x 
+1148,ii,[ phy_dev_fdmtCombCal.c : 296 ] FDMT: TXIQ: PHYID%d CHAIN%d-PRI: 
+1149,iI,[ phy_dev_fdmtCombCal.c : 300 ] FDMT: index: %d VAL: 0x%08x 
+1150,ii,[ phy_dev_fdmtCombCal.c : 303 ] FDMT: TXIQ: PHYID%d CHAIN%d-FCS: 
+1151,iI,[ phy_dev_fdmtCombCal.c : 307 ] FDMT: index: %d VAL: 0x%08x 
+1152,ii,[ phy_dev_fdmtCombCal.c : 332 ] FDMT: RXIQ: PHYID%d CHAIN%d-PRI: 
+1153,iI,[ phy_dev_fdmtCombCal.c : 336 ] FDMT: index: %d VAL: 0x%08x 
+1154,ii,[ phy_dev_fdmtCombCal.c : 339 ] FDMT: RXIQ: PHYID%d CHAIN%d-FCS: 
+1155,iI,[ phy_dev_fdmtCombCal.c : 343 ] FDMT: index: %d VAL: 0x%08x 
+1156,,[ phy_dev_fdmtCombCal.c : 506 ] FDMT: run_fdmt_txiq_cal: started 
+ 
+1157,iiiiiii,[ phy_dev_fdmtCombCal.c : 580 ] TXIQ_TEMP_PER_CHAIN  Chain %d, Glut %d, %d, %d, %d, %d, avg %d 
+1158,,[ phy_dev_fdmtCombCal.c : 603 ] FDMT: run_fdmt_rxiq_cal: started 
+ 
+1159,ii,[ phy_dev_fdmtCombCal.c : 624 ] run_fdmt_rxiq_cal, glutIdx = %d, daGainPassed is %d 
+1160,iiiiiii,[ phy_dev_fdmtCombCal.c : 660 ] RXIQ_TEMP_PER_CHAIN Chain %d, Glut %d, %d, %d, %d, %d, avg %d 
+1161,,[ phy_dev_fdmtCombCal.c : 665 ] FDMT: run_fdmt_rxiq_cal: completed 
+ 
+1162,i,[ phy_dev_fdmtCombCal.c : 1185 ] FDMT: init_cal_rxgain_lut: fdmtIqData->restoreflag: %d
+ 
+1163,iiii,[ phy_dev_fdmtCombCal.c : 4251 ] FDMT: PhyId %d, Chn %d, estDc = (%d, %d) 
+1164,iiii,[ phy_dev_fdmtCombCal.c : 4265 ] FDMT: PhyId %d, Chn %d, estDc = (%d, %d) 
+1165,i,[ phy_dev_fdmtCombCal.c : 4512 ] GDP Cal time: gdpcal_docal: time = %d us
+ 
+1166,I,[ phy_dev_fdmtCombCal.c : 4599 ] IQ Cal override da/dac gain for calVersion %u ( old ) 
+1167,IIIiii,[ phy_dev_fdmtCombCal.c : 5005 ] save_restore_dctxdcoc_lut (Restore): mem_ptr = 0x%08x, *regVal = 0x%08x, readback = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1168,IIiii,[ phy_dev_fdmtCombCal.c : 5018 ] save_restore_dctxdcoc_lut (Save): mem_ptr = 0x%08x, *regVal = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1169,IIiii,[ phy_dev_fdmtCombCal.c : 5083 ] save_restore_cl_tab (Restore): mem_ptr = 0x%08x, word32 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1170,IIiii,[ phy_dev_fdmtCombCal.c : 5095 ] save_restore_cl_tab (Save): mem_ptr = 0x%08x, word32 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1171,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5184 ] Restore: TX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1172,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5187 ] Restore: RX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d phyrfChainIdx = %d, mode = %d 
+1173,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5203 ] Save: TX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1174,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5206 ] Save: RX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d phyrfChainIdx = %d, mode = %d 
+1175,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5238 ] Restore: TX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1176,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5241 ] Restore: RX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d phyrfChainIdx = %d, mode = %d 
+1177,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5257 ] Save: TX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1178,IIIIIIiii,[ phy_dev_fdmtCombCal.c : 5260 ] Save: RX:  cal_coeff_l[%02d]= 0x%08x, cal_coeff_u[%02d]= 0x%08x, mem_ptr1 = 0x%08x, mem_ptr2 = 0x%08x, freq = %d phyrfChainIdx = %d, mode = %d 
+1179,iIIIIiii,[ phy_dev_fdmtCombCal.c : 5353 ] save_restore_rxcorr_mapping_indices (Restore): rxGainIdx = %d, mem_ptr[0] = 0x%08x, mem_ptr[1] = 0x%08x,                         word32[0] = 0x%08x, word32[1] = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+ 
+1180,iIIIIiii,[ phy_dev_fdmtCombCal.c : 5375 ] save_restore_rxcorr_mapping_indices (Save): rxGainIdx = %d, mem_ptr[0] = 0x%08x, mem_ptr[1] = 0x%08x,                         word32[0] = 0x%08x, word32[1] = 0x%08x, freq = %d, phyrfChainIdx = %d, mode = %d 
+1181,,[ phy_dev_fdmtCombCal.c : 5612 ] GDPC : gdpcal_docal : Not Enabled For IRON: 
+ 
+1182,,[ phy_dev_fdmtCombCal.c : 5619 ] GDPC : gdpcal_docal : Enabled For MALAGA: 
+ 
+1183,,[ phy_dev_fdmtCombCal.c : 5668 ] GDPC : Passing the HWS Results to Halphy variables: 
+ 
+1184,iii,[ phy_dev_fdmtCombCal.c : 6841 ] GDP: ro_txgain_Idx : phy_idx = %d , phyrftxChainIdx = %d , rxgainNum %d 
+1185,i,[ phy_dev_fdmtCombCal.c : 6843 ] GDP: RdBck : LATEST_TXGAIN_IDX = %d  
+1186,Iiiiiiii,[ phy_dev_fdmtCombCal.c : 6844 ] GDP: RdBck : RO_TXGAIN_0 = 0x%08x RO_DAC_GAIN %d RO_BBF_GAIN %d RO_UPC_GAIN %d RO_DA_GAIN %d RO_IPA_GAIN  %d RO_XPA_GAIN  %d RO_XPA_BIAS %d  
+1187,Iiii,[ phy_dev_fdmtCombCal.c : 6845 ] GDP: RdBck : RO_TXGAIN_1 = 0x%08x RO_TX_GAIN_ADDR %d RO_RX_IDX %d RO_TX_IDX %d  
+1188,iII,[ phy_dev_fdmtCombCal.c : 6881 ] GDP: Chain: %d RO_RX_GAIN: 0x%08x RO_RX_GAIN_ADDR: %3d 
+1189,iiiiii,[ phy_dev_fdmtCombCal.c : 6882 ] GDP: RO_XLNA_GAIN = %d , RO_LNA_GAIN = %d , RO_GM_GAIN = %d , RO_TIA_GAIN = %d , RO_BQ_GAIN = %d , RO_PGA_GAIN %d 
+1190,ii,[ phy_dev_NFCal.c : 71 ] phyNFCal nRegToAccess = %d bwCode = %d 
+1191,iiiIii,[ phy_dev_NFCal.c : 89 ] phyNFCal: Cal result(avg) write phyId[%d] chain[%d] write[%d] = 0x%08x, %d %d 
+1192,IiiiIii,[ phy_dev_NFCal.c : 117 ] phyNFCal: nfType = 0x%08x phyId[%d] chain[%d] read[%d] = 0x%08x, %d %d 
+1193,Ii,[ phy_dev_NFCal.c : 140 ] phyNFCal : Entering Force fixed values calFlags = %08x phyId = %d 
+1194,,[ phy_dev_NFCal.c : 147 ] phyNFCAL: Running Noise Floor CAL 
+1195,iI,[ phy_dev_NFCal.c : 151 ] phyNFCal: Noise Floor CAL phyId = %d calFlags = %08x completed 
+1196,,[ phy_dev_NFCal.c : 464 ] phyNFCal: NF cal done 
+1197,I,[ phy_dev_NFCal.c : 502 ] phyNFCal: ENABLE_CONTINUOUS_NOISEFLOOR was set, calFlags = %08x 
+1198,I,[ phy_dev_NFCal.c : 509 ] phyNFCal: ENABLE_CONTINUOUS_NOISEFLOOR was cleared, calFlags = %08x 
+1199,I,[ phy_dev_NFCal.c : 517 ] phyNFCal: BypassXlnaMode was set, calFlags = %08x 
+1200,ii,[ phy_dev_NFCal.c : 568 ] phyNFCal: CAL Timed out...!!! loopCount = %d, maxLoopCount = %d 
+1201,ii,[ phy_dev_NFCal.c : 572 ] phyNFCal: CAL Success..!!! loopCount = %d, maxLoopCount = %d 
+1202,,[ phy_dev_NFCal.c : 707 ] phyNFCAL: Enter NFCAL Mode 
+1203,,[ phy_dev_NFCal.c : 730 ] phyNFCAL: Exit NFCAL Mode 
+1204,IiIIIII,[ phy_dev_NFCal.c : 851 ] NFCAL phyId %u, phy_idx %d, cf_cca_count_maxc %u, mincca_firpwr_thr_db2 %u, mincca_relpwr_thr_db2 %u enable_noisefloor %u, enable_continuous_noisefloor %u 
+1205,IiIIII,[ phy_dev_NFCal.c : 853 ] NFCAL phyId %u, phy_idx %d, nfcal_done_event %u, nfcal_done_event_mask %u, nfcal_error %u, nfcal_mask %u 
+1206,IIiIIIII,[ phy_dev_NFCal.c : 856 ] NFCAL phyId %u, Chan %u, phy_idx %d, Chain %u, curr_cca_count %u, cca_2nd_check_firpwr_count %u, cca_2nd_check_relpwr_count %u, nf_cal_gtc_mask %u 
+1207,iII,[ phy_dev_paprd_curve_fit_on_binning.c : 236 ] curvefit_coef(%d) = %f + j*%f 
+1208,i,[ phy_dev_paprd_curve_fit_on_binning.c : 401 ] max_bin = %d 
+1209,iiii,[ phy_dev_paprd_curve_fit_on_binning.c : 402 ] curve_fit_noise_bin[%d] = %d, curve_fit_sm_sgi_gain[%d] = %d 
+1210,iII,[ phy_dev_paprd_curve_fit_on_binning.c : 489 ] curvefit_coef(%d) = %f + j*%f 
+1211,iii,[ phy_dev_paprd_curve_fit_on_binning.c : 504 ] tbl[%d] = %d / %d 
+1212,iII,[ phy_dev_paprd_curve_fit_on_binning.c : 505 ] hex_tbl[%d] = 0x%04x / 0x%04x 
+1213,iI,[ phy_dev_paprd_curve_fit_on_binning.c : 515 ] hex_32bit[%d] = 0x%08x 
+1214,iI,[ phy_dev_PDCCal.c : 67 ] PDCCal: dpd_rxgain_idx %d, rxgain:0x%x 
+1215,i,[ phy_dev_PDCCal.c : 145 ] PDCCAL: Loading Rxgain Value info for Chain %d  
+1216,i,[ phy_dev_PDCCal.c : 150 ] PDCCAL: Read-DPD table Offset %d  
+1217,i,[ phy_dev_PDCCal.c : 151 ] PDCCAL: Read-DPD table Offsetby2 %d  
+1218,i,[ phy_dev_PDCCal.c : 157 ] PDCCAL: Used-DPD table Offset %d  
+1219,i,[ phy_dev_PDCCal.c : 164 ] PDCCAL: Used-DPD table Offsetby2 %d  
+1220,I,[ phy_dev_PDCCal.c : 165 ] PDCCAL: Addr 0x%x  
+1221,iII,[ phy_dev_PDCCal.c : 177 ] PDCCAL: Before entry index = %d Addr = 0x%x  Value = 0x%x 
+1222,iII,[ phy_dev_PDCCal.c : 200 ] PDCCAL: After entry index = %d Addr = 0x%x  Value = 0x%x 
+1223,i,[ phy_dev_PDCCal.c : 218 ] Dummy print - %d 
+1224,i,[ phy_dev_PDCCal.c : 240 ] PDCCAL: Changing Rxgain offset for Chain %d  
+1225,i,[ phy_dev_PDCCal.c : 250 ] PDCCAL: Read-DPD table Offset %d  
+1226,i,[ phy_dev_PDCCal.c : 251 ] PDCCAL: Read-DPD table Offsetby2 %d  
+1227,i,[ phy_dev_PDCCal.c : 257 ] PDCCAL: Used-DPD table Offset %d  
+1228,iiii,[ phy_dev_PDCCal.c : 283 ] Q5_PDC: phyPDCCal_readGlut, phy_idx %d, chain_idx %d, tx_gain_idx %d, glutIdx %d 
+1229,,[ phy_dev_PDCCal.c : 293 ] PDCCal: phyPDCCal_runCal 
+1230,iiiii,[ phy_dev_PDCCal.c : 378 ] PDCCal: phyPDCCal_runCal, Enter Calibration, tgapIdx = %d, calChainMask = %d, pdc_delay_3 %d, pdc_delay_2 %d, pdc_delay_1 %d 
+1231,ii,[ phy_dev_PDCCal.c : 397 ] PDCCaL: phyPDCCal_runCal, don`t count pdc_cal_max_count with skip1stGap = %d and calSetIdx = %d 
+1232,iiiiiii,[ phy_dev_PDCCal.c : 424 ] PDC_TEMP_PER_CHAIN  gapIdx %d, calChainMask %d, %d, %d, %d, %d, avg %d 
+1233,i,[ phy_dev_PDCCal.c : 441 ] PDCCal: phyPDCCal_runCal, calTime[us] %d 
+1234,,[ phy_dev_PDCCal.c : 452 ] PDCCal: phyPDCCal_saveRestoreCsr 
+1235,,[ phy_dev_PDCCal.c : 574 ] PDCCal: phyPDCCal_setupBBRegs 
+1236,,[ phy_dev_PDCCal.c : 675 ] PDCCal: phyPDCCal_setupBBRegs 
+1237,iiiii,[ phy_dev_PDCCal.c : 747 ] PDCCAL:rfaChIdx %d ,chain_idx %d ,lpChain %d lbattn %d D_DPD_XPA_GC %d 
+1238,,[ phy_dev_PDCCal.c : 769 ] PDCCal: phyPDCCal_runMeas 
+1239,II,[ phy_dev_PDCCal.c : 794 ] PDC CAL CAL_CHAIN_SELECT_L_CAL_CHAIN_MASK address 0x%x VALUE 0x%x 
+1240,i,[ phy_dev_PDCCal.c : 809 ] PDCCal: phyPDCCal_runMeas pdcCalData->runNum %d  
+1241,,[ phy_dev_PDCCal.c : 820 ] PDCCal: phyPDCCal_runMeas, Skip first gap run 
+1242,,[ phy_dev_PDCCal.c : 837 ] PDCCal: phyPDCCal_runMeas, Dummy run 
+1243,,[ phy_dev_PDCCal.c : 855 ] PDCCal: phyPDCCal_runMeas, HW Calibration Fail!!! 
+1244,iI,[ phy_dev_PDCCal.c : 891 ] PDCCal: phyPDCCal_getRoRxGainAgcPwr, chainIdx %d, RO_RX_GAIN 0x%08x  
+1245,iI,[ phy_dev_PDCCal.c : 898 ] PDCCal: phyPDCCal_getRoRxGainAgcPwr, phyIdx %d, agcPwr %ld 
+1246,iI,[ phy_dev_PDCCal.c : 899 ] PDCCal: phyPDCCal_getRoRxGainAgcPwr, phyIdx %d, agcSized %ld 
+1247,,[ phy_dev_PDCCal.c : 908 ] PDCCal: phyPDCCal_setGainSettings 
+1248,iiiii,[ phy_dev_PDCCal.c : 928 ] PDCCal: phyPDCCal_setGainSettings, phy_idx %d, chain_idx %d, calTxGainIdx %d, calRxGainIdx %d, calDacGain %d 
+1249,,[ phy_dev_PDCCal.c : 940 ] PDCCal: phyPDCCal_programRun 
+1250,iiiii,[ phy_dev_PDCCal.c : 1010 ] PDCCal: phyPDCCal_retrieveSavedRxGain, phy_idx %d, chain_idx %d, calTxGainIdx %d, calRxGainIdx %d, calDacGainDb %d 
+1251,,[ phy_dev_PDCCal.c : 1486 ] Q5_PDC: phyPDCCal_setupWfmPlayback_Marina 
+1252,,[ phy_dev_PDCCal.c : 1561 ] PDCCal: phyPDCCal_dataReset 
+1253,,[ phy_dev_PDCCal.c : 1609 ] PDCCal: phyPDCCal_readCalinfoMem 
+1254,iii,[ phy_dev_PDCCal.c : 1634 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad1_1st_sum[%d][%d] = %d 
+1255,iii,[ phy_dev_PDCCal.c : 1635 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad1_sum_xy[%d][%d] = %d 
+1256,iii,[ phy_dev_PDCCal.c : 1636 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad1_sum_x2y[%d][%d] = %d 
+1257,iii,[ phy_dev_PDCCal.c : 1645 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad2_1st_sum[%d][%d] = %d 
+1258,iii,[ phy_dev_PDCCal.c : 1646 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad2_sum_xy[%d][%d] = %d 
+1259,iii,[ phy_dev_PDCCal.c : 1647 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad2_sum_x2y[%d][%d] = %d 
+1260,iii,[ phy_dev_PDCCal.c : 1656 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad3_1st_sum[%d][%d] = %d 
+1261,iii,[ phy_dev_PDCCal.c : 1657 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad3_sum_xy[%d][%d] = %d 
+1262,iii,[ phy_dev_PDCCal.c : 1658 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.quad3_sum_x2y[%d][%d] = %d 
+1263,iii,[ phy_dev_PDCCal.c : 1667 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.linear_1st_sum[%d][%d] = %d 
+1264,iii,[ phy_dev_PDCCal.c : 1668 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.linear_sum_y[%d][%d] = %d 
+1265,iii,[ phy_dev_PDCCal.c : 1669 ] PDCCal: phyPDCCal_readCalinfoMem, pdc_hw_out.linear_sum_xy[%d][%d] = %d 
+1266,,[ phy_dev_PDCCal.c : 1691 ] PDCCal: phyPDCCal_runHwCal 
+1267,ii,[ phy_dev_PDCCal.c : 1708 ] PDCCaL: phyPDCCal_runHwCal, don`t readCalinfoMem with skip1stGap = %d and calSetIdx = %d 
+1268,,[ phy_dev_PDCCal.c : 1722 ] PDCCal: phyPDCCal_programPDCCoeffs_Marina 
+1269,iiiiI,[ phy_dev_PDCCal.c : 1754 ] PDCCal: phyPDCCal_programPDCCoeffs, pdcCalData->calCoeffSet %d, setIdx %d, phy_idx %d, chain_idx %d PhyRfChainBase 0x%x 
+1270,II,[ phy_dev_PDCCal.c : 1755 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1271,II,[ phy_dev_PDCCal.c : 1756 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1272,II,[ phy_dev_PDCCal.c : 1757 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1273,II,[ phy_dev_PDCCal.c : 1758 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1274,II,[ phy_dev_PDCCal.c : 1759 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1275,II,[ phy_dev_PDCCal.c : 1760 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1276,II,[ phy_dev_PDCCal.c : 1761 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1277,II,[ phy_dev_PDCCal.c : 1762 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1278,II,[ phy_dev_PDCCal.c : 1763 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1279,II,[ phy_dev_PDCCal.c : 1764 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1280,II,[ phy_dev_PDCCal.c : 1765 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1281,iiiiI,[ phy_dev_PDCCal.c : 1782 ] PDCCal: phyPDCCal_programPDCCoeffs, pdcCalData->calCoeffSet %d, setIdx %d, phy_idx %d, chain_idx %d PhyRfChainBase 0x%x 
+1282,II,[ phy_dev_PDCCal.c : 1783 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1283,II,[ phy_dev_PDCCal.c : 1784 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1284,II,[ phy_dev_PDCCal.c : 1785 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1285,II,[ phy_dev_PDCCal.c : 1786 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1286,II,[ phy_dev_PDCCal.c : 1787 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1287,II,[ phy_dev_PDCCal.c : 1788 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1288,II,[ phy_dev_PDCCal.c : 1789 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1289,II,[ phy_dev_PDCCal.c : 1790 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1290,II,[ phy_dev_PDCCal.c : 1791 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1291,II,[ phy_dev_PDCCal.c : 1792 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1292,II,[ phy_dev_PDCCal.c : 1793 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1293,iiiiI,[ phy_dev_PDCCal.c : 1810 ] PDCCal: phyPDCCal_programPDCCoeffs, pdcCalData->calCoeffSet %d, setIdx %d, phy_idx %d, chain_idx %d PhyRfChainBase 0x%x 
+1294,II,[ phy_dev_PDCCal.c : 1811 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1295,II,[ phy_dev_PDCCal.c : 1812 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1296,II,[ phy_dev_PDCCal.c : 1813 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1297,II,[ phy_dev_PDCCal.c : 1814 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1298,II,[ phy_dev_PDCCal.c : 1815 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1299,II,[ phy_dev_PDCCal.c : 1816 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1300,II,[ phy_dev_PDCCal.c : 1817 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1301,II,[ phy_dev_PDCCal.c : 1818 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1302,II,[ phy_dev_PDCCal.c : 1819 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1303,II,[ phy_dev_PDCCal.c : 1820 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1304,II,[ phy_dev_PDCCal.c : 1821 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1305,II,[ phy_dev_PDCCal.c : 1833 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1306,II,[ phy_dev_PDCCal.c : 1834 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1307,II,[ phy_dev_PDCCal.c : 1835 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1308,II,[ phy_dev_PDCCal.c : 1836 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1309,II,[ phy_dev_PDCCal.c : 1837 ] PDCCal: phyPDCCal_programPDCCoeffs, address = 0x%x, value = 0x%x 
+1310,,[ phy_dev_PDCCal.c : 1850 ] PDCCal: phyPDCCal_runPostprocess 
+1311,iii,[ phy_dev_PDCCal.c : 1980 ] PDCCal: phyPDCCal_runPostprocess, quad_block_num[0] %d, quad_block_num[1] %d, quad_block_num[2] %d 
+1312,iii,[ phy_dev_PDCCal.c : 1981 ] PDCCal: phyPDCCal_runPostprocess, quad_step[0] %d, quad_step[1] %d, quad_step[2] %d 
+1313,ii,[ phy_dev_PDCCal.c : 1982 ] PDCCal: phyPDCCal_runPostprocess, linear_block_num %d, linear_step %d 
+1314,III,[ phy_dev_PDCCal.c : 1983 ] PDCCal: phyPDCCal_runPostprocess, quad_seg_sum_x2y[0] %lld, quad_seg_sum_x2y[1] %lld, quad_seg_sum_x2y[2] %lld 
+1315,III,[ phy_dev_PDCCal.c : 1984 ] PDCCal: phyPDCCal_runPostprocess, quad_seg_sum_xy[0] %lld, quad_seg_sum_xy[1] %lld, quad_seg_sum_xy[2] %lld 
+1316,III,[ phy_dev_PDCCal.c : 1985 ] PDCCal: phyPDCCal_runPostprocess, quad_seg_1st_sum[0] %lld, quad_seg_1st_sum[1] %lld, quad_seg_1st_sum[2] %lld 
+1317,III,[ phy_dev_PDCCal.c : 1986 ] PDCCal: phyPDCCal_runPostprocess, linear_seg_sum_xy %lld, linear_seg_sum_y %lld, linear_seg_1st_sum %lld 
+1318,iii,[ phy_dev_PDCCal.c : 2012 ] PDCCal: phyPDCCal_runPostprocess, sum_x2 %d, sum_x3 %d, sum_x4 %d 
+1319,iII,[ phy_dev_PDCCal.c : 2013 ] PDCCal: phyPDCCal_runPostprocess, div %d, d1 %lld, d0 %lld 
+1320,III,[ phy_dev_PDCCal.c : 2014 ] PDCCal: phyPDCCal_runPostprocess, a1[0] %lld, b1[0] %lld, c1[0] %lld 
+1321,III,[ phy_dev_PDCCal.c : 2015 ] PDCCal: phyPDCCal_runPostprocess, a1[1] %lld, b1[1] %lld, c1[1] %lld 
+1322,III,[ phy_dev_PDCCal.c : 2016 ] PDCCal: phyPDCCal_runPostprocess, a1[2] %lld, b1[2] %lld, c1[2] %lld 
+1323,III,[ phy_dev_PDCCal.c : 2038 ] PDCCal: phyPDCCal_runPostprocess, a2 %lld, b2 %lld, c2 %lld 
+1324,iiIiiiiII,[ phy_dev_PDCCal.c : 2112 ] PDCCal: phyPDCCal_runPostprocess, seg %d order %d sum_y %lld, sum_x %d, sum_x2 %d, sum_x3 %d, sum_x4 %d, sum_xy %lld, sum_x2y %lld 
+1325,iiIII,[ phy_dev_PDCCal.c : 2131 ] PDCCal: phyPDCCal_runPostprocess, seg %d order %d a_inv %lld, b_inv %lld, c_inv %lld 
+1326,iIiI,[ phy_dev_PDCCal.c : 2145 ] PDCCal: phyPDCCal_runPostprocess, a_inv1_all[%d] %lld, b_inv1_all[%d] %lld 
+1327,iiii,[ phy_dev_PDCCal.c : 2146 ] PDCCal: phyPDCCal_runPostprocess, quad_step[%d] %d, quad_block_num[%d] %d 
+1328,iii,[ phy_dev_PDCCal.c : 2147 ] PDCCal: phyPDCCal_runPostprocess, observation_window %d, quad_step_size[%d] %d 
+1329,i,[ phy_dev_PDCCal.c : 2148 ] PDCCal: phyPDCCal_runPostprocess, rescale_factor %d 
+1330,iiIiI,[ phy_dev_PDCCal.c : 2149 ] PDCCal: phyPDCCal_runPostprocess, rescale_factor %d, a_inv1_all[%d] %lld, b_inv1_all[%d] %lld 
+1331,I,[ phy_dev_PDCCal.c : 2161 ] PDCCal: phyPDCCal_runPostprocess, b_inv2 %lld 
+1332,iiii,[ phy_dev_PDCCal.c : 2185 ] PDCCal: phyPDCCal_runPostprocess, setidx %d pdcCalData->pLinearBinv[%d][%d] to %d for PA drooping 
+1333,iiii,[ phy_dev_PDCCal.c : 2192 ] PDCCal: phyPDCCal_runPostprocess, setidx %d pdcCalData->pLinearBinv[%d][%d] to %d for PA rising 
+1334,iiiiiii,[ phy_dev_PDCCal.c : 2196 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p1Ainv[%d][%d] %d, pdcCalData->p1Binv[%d][%d] %d 
+1335,iiiiiii,[ phy_dev_PDCCal.c : 2197 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p2Ainv[%d][%d] %d, pdcCalData->p2Binv[%d][%d] %d 
+1336,iiiiiii,[ phy_dev_PDCCal.c : 2198 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p3Ainv[%d][%d] %d, pdcCalData->p3Binv[%d][%d] %d 
+1337,iiii,[ phy_dev_PDCCal.c : 2199 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->pLinearBinv[%d][%d] %d 
+1338,iiiii,[ phy_dev_PDCCal.c : 2200 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->quad1Step %d, pdcCalData->quad2Step %d, pdcCalData->quad3Step %d, pdcCalData->linearStep %d 
+1339,iiii,[ phy_dev_PDCCal.c : 2201 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p1GainStartPoint[%d][%d] %d 
+1340,iiii,[ phy_dev_PDCCal.c : 2203 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p2GainStartPoint[%d][%d] %d 
+1341,iiii,[ phy_dev_PDCCal.c : 2205 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->p3GainStartPoint[%d][%d] %d 
+1342,iiii,[ phy_dev_PDCCal.c : 2207 ] PDCCal: phyPDCCal_runPostprocess, setidx %d , pdcCalData->pLinearGainStartPoint[%d][%d] %d 
+1343,,[ phy_dev_PDCCal.c : 2223 ] PDCCal: RFA_TYPE_IRON 
+1344,,[ phy_dev_PDCCal.c : 2227 ] PDCCal: RFA_TYPE_MALAGA 
+1345,,[ phy_dev_PDCCal.c : 2308 ] PDC Marina Debug Commands Enabled 
+1346,i,[ phy_dev_PDCCal.c : 2345 ] PDC Debug num_block_1 %d 
+1347,i,[ phy_dev_PDCCal.c : 2346 ] PDC Debug num_block_2 %d 
+1348,i,[ phy_dev_PDCCal.c : 2347 ] PDC Debug num_block_3 %d 
+1349,i,[ phy_dev_PDCCal.c : 2348 ] PDC Debug num_block_4 %d 
+1350,i,[ phy_dev_PDCCal.c : 2349 ] PDC Debug cal_step_size_1 %d 
+1351,i,[ phy_dev_PDCCal.c : 2350 ] PDC Debug cal_step_size_2 %d 
+1352,i,[ phy_dev_PDCCal.c : 2351 ] PDC Debug cal_step_size_3 %d 
+1353,i,[ phy_dev_PDCCal.c : 2352 ] PDC Debug cal_step_size_4 %d 
+1354,i,[ phy_dev_PDCCal.c : 2353 ] PDC Debug p1NStep %d 
+1355,i,[ phy_dev_PDCCal.c : 2354 ] PDC Debug p1NMax %d 
+1356,i,[ phy_dev_PDCCal.c : 2355 ] PDC Debug p2NMax %d 
+1357,i,[ phy_dev_PDCCal.c : 2356 ] PDC Debug pdc_glut_idx %d 
+1358,i,[ phy_dev_PDCCal.c : 2357 ] PDC Debug skip1stGap %d 
+1359,i,[ phy_dev_PDCCal.c : 2358 ] PDC Debug lbAttn %d 
+1360,i,[ phy_dev_PDCCal.c : 2359 ] PDC Debug numDumRun %d 
+1361,i,[ phy_dev_PDCCal.c : 2360 ] PDC Debug delay[0] %d 
+1362,i,[ phy_dev_PDCCal.c : 2361 ] PDC Debug delay[1] %d 
+1363,i,[ phy_dev_PDCCal.c : 2362 ] PDC Debug delay[2] %d 
+1364,i,[ phy_dev_PDCCal.c : 2363 ] PDC Debug pdc_glut_idx1 %d 
+1365,i,[ phy_dev_PDCCal.c : 2364 ] PDC Debug lbAttn1 %d 
+1366,i,[ phy_dev_PDCCal.c : 2365 ] PDC Debug delay1[0] %d 
+1367,i,[ phy_dev_PDCCal.c : 2366 ] PDC Debug delay1[1] %d 
+1368,i,[ phy_dev_PDCCal.c : 2367 ] PDC Debug delay1[2] %d 
+1369,i,[ phy_dev_PDCCal.c : 2368 ] PDC Debug droopCompStart %d 
+1370,i,[ phy_dev_PDCCal.c : 2369 ] PDC Debug gapTh0 %d 
+1371,i,[ phy_dev_PDCCal.c : 2370 ] PDC Debug gapTh1 %d 
+1372,i,[ phy_dev_PDCCal.c : 2371 ] PDC Debug gapTh2 %d 
+1373,i,[ phy_dev_PDCCal.c : 2372 ] PDC Debug pdcGapWarConfig %d 
+1374,i,[ phy_dev_PDCCal.c : 2373 ] PDC Debug coeffMask %d 
+1375,i,[ phy_dev_PDCCal.c : 2374 ] PDC Debug pdcCoeffSetMax %d 
+1376,i,[ phy_dev_PDCCal.c : 2375 ] PDC Debug disable_pdc %d 
+1377,,[ phy_dev_PDCCal.c : 2380 ] Q5_PDC: phyPDCCal_force_coefficents 
+1378,,[ phy_dev_PDCCal.c : 2385 ] PDCCal: RFA_TYPE_IRON 
+1379,,[ phy_dev_PDCCal.c : 2404 ] PDCCal: RFA_TYPE_MALAGA 
+1380,,[ phy_dev_PDCCal.c : 2447 ] PDCCal: phyPDCCal_enable_presettings 
+1381,,[ phy_dev_PDCCal.c : 2484 ] PDCCal: phyPDCCal_docal 
+1382,i,[ phy_dev_PDCCal.c : 2508 ] Q5_PDC: phyPDCCal_runCal, calTime[us] %d 
+1383,,[ phy_dev_PDCCal.c : 2516 ] Q5_PDC: phyPDCCal_save 
+1384,,[ phy_dev_PDCCal.c : 2553 ] Q5_PDC: phyPDCCal_restore 
+1385,,[ phy_dev_PDCCal.c : 2597 ] PDCCal: phyPDCCal_enable 
+1386,,[ phy_dev_PDCCal.c : 2628 ] PDCCal: phyPDCCal_disable 
+1387,iii,[ phy_dev_paprd_core.c : 57 ] phy_core_PaprdChangeTrainingIndex(): Change training position to chain index %d and dpd table index %d dynGlutIndex = %d 
+ 
+1388,i,[ phy_dev_paprd_core.c : 80 ] Invalid channel %d 
+1389,ii,[ phy_dev_paprd_core.c : 90 ] DPD target Power Max = %d , Target Power Min = %d 
+1390,i,[ phy_dev_paprd_core.c : 138 ] phy_core_PaprdLoopbackTrainingComplete: dynamicDPDglutIndex %d 
+1391,ii,[ phy_dev_paprd_core.c : 162 ] DPD NMSE check fail : nmsex10 = %d nmselimitx10 = %d 
+1392,ii,[ phy_dev_paprd_core.c : 174 ]  SQ > SQ limit, DPD cal failed at chain %d and table index %d 
+1393,I,[ phy_dev_paprd_core.c : 175 ]  SQ = %lu 
+1394,IIIIII,[ phy_dev_paprd_core.c : 183 ] PAPRD_Training_Pass txChain %u, dpdTable = %u, glutIdx = %u, dpdType = %02d, SQ %04d, nmse %04d 
+1395,IIIIII,[ phy_dev_paprd_core.c : 193 ] PAPRD_Training_Fail txChain %u, dpdTable = %u, glutIdx = %u, dpdType = %02d, SQ %04d, nmse %04d 
+1396,i,[ phy_dev_paprd_core.c : 262 ] phy_core_PaprdProcessTrainingData: dynamicDPDglutIndex %d 
+1397,i,[ phy_dev_paprd_core.c : 282 ] -Q5-PAPRD-: Prgrammed AMAM Noise ratio = %d 
+ 
+1398,i,[ phy_dev_paprd_core.c : 283 ] -Q5-PAPRD-: Prgrammed AMPM Noise ratio = %d 
+ 
+1399,I,[ phy_dev_paprd_core.c : 309 ] --Q5-PAPRD-: Board id is 0%x 
+1400,I,[ phy_dev_paprd_core.c : 310 ] --Q5-PAPRD-: Phy Id is 0%x 
+1401,I,[ phy_dev_paprd_core.c : 311 ] --Q5-PAPRD-: SBS Mode  0%x 
+1402,I,[ phy_dev_paprd_core.c : 313 ] --Q5-PAPRD-: Bw Idx is  0%x 
+1403,i,[ phy_dev_paprd_core.c : 414 ] -Q5-PAPRD-:max_idx = %d (before adding bin#1) 
+1404,,[ phy_dev_paprd_core.c : 419 ] -Q5-PAPRD-:		X	Y	theta 
+1405,IIII,[ phy_dev_paprd_core.c : 423 ] -Q5-PAPRD-[%2u]:%4lu	%4lu	%4d 
+1406,I,[ phy_dev_paprd_core.c : 647 ] small signal gain is %ld 
+1407,II,[ phy_dev_paprd_core.c : 654 ] PA_in[%2d] = 0x%lx 
+1408,iI,[ phy_dev_paprd_core.c : 677 ] phy_core_PaprdCalcGainFxp : max bins %d X[GfxpIdx] %lu 
+1409,Ii,[ phy_dev_paprd_core.c : 687 ] small signal gain is %ld, max_bins %d 
+1410,i,[ phy_dev_paprd_core.c : 749 ] phy_core_PaprdWarmPacketSupport: dynamicDPDglutIndex %d 
+1411,iiiiIi,[ phy_dev_paprd_core.c : 795 ] warmpacketsupport %d: warmpacket_cnt %d max_warmpackets %d tlbidx %d s:%x ch:%d 
+1412,ii,[ phy_dev_paprd_core.c : 938 ] PARPD:DPD Failed for txChain %d tpc tableIndex %d 
+1413,ii,[ phy_dev_paprd_core.c : 947 ] PAPRD:UpdateLoopBackInfo wrong chain or GlutIdx: txChain %d tableIndex %d 
+1414,iii,[ phy_dev_paprd_core.c : 966 ] PAPRD:UpdateLoopBackInfo: phyId %d txChain %d tableIndex %d 
+1415,ii,[ phy_dev_paprd_core.c : 974 ] PAPRD:phy_core_GetLoopbackInfo wrong chain or table index: txChain %d tableIndex %d 
+1416,iii,[ phy_dev_paprd_core.c : 988 ] PAPRD:phy_core_GetLoopbackInfo: phyId %d txChain %d tableIndex %d 
+1417,i,[ phy_dev_mem_paprd.c : 1166 ] orig:table_idx=%d 
+1418,,[ phy_dev_mem_paprd.c : 1189 ] loading kernel setting for band 0 ch 0 cbw 0 malaga adc120 new
+ 
+1419,,[ phy_dev_mem_paprd.c : 1206 ] loading kernel setting for band 0 ch 0 cbw 0 malaga adc240 new
+ 
+1420,,[ phy_dev_mem_paprd.c : 1243 ] loading kernel setting for band 0 ch 0 cbw 1 malaga adcrate 120
+ 
+1421,,[ phy_dev_mem_paprd.c : 1265 ] loading kernel setting for band 0 ch 0 cbw 1 malaga adcrate 240
+ 
+1422,,[ phy_dev_mem_paprd.c : 1287 ] loading kernel setting for band 0 ch 0 cbw 0 malaga adc120 new
+ 
+1423,,[ phy_dev_mem_paprd.c : 1308 ] loading kernel setting for band 0 ch 0 cbw 0 malaga adc240 new
+ 
+1424,,[ phy_dev_mem_paprd.c : 1330 ] loading kernel setting for band 0 ch 0 cbw 1 malaga adcrate 240formask
+ 
+1425,,[ phy_dev_mem_paprd.c : 1345 ] can't find the kernel setting for the Band/Ch/CBW mode, use memless setting 
+ 
+1426,iiiiiii,[ phy_dev_mem_paprd.c : 1361 ] Kernel Dump : eDPD_delay_DDR %d, %d, %d, %d, %d, %d, %d 
+1427,i,[ phy_dev_mem_paprd.c : 1363 ] Kernel Dump : eDPD_delay_DDR_len %d 
+1428,IIiiiii,[ phy_dev_mem_paprd.c : 1371 ] Kernel Dump : eDPD_action_list[%u-%u] %d, %d, %d, %d, %d 
+1429,IIiiiii,[ phy_dev_mem_paprd.c : 1378 ] Kernel Dump : eDPD_delay_list[%u-%u] %d, %d, %d, %d, %d 
+1430,IIiiiii,[ phy_dev_mem_paprd.c : 1385 ] Kernel Dump : lut_coef_map[%u-%u] %d, %d, %d, %d, %d 
+1431,iiiiii,[ phy_dev_mem_paprd.c : 1390 ] Kernel Dump : eDPD_standalone_coef_map %d, %d, %d, %d, %d, %d 
+1432,IIiiiiii,[ phy_dev_mem_paprd.c : 1397 ] Kernel Dump : eDPD_delay_map[%u-%u] %d, %d, %d, %d, %d, %d 
+1433,i,[ phy_dev_mem_paprd.c : 1804 ] rxiq Mask = %d 
+1434,i,[ phy_dev_mem_paprd.c : 1805 ] rxiq with taps = %d 
+1435,,[ phy_dev_mem_paprd.c : 1924 ] HW_ACC_DC_CAL start
+ 
+1436,I,[ phy_dev_mem_paprd.c : 1932 ] before HW ACC DC_RXIQ_CAL begins: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1437,,[ phy_dev_mem_paprd.c : 1938 ] HW ACCELERATOR complete! perform LDL to get mem_coef: 
+1438,ii,[ phy_dev_mem_paprd.c : 1975 ] DCEst done with dco_even = %d/%d  
+1439,ii,[ phy_dev_mem_paprd.c : 1976 ] DCEst done with dco_odd = %d/%d  
+1440,ii,[ phy_dev_mem_paprd.c : 1977 ] DCEst done with dco = %d/%d  
+1441,ii,[ phy_dev_mem_paprd.c : 1986 ] rxiq_coef.x0 = %d/%d  
+1442,ii,[ phy_dev_mem_paprd.c : 1989 ] rxiq_coef.conj_x0 = %d/%d  
+1443,ii,[ phy_dev_mem_paprd.c : 1993 ] rxiq_coef.conj_x1_minus_conj_xm1= %d/%d  
+1444,,[ phy_dev_mem_paprd.c : 2002 ] HW_ACC_DC_RXIQ_COMBINE_CAL done, status_ goes to MEMLESS_EST_FOR_SELF_EQL
+ 
+1445,,[ phy_dev_mem_paprd.c : 2009 ] HW_ACC_DC_CAL done, status_ goes to LB_IMPAIR_EST
+ 
+1446,,[ phy_dev_mem_paprd.c : 2016 ] HW_ACC_DC_CAL timeout !!!, status_ goes to LB_IMPAIR_EST
+ 
+1447,I,[ phy_dev_mem_paprd.c : 2021 ] after HW ACC: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1448,,[ phy_dev_mem_paprd.c : 2045 ] Skip HW_ACC_DC_CAL, status_ goes to LB_IMPAIR_EST
+ 
+1449,i,[ phy_dev_mem_paprd.c : 2069 ] status_ goes to HW_ACC_RXIQ_CAL, dpdmemtrain_[thread_id].sample_cnt = %d  
+1450,,[ phy_dev_mem_paprd.c : 2086 ] HW_ACC_RXIQ_CAL start
+ 
+1451,I,[ phy_dev_mem_paprd.c : 2094 ] before HW ACC DC_RXIQ_CAL begins: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1452,,[ phy_dev_mem_paprd.c : 2100 ] HW ACCELERATOR complete! perform LDL to get mem_coef: 
+1453,ii,[ phy_dev_mem_paprd.c : 2107 ] rxiq_coef.x0 = %d/%d  
+1454,ii,[ phy_dev_mem_paprd.c : 2110 ] rxiq_coef.conj_x0 = %d/%d  
+1455,ii,[ phy_dev_mem_paprd.c : 2114 ] rxiq_coef.conj_x1_minus_conj_xm1= %d/%d  
+1456,,[ phy_dev_mem_paprd.c : 2123 ] HW_ACC_RXIQ_CAL done, status_ goes to MEMLESS_EST_FOR_SELF_EQL
+ 
+1457,,[ phy_dev_mem_paprd.c : 2128 ] HW_ACC_RXIQ_CAL timeout !!!, do SW rxiq estimation
+ 
+1458,I,[ phy_dev_mem_paprd.c : 2133 ] after HW ACC: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1459,,[ phy_dev_mem_paprd.c : 2157 ] Skip HW_ACC_RXIQ_CAL, do SW rxiq estimation
+ 
+1460,I,[ phy_dev_mem_paprd.c : 2178 ] RXIQ_TRAINING done, time stamp: %lu 
+1461,,[ phy_dev_mem_paprd.c : 2180 ] RXIQ done and status_ goes to MEMLESS_EST_FOR_SELF_EQL
+ 
+1462,,[ phy_dev_mem_paprd.c : 2204 ] Skip SELF_EQL_TRAINING and status_ goes to EDPD_RAWDATA_REFILL
+ 
+1463,,[ phy_dev_mem_paprd.c : 2213 ] Skip MEMLESS_EST_FOR_SELF_EQL and reuse memless bin tbl
+ 
+1464,iii,[ phy_dev_mem_paprd.c : 2241 ] memless_coef_for_self_eql[%d] = %d/%d
+ 
+1465,,[ phy_dev_mem_paprd.c : 2243 ] memless_est_on_tx done and status_ goes to SELF_EQL_TRAINING
+ 
+1466,,[ phy_dev_mem_paprd.c : 2269 ] HW_ACC_SELFEQL_CAL start 
+1467,I,[ phy_dev_mem_paprd.c : 2278 ] before HW ACC SELFEQL_CAL begins: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1468,,[ phy_dev_mem_paprd.c : 2284 ] HW ACCELERATOR complete! perform LDL to get mem_coef: 
+1469,i,[ phy_dev_mem_paprd.c : 2297 ] coef_max_val = %d 
+1470,i,[ phy_dev_mem_paprd.c : 2301 ] eql_nshift = %d 
+1471,iii,[ phy_dev_mem_paprd.c : 2308 ] self_eql_coef[%d] = %d/%d
+ 
+1472,iii,[ phy_dev_mem_paprd.c : 2316 ] self_eql_coef[%d] = %d/%d
+ 
+1473,,[ phy_dev_mem_paprd.c : 2321 ] HW_ACC_SELFEQL_CAL done and status_ goes to POWER_NORM_FACTOR_EST
+ 
+1474,,[ phy_dev_mem_paprd.c : 2330 ] HW_ACC_SELFEQL_CAL timeout !!!, status_ goes to WAIT_FOR_SETTLE_EQL
+ 
+1475,I,[ phy_dev_mem_paprd.c : 2335 ] after HW ACC: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1476,,[ phy_dev_mem_paprd.c : 2360 ] Skip HW_ACC_SELFEQL_CAL, status_ goes to WAIT_FOR_SETTLE_EQL
+ 
+1477,,[ phy_dev_mem_paprd.c : 2378 ] status_ goes to SELF_EQL_TRAINING  
+1478,i,[ phy_dev_mem_paprd.c : 2409 ] coef_max_val = %d 
+1479,i,[ phy_dev_mem_paprd.c : 2413 ] eql_nshift = %d 
+1480,iii,[ phy_dev_mem_paprd.c : 2420 ] self_eql_coef[%d] = %d/%d
+ 
+1481,iii,[ phy_dev_mem_paprd.c : 2428 ] self_eql_coef[%d] = %d/%d
+ 
+1482,,[ phy_dev_mem_paprd.c : 2433 ] SELF_EQL_TRAINING done and status_ goes to POWER_NORM_FACTOR_EST
+ 
+1483,,[ phy_dev_mem_paprd.c : 2449 ] POWER_NORM_FACTOR_EST start
+ 
+1484,I,[ phy_dev_mem_paprd.c : 2471 ] before HW ACC begins: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1485,,[ phy_dev_mem_paprd.c : 2477 ] HW ACCELERATOR complete! perform LDL to get mem_coef: 
+1486,I,[ phy_dev_mem_paprd.c : 2482 ] HW ACC before Rxx Rxy, time stamp: %lu 
+1487,ii,[ phy_dev_mem_paprd.c : 2486 ] mem_coef.x0 = %d/%d  
+1488,i,[ phy_dev_mem_paprd.c : 2495 ] apply scaling on rxiq coef, power_norm_factor = %d  
+1489,,[ phy_dev_mem_paprd.c : 2508 ] POWER_NORM_FACTOR_EST timeout !!!, skip
+ 
+1490,,[ phy_dev_mem_paprd.c : 2511 ] POWER_NORM_FACTOR_EST done, status_ goes to EDPD_RAWDATA_REFILL
+ 
+1491,,[ phy_dev_mem_paprd.c : 2531 ] buff refill for selfeql
+ 
+1492,,[ phy_dev_mem_paprd.c : 2543 ] EDPD_RAWDATA_REFILL done, status_ goes to HW_ACC
+ 
+1493,,[ phy_dev_mem_paprd.c : 2547 ] Skip EDPD_RAWDATA_REFILL, status_ goes to HW_ACC
+ 
+1494,I,[ phy_dev_mem_paprd.c : 2564 ] before HW ACC begins: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1495,,[ phy_dev_mem_paprd.c : 2570 ] HW ACCELERATOR complete! perform LDL to get mem_coef: 
+1496,I,[ phy_dev_mem_paprd.c : 2575 ] HW ACC before Rxx Rxy, time stamp: %lu 
+1497,i,[ phy_dev_mem_paprd.c : 2589 ] large coef with HW ACC at kernel %d 
+1498,iii,[ phy_dev_mem_paprd.c : 2598 ] mem_coef[%d].real/imag is %d / %d 
+1499,I,[ phy_dev_mem_paprd.c : 2621 ] HW ACC before enter WAIT_FOR_SETTLE_NMSE, time stamp: %lu 
+1500,,[ phy_dev_mem_paprd.c : 2625 ] HW ACCELERATOR TIME OUT! TRY pure SW post processing 
+1501,,[ phy_dev_mem_paprd.c : 2626 ] status_ goes to WAIT_FOR_SETTLE 
+1502,I,[ phy_dev_mem_paprd.c : 2635 ] after HW ACC: EDPD_CAL_ACC_DBG_CTRL_L = 0x%x 
+1503,,[ phy_dev_mem_paprd.c : 2659 ] Skip HW ACCELERATOR! do pure SW post processing 
+1504,,[ phy_dev_mem_paprd.c : 2660 ] status_ goes to WAIT_FOR_SETTLE 
+1505,i,[ phy_dev_mem_paprd.c : 2676 ] status_ goes to MEM_COEFF_TRAINING, dpdmemtrain_[thread_id].sample_cnt = %d  
+1506,I,[ phy_dev_mem_paprd.c : 2721 ] SW before Rxx\Rxy, time stamp: %lu 
+1507,I,[ phy_dev_mem_paprd.c : 2727 ] SW before Rxx Rxy, time stamp: %lu 
+1508,iii,[ phy_dev_mem_paprd.c : 2743 ] mem_coef[%d].real/imag is %d / %d 
+1509,I,[ phy_dev_mem_paprd.c : 2754 ] SW before enter WAIT_FOR_SETTLE_NMSE, time stamp: %lu 
+1510,I,[ phy_dev_mem_paprd.c : 2770 ] WAIT_FOR_SETTLE_NMSE, time stamp: %lu 
+1511,i,[ phy_dev_mem_paprd.c : 2772 ] status_ goes to NMSE calc, dpdmemtrain_[thread_id].sample_cnt = %d  
+1512,i,[ phy_dev_mem_paprd.c : 2808 ] NMSE_acc is %d  
+1513,i,[ phy_dev_mem_paprd.c : 2809 ] tx_acc is %d  
+1514,i,[ phy_dev_mem_paprd.c : 2817 ] nmsex10 is %d  
+1515,i,[ phy_dev_mem_paprd.c : 2818 ] PHYDEVLIB_DPD_DATA size %d  
+1516,II,[ phy_dev_mem_paprd.c : 2930 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_CTRL_0_L 
+1517,II,[ phy_dev_mem_paprd.c : 2931 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_CTRL_0_U 
+1518,II,[ phy_dev_mem_paprd.c : 2932 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_CTRL_1_L 
+1519,II,[ phy_dev_mem_paprd.c : 2933 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SAMPLE_OFFSET_L 
+1520,II,[ phy_dev_mem_paprd.c : 2934 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_STATUS_L 
+1521,II,[ phy_dev_mem_paprd.c : 2935 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DC_CTRL_L 
+1522,II,[ phy_dev_mem_paprd.c : 2936 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DC_CTRL_U 
+1523,II,[ phy_dev_mem_paprd.c : 2937 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_RXIQ_CTRL0_L 
+1524,II,[ phy_dev_mem_paprd.c : 2938 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_RXIQ_CTRL0_U 
+1525,II,[ phy_dev_mem_paprd.c : 2939 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_RXIQ_CTRL1_L 
+1526,II,[ phy_dev_mem_paprd.c : 2940 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_RXIQ_CTRL1_U 
+1527,II,[ phy_dev_mem_paprd.c : 2941 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_BASE_DLY_CTRL_L 
+1528,II,[ phy_dev_mem_paprd.c : 2942 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_BASE_DLY_CTRL_U 
+1529,II,[ phy_dev_mem_paprd.c : 2943 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_0_L 
+1530,II,[ phy_dev_mem_paprd.c : 2944 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_0_U 
+1531,II,[ phy_dev_mem_paprd.c : 2945 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_1_L 
+1532,II,[ phy_dev_mem_paprd.c : 2946 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_1_U 
+1533,II,[ phy_dev_mem_paprd.c : 2947 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_2_L 
+1534,II,[ phy_dev_mem_paprd.c : 2948 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_2_U 
+1535,II,[ phy_dev_mem_paprd.c : 2949 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_3_L 
+1536,II,[ phy_dev_mem_paprd.c : 2950 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_3_U 
+1537,II,[ phy_dev_mem_paprd.c : 2951 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_4_L 
+1538,II,[ phy_dev_mem_paprd.c : 2952 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_4_U 
+1539,II,[ phy_dev_mem_paprd.c : 2953 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_5_L 
+1540,II,[ phy_dev_mem_paprd.c : 2954 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_5_U 
+1541,II,[ phy_dev_mem_paprd.c : 2955 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_6_L 
+1542,II,[ phy_dev_mem_paprd.c : 2956 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_6_U 
+1543,II,[ phy_dev_mem_paprd.c : 2957 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_7_L 
+1544,II,[ phy_dev_mem_paprd.c : 2958 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_7_U 
+1545,II,[ phy_dev_mem_paprd.c : 2959 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_8_L 
+1546,II,[ phy_dev_mem_paprd.c : 2960 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_8_U 
+1547,II,[ phy_dev_mem_paprd.c : 2961 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_9_L 
+1548,II,[ phy_dev_mem_paprd.c : 2962 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_9_U 
+1549,II,[ phy_dev_mem_paprd.c : 2963 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_10_L 
+1550,II,[ phy_dev_mem_paprd.c : 2964 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_10_U 
+1551,II,[ phy_dev_mem_paprd.c : 2965 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_11_L 
+1552,II,[ phy_dev_mem_paprd.c : 2966 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_11_U 
+1553,II,[ phy_dev_mem_paprd.c : 2967 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_12_L 
+1554,II,[ phy_dev_mem_paprd.c : 2968 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_12_U 
+1555,II,[ phy_dev_mem_paprd.c : 2969 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_13_L 
+1556,II,[ phy_dev_mem_paprd.c : 2970 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_13_U 
+1557,II,[ phy_dev_mem_paprd.c : 2971 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_14_L 
+1558,II,[ phy_dev_mem_paprd.c : 2972 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_14_U 
+1559,II,[ phy_dev_mem_paprd.c : 2973 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_15_L 
+1560,II,[ phy_dev_mem_paprd.c : 2974 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_DELAY_TABLE_15_U 
+1561,II,[ phy_dev_mem_paprd.c : 2975 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_0_L 
+1562,II,[ phy_dev_mem_paprd.c : 2976 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_0_U 
+1563,II,[ phy_dev_mem_paprd.c : 2977 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_1_L 
+1564,II,[ phy_dev_mem_paprd.c : 2978 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_1_U 
+1565,II,[ phy_dev_mem_paprd.c : 2979 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_2_L 
+1566,II,[ phy_dev_mem_paprd.c : 2980 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_2_U 
+1567,II,[ phy_dev_mem_paprd.c : 2981 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_3_L 
+1568,II,[ phy_dev_mem_paprd.c : 2982 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_3_U 
+1569,II,[ phy_dev_mem_paprd.c : 2983 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_4_L 
+1570,II,[ phy_dev_mem_paprd.c : 2984 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_4_U 
+1571,II,[ phy_dev_mem_paprd.c : 2985 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_KERNEL_ACTION_TABLE_5_L 
+1572,II,[ phy_dev_mem_paprd.c : 2986 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_0_L 
+1573,II,[ phy_dev_mem_paprd.c : 2987 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_0_U 
+1574,II,[ phy_dev_mem_paprd.c : 2988 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_1_L 
+1575,II,[ phy_dev_mem_paprd.c : 2989 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_1_U 
+1576,II,[ phy_dev_mem_paprd.c : 2990 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_2_L 
+1577,II,[ phy_dev_mem_paprd.c : 2991 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_2_U 
+1578,II,[ phy_dev_mem_paprd.c : 2992 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_3_L 
+1579,II,[ phy_dev_mem_paprd.c : 2993 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_3_U 
+1580,II,[ phy_dev_mem_paprd.c : 2994 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_4_L 
+1581,II,[ phy_dev_mem_paprd.c : 2995 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_4_U 
+1582,II,[ phy_dev_mem_paprd.c : 2996 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_5_L 
+1583,II,[ phy_dev_mem_paprd.c : 2997 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_5_U 
+1584,II,[ phy_dev_mem_paprd.c : 2998 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_6_L 
+1585,II,[ phy_dev_mem_paprd.c : 2999 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SPARE_CTRL_L 
+1586,II,[ phy_dev_mem_paprd.c : 3048 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_CASCADE_MODE_CTRL_L 
+1587,II,[ phy_dev_mem_paprd.c : 3049 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG0_L 
+1588,II,[ phy_dev_mem_paprd.c : 3050 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG0_U 
+1589,II,[ phy_dev_mem_paprd.c : 3051 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG1_L 
+1590,II,[ phy_dev_mem_paprd.c : 3052 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG1_U 
+1591,II,[ phy_dev_mem_paprd.c : 3053 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG2_L 
+1592,II,[ phy_dev_mem_paprd.c : 3054 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG2_U 
+1593,II,[ phy_dev_mem_paprd.c : 3055 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG3_L 
+1594,II,[ phy_dev_mem_paprd.c : 3056 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG3_U 
+1595,II,[ phy_dev_mem_paprd.c : 3057 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG4_L 
+1596,II,[ phy_dev_mem_paprd.c : 3058 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG4_U 
+1597,II,[ phy_dev_mem_paprd.c : 3059 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG5_L 
+1598,II,[ phy_dev_mem_paprd.c : 3060 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG5_U 
+1599,II,[ phy_dev_mem_paprd.c : 3061 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG6_L 
+1600,II,[ phy_dev_mem_paprd.c : 3062 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG6_U 
+1601,II,[ phy_dev_mem_paprd.c : 3063 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG7_L 
+1602,II,[ phy_dev_mem_paprd.c : 3064 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG7_U 
+1603,II,[ phy_dev_mem_paprd.c : 3065 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG8_L 
+1604,II,[ phy_dev_mem_paprd.c : 3066 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG8_U 
+1605,II,[ phy_dev_mem_paprd.c : 3067 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG9_L 
+1606,II,[ phy_dev_mem_paprd.c : 3068 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG9_U 
+1607,II,[ phy_dev_mem_paprd.c : 3069 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG10_L 
+1608,II,[ phy_dev_mem_paprd.c : 3070 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG10_U 
+1609,II,[ phy_dev_mem_paprd.c : 3071 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG11_L 
+1610,II,[ phy_dev_mem_paprd.c : 3072 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG11_U 
+1611,II,[ phy_dev_mem_paprd.c : 3073 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG12_L 
+1612,II,[ phy_dev_mem_paprd.c : 3074 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG12_U 
+1613,II,[ phy_dev_mem_paprd.c : 3075 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG13_L 
+1614,II,[ phy_dev_mem_paprd.c : 3076 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG13_U 
+1615,II,[ phy_dev_mem_paprd.c : 3077 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG14_L 
+1616,II,[ phy_dev_mem_paprd.c : 3078 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG14_U 
+1617,II,[ phy_dev_mem_paprd.c : 3079 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG15_L 
+1618,II,[ phy_dev_mem_paprd.c : 3080 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG15_U 
+1619,II,[ phy_dev_mem_paprd.c : 3081 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG16_L 
+1620,II,[ phy_dev_mem_paprd.c : 3082 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG16_U 
+1621,II,[ phy_dev_mem_paprd.c : 3083 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG17_L 
+1622,II,[ phy_dev_mem_paprd.c : 3084 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG17_U 
+1623,II,[ phy_dev_mem_paprd.c : 3085 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG18_L 
+1624,II,[ phy_dev_mem_paprd.c : 3086 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG18_U 
+1625,II,[ phy_dev_mem_paprd.c : 3087 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG19_L 
+1626,II,[ phy_dev_mem_paprd.c : 3088 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG19_U 
+1627,II,[ phy_dev_mem_paprd.c : 3089 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG20_L 
+1628,II,[ phy_dev_mem_paprd.c : 3090 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG20_U 
+1629,II,[ phy_dev_mem_paprd.c : 3091 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG21_L 
+1630,II,[ phy_dev_mem_paprd.c : 3092 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG21_U 
+1631,II,[ phy_dev_mem_paprd.c : 3093 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG22_L 
+1632,II,[ phy_dev_mem_paprd.c : 3094 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG22_U 
+1633,II,[ phy_dev_mem_paprd.c : 3095 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG23_L 
+1634,II,[ phy_dev_mem_paprd.c : 3096 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG23_U 
+1635,II,[ phy_dev_mem_paprd.c : 3097 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG24_L 
+1636,II,[ phy_dev_mem_paprd.c : 3098 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG24_U 
+1637,II,[ phy_dev_mem_paprd.c : 3099 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG25_L 
+1638,II,[ phy_dev_mem_paprd.c : 3100 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG25_U 
+1639,II,[ phy_dev_mem_paprd.c : 3101 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG26_L 
+1640,II,[ phy_dev_mem_paprd.c : 3102 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG26_U 
+1641,II,[ phy_dev_mem_paprd.c : 3103 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_DBG_CTRL_L 
+1642,II,[ phy_dev_mem_paprd.c : 3104 ] Regdump : Addr 0x%08x, Value 0x%08x, name EDPD_CAL_ACC_SHIFT_KERNEL_CTRL_L 
+1643,i,[ phy_dev_mem_paprd.c : 3194 ] rxiq done! sample_cnt = %d  
+1644,iiiiii,[ phy_dev_mem_paprd.c : 3196 ] rxiq_mask = %d/%d/%d/%d/%d/%d  
+1645,ii,[ phy_dev_mem_paprd.c : 3201 ] rxiq_coef.x0 = %d/%d  
+1646,ii,[ phy_dev_mem_paprd.c : 3208 ] rxiq_coef.conj_x0 = %d/%d  
+1647,ii,[ phy_dev_mem_paprd.c : 3215 ] rxiq_coef.conj_x1_minus_conj_xm1= %d/%d  
+1648,ii,[ phy_dev_mem_paprd.c : 3221 ] rxiq_coef.conj_x0_3rd= %d/%d  
+1649,ii,[ phy_dev_mem_paprd.c : 3227 ] rxiq_coef.x0_x0= %d/%d  
+1650,ii,[ phy_dev_mem_paprd.c : 3233 ] rxiq_coef.conj_x0_2nd= %d/%d  
+1651,ii,[ phy_dev_mem_paprd.c : 3265 ] DCEst done with dco = %d/%d  
+1652,iiii,[ phy_dev_mem_paprd.c : 3334 ] SQTiming done with offset = %d and SQAvg=%d/%d/%d 
+1653,i,[ phy_dev_mem_paprd.c : 3420 ] delay_ddr = %d  
+1654,ii,[ phy_dev_mem_paprd.c : 3447 ]  delay_ddr = %d start_pt = %d  
+1655,ii,[ phy_dev_mem_paprd.c : 3451 ] ----------is_160_mode = %d , sq_timing_offset = %d 
+1656,ii,[ phy_dev_mem_paprd.c : 3452 ] eDPD mem start_pt/stop_pt = %d / %d  
+1657,ii,[ phy_dev_mem_paprd.c : 3453 ]  coef_taps_training = %d and coef_taps_training_for_ls = %d 
+1658,I,[ phy_dev_mem_paprd.c : 3747 ] EDPD_CAL_ACC_BASE_DLY_CTRL_L = 0x%lx  
+1659,I,[ phy_dev_mem_paprd.c : 3748 ] EDPD_CAL_ACC_BASE_DLY_CTRL_U = 0x%lx  
+1660,iI,[ phy_dev_mem_paprd.c : 3761 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_%d_L = 0x%lx  
+1661,iI,[ phy_dev_mem_paprd.c : 3762 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_%d_U = 0x%lx  
+1662,I,[ phy_dev_mem_paprd.c : 3770 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_5_L = 0x%lx  
+1663,iI,[ phy_dev_mem_paprd.c : 3780 ] EDPD_CAL_ACC_KERNEL_DELAY_TABLE_%d_L = 0x%lx  
+1664,iI,[ phy_dev_mem_paprd.c : 3781 ] EDPD_CAL_ACC_KERNEL_DELAY_TABLE_%d_U = 0x%lx  
+1665,I,[ phy_dev_mem_paprd.c : 3815 ] EDPD_CAL_ACC_BASE_DLY_CTRL_L = 0x%lx  
+1666,I,[ phy_dev_mem_paprd.c : 3816 ] EDPD_CAL_ACC_BASE_DLY_CTRL_U = 0x%lx  
+1667,iI,[ phy_dev_mem_paprd.c : 3916 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_%d_L = 0x%lx  
+1668,iI,[ phy_dev_mem_paprd.c : 3917 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_%d_U = 0x%lx  
+1669,I,[ phy_dev_mem_paprd.c : 3952 ] EDPD_CAL_ACC_KERNEL_ACTION_TABLE_5_L = 0x%lx  
+1670,iI,[ phy_dev_mem_paprd.c : 3990 ] EDPD_CAL_ACC_KERNEL_DELAY_TABLE_%d_L = 0x%lx  
+1671,iI,[ phy_dev_mem_paprd.c : 3991 ] EDPD_CAL_ACC_KERNEL_DELAY_TABLE_%d_U = 0x%lx  
+1672,I,[ phy_dev_mem_paprd.c : 4119 ] EDPD_CAL_ACC_SAMPLE_OFFSET_L = 0x%lx  
+1673,I,[ phy_dev_mem_paprd.c : 4120 ] EDPD_CAL_ACC_DC_CTRL_L = 0x%lx  
+1674,I,[ phy_dev_mem_paprd.c : 4121 ] EDPD_CAL_ACC_DC_CTRL_U = 0x%lx  
+1675,I,[ phy_dev_mem_paprd.c : 4122 ] EDPD_CAL_ACC_RXIQ_CTRL0_L = 0x%lx  
+1676,I,[ phy_dev_mem_paprd.c : 4123 ] EDPD_CAL_ACC_RXIQ_CTRL0_U = 0x%lx  
+1677,I,[ phy_dev_mem_paprd.c : 4124 ] EDPD_CAL_ACC_RXIQ_CTRL1_L = 0x%lx  
+1678,I,[ phy_dev_mem_paprd.c : 4125 ] EDPD_CAL_ACC_RXIQ_CTRL1_U = 0x%lx  
+1679,I,[ phy_dev_mem_paprd.c : 4126 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_0_L = 0x%lx  
+1680,I,[ phy_dev_mem_paprd.c : 4127 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_0_U = 0x%lx  
+1681,I,[ phy_dev_mem_paprd.c : 4128 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_1_L = 0x%lx  
+1682,I,[ phy_dev_mem_paprd.c : 4129 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_1_U = 0x%lx  
+1683,I,[ phy_dev_mem_paprd.c : 4130 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_2_L = 0x%lx  
+1684,I,[ phy_dev_mem_paprd.c : 4131 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_2_U = 0x%lx  
+1685,I,[ phy_dev_mem_paprd.c : 4132 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_3_L = 0x%lx  
+1686,I,[ phy_dev_mem_paprd.c : 4133 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_3_U = 0x%lx  
+1687,I,[ phy_dev_mem_paprd.c : 4134 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_4_L = 0x%lx  
+1688,I,[ phy_dev_mem_paprd.c : 4135 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_4_U = 0x%lx  
+1689,I,[ phy_dev_mem_paprd.c : 4136 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_5_L = 0x%lx  
+1690,I,[ phy_dev_mem_paprd.c : 4137 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_5_U = 0x%lx  
+1691,I,[ phy_dev_mem_paprd.c : 4138 ] EDPD_CAL_ACC_EDPD_CAL_ACC_SELF_EQL_CORR_COEF_TABLE_6_L = 0x%lx  
+1692,I,[ phy_dev_mem_paprd.c : 4181 ] EDPD_CAL_ACC_TXRX_SAMPLE_MEM_START_ADDR_val physical address=0x%x 
+1693,,[ phy_dev_mem_paprd.c : 4210 ] HWACC RXIQ/DC CAL use short samples 
+1694,,[ phy_dev_mem_paprd.c : 4215 ] HWACC SELFEQL CAL use short samples 
+1695,,[ phy_dev_mem_paprd.c : 4220 ] POWER_NORM_FACTOR_EST use short samples 
+1696,I,[ phy_dev_mem_paprd.c : 4242 ] EDPD_CAL_ACC_CTRL_0_L_initial= 0x%lx  
+1697,I,[ phy_dev_mem_paprd.c : 4243 ] EDPD_CAL_ACC_CTRL_0_U_initial= 0x%lx  
+1698,I,[ phy_dev_mem_paprd.c : 4244 ] EDPD_CAL_ACC_CTRL_1_L_initial= 0x%lx  
+1699,I,[ phy_dev_mem_paprd.c : 4251 ] EDPD_CAL_ACC_STATUS_L 0x%x 
+1700,ii,[ phy_dev_mem_paprd.c : 4291 ] eDPD HW ACC: conflict operation_mode. (wanted = %d, actaul = %d)
+ 
+1701,iii,[ phy_dev_mem_paprd.c : 4301 ] EDPD_CAL_ACC_PAPRD_LUT(%d): %d + (%d * 1j)  
+1702,iii,[ phy_dev_mem_paprd.c : 4302 ] EDPD_CAL_ACC_PAPRD_LUT(%d): %d + (%d * 1j)  
+1703,I,[ phy_dev_mem_paprd.c : 4312 ] EDPD_CAL_ACC_CTRL_1_L_before set HW_ACTIVE = 0x%x 
+1704,I,[ phy_dev_mem_paprd.c : 4315 ] EDPD_CAL_ACC_CTRL_1_L_after set HW_ACTIVE = 0x%x 
+1705,I,[ phy_dev_mem_paprd.c : 4320 ] eDPD HW ACC activated, time stamp: %lu 
+1706,I,[ phy_dev_mem_paprd.c : 4347 ] eDPD HW ACC done, time stamp: %lu 
+1707,I,[ phy_dev_mem_paprd.c : 4351 ] EDPD_CAL_ACC_CTRL_1_L_after HW ACC done = 0x%x 
+1708,iii,[ phy_dev_mem_paprd.c : 4598 ] init_EQL: mem_dpd_q = %d, buf_len_eql = %d, eql_coef_taps = %d
+ 
+1709,iiii,[ phy_dev_mem_paprd.c : 4685 ] txiq rxiq=(%d, %d, %d, %d) 
+1710,I,[ phy_dev_mem_paprd.c : 4992 ] buff refill start, time stamp: %lu
+ 
+1711,,[ phy_dev_mem_paprd.c : 5008 ] Skip buff refill
+ 
+1712,Iiiii,[ phy_dev_mem_paprd.c : 5090 ] -Q5-PAPRD-: EDPD data tx_i/q, rx_i/q[%5d]:%d %d %d %d 
+1713,Iiiii,[ phy_dev_mem_paprd.c : 5098 ] -Q5-PAPRD-: EDPD data tx_i/q, rx_i/q[%5d]:%d %d %d %d 
+1714,I,[ phy_dev_mem_paprd.c : 5121 ] buff refill end, time stamp: %lu
+ 
+1715,ii,[ phy_dev_mem_paprd.c : 5182 ] for channel %d - using self equalizer, rxiqmask = %d  
+1716,i,[ phy_dev_mem_paprd.c : 5221 ] pPaprdStruct->tableIndex %d
+ 
+1717,III,[ phy_dev_mem_paprd.c : 5222 ] enable_self_eql 0x%x mem_dpd_q 0x%x rxIQMask 0x%x
+ 
+1718,iI,[ phy_dev_mem_paprd.c : 5223 ] edpdSelfEqualizerEnable[%d] 0x%x
+ 
+1719,,[ phy_dev_mem_paprd.c : 5366 ] ddr*1 
+1720,,[ phy_dev_mem_paprd.c : 5392 ] ddr*2 
+1721,i,[ phy_dev_mem_paprd.c : 5411 ] for channel %d - using hard coded ddr2ndset 
+1722,i,[ phy_dev_mem_paprd.c : 5419 ] for channel %d - using hard coded ddr2ndset 
+1723,,[ phy_dev_mem_paprd.c : 5454 ] eDPD OUTPUT-------------------------> 
+1724,i,[ phy_dev_mem_paprd.c : 5455 ] int memDpd_bin_size_sel = %d 
+1725,i,[ phy_dev_mem_paprd.c : 5456 ] int q0_for_lut_xq0_abs_xq12    = %d 
+1726,i,[ phy_dev_mem_paprd.c : 5457 ] int q1_for_lut_xq1_abs_xq13    = %d 
+1727,i,[ phy_dev_mem_paprd.c : 5458 ] int q2_for_lut_xq2_abs_xq14    = %d 
+1728,i,[ phy_dev_mem_paprd.c : 5459 ] int q3_for_lut_xq3_abs_xq15    = %d 
+1729,i,[ phy_dev_mem_paprd.c : 5460 ] int q4_for_lut_xq4_abs_xq16    = %d 
+1730,i,[ phy_dev_mem_paprd.c : 5461 ] int q5_for_lut_xq5_abs_xq17    = %d 
+1731,i,[ phy_dev_mem_paprd.c : 5462 ] int q6_for_lut_xq6_abs_xq18    = %d 
+1732,i,[ phy_dev_mem_paprd.c : 5463 ] int q7_for_lut_xq7_abs_xq19    = %d 
+1733,i,[ phy_dev_mem_paprd.c : 5464 ] int q8_for_lut_xq8_a1          = %d 
+1734,i,[ phy_dev_mem_paprd.c : 5465 ] int q9_for_Xq9AbsXq20AbsXq21   = %d 
+1735,i,[ phy_dev_mem_paprd.c : 5466 ] int q10_for_Xq10AbsXq22AbsXq23 = %d 
+1736,i,[ phy_dev_mem_paprd.c : 5467 ] int q11_for_Xq11AbsXq24AbsXq25 = %d 
+1737,i,[ phy_dev_mem_paprd.c : 5468 ] int q12_for_lut_xq0_abs_xq12   = %d 
+1738,i,[ phy_dev_mem_paprd.c : 5469 ] int q13_for_lut_xq1_abs_xq13   = %d 
+1739,i,[ phy_dev_mem_paprd.c : 5470 ] int q14_for_lut_xq2_abs_xq14   = %d 
+1740,i,[ phy_dev_mem_paprd.c : 5471 ] int q15_for_lut_xq3_abs_xq15   = %d 
+1741,i,[ phy_dev_mem_paprd.c : 5472 ] int q16_for_lut_xq4_abs_xq16   = %d 
+1742,i,[ phy_dev_mem_paprd.c : 5473 ] int q17_for_lut_xq5_abs_xq17   = %d 
+1743,i,[ phy_dev_mem_paprd.c : 5474 ] int q18_for_lut_xq6_abs_xq18   = %d 
+1744,i,[ phy_dev_mem_paprd.c : 5475 ] int q19_for_lut_xq7_abs_xq19   = %d 
+1745,i,[ phy_dev_mem_paprd.c : 5476 ] int q20_for_Xq9AbsXq20AbsXq21  = %d 
+1746,i,[ phy_dev_mem_paprd.c : 5477 ] int q21_for_Xq9AbsXq20AbsXq21  = %d 
+1747,i,[ phy_dev_mem_paprd.c : 5478 ] int q22_for_Xq10AbsXq22AbsXq23 = %d 
+1748,i,[ phy_dev_mem_paprd.c : 5479 ] int q23_for_Xq10AbsXq22AbsXq23 = %d 
+1749,i,[ phy_dev_mem_paprd.c : 5480 ] int q24_for_Xq11AbsXq24AbsXq25 = %d 
+1750,i,[ phy_dev_mem_paprd.c : 5481 ] int q25_for_Xq11AbsXq24AbsXq25 = %d 
+1751,iI,[ phy_dev_mem_paprd.c : 5485 ] int32 memDpd_paprd_memless_table[%d] = 0x%x 
+1752,iI,[ phy_dev_mem_paprd.c : 5491 ] int32 memDpd_lut_x0_abs_x1[%d] = 0x%x 
+1753,iI,[ phy_dev_mem_paprd.c : 5495 ] int32 memDpd_lut_x0_abs_x2[%d] = 0x%x 
+1754,iI,[ phy_dev_mem_paprd.c : 5499 ] int32 memDpd_lut_xq0_abs_xq12[%d] = 0x%x 
+1755,iI,[ phy_dev_mem_paprd.c : 5503 ] int32 memDpd_lut_xq1_abs_xq13[%d] = 0x%x 
+1756,iI,[ phy_dev_mem_paprd.c : 5507 ] int32 memDpd_lut_xq2_abs_xq14[%d] = 0x%x 
+1757,iI,[ phy_dev_mem_paprd.c : 5511 ] int32 memDpd_lut_xq3_abs_xq15[%d] = 0x%x 
+1758,iI,[ phy_dev_mem_paprd.c : 5515 ] int32 memDpd_lut_xq4_abs_xq16[%d] = 0x%x 
+1759,iI,[ phy_dev_mem_paprd.c : 5519 ] int32 memDpd_lut_xq5_abs_xq17[%d] = 0x%x 
+1760,iI,[ phy_dev_mem_paprd.c : 5523 ] int32 memDpd_lut_xq6_abs_xq18[%d] = 0x%x 
+1761,iI,[ phy_dev_mem_paprd.c : 5527 ] int32 memDpd_lut_xq7_abs_xq19[%d] = 0x%x 
+1762,iI,[ phy_dev_mem_paprd.c : 5531 ] int32 memDpd_standalone_coef[%d] = 0x%x 
+1763,i,[ phy_dev_mem_paprd.c : 5534 ] int memDpd_standalone_coefShift = %d 
+1764,i,[ phy_dev_mem_paprd.c : 5550 ] eDPD with lDPD Postprocessing table_idx=%d
+ 
+1765,I,[ phy_dev_mem_paprd.c : 5583 ] all eDPD post processing done, time stamp: %lld 
+1766,I,[ phy_dev_mem_paprd.c : 5605 ] --Q5-PAPRD-: Board id is 0%x 
+1767,I,[ phy_dev_mem_paprd.c : 5606 ] --Q5-PAPRD-: Phy Id is 0%x 
+1768,I,[ phy_dev_mem_paprd.c : 5607 ] --Q5-PAPRD-: SBS Mode  0%x 
+1769,I,[ phy_dev_mem_paprd.c : 5609 ] --Q5-PAPRD-: Bw Idx is  0%x 
+1770,,[ phy_dev_mem_paprd.c : 5656 ] Incorrect paprdtype for memory DPD 
+ 
+1771,,[ phy_dev_mem_paprd.c : 5662 ]  training not done for curr_table_idx  
+ 
+1772,I,[ phy_dev_mem_paprd.c : 5685 ] wlanBase = 0x%x
+ 
+1773,I,[ phy_dev_mem_paprd.c : 5686 ] EDPD CAL_ACC BAse = 0x%x
+ 
+1774,iii,[ phy_dev_mem_paprd.c : 5688 ] table_idx_search parameter:dpd_on_5G=%d txChain=%d bwCode=%d
+ 
+1775,i,[ phy_dev_mem_paprd.c : 5711 ] adcConfig =%d bwCode = 5d 
+ 
+1776,i,[ phy_dev_mem_paprd.c : 5729 ] table_idx=%d
+ 
+1777,iiiii,[ phy_dev_mem_paprd.c : 5745 ] min_loop_dly=%d sq_idx=%d sq_timing_offset=%d is_160_mode=%d dpdtrain_DAC_ADC_config=%d
+ 
+1778,I,[ phy_dev_mem_paprd.c : 5750 ] edpdHwaccCtrl = 0x%x 
+ 
+1779,i,[ phy_dev_mem_paprd.c : 5767 ] edpd_hw_acc_enable = %d 
+ 
+1780,i,[ phy_dev_mem_paprd.c : 5768 ] edpd_refill_mem_enable = %d 
+ 
+1781,i,[ phy_dev_mem_paprd.c : 5769 ] edpd_hw_acc_dc_rxiq_cal = %d 
+ 
+1782,i,[ phy_dev_mem_paprd.c : 5770 ] edpd_hw_acc_selfeql_cal = %d 
+ 
+1783,i,[ phy_dev_mem_paprd.c : 5771 ] edpd_hw_acc_dc_rxiq_combine_cal = %d 
+ 
+1784,,[ phy_dev_mem_paprd.c : 5782 ] init memless_tbl_for_self_eql_I/Q with memless bin tbl
+ 
+1785,iI,[ phy_dev_mem_paprd.c : 5789 ] hex_32bit[%d] = 0x%08x  
+1786,I,[ phy_dev_mem_paprd.c : 5798 ] iq sample begins, time stamp: %lu 
+1787,i,[ phy_dev_mem_paprd.c : 5799 ] WHAL_EDPD_NUM_SAMPLES_PER_CHUNK=%d 
+1788,,[ phy_dev_mem_paprd.c : 5814 ] buff refill start for eDPD Lithium 160Mode
+ 
+1789,,[ phy_dev_mem_paprd.c : 5817 ] buff refill done for eDPD Lithium 160Mode
+ 
+1790,i,[ phy_dev_mem_paprd.c : 5920 ] input restart! dpdmemtrain_[thread_id].sample_cnt = %d
+ 
+1791,i,[ phy_dev_mem_paprd.c : 5931 ] done_mem_training=%d 
+1792,i,[ phy_dev_mem_paprd.c : 5942 ] memless kernel noise bin =%d 
+1793,I,[ phy_dev_mem_paprd.c : 5966 ] all eDPD post processing done, time stamp: %lu 
+1794,,[ phy_dev_paprd_device.c : 636 ] -Q5-PAPRD-: phy_paprd_device_InitStaticSettings 
+1795,,[ phy_dev_paprd_device.c : 666 ] -Q5-PAPRD-: Porting PAC BDF 
+1796,,[ phy_dev_paprd_device.c : 718 ] -Q5-PAPRD-: phy_paprd_device_InitStaticSettings 
+1797,,[ phy_dev_paprd_device.c : 750 ] forcing sampling mode ******** 
+1798,i,[ phy_dev_paprd_device.c : 754 ] -Q5-PAPRD-: LDPDADCDAC Config setting %d  
+1799,i,[ phy_dev_paprd_device.c : 755 ] -Q5-PAPRD-: EDPDADCDAC Config setting %d  
+1800,,[ phy_dev_paprd_device.c : 757 ] -Q5-PAPRD-: phy_paprd_device_InitStaticSettings 
+1801,,[ phy_dev_paprd_device.c : 759 ] -Q5-PAPRD-: PAPRD Struct and cal settings  
+1802,i,[ phy_dev_paprd_device.c : 760 ] -Q5-PAPRD-: PaprdType = %d  
+1803,i,[ phy_dev_paprd_device.c : 761 ] -Q5-PAPRD-: Tx Chain index = %d  
+1804,i,[ phy_dev_paprd_device.c : 762 ] -Q5-PAPRD-: Table index = %d  
+1805,i,[ phy_dev_paprd_device.c : 763 ] -Q5-PAPRD-: Glut index = %d  
+1806,i,[ phy_dev_paprd_device.c : 764 ] -Q5-PAPRD-: Tx gain index = %d  
+1807,i,[ phy_dev_paprd_device.c : 765 ] -Q5-PAPRD-: paprd debugmode = %d  
+1808,,[ phy_dev_paprd_device.c : 769 ] -Q5-PAPRD-: PHY input fields  
+1809,i,[ phy_dev_paprd_device.c : 770 ] -Q5-PAPRD-: phyId  = %d  
+1810,I,[ phy_dev_paprd_device.c : 771 ] -Q5-PAPRD-: phyBase  = 0x%08x  
+1811,i,[ phy_dev_paprd_device.c : 772 ] -Q5-PAPRD-: TxChainmask = %d  
+1812,i,[ phy_dev_paprd_device.c : 773 ] -Q5-PAPRD-: Channel  = %d  
+1813,i,[ phy_dev_paprd_device.c : 774 ] -Q5-PAPRD-: BwCode = %d 
+1814,i,[ phy_dev_paprd_device.c : 776 ] -Q5-PAPRD-: g_forceRfaRxG = %d 
+1815,i,[ phy_dev_paprd_device.c : 777 ] -Q5-PAPRD-: g_loopDly = %d 
+1816,i,[ phy_dev_paprd_device.c : 778 ] -Q5-PAPRD-: g_numCand = %d 
+1817,i,[ phy_dev_paprd_device.c : 779 ] -Q5-PAPRD-: hwsearch/force (info) flag = %d 
+1818,i,[ phy_dev_paprd_device.c : 780 ] -Q5-PAPRD-: forced sq_idx_value = %d 
+1819,IIiiiii,[ phy_dev_paprd_device.c : 860 ] phy_paprd_get_glut_idx_for_dpd_table dpdTable %u, glut %u, mintxPowerdB4 %d, dpdPowerdB4 %d, regulatoryPowerdB4 %d, regulatoryBackOffdB4 %d, tempOffset %d 
+1820,IIiiii,[ phy_dev_paprd_device.c : 867 ] phy_paprd_get_glut_idx_for_dpd_table dpdTable %u, glut %u, dpdPowerdB4 %d, regulatoryPowerdB4 %d, regulatoryBackOffdB4 %d, tempDeltadB4 %d 
+1821,,[ phy_dev_paprd_device.c : 1167 ] Invalid value returned from getTPCGainIdxFromGlut() Getting gainIdx values from registers!!!! 
+1822,i,[ phy_dev_paprd_device.c : 1178 ] MM_PAPRD: forcedTx Gain fromforcetxGDacG = %d  
+1823,i,[ phy_dev_paprd_device.c : 1185 ] Invalid txgain_idx_cal value = %d (expect 0..63) 
+1824,ii,[ phy_dev_paprd_device.c : 1197 ] phy_paprd_device_ReadGlut. glutIndx %d, powerMeasured get from glut: %d 
+1825,iiIIi,[ phy_dev_paprd_device.c : 1206 ] MM_PAPRD:Chain = %d, dpdTable = %d, table_offset = %lu, glut_idx_offset = %lx, txgain_index = %d 
+1826,I,[ phy_dev_paprd_device.c : 1335 ] paprd override dpdBdfGm for calVersion %u ( old ) 
+1827,i,[ phy_dev_paprd_device.c : 1360 ] forceing dpdBdfGm with value = %d 
+1828,iI,[ phy_dev_paprd_device.c : 1403 ] LUT3_7 for chain %d read value = 0x%08x
+ 
+1829,iI,[ phy_dev_paprd_device.c : 1407 ] ISEL_1 for chain %d read value = 0x%08x
+ 
+1830,iI,[ phy_dev_paprd_device.c : 1411 ] ISEL_5 for chain %d read value = 0x%08x
+ 
+1831,iI,[ phy_dev_paprd_device.c : 1417 ] TXFE_PA5 for chain %d read value = 0x%08x
+ 
+1832,,[ phy_dev_paprd_device.c : 1439 ] ****** LUT3_7 ******** 
+ 
+1833,iI,[ phy_dev_paprd_device.c : 1441 ] LUT3_7 for chain %d read value = 0x%08x
+ 
+1834,iI,[ phy_dev_paprd_device.c : 1445 ] LUT3_7 for chain %d writen value = 0x%08x
+ 
+1835,,[ phy_dev_paprd_device.c : 1448 ] ****** iSEL_1 ******** 
+ 
+1836,iI,[ phy_dev_paprd_device.c : 1450 ] ISEL_1 for chain %d read value = 0x%08x
+ 
+1837,iI,[ phy_dev_paprd_device.c : 1454 ] ISEL_1 for chain %d writen value = 0x%08x
+ 
+1838,,[ phy_dev_paprd_device.c : 1456 ] ****** iSEL_5 ******** 
+ 
+1839,iI,[ phy_dev_paprd_device.c : 1458 ] ISEL_5 for chain %d read value = 0x%08x
+ 
+1840,iI,[ phy_dev_paprd_device.c : 1462 ] ISEL_5 for chain %d writen value = 0x%08x
+ 
+1841,,[ phy_dev_paprd_device.c : 1466 ] ****** TXFE_PA5 ******** 
+ 
+1842,iI,[ phy_dev_paprd_device.c : 1468 ] TXFE_PA5 for chain %d read value = 0x%08x
+ 
+1843,iI,[ phy_dev_paprd_device.c : 1472 ] TXFE_PA5 for chain %d writen value = 0x%08x
+ 
+1844,iI,[ phy_dev_paprd_device.c : 1484 ] LUT3_7 for chain %d not writing but read value = 0x%08x
+ 
+1845,iI,[ phy_dev_paprd_device.c : 1487 ] ISEL_1 for chain %d not writing but read value = 0x%08x
+ 
+1846,iI,[ phy_dev_paprd_device.c : 1490 ] ISEL_5 for chain %d not writing but read value = 0x%08x
+ 
+1847,iI,[ phy_dev_paprd_device.c : 1495 ] TXFE_PA5 for chain %d not writing but read value = 0x%08x
+ 
+1848,,[ phy_dev_paprd_device.c : 1502 ] DPD_HEATER_DISABLED 
+1849,Iiiiiii,[ phy_dev_paprd_device.c : 1590 ] phy_paprd_device_Rfa_programming : baseAddr 0x%08x, txChain %d, lpChain %d, tbdIdx %d, dpdBdfGm %d, dpdGc %d, cAtten %d 
+1850,i,[ phy_dev_paprd_device.c : 2663 ] phy_paprd_device_set_dacgain: dynamicDPDglutIndex %d 
+1851,i,[ phy_dev_paprd_device.c : 2698 ] MM_PAPRD: forced dac gain fromforcetxGDacG = %d  
+1852,iiIi,[ phy_dev_paprd_device.c : 2701 ] PAPRD: txgain_index = %d, phyId %d, phyRfBase 0x%08x, dpdDacGain %d 
+1853,i,[ phy_dev_paprd_device.c : 2754 ] phy_paprd_device_InitTrainingRegisters: dynamicDPDglutIndex %d 
+1854,IIIII,[ phy_dev_paprd_device.c : 2777 ] phy_paprd_device_InitTrainingRegisters phyIdx %u, phyrfChainIdx %u, rfaChain %u, finalAddr 0x%08x, finalValue 0x%08x 
+1855,III,[ phy_dev_paprd_device.c : 2796 ] phy_paprd_device_InitTrainingRegisters phyIdx %u, phyrfChainIdx %u, finalAddr 0x%08x 
+1856,i,[ phy_dev_paprd_device.c : 2801 ] -Q5-PAPRDTUNING-:DynBW = %d 
+1857,,[ phy_dev_paprd_device.c : 2812 ] ****************** BEFORE Settings *************** 
+1858,,[ phy_dev_paprd_device.c : 2819 ] Cannot use dpdtrain_DAC_ADC_config = 2 when dac rate is 960Mhz! 
+1859,,[ phy_dev_paprd_device.c : 2820 ] Now force dpdtrain_DAC_ADC_config = 1 
+1860,,[ phy_dev_paprd_device.c : 2824 ] ****************** Interim Section  *************** 
+1861,,[ phy_dev_paprd_device.c : 2825 ] *************************************************** 
+1862,,[ phy_dev_paprd_device.c : 2826 ] *************************************************** 
+1863,i,[ phy_dev_paprd_device.c : 2830 ] dpdtrain_DAC_ADC_config = %d 
+1864,i,[ phy_dev_paprd_device.c : 2867 ] dpdtrain_DAC_ADC_config = %d 
+1865,i,[ phy_dev_paprd_device.c : 2891 ] dpdtrain_DAC_ADC_config = %d 
+1866,,[ phy_dev_paprd_device.c : 2909 ] ****************** After Settings *************** 
+1867,iiii,[ phy_dev_paprd_device.c : 2919 ] forced adc config = %d, ADCrate = %d, dcconfig = %d, dclen = %d 
+1868,i,[ phy_dev_paprd_device.c : 2921 ] Programmed DC length Config = %d
+ 
+1869,i,[ phy_dev_paprd_device.c : 2935 ]  RXIQ Correction Flag = %d
+  
+1870,iii,[ phy_dev_paprd_device.c : 3003 ] DPDTRAIN_SQ_MAX_RATIO=%d DPDTRAIN_SQ_MIN_RATIO=%d DPDTRAIN_Stq2len =%d 
+1871,i,[ phy_dev_paprd_device.c : 3006 ] Q5-PAPRD:-:5G/2G_Tobe_prgramed_Minloop_delay=%d
+ 
+1872,iiI,[ phy_dev_paprd_device.c : 3016 ] -Q5 - PAPRDTUNING - :min loopback delay = %d, num Candidates = %d, PHYRF_CAL_MEAS_CTRL_4_U = 0x%x 
+1873,i,[ phy_dev_paprd_device.c : 3040 ] DPDTRAIN_MEM_NUM_TRAIN_SAMPLES=%d 
+1874,i,[ phy_dev_paprd_device.c : 3072 ] force SQ with SQ idx = %d 
+  
+1875,,[ phy_dev_paprd_device.c : 3078 ] NOT force SQ 
+1876,I,[ phy_dev_paprd_device.c : 3111 ] -Q5-DPD: PhyBase in Diff LDPD EDPD 0x%08x
+ 
+1877,I,[ phy_dev_paprd_device.c : 3124 ] PhyBase inside DMA`Vreg init is = 0x%x 
+1878,I,[ phy_dev_paprd_device.c : 3126 ] -Q5-DPD: PhyBase in DMA Vreg fn is  0x%08x
+ 
+1879,,[ phy_dev_paprd_device.c : 3129 ] After mem_init():  
+1880,II,[ phy_dev_paprd_device.c : 3149 ] -edpdRawData DDR edpdTrainData address for phyId %u before alignment = 0x%x 
+1881,II,[ phy_dev_paprd_device.c : 3151 ] FTM -edpdRawData DDR edpdTrainData address for phyId %u after  alignment = 0x%x 
+1882,II,[ phy_dev_paprd_device.c : 3222 ] PAPRD: edpdRawData for phyId %u, DDR edpdTrainData addr = 0x%x 
+1883,i,[ phy_dev_paprd_device.c : 3226 ] -edpdRawData->fw_ucode_chunks = %d 
+1884,I,[ phy_dev_paprd_device.c : 3245 ]  --Q5-PAPRD:- AGC2Pwr is 0x%02x
+ 
+1885,i,[ phy_dev_paprd_device.c : 3246 ]  --Q5-PAPRD:- AGC2Pwr is %d
+ 
+1886,i,[ phy_dev_paprd_device.c : 3249 ] -Q5-PAPRDTUNING-:DynBW = %d 
+1887,i,[ phy_dev_paprd_device.c : 3261 ] ADC OVRD_VAL : %d 
+1888,i,[ phy_dev_paprd_device.c : 3262 ] currDOWNRT_SEL : %d 
+1889,,[ phy_dev_paprd_device.c : 3266 ] Invalid currDOWNRT_SEL
+ 
+1890,,[ phy_dev_paprd_device.c : 3272 ] no such ADC rate!!!! 
+1891,,[ phy_dev_paprd_device.c : 3279 ] ADC rate shouldn't < 120 MHz!!!! 
+1892,i,[ phy_dev_paprd_device.c : 3284 ] currDCLEN : %d 
+1893,i,[ phy_dev_paprd_device.c : 3293 ]  Before forcerxGain the value of forceRxGainAdcShiftMask is %d
+ 
+1894,,[ phy_dev_paprd_device.c : 3298 ]  Forcing for  AdcShiftMask  
+1895,II,[ phy_dev_paprd_device.c : 3306 ] rxGain Force Flag %u , Force Value 0x%x 
+1896,I,[ phy_dev_paprd_device.c : 3395 ] EDPD_SUBBAND_MASK_320 = 0x%x 
+1897,I,[ phy_dev_paprd_device.c : 3396 ] EDPD_SUBBAND_MASK_160 = 0x%x 
+1898,I,[ phy_dev_paprd_device.c : 3397 ] EDPD_SUBBAND_MASK_240 = 0x%x 
+1899,I,[ phy_dev_paprd_device.c : 3398 ] EDPD_SUBBAND_SWITCH_US = 0x%x 
+1900,,[ phy_dev_paprd_device.c : 3473 ] -Q5-PAPRD-: phy_paprd_device_XmitTrainningFrame 
+1901,,[ phy_dev_paprd_device.c : 3591 ] clearCalInfoMem 
+1902,I,[ phy_dev_paprd_device.c : 3609 ] -Q5-DPD: PhyBase in Clear cal info mem 0x%08x
+ 
+1903,,[ phy_dev_paprd_device.c : 3610 ] clean edpd calinfomem 
+1904,IIIIII,[ phy_dev_paprd_device.c : 3642 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1905,IIIIII,[ phy_dev_paprd_device.c : 3662 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1906,IIIIII,[ phy_dev_paprd_device.c : 3695 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1907,IIIIII,[ phy_dev_paprd_device.c : 3716 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1908,,[ phy_dev_paprd_device.c : 3721 ] clean ldpd calinfomem 
+1909,I,[ phy_dev_paprd_device.c : 3940 ] -Q5-DPD: PhyBase in readPhyDbg fn is  0x%08x
+ 
+1910,I,[ phy_dev_paprd_device.c : 3941 ] readPhyDbgCapMem:rfBase=0x%x 
+1911,IIIIII,[ phy_dev_paprd_device.c : 3968 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1912,IIIIII,[ phy_dev_paprd_device.c : 4010 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1913,,[ phy_dev_paprd_device.c : 4013 ] i--Q5--PAPRDPHYDBG-IQ delay 1ms 
+1914,IIIIII,[ phy_dev_paprd_device.c : 4062 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1915,IIIIII,[ phy_dev_paprd_device.c : 4105 ] --Q5--CALINFOMEM0[%5d] Mem1[%5d] %5d %5d %5d %5d 
+1916,,[ phy_dev_paprd_device.c : 4108 ] j--Q5--PAPRDPHYDBG-IQ delay 1ms 
+1917,III,[ phy_dev_paprd_device.c : 4158 ] -Q5-PAPRD : dpd_rx_iq_coef.real/imag is %ld + %ld*j RSBx10=%ld 
+1918,i,[ phy_dev_paprd_device.c : 4159 ] -Q5-PAPRD : Sample Count is %d 
+1919,II,[ phy_dev_paprd_device.c : 4178 ] -Q5-PAPRD-: EDPD data tx_i/q, rx_i/q phyId %u, edpdTrainData Addr 0x%x 
+1920,IIIII,[ phy_dev_paprd_device.c : 4207 ] -Q5-PAPRD-: EDPD data tx_i/q, rx_i/q[%5d]:%5d %5d %5d %5d 
+1921,I,[ phy_dev_paprd_device.c : 4225 ] -Q5-DPD: PhyBase in RXIQ Correction LUT Programming  0x%08x
+ 
+1922,I,[ phy_dev_paprd_device.c : 4265 ] -Q5-PAPRD-: Addr 0x%x  
+1923,iI,[ phy_dev_paprd_device.c : 4270 ] -Q5-PAPRD-: RxIQ Lut Value %d Addr = 0x%x 
+ 
+1924,i,[ phy_dev_paprd_device.c : 4308 ] phy_paprd_device_TrainingStatus : dynamicDPDglutIndex %d 
+1925,i,[ phy_dev_paprd_device.c : 4331 ] -Q5-PAPRD:- Programmed SQ Limit is %d 
+ 
+1926,I,[ phy_dev_paprd_device.c : 4340 ] -Q5-DPD: phyRfBase in Training Status is  0x%08x
+ 
+1927,IIIIII,[ phy_dev_paprd_device.c : 4355 ] PAPRD_Training_Path txChain %u, dpdTable = %u, glutIdx = %u, txGainIdx = %02d, dpdDacGaindB8 %04d, dpdTrainingPower %04d 
+1928,IIIIIiI,[ phy_dev_paprd_device.c : 4360 ] PAPRD_Training_Path txChain %u, dpdTable = %u, glutIdx = %u, dpd_gc %u, cAtten %u, dpdTrainRxGain %d, agc2pwr %04d 
+1929,,[ phy_dev_paprd_device.c : 4364 ] -Q5-PAPRD-: Getting Inside Device DebugPrint  
+1930,,[ phy_dev_paprd_device.c : 4370 ] -Q5-PAPRD-: Getting Inside TraininingCheckSignalSQuality  
+1931,i,[ phy_dev_paprd_device.c : 4372 ] -Q5-PAPRD-: SQ Value is %d  
+1932,iIi,[ phy_dev_paprd_device.c : 4396 ] -Q5-PAPRDTUNING-:sq PASS: sq_idx_sw %d sq_idx_hw %ld force_sq_idx %d 
+1933,iii,[ phy_dev_paprd_device.c : 4400 ] bwCode: %d warmpacket_cnt %d max_warmpackets %d 
+1934,ii,[ phy_dev_paprd_device.c : 4408 ] warm_hw_sq_idx %d warm_valid %d 
+1935,ii,[ phy_dev_paprd_device.c : 4416 ] -Q5-PAPRDTUNING-:sq FAIL : warm_hw_sq_idx %d warm_valid %d 
+1936,iiIi,[ phy_dev_paprd_device.c : 4418 ] -Q5-PAPRDTUNING-:sq FAIL : %d sq_idx_sw %d sq_idx_hw %ld force_sq_idx %d 
+1937,,[ phy_dev_paprd_device.c : 4427 ] -Q5-PAPRD-:DPD training Failed. Paprd Done bit is not set in HW! 
+1938,,[ phy_dev_paprd_device.c : 4437 ]  Device Dump Iq samples 
+1939,,[ phy_dev_paprd_device.c : 4447 ] phy_dev_phydbg_capture_enable 
+1940,I,[ phy_dev_paprd_device.c : 4456 ] -Q5-DPD: PhyBase in PhyDbg Capture Enable is  0x%08x
+ 
+1941,I,[ phy_dev_paprd_device.c : 4474 ] DPDTRAIN_CALINFO_MEM_CAP_EN = 0x%x 
+1942,I,[ phy_dev_paprd_device.c : 4477 ] DPDTRAIN_MEMCAP_CHUNK_SIZE = 0x%x 
+1943,I,[ phy_dev_paprd_device.c : 4479 ] WFAX_PHYRF_DPDTRAIN_MEAS_U = 0x%x 
+1944,I,[ phy_dev_paprd_device.c : 4482 ] WFAX_PHYRF_DPDTRAIN_MEAS_L = 0x%x 
+1945,I,[ phy_dev_paprd_device.c : 4484 ] PHYRF_CAL_RESULTS_RDY_EVENT = 0x%x 
+1946,I,[ phy_dev_paprd_device.c : 4486 ] PHYRF_CAL_RESULTS_RDY_EVENT_MASK = 0x%x 
+1947,,[ phy_dev_paprd_device.c : 4507 ] phy_dev_phydbg_capture_stop 
+1948,I,[ phy_dev_paprd_device.c : 4517 ] -Q5-DPD: PhyBase in PhyDbg Capture Stop is 0x%08x
+ 
+1949,I,[ phy_dev_paprd_device.c : 4527 ] DPDTRAIN_CALINFO_MEM_CAP_EN = 0x%x 
+1950,I,[ phy_dev_paprd_device.c : 4530 ] DPDTRAIN_MEMCAP_CHUNK_SIZE = 0x%x 
+1951,I,[ phy_dev_paprd_device.c : 4532 ] WFAX_PHYRF_DPDTRAIN_MEAS_U = 0x%x 
+1952,I,[ phy_dev_paprd_device.c : 4535 ] WFAX_PHYRF_DPDTRAIN_MEAS_L = 0x%x 
+1953,I,[ phy_dev_paprd_device.c : 4537 ] PHYRF_CAL_RESULTS_RDY_EVENT = 0x%x 
+1954,I,[ phy_dev_paprd_device.c : 4539 ] PHYRF_CAL_RESULTS_RDY_EVENT_MASK = 0x%x 
+1955,I,[ phy_dev_paprd_device.c : 4570 ] -Q5-DPD: PhyBase in DebugPrint 0x%08x
+ 
+1956,I,[ phy_dev_paprd_device.c : 4583 ] -Q5-PAPRDTUNING-:DPD training AGC2 size %x 
+1957,I,[ phy_dev_paprd_device.c : 4586 ] -Q5-PAPRDTUNING-:DPD training AGC2 pwr 0x%8x 
+1958,I,[ phy_dev_paprd_device.c : 4590 ] -Q5-PAPRDTUNING-:DPD training rx gain idx 0x%x 
+1959,I,[ phy_dev_paprd_device.c : 4594 ] -Q5-PAPRDTUNING-:SQ index HW is %u 
+1960,I,[ phy_dev_paprd_device.c : 4597 ] -Q5-PAPRD-:DPD training done %u 
+1961,I,[ phy_dev_paprd_device.c : 4600 ] -Q5-PAPRD-:DPD training active %u 
+1962,I,[ phy_dev_paprd_device.c : 4603 ] -Q5-PAPRD-:DPD training incomplete %u 
+1963,I,[ phy_dev_paprd_device.c : 4609 ] DPDTRAIN_MEM_NUM_TRAIN_SAMPLES = 0x%x 
+1964,I,[ phy_dev_paprd_device.c : 4612 ] DPDTRAIN_NUM_TRAIN_SAMPLES = 0x%x 
+1965,i,[ phy_dev_paprd_device.c : 4621 ] -Q5-PAPRD-:HMT CALENGINE0_SAVED_GAIN0_L, CALENGINE0_EVEN_GAIN DC estimate I %d 
+1966,i,[ phy_dev_paprd_device.c : 4622 ] -Q5-PAPRD-:HMT CALENGINE0_SAVED_GAIN0_L, CALENGINE0_EVEN_GAIN DC estimate Q %d 
+1967,I,[ phy_dev_paprd_device.c : 4639 ] -Q5-PAPRD-:HW calculated stage2 min dispersion = %u 
+1968,I,[ phy_dev_paprd_device.c : 4640 ] -Q5-PAPRD-:Dispersion value at SQ Stage2 (minimum index - 1) = %u 
+1969,I,[ phy_dev_paprd_device.c : 4641 ] -Q5-PAPRD-:Dispersion value at SQ Stage2 (minimum index + 1) = %u 
+1970,iI,[ phy_dev_paprd_device.c : 4669 ] -Q5-PAPRD-: Chain%d RORxGain-HEX  = 0x%08x 
+1971,iII,[ phy_dev_paprd_device.c : 4682 ] -Q5-PAPRD-: DBG_%d_U addr = 0x%08x value = 0x%08x
+ 
+1972,iII,[ phy_dev_paprd_device.c : 4686 ] -Q5-PAPRD-: DBG_%d_L addr = 0x%08x value = 0x%08x
+ 
+1973,I,[ phy_dev_paprd_device.c : 4733 ] -Q5-DPD: phyRfBase in CheckSignal Quality is  0x%08x
+ 
+1974,I,[ phy_dev_paprd_device.c : 4746 ] -Q5-PAPRD-:Dispersion value at SQ Stage2 (minimum index - 1) = %u 
+1975,I,[ phy_dev_paprd_device.c : 4747 ] -Q5-PAPRD-:Dispersion value at SQ Stage2 (minimum index + 1) = %u 
+1976,iiii,[ phy_dev_paprd_device.c : 4803 ] -Q5-PAPRD-: In training signal quality --- Bin idx %d -- accum count = %d, X value = %d, Average X = %d 
+1977,iiii,[ phy_dev_paprd_device.c : 4860 ] -Q5-PAPRD-: In training signal quality --- Bin idx %d -- accum count = %d, X value = %d, Average X = %d 
+1978,i,[ phy_dev_paprd_device.c : 4869 ] -Q5-PAPRD-:Max value of Averaged X = %d 
+1979,iiii,[ phy_dev_paprd_device.c : 4886 ] -Q5-PAPRD-:Bin %d chk_acc = %d, cnt = %d, diffn = %d 
+1980,i,[ phy_dev_paprd_device.c : 4901 ] -Q5-PAPRD-: Averaged SQ value is %d 
+1981,IIIII,[ phy_dev_paprd_device.c : 4947 ] DpdBinningInfo-[%2u]:%8u	 %8u	 %8u	 %8u 
+1982,I,[ phy_dev_paprd_device.c : 4964 ] -Q5-DPD: phyRfBase in RdTrainmem 0x%08x
+ 
+1983,,[ phy_dev_paprd_device.c : 4991 ] -Q5-PAPRD-:Read back DPD training data from memory: 
+1984,ii,[ phy_dev_paprd_device.c : 4992 ] -Q5-PAPRD-:Raw Data: chain %d dpd table %d 
+1985,,[ phy_dev_paprd_device.c : 4993 ] -Q5-PAPRD-:DpdTrainData0	  DpdTrainData1	 DpdTrainData2	 DpdTrainData3 
+1986,IIIII,[ phy_dev_paprd_device.c : 4996 ] -Q5-PAPRD-[%2u]:%8u	 %8u	 %8u	 %8u 
+1987,I,[ phy_dev_paprd_device.c : 5027 ] -Q5-DPD: PhyBase in RdTrainmem PAC 0x%08x
+ 
+1988,,[ phy_dev_paprd_device.c : 5056 ] -Q5-PAPRD-:Read back DPD training data from memory: 
+1989,ii,[ phy_dev_paprd_device.c : 5057 ] -Q5-PAPRD-:Raw Data: chain %d pac table %d 
+1990,,[ phy_dev_paprd_device.c : 5058 ] -Q5-PAPRD-:pa_bin_count	  pa_ang_delta_val	 pa_output_val	 pa_input_val 
+1991,IIIII,[ phy_dev_paprd_device.c : 5061 ] -Q5-PAPRD-[%2u]:%8u	 %8u	 %8u	 %8u 
+1992,i,[ phy_dev_paprd_device.c : 5070 ] -Q5-PAPRD-:max pa_bin_count = %d 
+  
+1993,,[ phy_dev_paprd_device.c : 6060 ] Invalid tableOffset 
+1994,,[ phy_dev_paprd_device.c : 6066 ] Invalid tableType 
+1995,,[ phy_dev_paprd_device.c : 6099 ] Invalid tableOffset 
+1996,,[ phy_dev_paprd_device.c : 6105 ] Invalid tableType 
+1997,iIIII,[ phy_dev_paprd_device.c : 6108 ] MM_ctrl_save_FCS: %d paprdCtrl_0: 0x%x paprdCtrl_1: 0x%x paprdCtrl_2: 0x%x paprdCtrl_3: 0x%x 
+1998,i,[ phy_dev_paprd_device.c : 6172 ] paprdType %d 
+1999,,[ phy_dev_paprd_device.c : 6197 ] Invalid tableType 
+2000,,[ phy_dev_paprd_device.c : 6201 ] Invalid tableOffset 
+2001,iIIII,[ phy_dev_paprd_device.c : 6239 ] MM_ctrl_restore_FCS: %d paprdCtrl_0: 0x%x paprdCtrl_1: 0x%x paprdCtrl_2: 0x%x paprdCtrl_3: 0x%x 
+2002,IIIIIIIi,[ phy_dev_paprd_device.c : 6549 ] ValidateDpdLuts Error           MemLess[%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. Correcting %d ... 
+2003,IIIIIII,[ phy_dev_paprd_device.c : 6561 ] ValidateDpdLuts Clean           MemLess[%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. 
+2004,IIIIIIIi,[ phy_dev_paprd_device.c : 6579 ] ValidateDpdLuts Error     memStandAlone[%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. Correcting %d ... 
+2005,IIIIIII,[ phy_dev_paprd_device.c : 6591 ] ValidateDpdLuts Clean     memStandAlone[%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. 
+2006,IIIIIIIIi,[ phy_dev_paprd_device.c : 6611 ] ValidateDpdLuts Error memAbsx[%02d][%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. Correcting %d ... 
+2007,IIIIIIII,[ phy_dev_paprd_device.c : 6623 ] ValidateDpdLuts Clean memAbsx[%02d][%02d][%02d][%02d][%02d] Addr 0x%08x, Expected 0x%08x, Actual 0x%08x. 
+2008,I,[ phy_dev_paprd_device.c : 6633 ] ValidateDpdLuts noError in Attempt %02d. Breaking ... 
+2009,iI,[ phy_dev_paprd_device.c : 6638 ] ValidateDpdLuts %d Errors in Attempt %02d ... 
+2010,II,[ phy_dev_paprd_device.c : 6642 ] ValidateDpdLuts time = %06d us , Attempts %02d 
+2011,I,[ phy_dev_paprd_device.c : 6773 ] -Q5-DPD: PhyBase in Populate Paprd tables is  0x%08x
+ 
+2012,iii,[ phy_dev_paprd_device.c : 6834 ] (%d %d) Populate DPD LUT of Chain training_done_for_curr_table_idx %d 
+2013,iii,[ phy_dev_paprd_device.c : 6845 ] Populate DPD LUT valid_gain_idx %d gsmall %d paprdType %d 
+2014,,[ phy_dev_paprd_device.c : 6847 ] warning!!! eDPD only support 4 table!!! 
+2015,,[ phy_dev_paprd_device.c : 6851 ] Invalid tableType 
+2016,,[ phy_dev_paprd_device.c : 6855 ] Invalid tableOffset 
+2017,iiII,[ phy_dev_paprd_device.c : 6866 ] TableType %d TableOffset %d Valid Gain Addr = 0x%x, Value = 0x%x 
+2018,iiII,[ phy_dev_paprd_device.c : 6876 ] TableType %d TableOffset %d SM Gain Addr = 0x%x, Value = 0x%x 
+2019,iII,[ phy_dev_paprd_device.c : 6891 ] WFAX_PHYRF_PAPRD_TABLE_TYPE_L_B%d Addr = 0x%x, Value = 0x%x 
+2020,iII,[ phy_dev_paprd_device.c : 6893 ] WFAX_PHYRF_PAPRD_CTRL_L_B%d Addr = 0x%x, Value = 0x%x 
+2021,iII,[ phy_dev_paprd_device.c : 6908 ] WFAX_PHYRF_PAPRD_CTRL_L_B%d Addr = 0x%x, Value = 0x%x 
+2022,I,[ phy_dev_paprd_device.c : 6922 ]  populate-PAPRD:ddress : %x 
+2023,iiII,[ phy_dev_paprd_device.c : 6924 ]  populate-PAPRD:tableType: %d tableIdx: %d at even entry: %2d from is : %x 
+2024,iiII,[ phy_dev_paprd_device.c : 6926 ]  populate-PAPRD:tableType: %d tableIdx: %d at  odd entry: %2d from is : %x 
+2025,,[ phy_dev_paprd_device.c : 6934 ] Start Populated MemoryDPD Table! 
+2026,i,[ phy_dev_paprd_device.c : 6949 ] int delay ddr x1 = %d 
+2027,i,[ phy_dev_paprd_device.c : 6950 ] int delay ddr x2 = %d 
+2028,i,[ phy_dev_paprd_device.c : 6951 ] int delay ddr x3 = %d 
+2029,i,[ phy_dev_paprd_device.c : 6952 ] int delay ddr x4 = %d 
+2030,i,[ phy_dev_paprd_device.c : 6953 ] int delay ddr x5 = %d 
+2031,i,[ phy_dev_paprd_device.c : 6954 ] int delay ddr x6 = %d 
+2032,i,[ phy_dev_paprd_device.c : 6955 ] int delay ddr x7 = %d 
+2033,i,[ phy_dev_paprd_device.c : 6956 ] int delay ddr_2nd_set x1 = %d 
+2034,i,[ phy_dev_paprd_device.c : 6957 ] int delay ddr_2nd_set x2 = %d 
+2035,i,[ phy_dev_paprd_device.c : 6958 ] int delay ddr_2nd_set x3 = %d 
+2036,i,[ phy_dev_paprd_device.c : 6959 ] int delay ddr_2nd_set x4 = %d 
+2037,i,[ phy_dev_paprd_device.c : 6960 ] int delay ddr_2nd_set x5 = %d 
+2038,i,[ phy_dev_paprd_device.c : 6961 ] int delay ddr_2nd_set x6 = %d 
+2039,i,[ phy_dev_paprd_device.c : 6962 ] int delay ddr_2nd_set x7 = %d 
+2040,,[ phy_dev_paprd_device.c : 7133 ] Invalid tableOffset 
+2041,,[ phy_dev_paprd_device.c : 7174 ] Invalid tableOffset 
+2042,iII,[ phy_dev_paprd_device.c : 7187 ] WFAX_PHYRF_EDPD_CTRL_5_L_B%d Addr = 0x%x, Value = 0x%x 
+2043,iII,[ phy_dev_paprd_device.c : 7189 ] WFAX_PHYRF_EDPD_CTRL_6_L_B%d Addr = 0x%x, Value = 0x%x 
+2044,iII,[ phy_dev_paprd_device.c : 7193 ] WFAX_PHYRF_EDPD_CTRL_5_U_B%d Addr = 0x%x, Value = 0x%x 
+2045,iII,[ phy_dev_paprd_device.c : 7195 ] WFAX_PHYRF_EDPD_CTRL_6_U_B%d Addr = 0x%x, Value = 0x%x 
+2046,,[ phy_dev_paprd_device.c : 7204 ] Finished populating DPD LUT into memory! 
+2047,I,[ phy_dev_paprd_device.c : 7230 ] Populate PAC LUT baseAddr =  0x%x  
+2048,iiii,[ phy_dev_paprd_device.c : 7236 ] ( k %d txChain %d tableIndex %d) Populate PAC LUT of Chain training_done_for_curr_table_idx %d 
+2049,i,[ phy_dev_paprd_device.c : 7247 ] Populate PAC LUT valid_gain_dx %d  
+2050,I,[ phy_dev_paprd_device.c : 7315 ]  populate-PAC:address : %x 
+2051,iiII,[ phy_dev_paprd_device.c : 7318 ]  populate-PAC:tableType: %d tableIdx: %d at even entry: %2d coef I is : 0x%x 
+2052,iiII,[ phy_dev_paprd_device.c : 7319 ]  populate-PAC:tableType: %d tableIdx: %d at even entry: %2d coef Q is : 0x%x 
+2053,iiII,[ phy_dev_paprd_device.c : 7322 ]  populate-PAC:tableType: %d tableIdx: %d at odd entry: %2d coef I is : 0x%x 
+2054,iiII,[ phy_dev_paprd_device.c : 7323 ]  populate-PAC:tableType: %d tableIdx: %d at odd entry: %2d coef Q is : 0x%x 
+2055,I,[ phy_dev_paprd_device.c : 7332 ] populate PAC alpha regVal = 0x%x 
+2056,iI,[ phy_dev_paprd_device.c : 7333 ]  dtu alpha debug ADDR PAC_ALPHA_L_B0_%d = 0x%08x 
+2057,iI,[ phy_dev_paprd_device.c : 7339 ]  dtu alpha debug ADDR PAC_ALPHA_U_B0_%d = 0x%08x 
+2058,iiIiI,[ phy_dev_paprd_device.c : 7349 ]  populate-PAC alpha:tableType: %d tableIdx: %d at even entry: %2d coef I is : %d (0x%08x) 
+2059,iiIiI,[ phy_dev_paprd_device.c : 7350 ]  populate-PAC alpha:tableType: %d tableIdx: %d at even entry: %2d coef Q is : %d (0x%08x) 
+2060,iiIiI,[ phy_dev_paprd_device.c : 7353 ]  populate-PAC alpha:tableType: %d tableIdx: %d at odd entry: %2d coef I is : %d (0x%08x) 
+2061,iiIiI,[ phy_dev_paprd_device.c : 7354 ]  populate-PAC alpha:tableType: %d tableIdx: %d at odd entry: %2d coef Q is : %d (0x%08x) 
+2062,i,[ phy_dev_paprd_device.c : 7399 ] -Q5-PAC: iir index = %d
+ 
+2063,,[ phy_dev_paprd_device.c : 7424 ] Finished populating PAC LUT into memory! 
+2064,Iii,[ phy_dev_paprd_device.c : 7540 ] phy_paprd_device_exit_cal : baseAddr 0x%08x, txChain %d, lpChain %d 
+2065,iI,[ phy_dev_paprd_device.c : 7561 ] LUT3_7 for chain %d read value = 0x%08x
+ 
+2066,iI,[ phy_dev_paprd_device.c : 7567 ] ISEL_1 for chain %d read value = 0x%08x
+ 
+2067,iI,[ phy_dev_paprd_device.c : 7573 ] ISEL_5 for chain %d read value = 0x%08x
+ 
+2068,iI,[ phy_dev_paprd_device.c : 7580 ] TXFE_PA5 for chain %d read value = 0x%08x
+ 
+2069,i,[ phy_dev_paprd_device.c : 7698 ] -Q5-PAPRD-:channel freq %d 
+2070,ii,[ phy_dev_paprd_device.c : 7699 ] -Q5-PAPRD-:txChain %d dpd tableIndex %d 
+2071,i,[ phy_dev_paprd_device.c : 7700 ] -Q5-PAPRD-:forced_sq_idx %d 
+2072,ii,[ phy_dev_paprd_device.c : 7701 ] -Q5-PAPRD-:sq_idx_sw %d sq_idx_hw %d 
+2073,iiiii,[ phy_dev_paprd_device.c : 7718 ] phy_paprd_device_GetComplete: phyId %d channel %d, enable %d phyInput CM %d  validmask %d 
+2074,II,[ phy_dev_paprd_device.c : 7744 ] --Q5--PAPRD: dpdComplete validmask 0x%lx phyInput->validChainMask 0x%x 
+2075,i,[ phy_dev_paprd_device.c : 8016 ] -Q5-PAPRDTUNING-: max_bin  %d 
+2076,i,[ phy_dev_paprd_device.c : 8017 ] -Q5-PAPRDTUNING-: base_bin %d 
+2077,ii,[ phy_dev_paprd_device.c : 8058 ] -Q5-PAPRDTUNING-: WARMUP: dpdDynDacgain %d, max_dac_gain %d  
+2078,ii,[ phy_dev_paprd_device.c : 8066 ] -Q5-PAPRDTUNING-: WARMUP: compression %d/64, new upbound dacgain %d  
+2079,,[ phy_dev_paprd_device.c : 8070 ] -Q5-PAPRDTUNING-: WARMUP greater than max_dac_gain 
+2080,ii,[ phy_dev_paprd_device.c : 8079 ] -Q5-PAPRDTUNING-: WARMUP: old rxgain %d, new rxgain %d  
+2081,iiii,[ phy_dev_paprd_device.c : 8117 ] x_base_bin:%d y_base_bin:%d x_max_bin:%d y_max_bin:%d 
+2082,ii,[ phy_dev_paprd_device.c : 8118 ] -Q5-PAPRDTUNING-: bin_idx %d compression %d/64 
+2083,ii,[ phy_dev_paprd_device.c : 8141 ] -Q5-PAPRDTUNING-:DPD FAIL. Improper compression. dacgain decrease %d to  %d 
+2084,ii,[ phy_dev_paprd_device.c : 8214 ] PAPRD SAVE(1) : RESTORE(2) : PRINT(3)  (phyId= %d), cmd %d 
+2085,I,[ phy_dev_paprd_device.c : 8225 ] PAPRD_CTRL_L_B0 = 0x%x 
+2086,I,[ phy_dev_paprd_device.c : 8227 ] PAPRD_VALID_GAIN_L_B0 = 0x%x 
+2087,I,[ phy_dev_paprd_device.c : 8229 ] PHYRF_PAPRD_TABLE_TYPE_L_B0 = 0x%x 
+2088,I,[ phy_dev_paprd_device.c : 8234 ] PAPRD_CTRL_L_B1 = 0x%x 
+2089,I,[ phy_dev_paprd_device.c : 8236 ] PAPRD_VALID_GAIN_L_B1 = 0x%x 
+2090,I,[ phy_dev_paprd_device.c : 8238 ] PHYRF_PAPRD_TABLE_TYPE_L_B1 = 0x%x 
+2091,II,[ phy_dev_paprd_device.c : 8256 ] PAPRD_CTRL_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2092,II,[ phy_dev_paprd_device.c : 8262 ] PAPRD_VALID_GAIN_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2093,II,[ phy_dev_paprd_device.c : 8268 ] PHYRF_PAPRD_TABLE_TYPE_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2094,II,[ phy_dev_paprd_device.c : 8276 ] PAPRD_CTRL_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2095,II,[ phy_dev_paprd_device.c : 8282 ] PAPRD_VALID_GAIN_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2096,II,[ phy_dev_paprd_device.c : 8288 ] PHYRF_PAPRD_TABLE_TYPE_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2097,II,[ phy_dev_paprd_device.c : 8308 ] PAPRD_CTRL_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2098,II,[ phy_dev_paprd_device.c : 8314 ] PAPRD_VALID_GAIN_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2099,II,[ phy_dev_paprd_device.c : 8320 ] PHYRF_PAPRD_TABLE_TYPE_L_B0 = 0x%x paprd_ctrl = 0x%x 
+2100,II,[ phy_dev_paprd_device.c : 8328 ] PAPRD_CTRL_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2101,II,[ phy_dev_paprd_device.c : 8334 ] PAPRD_VALID_GAIN_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2102,II,[ phy_dev_paprd_device.c : 8340 ] PHYRF_PAPRD_TABLE_TYPE_L_B1 = 0x%x paprd_ctrl_1 = 0x%x 
+2103,I,[ phy_dev_paprd_device.c : 8349 ] CUREENT HW TABLE  = 0x%x 
+2104,ii,[ phy_dev_paprd_device.c : 8393 ] EDPD NEW CTRL REGISTERS   SAVE(1) : RESTORE(2) : PRINT(3)  (phyId= %d), cmd %d 
+2105,I,[ phy_dev_paprd_device.c : 8407 ] PHYRF_EDPD_CTRL_0_L_B0 = 0x%x 
+2106,I,[ phy_dev_paprd_device.c : 8410 ] PHYRF_EDPD_CTRL_0_U_B0 = 0x%x 
+2107,I,[ phy_dev_paprd_device.c : 8413 ] PHYRF_EDPD_CTRL_1_L_B0 = 0x%x 
+2108,I,[ phy_dev_paprd_device.c : 8416 ] PHYRF_EDPD_CTRL_1_U_B0 = 0x%x 
+2109,I,[ phy_dev_paprd_device.c : 8419 ] PHYRF_EDPD_CTRL_2_L_B0 = 0x%x 
+2110,I,[ phy_dev_paprd_device.c : 8422 ] PHYRF_EDPD_CTRL_2_U_B0 = 0x%x 
+2111,I,[ phy_dev_paprd_device.c : 8425 ] PHYRF_EDPD_CTRL_3_L_B0 = 0x%x 
+2112,I,[ phy_dev_paprd_device.c : 8433 ] PHYRF_EDPD_CTRL_4_L_B0 = 0x%x 
+2113,I,[ phy_dev_paprd_device.c : 8441 ] PHYRF_EDPD_CTRL_5_L_B0 = 0x%x 
+2114,I,[ phy_dev_paprd_device.c : 8444 ] PHYRF_EDPD_CTRL_5_U_B0 = 0x%x 
+2115,I,[ phy_dev_paprd_device.c : 8447 ] PHYRF_EDPD_CTRL_6_L_B0 = 0x%x 
+2116,I,[ phy_dev_paprd_device.c : 8450 ] PHYRF_EDPD_CTRL_6_U_B0 = 0x%x 
+2117,I,[ phy_dev_paprd_device.c : 8453 ] PHYRF_EDPD_CTRL_7_L_B0 = 0x%x 
+2118,I,[ phy_dev_paprd_device.c : 8456 ] PHYRF_EDPD_CTRL_7_U_B0 = 0x%x 
+2119,I,[ phy_dev_paprd_device.c : 8459 ] PHYRF_EDPD_CTRL_8_L_B0 = 0x%x 
+2120,II,[ phy_dev_paprd_device.c : 8466 ] PHYRF_EDPD_CTRL_0_L_B1 = 0x%x addr = 0x%x 
+2121,II,[ phy_dev_paprd_device.c : 8469 ] PHYRF_EDPD_CTRL_0_U_B1 = 0x%x addr = 0x%x 
+2122,II,[ phy_dev_paprd_device.c : 8472 ] PHYRF_EDPD_CTRL_1_L_B1 = 0x%x addr = 0x%x 
+2123,II,[ phy_dev_paprd_device.c : 8475 ] PHYRF_EDPD_CTRL_1_U_B1 = 0x%x addr = 0x%x 
+2124,II,[ phy_dev_paprd_device.c : 8478 ] PHYRF_EDPD_CTRL_2_L_B1 = 0x%x addr = 0x%x 
+2125,II,[ phy_dev_paprd_device.c : 8481 ] PHYRF_EDPD_CTRL_2_U_B1 = 0x%x addr = 0x%x 
+2126,II,[ phy_dev_paprd_device.c : 8484 ] PHYRF_EDPD_CTRL_3_L_B1 = 0x%x addr = 0x%x 
+2127,II,[ phy_dev_paprd_device.c : 8492 ] PHYRF_EDPD_CTRL_4_L_B1 = 0x%x addr = 0x%x 
+2128,II,[ phy_dev_paprd_device.c : 8499 ] PHYRF_EDPD_CTRL_5_L_B1 = 0x%x addr = 0x%x 
+2129,II,[ phy_dev_paprd_device.c : 8502 ] PHYRF_EDPD_CTRL_5_U_B1 = 0x%x addr = 0x%x 
+2130,II,[ phy_dev_paprd_device.c : 8505 ] PHYRF_EDPD_CTRL_6_L_B1 = 0x%x addr = 0x%x 
+2131,II,[ phy_dev_paprd_device.c : 8508 ] PHYRF_EDPD_CTRL_6_U_B1 = 0x%x addr = 0x%x 
+2132,II,[ phy_dev_paprd_device.c : 8511 ] PHYRF_EDPD_CTRL_7_L_B1 = 0x%x addr = 0x%x 
+2133,II,[ phy_dev_paprd_device.c : 8514 ] PHYRF_EDPD_CTRL_7_U_B1 = 0x%x addr = 0x%x 
+2134,II,[ phy_dev_paprd_device.c : 8517 ] PHYRF_EDPD_CTRL_8_L_B1 = 0x%x addr = 0x%x 
+2135,II,[ phy_dev_paprd_device.c : 8534 ] PHYRF_EDPD_CTRL_0_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2136,II,[ phy_dev_paprd_device.c : 8539 ] PHYRF_EDPD_CTRL_0_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2137,II,[ phy_dev_paprd_device.c : 8544 ] PHYRF_EDPD_CTRL_1_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2138,II,[ phy_dev_paprd_device.c : 8549 ] PHYRF_EDPD_CTRL_1_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2139,II,[ phy_dev_paprd_device.c : 8554 ] PHYRF_EDPD_CTRL_2_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2140,II,[ phy_dev_paprd_device.c : 8559 ] PHYRF_EDPD_CTRL_2_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2141,II,[ phy_dev_paprd_device.c : 8564 ] PHYRF_EDPD_CTRL_3_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2142,II,[ phy_dev_paprd_device.c : 8569 ] PHYRF_EDPD_CTRL_4_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2143,II,[ phy_dev_paprd_device.c : 8581 ] PHYRF_EDPD_CTRL_5_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2144,II,[ phy_dev_paprd_device.c : 8586 ] PHYRF_EDPD_CTRL_5_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2145,II,[ phy_dev_paprd_device.c : 8591 ] PHYRF_EDPD_CTRL_6_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2146,II,[ phy_dev_paprd_device.c : 8596 ] PHYRF_EDPD_CTRL_6_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2147,II,[ phy_dev_paprd_device.c : 8601 ] PHYRF_EDPD_CTRL_7_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2148,II,[ phy_dev_paprd_device.c : 8606 ] PHYRF_EDPD_CTRL_7_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2149,II,[ phy_dev_paprd_device.c : 8611 ] PHYRF_EDPD_CTRL_8_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2150,II,[ phy_dev_paprd_device.c : 8620 ] PHYRF_EDPD_CTRL_0_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2151,II,[ phy_dev_paprd_device.c : 8625 ] PHYRF_EDPD_CTRL_0_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2152,II,[ phy_dev_paprd_device.c : 8630 ] PHYRF_EDPD_CTRL_1_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2153,II,[ phy_dev_paprd_device.c : 8635 ] PHYRF_EDPD_CTRL_1_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2154,II,[ phy_dev_paprd_device.c : 8640 ] PHYRF_EDPD_CTRL_2_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2155,II,[ phy_dev_paprd_device.c : 8645 ] PHYRF_EDPD_CTRL_2_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2156,II,[ phy_dev_paprd_device.c : 8650 ] PHYRF_EDPD_CTRL_3_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2157,II,[ phy_dev_paprd_device.c : 8661 ] PHYRF_EDPD_CTRL_4_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2158,II,[ phy_dev_paprd_device.c : 8673 ] PHYRF_EDPD_CTRL_5_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2159,II,[ phy_dev_paprd_device.c : 8678 ] PHYRF_EDPD_CTRL_5_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2160,II,[ phy_dev_paprd_device.c : 8683 ] PHYRF_EDPD_CTRL_6_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2161,II,[ phy_dev_paprd_device.c : 8688 ] PHYRF_EDPD_CTRL_6_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2162,II,[ phy_dev_paprd_device.c : 8693 ] PHYRF_EDPD_CTRL_7_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2163,II,[ phy_dev_paprd_device.c : 8698 ] PHYRF_EDPD_CTRL_7_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2164,II,[ phy_dev_paprd_device.c : 8703 ] PHYRF_EDPD_CTRL_8_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2165,II,[ phy_dev_paprd_device.c : 8721 ] PHYRF_EDPD_CTRL_0_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2166,II,[ phy_dev_paprd_device.c : 8726 ] PHYRF_EDPD_CTRL_0_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2167,II,[ phy_dev_paprd_device.c : 8731 ] PHYRF_EDPD_CTRL_1_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2168,II,[ phy_dev_paprd_device.c : 8736 ] PHYRF_EDPD_CTRL_1_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2169,II,[ phy_dev_paprd_device.c : 8741 ] PHYRF_EDPD_CTRL_2_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2170,II,[ phy_dev_paprd_device.c : 8746 ] PHYRF_EDPD_CTRL_2_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2171,II,[ phy_dev_paprd_device.c : 8751 ] PHYRF_EDPD_CTRL_3_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2172,II,[ phy_dev_paprd_device.c : 8756 ] PHYRF_EDPD_CTRL_4_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2173,II,[ phy_dev_paprd_device.c : 8768 ] PHYRF_EDPD_CTRL_5_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2174,II,[ phy_dev_paprd_device.c : 8773 ] PHYRF_EDPD_CTRL_5_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2175,II,[ phy_dev_paprd_device.c : 8778 ] PHYRF_EDPD_CTRL_6_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2176,II,[ phy_dev_paprd_device.c : 8783 ] PHYRF_EDPD_CTRL_6_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2177,II,[ phy_dev_paprd_device.c : 8788 ] PHYRF_EDPD_CTRL_7_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2178,II,[ phy_dev_paprd_device.c : 8793 ] PHYRF_EDPD_CTRL_7_U_B0 = 0x%x edpd_ctrl = 0x%x 
+2179,II,[ phy_dev_paprd_device.c : 8798 ] PHYRF_EDPD_CTRL_8_L_B0 = 0x%x edpd_ctrl = 0x%x 
+2180,II,[ phy_dev_paprd_device.c : 8807 ] PHYRF_EDPD_CTRL_0_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2181,II,[ phy_dev_paprd_device.c : 8812 ] PHYRF_EDPD_CTRL_0_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2182,II,[ phy_dev_paprd_device.c : 8817 ] PHYRF_EDPD_CTRL_1_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2183,II,[ phy_dev_paprd_device.c : 8822 ] PHYRF_EDPD_CTRL_1_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2184,II,[ phy_dev_paprd_device.c : 8827 ] PHYRF_EDPD_CTRL_2_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2185,II,[ phy_dev_paprd_device.c : 8832 ] PHYRF_EDPD_CTRL_2_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2186,II,[ phy_dev_paprd_device.c : 8837 ] PHYRF_EDPD_CTRL_3_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2187,II,[ phy_dev_paprd_device.c : 8848 ] PHYRF_EDPD_CTRL_4_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2188,II,[ phy_dev_paprd_device.c : 8860 ] PHYRF_EDPD_CTRL_5_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2189,II,[ phy_dev_paprd_device.c : 8865 ] PHYRF_EDPD_CTRL_5_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2190,II,[ phy_dev_paprd_device.c : 8870 ] PHYRF_EDPD_CTRL_6_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2191,II,[ phy_dev_paprd_device.c : 8875 ] PHYRF_EDPD_CTRL_6_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2192,II,[ phy_dev_paprd_device.c : 8880 ] PHYRF_EDPD_CTRL_7_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2193,II,[ phy_dev_paprd_device.c : 8885 ] PHYRF_EDPD_CTRL_7_U_B1 = 0x%x edpd_ctrl = 0x%x 
+2194,II,[ phy_dev_paprd_device.c : 8890 ] PHYRF_EDPD_CTRL_8_L_B1 = 0x%x edpd_ctrl = 0x%x 
+2195,,[ phy_dev_paprd_device.c : 9085 ] ******Memory DPD 
+2196,,[ phy_dev_paprd_device.c : 9089 ] ******Memless DPD_curve fitting on 
+2197,,[ phy_dev_paprd_device.c : 9095 ] ******Memless DPD_curve fitting off 
+2198,I,[ phy_dev_paprd_device.c : 9174 ] -Q5-DPD: PhyBase in print adc dac rate config is  0x%08x
+ 
+2199,i,[ phy_dev_paprd_device.c : 9175 ] ADC OVRD Flag : %d 
+2200,i,[ phy_dev_paprd_device.c : 9176 ] ADC OVRD VAL : %d 
+2201,i,[ phy_dev_paprd_device.c : 9178 ] DPDTRAIN_CPT_480 : %d 
+2202,i,[ phy_dev_paprd_device.c : 9179 ] DPDTRAIN_RX_DOWNRT_SEL : %d 
+2203,i,[ phy_dev_paprd_device.c : 9181 ] DPDTRAIN_TX_DOWNRT_SEL : %d 
+2204,i,[ phy_dev_paprd_device.c : 9182 ] DPDTRAIN_RX_SQFIR_EN :   %d 
+2205,i,[ phy_dev_paprd_device.c : 9183 ] DPDTRAIN_RX_DYN_PHASE_SEL : %d 
+2206,i,[ phy_dev_paprd_device.c : 9184 ] DPDTRAIN_BINNING_DOWNSAMPLE_EN : %d 
+2207,i,[ phy_dev_paprd_device.c : 9186 ] DAC_BW : %d 
+2208,i,[ phy_dev_paprd_device.c : 9187 ] ADC_BW : %d 
+2209,ii,[ phy_dev_paprd_device.c : 9200 ] -Q5-PAPRD-: RxGain and maxBin Value is %d and %d  
+2210,i,[ phy_dev_paprd_device.c : 9215 ] Txount value is %d 
+ 
+2211,ii,[ phy_dev_paprd_device.c : 9430 ] PAPRD: ConfigTempScaling() fcsEnabled: %d, scaling factor %d 
+2212,I,[ phy_dev_paprd_device.c : 9479 ] paprd override dpdDacGain for calVersion %u ( old ) 
+2213,IIi,[ phy_dev_paprd_device.c : 9491 ] eDpd dpdPktDacGain[%u][%u] = %d 
+2214,iiiiiii,[ phy_dev_paprd_device.c : 9502 ] PAPRD: paprdType %d, curTemp %d, DacGnTmpThrhld %d, tempBackoffdB8 %d, regulatoryBackoffdB8 %d, warmUpPkt %d, dpdDacGaindB8 %d 
+2215,IIIIII,[ phy_dev_paprd_device.c : 9556 ] phy_paprd_device_set_loopback_chain_fem_to_high_isolation phyId %u, bandCode %u, isSbs %u, force_or_revert %u, txChain %u, force_chain_mask 0x%x 
+2216,,[ phy_dev_paprd_device.c : 9599 ] i--Q5--PAPRDPHYDBG-IQ delay 1ms 
+2217,IIIII,[ phy_dev_paprd_device.c : 9607 ] eDpd_Iq_Sample_tx_i_tx_q_rx_i_rx_q[%5u]%5d %5d %5d %5d 
+2218,IIIII,[ phy_dev_paprd_device.c : 9632 ] lDpd_Iq_Sample_tx_i_tx_q_rx_i_rx_q[%5u]%5d %5d %5d %5d 
+2219,I,[ phy_dev_paprd_device.c : 9650 ] finalAddr 0x%08x 
+2220,II,[ phy_dev_paprd_device.c : 9651 ] Regdump : Addr 0x%08x, Value 0x%08x, name WFAX_PHYRF_TXCORR_OVRD_CTRL_L 
+2221,II,[ phy_dev_paprd_device.c : 9652 ] Regdump : Addr 0x%08x, Value 0x%08x, name WFAX_PHYRF_PAPRD_RATE_MASK_L 
+2222,II,[ phy_dev_paprd_device.c : 9653 ] Regdump : Addr 0x%08x, Value 0x%08x, name WFAX_PHYRF_PAPRD_DELAY_DDR_RATE_MASK_L 
+2223,III,[ phy_dev_paprd_device.c : 9657 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_CTRL_L_B0 
+2224,III,[ phy_dev_paprd_device.c : 9658 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_CTRL_U_B0 
+2225,III,[ phy_dev_paprd_device.c : 9659 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_CTRL_OVRD_L_B0 
+2226,III,[ phy_dev_paprd_device.c : 9660 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_CTRL_OVRD_U_B0 
+2227,III,[ phy_dev_paprd_device.c : 9661 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_0_L_B0 
+2228,III,[ phy_dev_paprd_device.c : 9662 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_0_U_B0 
+2229,III,[ phy_dev_paprd_device.c : 9663 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_1_L_B0 
+2230,III,[ phy_dev_paprd_device.c : 9664 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_1_U_B0 
+2231,III,[ phy_dev_paprd_device.c : 9665 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_2_L_B0 
+2232,III,[ phy_dev_paprd_device.c : 9666 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_2_U_B0 
+2233,III,[ phy_dev_paprd_device.c : 9667 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_3_L_B0 
+2234,III,[ phy_dev_paprd_device.c : 9668 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_4_L_B0 
+2235,III,[ phy_dev_paprd_device.c : 9669 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_4_U_B0 
+2236,III,[ phy_dev_paprd_device.c : 9670 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_5_L_B0 
+2237,III,[ phy_dev_paprd_device.c : 9671 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_5_U_B0 
+2238,III,[ phy_dev_paprd_device.c : 9672 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_6_L_B0 
+2239,III,[ phy_dev_paprd_device.c : 9673 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_6_U_B0 
+2240,III,[ phy_dev_paprd_device.c : 9674 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_7_L_B0 
+2241,III,[ phy_dev_paprd_device.c : 9675 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_7_U_B0 
+2242,III,[ phy_dev_paprd_device.c : 9676 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_8_L_B0 
+2243,III,[ phy_dev_paprd_device.c : 9677 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_8_U_B0 
+2244,III,[ phy_dev_paprd_device.c : 9678 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_9_L_B0 
+2245,III,[ phy_dev_paprd_device.c : 9679 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_9_U_B0 
+2246,III,[ phy_dev_paprd_device.c : 9680 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_10_L_B0 
+2247,III,[ phy_dev_paprd_device.c : 9681 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_10_U_B0 
+2248,III,[ phy_dev_paprd_device.c : 9682 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_11_L_B0 
+2249,III,[ phy_dev_paprd_device.c : 9683 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_11_U_B0 
+2250,III,[ phy_dev_paprd_device.c : 9684 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_12_L_B0 
+2251,III,[ phy_dev_paprd_device.c : 9685 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_12_U_B0 
+2252,III,[ phy_dev_paprd_device.c : 9686 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_13_L_B0 
+2253,III,[ phy_dev_paprd_device.c : 9687 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_13_U_B0 
+2254,III,[ phy_dev_paprd_device.c : 9688 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_14_L_B0 
+2255,III,[ phy_dev_paprd_device.c : 9689 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_14_U_B0 
+2256,III,[ phy_dev_paprd_device.c : 9690 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_15_L_B0 
+2257,III,[ phy_dev_paprd_device.c : 9691 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_15_U_B0 
+2258,III,[ phy_dev_paprd_device.c : 9692 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_16_L_B0 
+2259,III,[ phy_dev_paprd_device.c : 9693 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_16_U_B0 
+2260,III,[ phy_dev_paprd_device.c : 9694 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_17_L_B0 
+2261,III,[ phy_dev_paprd_device.c : 9695 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_17_U_B0 
+2262,III,[ phy_dev_paprd_device.c : 9696 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_18_L_B0 
+2263,III,[ phy_dev_paprd_device.c : 9697 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_19_L_B0 
+2264,III,[ phy_dev_paprd_device.c : 9698 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_19_U_B0 
+2265,III,[ phy_dev_paprd_device.c : 9699 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_20_L_B0 
+2266,III,[ phy_dev_paprd_device.c : 9700 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_20_U_B0 
+2267,III,[ phy_dev_paprd_device.c : 9701 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_21_L_B0 
+2268,III,[ phy_dev_paprd_device.c : 9702 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_21_U_B0 
+2269,III,[ phy_dev_paprd_device.c : 9703 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_22_L_B0 
+2270,III,[ phy_dev_paprd_device.c : 9704 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_22_U_B0 
+2271,III,[ phy_dev_paprd_device.c : 9705 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_23_L_B0 
+2272,III,[ phy_dev_paprd_device.c : 9706 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_23_U_B0 
+2273,III,[ phy_dev_paprd_device.c : 9707 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_24_L_B0 
+2274,III,[ phy_dev_paprd_device.c : 9708 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_25_L_B0 
+2275,III,[ phy_dev_paprd_device.c : 9709 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_25_U_B0 
+2276,III,[ phy_dev_paprd_device.c : 9710 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_26_L_B0 
+2277,III,[ phy_dev_paprd_device.c : 9711 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_26_U_B0 
+2278,III,[ phy_dev_paprd_device.c : 9712 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_27_L_B0 
+2279,III,[ phy_dev_paprd_device.c : 9713 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_27_U_B0 
+2280,III,[ phy_dev_paprd_device.c : 9714 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_28_L_B0 
+2281,III,[ phy_dev_paprd_device.c : 9715 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_28_U_B0 
+2282,III,[ phy_dev_paprd_device.c : 9716 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_29_L_B0 
+2283,III,[ phy_dev_paprd_device.c : 9717 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_29_U_B0 
+2284,III,[ phy_dev_paprd_device.c : 9718 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_30_L_B0 
+2285,III,[ phy_dev_paprd_device.c : 9719 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_31_L_B0 
+2286,III,[ phy_dev_paprd_device.c : 9720 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_31_U_B0 
+2287,III,[ phy_dev_paprd_device.c : 9721 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_32_L_B0 
+2288,III,[ phy_dev_paprd_device.c : 9722 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CTRL_32_U_B0 
+2289,III,[ phy_dev_paprd_device.c : 9723 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_TABLE_TYPE_L_B0 
+2290,III,[ phy_dev_paprd_device.c : 9724 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_TABLE_TYPE_EXT_L_B0 
+2291,III,[ phy_dev_paprd_device.c : 9725 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CASCADE_MODE_EN_L_B0 
+2292,III,[ phy_dev_paprd_device.c : 9726 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_CASCADE_MODE_EN_EXT_L_B0 
+2293,III,[ phy_dev_paprd_device.c : 9727 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_KERNEL_MAP_MASK_L_B0 
+2294,III,[ phy_dev_paprd_device.c : 9728 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_EDPD_KERNEL_MAP_MASK_EXT_L_B0 
+2295,III,[ phy_dev_paprd_device.c : 9729 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_VALID_GAIN_L_B0 
+2296,III,[ phy_dev_paprd_device.c : 9730 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_VALID_GAIN_U_B0 
+2297,III,[ phy_dev_paprd_device.c : 9731 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_VALID_GAIN_EXT_L_B0 
+2298,III,[ phy_dev_paprd_device.c : 9732 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_VALID_GAIN_EXT_U_B0 
+2299,III,[ phy_dev_paprd_device.c : 9733 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_0_L_B0 
+2300,III,[ phy_dev_paprd_device.c : 9734 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_0_U_B0 
+2301,III,[ phy_dev_paprd_device.c : 9735 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_1_L_B0 
+2302,III,[ phy_dev_paprd_device.c : 9736 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_1_U_B0 
+2303,III,[ phy_dev_paprd_device.c : 9737 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_2_L_B0 
+2304,III,[ phy_dev_paprd_device.c : 9738 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_2_U_B0 
+2305,III,[ phy_dev_paprd_device.c : 9739 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_3_L_B0 
+2306,III,[ phy_dev_paprd_device.c : 9740 ] Regdump : Addr 0x%08x, Chain %u, Value 0x%08x, name WFAX_PHYRF_PAPRD_SM_SIG_GAIN_TBL_3_U_B0 
+2307,iiii,[ phy_dev_paprd_device.c : 9758 ] phy_paprd_device_SetPaprdGainIdx : chainIdx - %d, gain_idx - %d, dac_gain - %d, glutIdx - %d 
+2308,I,[ phy_dev_paprd_device.c : 9780 ] phyPaprdDeviceCal calCmdId : %u 
+2309,,[ phy_dev_paprd_device.c : 9784 ]  Device Hw Enable 
+2310,,[ phy_dev_paprd_device.c : 9788 ]  Device Hw Disable 
+2311,,[ phy_dev_paprd_device.c : 9795 ]  Device Stop Training 
+2312,,[ phy_dev_paprd_device.c : 9799 ]  Device Init Static Settings 
+2313,,[ phy_dev_paprd_device.c : 9803 ]  Device  Reset Training 
+2314,,[ phy_dev_paprd_device.c : 9807 ]  Device Training Status 
+2315,,[ phy_dev_paprd_device.c : 9811 ]  Device Restore Settings 
+2316,,[ phy_dev_paprd_device.c : 9815 ]  Device Populate tables V2 
+2317,,[ phy_dev_paprd_device.c : 9819 ]  Device read Glut 
+2318,,[ phy_dev_paprd_device.c : 9824 ]  Device Set Tx Gain index 
+2319,,[ phy_dev_paprd_device.c : 9828 ]  Device Get Complete 
+2320,,[ phy_dev_paprd_device.c : 9832 ]  Device Config Temp Scaling 
+2321,,[ phy_dev_paprd_device.c : 9836 ]  Core Paprd Loopback Training Complete 
+2322,,[ phy_dev_paprd_device.c : 9840 ]  Core Enable DPD  
+2323,,[ phy_dev_paprd_device.c : 9844 ]  Core Find temp Scaling 
+2324,,[ phy_dev_paprd_device.c : 9848 ]  phyrf post processing 
+2325,,[ phy_dev_paprd_device.c : 9852 ]  Device Set Dac Gain  
+2326,,[ phy_dev_paprd_device.c : 9856 ]  Device Init Training Registers 
+2327,,[ phy_dev_paprd_device.c : 9860 ]  Device Setup AGC 
+2328,,[ phy_dev_paprd_device.c : 9864 ]  Device Setup VREG 
+2329,,[ phy_dev_paprd_device.c : 9868 ]  Device RFA Programming 
+2330,,[ phy_dev_paprd_device.c : 9872 ]  Device Save Pre cal setting 
+2331,,[ phy_dev_paprd_device.c : 9876 ]  Device exit cal 
+2332,,[ phy_dev_paprd_device.c : 9880 ]  Device Dump Registers 
+2333,,[ phy_dev_paprd_device.c : 9884 ]  Device Dump Iq samples 
+2334,,[ phy_dev_paprd_device.c : 9893 ]  Device Dump Binning Info 
+2335,,[ phy_dev_PkDetCal.c : 45 ] PeakDet: Semaphore request failed!! Disabling PkDet cal!! 
+2336,II,[ phy_dev_PkDetCal.c : 68 ] PeakDet: remainingChains: %x, counter: %x 
+2337,II,[ phy_dev_PkDetCal.c : 78 ] PeakDet: check while, remainingChains=%x, counter:%x 
+2338,II,[ phy_dev_PkDetCal.c : 124 ] PeakDet: remainingChains=%x, counter:%x 
+2339,III,[ phy_dev_PkDetCal.c : 140 ] PeakDet: dcoc_valid = 0x%08x, dcoc_sat = 0x%08x, calStatus = 0x%08x 
+2340,Iii,[ phy_dev_PkDetCal.c : 145 ] PeakDet: remainingChains = %x DCOC_RES_Chain%d= %d  
+2341,iii,[ phy_dev_PkDetCal.c : 169 ] PKDET_DCOC_RES for chain %d  is = 'd%d thresVal = 'd%d  
+2342,II,[ phy_dev_PkDetCal.c : 201 ] PeakDet: RXTD_CHN_AGC_INIT_GAIN_L = 0x%08x, RXTD_GTC_CONFIG_1_L = 0x%08x 
+2343,II,[ phy_dev_PkDetCal.c : 225 ] PeakDet: RXTD_CHN_AGC_INIT_GAIN_L = 0x%08x, RXTD_GTC_CONFIG_1_L = 0x%08x 
+2344,,[ phy_dev_PkDetCal.c : 312 ] PeakDet: pkdet_save 
+2345,,[ phy_dev_PkDetCal.c : 326 ] PeakDet: pkdet_restore 
+2346,,[ phy_dev_PkDetCal.c : 340 ] PeakDet: Enter Peak Detector CAL 
+2347,,[ phy_dev_PkDetCal.c : 351 ] PeakDet: Entering phyPkDetCal_ipq5424 
+2348,,[ phy_dev_PkDetCal.c : 357 ] PeakDet: Calling pkdet_docal 
+2349,,[ phy_dev_PkDetCal.c : 267 ] PeakDet: Calling save restore routine for PeakDet 
+2350,,[ phy_dev_PkDetCal.c : 285 ] PeakDet: Restoring Results for PeakDet 
+2351,IIii,[ phy_dev_PkDetCal.c : 289 ] PeakDet: regCalResult = 0x%x regParameters = 0x%x chain = %d is_sbs=%d 
+2352,,[ phy_dev_PkDetCal.c : 296 ] PeakDet: Saving Results for PeakDet 
+2353,IIii,[ phy_dev_PkDetCal.c : 303 ] PeakDet: regCalResult = 0x%x regParameters = 0x%x chain = %d is_sbs=%d 
+2354,,[ phy_dev_RxDCOCal.c : 59 ] RXDCO: Reading calInfo mem 
+2355,,[ phy_dev_RxDCOCal.c : 140 ] RXDCO Cal: Validating HW results 
+2356,iii,[ phy_dev_RxDCOCal.c : 168 ] Chain - %d, Cal_gain - %d, Success - %d 
+2357,iiiiiiii,[ phy_dev_RxDCOCal.c : 175 ] ODAC_Imag - %d, ODAC_Real - %d, Res_Imag - %d, Res_Real - %d, RangeOK - %d, ResidualOK - %d, odac_upth - %d, odac_lowth - %d 
+2358,i,[ phy_dev_RxDCOCal.c : 182 ] RXDCO: cal_success_indicator - %d 
+2359,,[ phy_dev_RxDCOCal.c : 189 ] RXDCO: rxdco_cal_regs_restore 
+2360,i,[ phy_dev_RxDCOCal.c : 289 ] RXDCO: Setting up loopback for chain %d 
+2361,i,[ phy_dev_RxDCOCal.c : 355 ] RXDCO: Setting up baseband registers for chain %d 
+2362,,[ phy_dev_RxDCOCal.c : 513 ] RXDCO: Writing RxDCO LUTs 
+2363,ii,[ phy_dev_RxDCOCal.c : 550 ] RxDCO: Cal failed on phy%d chain%d! Writing zeros to DCO LUT... 
+2364,iiiii,[ phy_dev_RxDCOCal.c : 552 ] RXDCO: Programming the LUTS : phyIdx[%d] chainIdx[%d] range=(%d), (I,Q)=(%d, %d) 
+2365,,[ phy_dev_RxDCOCal.c : 578 ] RXDCO: Trigger Cal 
+2366,,[ phy_dev_RxDCOCal.c : 595 ] RXDCO: Check if cal is done 
+2367,Ii,[ phy_dev_RxDCOCal.c : 627 ] RXDCO: A_DELAY_USECS cal_done time out calDoneCount=%u, calStatus - %d 
+2368,ii,[ phy_dev_RxDCOCal.c : 631 ] RXDCO: A_DELAY_USECS cal_done early calDoneCount=%d, calStatus - %d 
+2369,,[ phy_dev_RxDCOCal.c : 636 ] RXDCO: cal_done failure and reset DO_CALIBRATE bit and CF_RESET_CORE !!!!! 
+2370,I,[ phy_dev_RxDCOCal.c : 642 ] WFAX_PHYRF_CAL_SEQ_CTRL_16_L.DO_CALIBRATE= %lu 
+2371,,[ phy_dev_RxDCOCal.c : 651 ] RXDCO: RxDCO setup 
+2372,,[ phy_dev_RxDCOCal.c : 680 ] RXDCO : Run RxDCO HW cal 
+2373,i,[ phy_dev_RxDCOCal.c : 746 ] RXDCO: cal done successful, range_iter=%d 
+2374,ii,[ phy_dev_RxDCOCal.c : 753 ] RxDCO : Range Iteration - %d Status - Cal Success - %d 
+2375,i,[ phy_dev_RxDCOCal.c : 759 ] RxDCO : Range Iteration - %d Status - CAL Completed but not Converged 
+2376,i,[ phy_dev_RxDCOCal.c : 765 ] RXDCO: Range Iteration - %d Status -  HW cal timeout 
+2377,,[ phy_dev_RxDCOCal.c : 780 ] RXDCO: Failed in all tries 
+2378,,[ phy_dev_RxDCOCal.c : 837 ] RXDCO: Entering rxdco_docal 
+2379,,[ phy_dev_RxDCOCal.c : 849 ] RXDCO: rxdco_docal, Starting RxDCO calibration 
+2380,ii,[ phy_dev_RxDCOCal.c : 850 ] RXDCO: rxdco_docal, phyInput->txChMask: %d, phyInput->rxChMask: %d 
+2381,,[ phy_dev_RxDCOCal.c : 870 ] RXDCO: rxdco_docal, RxDCO HW CAL TIME 
+2382,,[ phy_dev_RxDCOCal.c : 875 ] RXDCO: rxdco_docal, RxDCO LUT Processing and Programming Time 
+2383,,[ phy_dev_RxDCOCal.c : 882 ] RXDCO: rxdco_docal, RxDCO calibration done 
+2384,,[ phy_dev_RxDCOCal.c : 889 ] RXDCO: rxdco save 
+2385,,[ phy_dev_RxDCOCal.c : 903 ] RXDCO: rxdco_restore 
+2386,,[ phy_dev_RxDCOCal.c : 916 ] RXDCO: phyRxDCOCal_ipq5424 
+2387,,[ phy_dev_RxDCOCal.c : 326 ] RXDCO: Setting up interference detection logic 
+2388,i,[ phy_dev_RxDCOCal.c : 487 ] RXDCO: Loading cal gains for chain %d 
+2389,i,[ phy_dev_RxDCOCal.c : 424 ] RXDCO: Writing RxDCO Gain LUTs for chain %d 
+2390,i,[ phy_dev_RxDCOCal.c : 446 ] default_gaintbl_max = %d 
+2391,II,[ phy_dev_RxDCOCal.c : 467 ] RxDCO Gain LUT Write Address - 0x%x, Data - 0x%x
+ 
+2392,,[ phy_dev_RxDCOCal.c : 395 ] RXDCO: Loading CAL indexes 
+2393,,[ phy_dev_RxDCOCal.c : 407 ] CAL index out of range 
+2394,II,[ phy_dev_RxDCOCal.c : 418 ] RXDCO: CAL Saved Gains Write Address - 0x%x, Value - 0x%x
+ 
+2395,i,[ phy_dev_RxDCOCal.c : 304 ] RXDCO: Setting up RF registers for chain %d 
+2396,,[ phy_dev_RxDCOCal.c : 266 ] RXDCO: Set DCOC Range 
+2397,Ii,[ phy_dev_RxDCOCal.c : 281 ] Setting RXDCCAL_ODAC_RANGE_INIT to 0x%08x for chain %d 
+2398,,[ phy_dev_RxDCOCal.c : 209 ] RXDCO: Calling save restore routine for RxDCO 
+2399,,[ phy_dev_RxDCOCal.c : 228 ] RXDCO: Restoring LUTs for RxDCO 
+2400,iiii,[ phy_dev_RxDCOCal.c : 244 ] RXDCO: Restored Values for chain %d - dcoc_range %d, forced_val_I %d, forced_val_Q %d 
+2401,,[ phy_dev_RxDCOCal.c : 248 ] RXDCO: Saving LUTs for RxDCO 
+2402,iiii,[ phy_dev_RxDCOCal.c : 257 ] RXDCO: Saved Values for chain %d - dcoc_range %d, forced_val_I %d, forced_val_Q %d 
+2403,III,[ phy_dev_TPCcal.c : 22 ] phySetTPC API : phyID - 0x%x BandCode - 0x%x BwCode - 0x%x 
+2404,IIII,[ phy_dev_TPCcal.c : 23 ] phySetTPC API : CLPCMode - 0x%x readTPCStatus - 0x%x Force Mode - 0x%x Forced gain - 0x%x 
+2405,,[ phy_dev_TPCcal.c : 56 ] Incorrect Test Selection ... 
+2406,III,[ phy_dev_TPCcal.c : 67 ] setupTPC : Initializing the TPC registers for phyID - 0x%x, bandCode - 0x%x, bwCode - 0x%x 
+2407,,[ phy_dev_TPCcal.c : 106 ] setupTPC : Completed the Setup TPC settings... 
+2408,,[ phy_dev_TPCcal.c : 111 ] Resetting the TPC 
+2409,,[ phy_dev_TPCcal.c : 118 ] Programming the CCK OFDM Gain Difference 
+2410,,[ phy_dev_TPCcal.c : 127 ] Programming the Extended Range Power Offset 
+2411,,[ phy_dev_TPCcal.c : 139 ] Disabling all the Force Mode Registers 
+2412,,[ phy_dev_TPCcal.c : 151 ] Setting the DAC Gain Settings 
+2413,,[ phy_dev_TPCcal.c : 159 ] Programming the DAC BO Registers 
+2414,IIIIIII,[ phy_dev_TPCcal.c : 186 ] TPC_PHYDEVLIB maxQAM[0..6] %u %u %u %u %u %u %u 
+2415,IIIIIII,[ phy_dev_TPCcal.c : 191 ] TPC_PHYDEVLIB minQAM[0..6] %u %u %u %u %u %u %u 
+2416,IIIIIII,[ phy_dev_TPCcal.c : 196 ] TPC_PHYDEVLIB maxQAM MU[0..6] %u %u %u %u %u %u %u 
+2417,IIIIIII,[ phy_dev_TPCcal.c : 201 ] TPC_PHYDEVLIB minQAM MU[0..6] %u %u %u %u %u %u %u 
+2418,,[ phy_dev_TPCcal.c : 235 ] Enabling the TPC - CLPC or OLPC Mode 
+2419,II,[ phy_dev_TPCcal.c : 249 ] EnableTPCMode input->tgtPwrClpcThrDb4 %x with shift %x 
+2420,I,[ phy_dev_TPCcal.c : 250 ] EnableTPCMode Programmed OLPC Mode - 0x%x 
+2421,,[ phy_dev_TPCcal.c : 276 ] Clearing the GLUT 
+2422,,[ phy_dev_TPCcal.c : 288 ] Programming the GLUT 
+2423,I,[ phy_dev_TPCcal.c : 334 ] TPC Glut attempting WAR for calVersion %u ( old ) 
+2424,iii,[ phy_dev_TPCcal.c : 350 ] Override glut 1 txGainIndex to %d, measPwr %d dB8 ( delta from Orig %d dB8 ) 
+2425,Iiii,[ phy_dev_TPCcal.c : 373 ] Override glut %u txGainIndex to %d, measPwr %d dB8 ( delta from Orig +%d dB8 ) 
+2426,Iiii,[ phy_dev_TPCcal.c : 387 ] Override glut %u txGainIndex to %d, measPwr %d dB8 ( delta from Orig -%d dB8 ) 
+2427,Ii,[ phy_dev_TPCcal.c : 417 ] Calling PRogramming by Range phyBase - 0x%x, last_idx - %d 
+2428,,[ phy_dev_TPCcal.c : 461 ] Programming the PLUT 
+2429,,[ phy_dev_TPCcal.c : 531 ] Clearing the ALUT 
+2430,,[ phy_dev_TPCcal.c : 542 ] Programming the ALUT 
+2431,,[ phy_dev_TPCcal.c : 596 ] Programming the GLUT start and End index by pktType 
+2432,i,[ phy_dev_TPCcal.c : 600 ] pktMCSType = %d 
+ 
+2433,,[ phy_dev_TPCcal.c : 664 ] Programming the GLUT start and End index by Range 
+2434,i,[ phy_dev_TPCcal.c : 667 ] In ProgramGLUTIndicesByRange: powerRange = %d
+ 
+2435,Iii,[ phy_dev_TPCcal.c : 668 ] Inputs - phyBase - 0x%x, start_idx - %d, Last idx - %d 
+2436,,[ phy_dev_TPCcal.c : 673 ] Programming GLUT Indices Range 0
+ 
+2437,,[ phy_dev_TPCcal.c : 691 ] Programming GLUT Indices Range 1
+ 
+2438,,[ phy_dev_TPCcal.c : 704 ] Programming GLUT Indices Range 2
+ 
+2439,,[ phy_dev_TPCcal.c : 717 ] Programming GLUT Indices Range 3
+ 
+2440,,[ phy_dev_TPCcal.c : 735 ] Programming the GLUT start and End index by Range 
+2441,i,[ phy_dev_TPCcal.c : 738 ] In ProgramGLUTIndicesByRange: powerRange = %d
+ 
+2442,Iii,[ phy_dev_TPCcal.c : 739 ] Inputs - phyBase - 0x%x, start_idx - %d, Last idx - %d 
+2443,,[ phy_dev_TPCcal.c : 751 ] Programming GLUT Indices Range 0
+ 
+2444,,[ phy_dev_TPCcal.c : 765 ] Programming GLUT Indices Range 1
+ 
+2445,,[ phy_dev_TPCcal.c : 778 ] Programming GLUT Indices Range 2
+ 
+2446,,[ phy_dev_TPCcal.c : 791 ] Programming GLUT Indices Range 3
+ 
+2447,,[ phy_dev_TPCcal.c : 823 ] Programming the GLUT Mode Registers 
+2448,I,[ phy_dev_TPCcal.c : 837 ] TPC_PHYDEVLIB: TPC_GLUT_TARGET_PWR_LEVEL %x 
+2449,I,[ phy_dev_TPCcal.c : 844 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_4_L %x 
+2450,I,[ phy_dev_TPCcal.c : 851 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_5_L %x 
+2451,I,[ phy_dev_TPCcal.c : 858 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_2_L %x 
+2452,I,[ phy_dev_TPCcal.c : 865 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_3_L %x 
+2453,I,[ phy_dev_TPCcal.c : 872 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_0_L %x 
+2454,I,[ phy_dev_TPCcal.c : 879 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_1_L %x 
+2455,I,[ phy_dev_TPCcal.c : 886 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_6_L %x 
+2456,I,[ phy_dev_TPCcal.c : 893 ] TPC_PHYDEVLIB: TPC_GLUT_IDX_7_L %x 
+2457,ii,[ phy_dev_TPCcal.c : 911 ] ForceGLUTIdx = %d, Forced GLUT Idx = %d 
+2458,ii,[ phy_dev_TPCcal.c : 914 ] phyForcedGainMode forceTargetPower = %d, forcedTargetPower = %d 
+2459,ii,[ phy_dev_TPCcal.c : 915 ] phyForcedGainMode forceGLUTIdx = %d, forcedGLUTIdx = %d 
+2460,ii,[ phy_dev_TPCcal.c : 916 ] phyForcedGainMode forceTxGainIdx = %d, forcedTxGainIdx = %d 
+2461,ii,[ phy_dev_TPCcal.c : 917 ] phyForcedGainMode forceDacGain = %d, forcedDacGain = %d 
+2462,iii,[ phy_dev_TPCcal.c : 1061 ] Gain Mode = %d TPC PDET CAL for RFA Chain - %d successful and completed within loop count - %d 
+2463,iii,[ phy_dev_TPCcal.c : 1066 ] Gain Mode = %d TPC PDET CAL for RFA Chain - %d Failed after loop count - %d 
+2464,iii,[ phy_dev_TPCcal.c : 1076 ] Gain Mode = %d TPC PDET CAL for RFA Chain - %d Failed after loop count - %d 
+2465,iii,[ phy_dev_TPCcal.c : 1181 ] ATTN Settings : PDET GAIN IDX - %d, Attn CTRL OV - %d, ATTN CTRL OVD - %d 
+2466,IIi,[ phy_dev_TPCcal.c : 1254 ] roTpcResult 0x%x , pwr_valid 0x%x , retryIdx %d 
+2467,iII,[ phy_dev_TPCcal.c : 1260 ] Chain Number - %d, roPreamblePwr - 0x%x, DC_VALUE - 0x%x 
+2468,iII,[ phy_dev_TPCcal.c : 1292 ] -Q5-TPC:- tpcOnepointCal::bandCode %d Chain %u latestAccumulatedClpcError %u 
+2469,iII,[ phy_dev_TPCcal.c : 1323 ] tpcOnepointCal::phyId %d Chain %u thermalVal %u 
+2470,iiiiiiii,[ phy_dev_TPCcal.c : 1560 ] phyId %d chain %d: got clpcErrordB32 %d, dacGainCaldB8 %d, maxDacBoQAM5dB8 %d, maxDacBoQAM0dB8 %d, minDacBoQAM5dB8 %d, minDacBoQAM0dB8 %d 
+2471,iiiiii,[ phy_dev_TPCcal.c : 1570 ] ch %d, pwrdB8 %d, txGainIdx %d, minTxPwrdB4 %d, txPowerdB4 %d, maxTxPowerdB4 %d 
+2472,,[ phy_dev_TPCcal.c : 1628 ] phyOLPCTempUpdate_ipq5424 
+2473,iiiiiii,[ phy_dev_TPCcal.c : 1751 ] thermbased : txChain %d tcGlut %d type %d alpha %d curTemp %d calTemp %d powerdelta %d 
+2474,iiiii,[ phy_dev_TPCcal.c : 1759 ] clpcErrbased : txChain %d tcGlut %d type %d clpcErr %d powerdelta %d 
+2475,iiiii,[ phy_dev_TPCcal.c : 1763 ] failed : txChain %d tcGlut %d type %d clpcErr %d powerdelta %d 
+2476,,[ phy_dev_TPCcal.c : 1792 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: packet counter is the same. No packet send out. 
+2477,iiii,[ phy_dev_TPCcal.c : 1799 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: cmd_count_txgain_b0: %d, reg_count_tpcrb_b0: %d, cmd_count_txgain_b1: %d, reg_count_tpcrb_b1: %d 
+2478,iiii,[ phy_dev_TPCcal.c : 1812 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: dpd_txgain_idx_cal: %d, dpd_dac_gain_cal: %d, glut_max_dac_gain_cal: %d, glut_dac_gain_cal: %d 
+2479,iiiiii,[ phy_dev_TPCcal.c : 1831 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 0 latest_tx_iq_idx: %d latest_glut_idx: %d latest_txgain_idx: %d latest_dac_gain: %d latest_target_pwr: %d phyTpcTempPowerDelta: %d 
+2480,iiiiii,[ phy_dev_TPCcal.c : 1848 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 1 latest_tx_iq_idx: %d latest_glut_idx: %d latest_txgain_idx: %d latest_dac_gain: %d latest_target_pwr: %d phyTpcTempPowerDelta: %d 
+2481,iiiiii,[ phy_dev_TPCcal.c : 1865 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 2 latest_tx_iq_idx: %d latest_glut_idx: %d latest_txgain_idx: %d latest_dac_gain: %d latest_target_pwr: %d phyTpcTempPowerDelta: %d 
+2482,iiiiii,[ phy_dev_TPCcal.c : 1882 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 3 latest_tx_iq_idx: %d latest_glut_idx: %d latest_txgain_idx: %d latest_dac_gain: %d latest_target_pwr: %d phyTpcTempPowerDelta: %d 
+2483,iii,[ phy_dev_TPCcal.c : 1893 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 0 latest_accumulated_clpc_err: %d latest_clpc_err: %d latest_meas_pwr_out: %d 
+2484,iii,[ phy_dev_TPCcal.c : 1903 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 1 latest_accumulated_clpc_err: %d latest_clpc_err: %d latest_meas_pwr_out: %d 
+2485,iii,[ phy_dev_TPCcal.c : 1913 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 2 latest_accumulated_clpc_err: %d latest_clpc_err: %d latest_meas_pwr_out: %d 
+2486,iii,[ phy_dev_TPCcal.c : 1923 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: chain: 3 latest_accumulated_clpc_err: %d latest_clpc_err: %d latest_meas_pwr_out: %d 
+2487,Iii,[ phy_dev_TPCcal.c : 1933 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: TPC_GEN_CTRL_L: 0x%x olpc_mode: %d, target_pwr_clpc_thr_corr: %d 
+2488,iiii,[ phy_dev_TPCcal.c : 1946 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: tpc_alut_base: %d, clpc_pkt_dur_thr: %d, mask_out_clpc_err_update: %d, clpc_err_update_dis: %d 
+2489,iiiii,[ phy_dev_TPCcal.c : 1960 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: : chain: 0 latest_wsi_vht160_mode: %d latest_wsi_tx_gain_idx: %d latest_wsi_clpc_pkt_type: %d latest_wsi_tpc_pdet_gain_idx: %d latest_wsi_tpc_atten: %d 
+2490,iiiii,[ phy_dev_TPCcal.c : 1974 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: : chain: 1 latest_wsi_vht160_mode: %d latest_wsi_tx_gain_idx: %d latest_wsi_clpc_pkt_type: %d latest_wsi_tpc_pdet_gain_idx: %d latest_wsi_tpc_atten: %d 
+2491,iiiii,[ phy_dev_TPCcal.c : 1988 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: : chain: 2 latest_wsi_vht160_mode: %d latest_wsi_tx_gain_idx: %d latest_wsi_clpc_pkt_type: %d latest_wsi_tpc_pdet_gain_idx: %d latest_wsi_tpc_atten: %d 
+2492,iiiii,[ phy_dev_TPCcal.c : 2002 ] phyTPCDumpRegisters: TPC_DUMP_COMMON: : chain: 3 latest_wsi_vht160_mode: %d latest_wsi_tx_gain_idx: %d latest_wsi_clpc_pkt_type: %d latest_wsi_tpc_pdet_gain_idx: %d latest_wsi_tpc_atten: %d 
+2493,iiiiii,[ phy_dev_TPCcal.c : 2013 ] phyTPCDumpRegisters: chain 0, latest_wsi_temp_valid %d, latest_wsi_fullpkt_pwr_valid %d, latest_wsi_preamble_pwr_valid %d, latest_wsi_temp %d, latest_wsi_fullpkt_pwr %d, latest_wsi_preamble_pwr %d 
+2494,iiiiii,[ phy_dev_TPCcal.c : 2022 ] phyTPCDumpRegisters: chain 1, latest_wsi_temp_valid %d, latest_wsi_fullpkt_pwr_valid %d, latest_wsi_preamble_pwr_valid %d, latest_wsi_temp %d, latest_wsi_fullpkt_pwr %d, latest_wsi_preamble_pwr %d 
+2495,iiiiii,[ phy_dev_TPCcal.c : 2031 ] phyTPCDumpRegisters: chain 2, latest_wsi_temp_valid %d, latest_wsi_fullpkt_pwr_valid %d, latest_wsi_preamble_pwr_valid %d, latest_wsi_temp %d, latest_wsi_fullpkt_pwr %d, latest_wsi_preamble_pwr %d 
+2496,iiiiii,[ phy_dev_TPCcal.c : 2040 ] phyTPCDumpRegisters: chain 3, latest_wsi_temp_valid %d, latest_wsi_fullpkt_pwr_valid %d, latest_wsi_preamble_pwr_valid %d, latest_wsi_temp %d, latest_wsi_fullpkt_pwr %d, latest_wsi_preamble_pwr %d 
+2497,IIIIIIII,[ phy_dev_TPCcal.c : 2101 ] DumpTpcLuts: TPC_DUMP_GLUT: tpcTblIdx %3u |  tpcChainIdx %3u | tpcGainIdx %3u | pwrMeas %3d | minDacGain %3d | txGainIdx %3d | clpcError %3d | tpcClPktCnt %3d 
+2498,IIIIIIIII,[ phy_dev_TPCcal.c : 2128 ] DumpTpcLuts: TPC_DUMP_PLUT: tpcTblIdx %3u |  tpcChainIdx %3u | tpcPlutIdx %3u | pdadc[%3u-%3u] HEX:%8x | pdadc[%3u-%3u] HEX:%8x | 
+2499,IIIIIIIII,[ phy_dev_TPCcal.c : 2156 ] DumpTpcLuts: TPC_DUMP_ALUT: tpcTblIdx %3u |  tpcChainIdx %3u | tpcAlutIdx %3u | Alut tgtPwr Step [%3u-%3u] HEX:%8x | Alut tgtPwr Step [%3u-%3u]  HEX:%8x 
+2500,,[ phy_dev_TxBBFCal.c : 22 ] TXBBF: phyTxBBFCal_docal 
+2501,II,[ phy_dev_TxBBFCal.c : 38 ] TXBBF: r_tune_code - 0x%0x rctune - 0x%x 
+2502,I,[ phy_dev_TxBBFCal.c : 41 ] TXBBF: y_adj - 0x%0x 
+2503,,[ phy_dev_TxBBFCal.c : 109 ] ******************************************************* 
+2504,,[ phy_dev_TxBBFCal.c : 110 ] *                  TXBBF CAL SUMMARY                  * 
+2505,ii,[ phy_dev_TxBBFCal.c : 111 ] *                    PHY%d CHAIN%d                    * 
+2506,,[ phy_dev_TxBBFCal.c : 112 ] ******************************************************* 
+2507,,[ phy_dev_TxBBFCal.c : 113 ] *    CTUNE   *     BEFORE CAL     *     AFTER CAL     * 
+2508,,[ phy_dev_TxBBFCal.c : 114 ] ******************************************************* 
+2509,ii,[ phy_dev_TxBBFCal.c : 115 ] * TIA_CTUNE_0*       %d         *       %d        * 
+2510,,[ phy_dev_TxBBFCal.c : 116 ] ******************************************************* 
+2511,ii,[ phy_dev_TxBBFCal.c : 117 ] * TIA_CTUNE_1*       %d         *       %d        * 
+2512,,[ phy_dev_TxBBFCal.c : 118 ] ******************************************************* 
+2513,ii,[ phy_dev_TxBBFCal.c : 119 ] * TIA_CTUNE_2*       %d         *       %d        * 
+2514,,[ phy_dev_TxBBFCal.c : 120 ] ******************************************************* 
+2515,ii,[ phy_dev_TxBBFCal.c : 121 ] * TIA_CTUNE_3*       %d         *       %d        * 
+2516,,[ phy_dev_TxBBFCal.c : 122 ] ******************************************************* 
+2517,ii,[ phy_dev_TxBBFCal.c : 123 ] * TIA_CTUNE_4*       %d         *       %d        * 
+2518,,[ phy_dev_TxBBFCal.c : 124 ] ******************************************************* 
+2519,ii,[ phy_dev_TxBBFCal.c : 125 ] * TIA_CTUNE_5*       %d         *       %d        * 
+2520,,[ phy_dev_TxBBFCal.c : 126 ] ******************************************************* 
+2521,ii,[ phy_dev_TxBBFCal.c : 127 ] * BQ_CTUNE_0 *       %d         *       %d        * 
+2522,,[ phy_dev_TxBBFCal.c : 128 ] ******************************************************* 
+2523,ii,[ phy_dev_TxBBFCal.c : 129 ] * BQ_CTUNE_1 *       %d         *       %d        * 
+2524,,[ phy_dev_TxBBFCal.c : 130 ] ******************************************************* 
+2525,ii,[ phy_dev_TxBBFCal.c : 131 ] * BQ_CTUNE_2 *       %d         *       %d        * 
+2526,,[ phy_dev_TxBBFCal.c : 132 ] ******************************************************* 
+2527,ii,[ phy_dev_TxBBFCal.c : 133 ] * BQ_CTUNE_3 *       %d         *       %d        * 
+2528,,[ phy_dev_TxBBFCal.c : 134 ] ******************************************************* 
+2529,ii,[ phy_dev_TxBBFCal.c : 135 ] * BQ_CTUNE_4 *       %d         *       %d        * 
+2530,,[ phy_dev_TxBBFCal.c : 136 ] ******************************************************* 
+2531,ii,[ phy_dev_TxBBFCal.c : 137 ] * BQ_CTUNE_5 *       %d         *       %d        * 
+2532,,[ phy_dev_TxBBFCal.c : 138 ] ******************************************************* 
+2533,,[ phy_dev_TxBBFCal.c : 154 ] Debug: Calling TxBBF doCal 
+2534,ii,[ phy_dev_RxBBFCal.c : 98 ] RxBBFCal rfaOtpParam addr_12_rctune %d, addr_24_r_tune_code %d 
+2535,I,[ phy_dev_WifiRadar.c : 61 ] wifiradar: DDR address after  A_DMA = 0x%x 
+2536,I,[ phy_dev_WifiRadar.c : 208 ] wifiradar: DDR address before  A_DMA = 0x%x 
+2537,I,[ phy_dev_WifiRadar.c : 223 ] wifiradar: per chain, starttime = %u 
+2538,iiI,[ phy_dev_WifiRadar.c : 224 ] wifiradar:  rx_gain_cal_get_variance, reading ddr memory for phyId %d, chainIdx %d, bufferAddress 0x%08x 
+2539,i,[ phy_dev_WifiRadar.c : 225 ] wifiradar:  rx_gain_cal_get_variance, blockSize %d 
+2540,IIIII,[ phy_dev_WifiRadar.c : 245 ] rx_gain_cal_get_variance, (idx,ddrMemWord32[0],ddrMemWord32[1],rxReal,rxImag) = (%4d, 0x%08x, 0x%08x, %u, %u) 
+2541,I,[ phy_dev_WifiRadar.c : 254 ] wifiradar: per chain, endtime = %u 
+2542,IIIII,[ phy_dev_WifiRadar.c : 255 ] wifiradar: rx_gain_cal_get_variance, rxSampDcReal = %u, rxSampDcImag = %u, rxSampDcPwr = %u, rxSampPwr = %u, variance = %u 
+2543,,[ phy_dev_WifiRadar.c : 277 ] wifiradar: wifiRadarInput is NULL 
+2544,I,[ phy_dev_WifiRadar.c : 289 ] wifiradar: , starttime = %u 
+2545,I,[ phy_dev_WifiRadar.c : 291 ] wifiradar: , endtime = %u 
+2546,II,[ phyFem.c : 109 ] phyFem FEM Control0 - 0x%08x for phyId 0x%x 
+2547,II,[ phyFem.c : 121 ] phyFem SetMipiMode 0x%x for phyId 0x%x 
+2548,I,[ phyFem.c : 142 ] phyFem Rffe Fem TxIni for phyId 0x%x 
+2549,IIIII,[ phyFem.c : 293 ] phyFem phyProgRf360Mipi_ipq5424 phyId 0x%x, family_number 0x%x, device_number 0x%x, major_version 0x%x, minor_version 0x%x 
+2550,II,[ rfaConfig.c : 154 ] readRfaChipId, Read RFA chip ID: rc %u, rfaDeviceNumber %u 
+2551,I,[ rfaConfig.c : 213 ] INVALID FREQUENCY1 %u 
+2552,,[ rfaConfig.c : 235 ] REFCLK Lock Configuration Successful 
+2553,,[ rfaConfig.c : 239 ] REFCLK Lock Configuration Failure - LOCK Failure !!!!!!! 
+2554,ii,[ rfaConfig.c : 398 ] set_synth_channel, freq=%dMHz chanIdx=%d 
+2555,,[ rfaConfig.c : 440 ] set channel Recipe Start 
+2556,,[ rfaConfig.c : 449 ] set channel Recipe Complete 
+2557,,[ rfaConfig.c : 550 ] phyLoadRfaIniCommon_ipq5424 
+2558,,[ rfaConfig.c : 611 ] phyLoadRfaIniModal_ipq5424 
+2559,,[ rfaConfig.c : 694 ] Calling Set Alt Tbl Idx 
+2560,i,[ rfaConfig.c : 705 ] phyProgRFA loadIniMask %d 
+2561,,[ rfaConfig.c : 730 ] phyProgRFA Done 
+2562,,[ rfaConfig.c : 748 ] phyForceRxGain_ipq5424 
+2563,,[ rfaConfig.c : 831 ] Inside Rfa set Alt Tbl Idx 
+2564,,[ rfaConfig.c : 872 ] phySetRfaRefClk96MHz_ipq5424 Recipe Start 
+2565,,[ rfaConfig.c : 882 ] REFCLK 96MHZ override is successful 
+2566,,[ rfaConfig.c : 886 ] REFCLK 96MHz override failed - OVD Failure !!!!!! 
+2567,,[ rfaConfig.c : 889 ] phySetRfaRefClk96MHz_ipq5424 Recipe Complete 
+2568,,[ rfaConfig.c : 904 ] phyRfaPowerUpSeq_ipq5424 Recipe Start 
+2569,IIII,[ rfaConfig.c : 917 ] RFAChipID = [%lu, %lu, %lu, %lu] 
+2570,,[ rfaConfig.c : 925 ] phyRfaPowerUpSeq_ipq5424 Recipe Complete 
+2571,II,[ rfaConfig.c : 934 ] rfaRxGainTableModeOverride GainTableForceValue = %u, GainTableForceMode = %u 
+2572,iiiiii,[ rfaConfig.c : 1106 ] TSENS_HEATER_PRE_TEMP_PER_CHAIN isColdBoot %d, %d, %d, %d, %d, avg %d 
+2573,iiiiii,[ rfaConfig.c : 1122 ] HEATER_PRE_TEMP_PER_CHAIN isColdBoot %d, %d, %d, %d, %d, avg %d 
+2574,iiiiii,[ rfaConfig.c : 1202 ] FTPG isColdBoot %d, isTgtPwr %d ? TgtPwr %d : TxGain %d, txTime %d (usecs), phyOnState %d 
+2575,iiiiiiii,[ rfaConfig.c : 1236 ] HEATER_POST_TEMP_PER_CHAIN isColdBoot %d, Time %d (usecs), %d, %d, %d, %d, avg %d, tgtTemp %d 
+2576,iiiiiiii,[ rfaConfig.c : 1298 ] HEATER_POST_TEMP_PER_CHAIN isColdBoot %d, Time %d (usecs), %d, %d, %d, %d, avg %d, tgtTemp %d 
+2577,,[ rfaConfig.c : 1299 ] FTPG_HEATER_DISABLED 
+2578,II,[ rfaConfig.c : 1310 ] FTPG rfaChain %u, txDcoc 0x%08x 
+2579,iiii,[ rfaConfig.c : 1320 ] HEATER isColdBoot %d, Time %d (usecs), avgDegC %d, tgtAvgDegC %d 
+2580,,[ rfaOtpParam.c : 26 ] Reading the OTP values and programming the LDO Overrides 
+2581,I,[ rfaOtpParam.c : 29 ] OTP Read 31 - 0x%x 
+2582,II,[ rfaOtpParam.c : 34 ] Register Read ldo OVD : 0x%x, LDO_OV - 0x%x 
+2583,II,[ rfaOtpParam.c : 44 ] Programmed ldo OVD : 0x%x, LDO_OV - 0x%x 
+2584,I,[ rfaOtpParam.c : 55 ] writeSynthLDOvref: syn0_ldo11_vref = 0x%08lx 
+2585,,[ rfaOtpParam.c : 58 ] writeSynthLDOvref: Done writing Syth LDO vref codes. 
+2586,,[ rfaOtpParam.c : 70 ] writeLDOCode: Warning!! OTP is blank. Using default LDO codes. 
+2587,I,[ rfaOtpParam.c : 83 ] writeLDOCode: ldo2_val = 0x%08lx 
+2588,I,[ rfaOtpParam.c : 84 ] writeLDOCode: ldo3_val = 0x%08lx 
+2589,,[ rfaOtpParam.c : 88 ] Done writing LDO codes. 
+2590,,[ rfaOtpParam.c : 101 ] writeBqVcmCode: Warning!! OTP is blank. Using default BQ vcm codes. 
+2591,iI,[ rfaOtpParam.c : 112 ] writeBqVcmCode: bq_vcm_ch%d = 0x%08hhx 
+2592,,[ rfaOtpParam.c : 114 ] writeBqVcmCode: Done writing BQ vcm codes. 
+2593,,[ rfaOtpParam.c : 127 ] writeTxVoutcmCode: Warning!! OTP is blank. Using default TX Voutcm codes. 
+2594,iI,[ rfaOtpParam.c : 138 ] writeTxVoutcmCode: voutcm_ch%d = 0x%08hhx 
+2595,,[ rfaOtpParam.c : 140 ] Done writing TX Voutcm codes. 
+2596,,[ rfaOtpParam.c : 165 ] PA_PPA_BIAS_OTP: not getting applied !!!! 
+2597,II,[ rfaOtpParam.c : 169 ] PA_PPA_BIAS_OTP:Read Values from 32 and 33 - 0x%x, 0x%x 
+2598,Iiiii,[ rfaOtpParam.c : 195 ] Fields which are updated for Chain %u - PPA_BIAS_CAL_MAIN - %d, MPA_BIAS_CAL_MAIN - %d, PPA_BIAS_CAL_AUX - %d, MPA_BIAS_CAL_AUX - %d 
+2599,,[ rfaOtpParam.c : 203 ] rfaOtpOverrides: Applying LDO and VCM OTP values 
+2600,,[ rfaOtpParam.c : 219 ] rfaOtpOverrides: OTP values are applied 
+2601,ii,[ rfaProgReg.c : 347 ] Xtal: setxtalcalvalue capin %d capout %d 
+2602,ii,[ rfaProgReg.c : 351 ] Xtal: Getxtalcalvalue after Set Capin %d capout %d 
+2603,ii,[ rfaProgReg.c : 383 ] Xtal: Getxtalcalvalue capin %d capout %d 
+2604,I,[ rfaProgReg.c : 470 ] XTAL CLEAR RX_EN via WSI, Address=0x%x 
+2605,iiI,[ rfaProgReg.c : 506 ] XTAL CWTONE back up reg[%d] values : chain=%d, value=0x%x 
+2606,,[ rfaResetUtilsMalaga.c : 165 ] IQ_HEATER_DISABLED 
+2607,,[ rfaResetUtilsIron.c : 20 ] readClkSel_Iron 
+2608,,[ rfaResetUtilsIron.c : 42 ] saveRestoreRfaBasePtr_iron_regs 
+2609,I,[ rfaLutTableMalaga.c : 109 ] phyOverrideGainTable to old as calVersion is %u ( old ) 
+2610,I,[ rfaLutTableMalaga.c : 120 ] no phyOverrideGainTable as calVersion is %u 
+2611,,[ phyrf_adt_prof_seq.c : 36 ] HDS ADT No parameters 
+2612,i,[ phyrf_adt_prof_seq.c : 50 ] HDS ADT scanMode %d 
+2613,i,[ phyrf_adt_prof_seq.c : 56 ] HDS ADT scanMode %d 
+2614,i,[ phyrf_adt_prof_seq.c : 62 ] HDS ADT scanMode %d 
+2615,i,[ phyrf_adt_prof_seq.c : 68 ] HDS ADT scanMode %d 
+2616,ii,[ phyrf_adt_prof_seq.c : 74 ] HDS ADT resetFlags %d resetCause %d 
+2617,iiiiii,[ phyrf_adt_prof_seq.c : 81 ] HDS ADT enaRttPerBurst %d enaRttPerFrame %d enaContChanCapture %d enaFixedStrChain %d fixedStrChainIdx %d fixedStrChainIdxExt80 %d 
+2618,IIIII,[ phyrf_adt_prof_seq.c : 90 ] HDS ADT enableCfr %u enableCfrPerFrame %u enableCir %u enableCirPerFrame %u enableChanCap %u 
+2619,ii,[ phyrf_adt_prof_seq.c : 146 ] Inactive PHY %d, Skipping ADT Profile %d 
+2620,i,[ phyrf_adt_prof_seq.c : 186 ] ADT: SEQ ID %d  
+2621,,[ phyrf_hds_adt.c : 313 ] HDS ADT Agile not supported 
+2622,,[ phyrf_hds_adt.c : 349 ] HDS ADT Agile not supported 
+2623,,[ phyrf_hds_adt.c : 383 ] HDS ADT Agile not supported 
+2624,,[ phyrf_hds_adt.c : 403 ] HDS ADT Agile not supported 
+2625,,[ phyrf_hds_adt.c : 417 ] HDS ADT Agile not supported 
+2626,,[ phyrf_hds_adt.c : 432 ] HDS ADT Agile not supported 
+2627,,[ phyrf_hds_adt.c : 531 ] Failed to program ASSOC_ID 
+2628,,[ phyrf_hds_adt.c : 566 ] Failed to fetch ASSOC_ID 
+2629,IiiiiiiII,[ phyrf_hds_adt.c : 706 ] wifiRadar_dbg: rxChainMask 0x%x glutIdx %d txGainIdx %d glutEn %d blockAccumAvgEnable %d blockAccumNumBlocks %d ltfSymRepeat %d calAdcMapSel 0x%x, tlvRxChainMask 0x%x 
+2630,iiii,[ phyrf_hds_hdt.c : 548 ] HdtTpcPlutAlut isHomeChan %d GLUT_freq %d Curr_freq %d calEnableFlag %d 
+2631,iii,[ phyrf_hds_hdt.c : 581 ] TpcEnableClpc: phyId=%d, cur_tbl_idx=%d, clpc_corr_thr_dBm=%d 
+2632,I,[ phyrf_hds_hdt.c : 1260 ] phyRfTurnOn status %u 
+2633,I,[ phyrf_hds_hdt.c : 1263 ] phyRfTurnOff status %u 
+2634,iiiii,[ phyrf_hds_hdt.c : 1515 ] PHYRF_PHY_A %d scaledPower is %d and %d and %d and %d 
+2635,iiii,[ phyrf_hds_hdt.c : 1550 ] Dump_AOA: %d %d %d %d 
+2636,iiiiii,[ phyrf_hds_if.c : 45 ] HDS_ATTACH: Version:%d.%d.%d.%d NUM_HDT_SETTINGS:%d NUM_ADT_SETTINGS:%d 
+2637,IiIiiii,[ phyrf_hds_prof_seq.c : 137 ] HDS Start - Prev HDS phyId_bw_cm_swProfile: 0x%08x,  Prev freq: %d Curr HDS phyId_bw_cm_phyRfMode:0x%08x ,freq: %d, hdtProfileCounter %d,SW Profile: %d (changed %d) 
+2638,IIIIIIi,[ phyrf_hds_prof_seq.c : 140 ] HDS Chan: mhz: %u, freq1: %u, freq2: %u, phy_mode: %u, flags: %u, ext_flags: %u, home: %d 
+2639,ii,[ phyrf_hds_prof_seq.c : 269 ] HDS_SEQ_EDITOR: inserted setting= %d key: %d 
+2640,ii,[ phyrf_hds_prof_seq.c : 280 ] HDS_SEQ_EDITOR: In curr_sw_profile: %d skipping setting ID: %d 
+2641,II,[ phyrf_hds_prof_seq.c : 292 ] HDS_SEQ_EDITOR: Profile %u has NULL pointer at setting %u 
+2642,iI,[ phyrf_hds_prof_seq.c : 302 ] HDS - Setting %d Run time = %ld us 
+2643,ii,[ phyrf_hds_prof_seq.c : 328 ] HDS_SEQ_EDITOR: inserted setting= %d key: %d 
+2644,iiiiiii,[ phyrf_hds_prof_seq.c : 356 ] HDS INI = %d, CAL = %d, TPC = %d, MISC = %d, AF = %d, SW_THREAD = %d, SW_Profile= %d 
+2645,iiiiIIii,[ phyrf_hds_prof_seq.c : 363 ] HDS End: phyId %d bw %d freq %d cm %d Total_Settings_Run_Time %ld us Profile_Run_time %ld us SW_Profile %d, Prev_SW_Profile %d 
+2646,iii,[ phyrf_hds_seq_editor.c : 84 ] HDS_SEQ_EDITOR: setting_deletion_data[%d] : %d %d 
+2647,i,[ phyrf_hds_seq_editor.c : 88 ] HDS_SEQ_EDITOR: setting_deletion_data[%d] : --  
+2648,ii,[ phyrf_hds_seq_editor.c : 97 ] HDS_SEQ_EDITOR: hashidx: %d setting_insertion_data:%d 
+2649,,[ phyrf_hds_seq_editor.c : 100 ] HDS_SEQ_EDITOR: key already exists in insertion setting database 
+2650,,[ phyrf_hds_seq_editor.c : 168 ] HDS_SEQ_EDITOR: insertion data Member resetted 
+2651,,[ phyrf_hds_seq_editor.c : 194 ] HDS_SEQ_EDITOR: deletion data member resetted 
+2652,iiii,[ phyrf_hds_seq_editor.c : 215 ] HDS_SEQ_EDITOR: setting_insertion_data[%d]: %d %d settingid = %d 
+2653,i,[ phyrf_hds_seq_editor.c : 219 ] HDS_SEQ_EDITOR: setting_insertion_data[%d]: --  
+2654,III,[ wal_coex_main.c : 522 ] COEX_SET_BW: vdevId(%u) bw(%u) max_bw(%u) 
+2655,IIIIIIIII,[ wal_coex_main.c : 1456 ] COEX_SYSTEM_UPDATE: status(%u) stimulus(%u) hw_mode(%u) num_chains(%u) aggr_lim(%u) 3ant[bt_sep_ant(%u) ant_iso(%u) cfg_mode(%u) run_mode(%u)] 
+2656,IIIIIIII,[ wal_coex_main.c : 2319 ] WAL_COEX_MNGR: Error(0x%x) mac_bm(%u) Stimulus(%u) Reason(%u) BTSMState(0x%x) SysUpdateResult(%u) UwbSystemUpdateResult(%u) ConfigMngr(0x%x) 
+2657,I,[ wal_coex_main.c : 2749 ] COEX_ERR_FREQ_OCS_ENTER: ERROR: Time since since OCS exit = %u 
+2658,II,[ wal_coex_main.c : 3190 ] WAL_COEX_BDF: Flags(0x%x) Config(0x%x) 
+2659,i,[ wal_coex_main.c : 4100 ] WAL_COEX_SYNCOCS_TIMER: Incorrect bt_dur %d 
+2660,IIIII,[ wal_coex_sys_monitor.c : 1125 ] COEX_MON_BT_PS_PROF_IND: curtime(%u) NUM_BT_PROF(%u) bt_prof_count(%u) Profile_stop_ts(%u) monitor_profile_stop_period(%u) 
+2661,,[ wal_coex_wlan_event_handler.c : 269 ] COEX_VDEV_STATE: Disabling PTA coex because vdev is brought down 
+2662,IIIIIII,[ wal_coex_sys_update.c : 408 ] WAL_COEX_ALT_CHM: pdev(%u) chm(0x%x) enable_alt(%u) is_2gchan(%u) alt_chm(%u) selfgenAltChm (%u) pending(%u) 
+2663,I,[ wal_coex_bt.c : 854 ] COEX_UPDATE_AFH: Error: Wlan 2G but invalid bandwidth! phy mode 0x%x 
+2664,IIiII,[ wal_coex_bt.c : 1473 ] WAL_COEX_PROC_GPM: Error(0x%x) Warn(0x%x) status(%d) type(%u) subtype(%u) 
+2665,IIIIIi,[ wal_coex_bt.c : 2108 ] COEX_BT_INTERVAL_START: Error(0x%x) Warn(0x%x) bt_intrvl_cnt(%u) duration(%u) enable_bt_bw_lim(%u),mac_id %d 
+2666,IIII,[ wal_coex_bt.c : 2133 ] COEX_WLAN_INTERVAL_START: Error(0x%x) Warn(0x%x) wlan_intrvl_cnt(%u) duration(%u) 
+2667,IIIIIIII,[ wal_coex_bt.c : 2295 ] WAL_COEX_SCHED_INTERVAL: Error(0x%x) Warn(0x%x) bt_grant(%u) bt_duration(%u) interval(%u) bt_traffic_status(%u) is_bt_heavy(%u) WlanScanType(%u) 
+2668,IIIIIIII,[ wal_coex_bt.c : 2943 ] WAL_COEX_GPM_RECV: subtype[0x%x] timer(%u) F1(0x%lx) F2(0x%lx) F3(0x%lx) F4(0x%lx) F5(0x%lx) F6(0x%lx) 
+2669,IIIII,[ wal_coex_bt.c : 2951 ] WAL_COEX_GPM_RECV: subtype[0x%x] F7(0x%lx) F8(0x%lx) F9(0x%lx) F10(0x%lx) 
+2670,IIIIIIII,[ wal_coex_bt.c : 2963 ] WAL_COEX_GPM_RECV: subtype[0x%x] timer(%u) F1(0x%lx) F2(0x%lx) F3(0x%lx) F4(0x%lx) F5(0x%lx) F6(0x%lx) 
+2671,IIIIII,[ wal_coex_bt.c : 2987 ] WAL_COEX_GPM_RECV: type[0x%x] timer[%u]: [CAL GPM] seq[0x%x] cal_state[0x%x] mci_state[0x%x] wbtime(0x%x) 
+2672,IIII,[ wal_coex_bt.c : 2997 ] WAL_COEX_GPM_RECV: type[0x%x] subtype[0x%x] timer[%u], wbtime(%u) 
+2673,IIIII,[ wal_coex_bt.c : 3004 ] WAL_COEX_GPM_RECV: type[0x%x] timer[%u]: [BT 5g tx chain1]  status[0x%x] dutyCycle[%u] threshold[%u] 
+2674,III,[ wal_coex_bt.c : 3011 ] COEX_INVALID_GPM: type[0x%x] subtype[0x%x] timer[%u] : [Unknown GPM type subtype] 
+2675,Ii,[ wal_coex_bt.c : 3059 ] WAL_COEX_GPM_RECV: Subtype[0x%x] is not present in bt2wlan_gpm_indx entries or field index[%d] exceeding 
+2676,II,[ wal_coex_bt_gpm_handler.c : 451 ] COEX_GENERIC_ERROR: linkOp = 0x%x, AclActiveScoTimerState = 0x%x 
+2677,I,[ wal_coex_bt_gpm_handler.c : 738 ] WAL_COEX_GPM_RECV: Crash Info GPM crash with reason (%x) 
+2678,II,[ wal_coex_bt_gpm_handler.c : 763 ] WAL_COEX_BT_CSB: Type(%u) Id(%u) 
+2679,I,[ wal_coex_bt_gpm_handler.c : 1000 ] WAL_COEX_BTQ: Overflow(%u) 
+2680,IIII,[ wal_coex_bt_utils.c : 300 ] WAL_COEX_BT_ALLOC: Ret(%u) LocalId(%u) Remote_Id(%u) MinFreeLinkId(%u) 
+2681,III,[ wal_coex_bt_utils.c : 317 ] WAL_COEX_BT_DEALLOC: LocalId(%u) Remote_Id(%u) MinFreeLinkId(%u) 
+2682,III,[ wal_coex_bt_utils.c : 336 ] WAL_COEX_BTPROF_ADD: Status(%u) RemoteId(%u) ProfileType(%u) 
+2683,III,[ wal_coex_bt_utils.c : 364 ] WAL_COEX_BTPROF_DEL: Status(%u) RemoteId(%u) ProfileType(%u) 
+2684,IIIIIII,[ wal_coex_btle.c : 268 ] WAL_COEX_LE_LR: status(%u) state(0x%x) cmd_status(0x%x) local_id(%u) remote_id(%u) max_tx(%u) max_rx(%u) 
+2685,III,[ wal_coex_btle.c : 312 ] WAL_COEX_LE_ASHA: result(%u) curr(%u) prev(%u) 
+2686,IIIII,[ wal_coex_btle.c : 351 ] WAL_COEX_LE_ASHA: result(%u) id(%u) offset(%u) thresh(%u) is_asha(%u)  
+2687,IIIII,[ wal_coex_utils.c : 1242 ] COEX_FORCE_OCS: wlan_dur(%u) bt_dur(%u)  wlan_wght(%u) bt_wght(%u) algo(%u) 
+2688,I,[ wal_coex_utils.c : 1752 ] COEX_MCI_TIMER_HANDLER: Recovery(0x%x) 
+2689,II,[ wal_coex_utils.c : 1797 ] COEX_MCI_RECOVER: StimulusState(0x%x) RecoveryState(0x%x) 
+2690,,[ wal_coex_utils.c : 1823 ] WAL_COEX_TLV_CONTROL: Coex TLV Control commands only enabled on HMT1.0 
+2691,iiiiiiii,[ wal_coex_wghts.c : 1536 ] WAL_COEX_WGHTS: Static: W0[wl_idle(%d) sw_ctrl3(%d) sw_ctrl2(%d) sw_ctrl1(%d)] W1[sw_ctrl0(%d) wait_bcn(%d) wait_ack_cts(%d) selfgen(%d] 
+2692,iiii,[ wal_coex_wghts.c : 1539 ] WAL_COEX_WGHTS: Static: W10[rx_lvl3(%d) rx_lvl2(%d) rx_lvl1(%d) (%d)] 
+2693,iiiiiiii,[ wal_coex_wghts.c : 1550 ] WAL_COEX_WGHTS: FES Tx: W2[bcn(%d) conn(%d) scan(%d) ibss(%d)] W3[psp(%d) bar(%d) cts(%d) data_VI(%d)] 
+2694,iiiiiiii,[ wal_coex_wghts.c : 1560 ] WAL_COEX_WGHTS: FES Tx: W4[null(%d) data_BE(%d) data_VO(%d) data_BK(%d)] W5[om(%d) oc(%d) od(%d) oo(%d)] 
+2695,iiiiiiii,[ wal_coex_wghts.c : 1593 ] WAL_COEX_WGHTS: FES Rx: W6[bcn(%d) conn(%d) scan(%d) ibss(%d)] W7[psp(%d) bar(%d) cts(%d) rsvd(%d)] 
+2696,iiiiiiii,[ wal_coex_wghts.c : 1603 ] WAL_COEX_WGHTS: FES Rx: W8[null(%d) data(%d) qos(%d) rsvd(%d)] W9[om(%d) oc(%d) od(%d) oo(%d)] 
+2697,iii,[ wal_coex_wghts.c : 1629 ] WAL_COEX_FORCED_WGHTS: frame_type(%d), wlan_dur_wght(%d), bt_dur_wght(%d)  
+2698,iii,[ wal_coex_wlan.c : 99 ] COEX_DHCP_TMR_EXPIRED: DHCP tmr expired: DHCP flag (%d), DHCP Detected (%d) vdev_id(%d) 
+2699,IIIIIIII,[ wal_coex_wlan.c : 343 ] WAL_COEX_BAND_CHANGE: status(%u) band_changed(%u) single_mac(%u) mac(%u) 2x2(%u) new_freq(%u) New_cur_band(0x%04x) cxc(0x%x) 
+2700,II,[ wal_coex_wlan.c : 494 ] BTCOEX_DBG_MCI_2: wal_coex_reassess_wlanstate - [mac|band](0x%2x) state(0x%x) 
+2701,IIIIIIIII,[ wal_coex_wlan.c : 942 ] WAL_COEX_VDEV_STATE: Error(0x%x) id(%u) stimulus(%u) vdev_state(0x%x) strict_dur_scan(%u) num_peers(%u) pdev(%u) chan(%u) [2gndl|op|subop](0x%02x) 
+2702,IIII,[ wal_coex_sched.c : 236 ] COEX_TRF_FREERUN_FTM: NextIntvl(%u) SchedIntvl(%u) BtIntervalCnt(%u) WlanIntervalCnt(%u) 
+2703,iIIIi,[ wal_coex_sched.c : 1859 ] COEX_GET_T2BT: status(%d) t2bt(%u) sched_time(%u) curr_time(%u) duration(%d) 
+2704,II,[ wal_coex_sched.c : 2559 ] WAL_COEX_GET_INTERVAL: GET: OCS_Duration(%u) OCS_Interval(%u) 
+2705,II,[ wal_coex_sched.c : 2568 ] WAL_COEX_SET_INTERVAL: SET: OCS_Duration(%u) OCS_Interval(%u) 
+2706,IIII,[ wal_coex_policy.c : 909 ] WAL_COEX_ALGO: algo(%u) prev_algo(%u) [ftm|sep_ant|lte|nan|a2dp|hid|aptx_ll|voice](0x%08x), [wlan_ll|asha|ba|ant|not_conn|mpta_hlpr|force_pol](0x%08x) 
+2707,i,[ wal_coex_ftm.c : 40 ] WAL_COEX_FTM: wal_coex_ftm.c LINE=%d FTM_INIT 
+2708,i,[ wal_coex_ftm.c : 137 ] WAL_COEX_FTM: wal_coex_ftm.c LINE=%d FTM_CAL_START 
+2709,i,[ wal_coex_ftm.c : 140 ] WAL_COEX_FTM: wal_coex_ftm.c LINE=%d FTM_CAL_STOP 
+2710,iii,[ wal_coex_ftm.c : 144 ] WAL_COEX_FTM: wal_coex_ftm.c LINE=%d FTM_TX_RX_START state=%d, chan=%d 
+2711,iii,[ wal_coex_ftm.c : 167 ] WAL_COEX_FTM: wal_coex_ftm.c LINE=%d FTM_TX_RX_STOP state=%d chan=%d 
+2712,ii,[ wal_coex_pta.c : 88 ] COEX_PTA_ENABLE: [AP] coex enable.. en_coex = %d, dis_bttx_concurrency = %d 
+2713,iiii,[ wal_coex_pta.c : 214 ] COEX_GENERIC_ERROR: [AP] Either Invalid Duty Cycle or OCS not Configured.Current duty_cycle:(%d),wlan_duration:(%d),pta0_algo:(%d), pta1_algo:(%d) 
+2714,,[ wal_coex_pta.c : 217 ] COEX_GENERIC_ERROR: Failed To Enable Coex. CXC HW Module not Powered Up 
+2715,,[ wal_coex_pta.c : 231 ] COEX_GENERIC_ERROR: Either Invalid 2G MacID or 2G Mac is not Enabled 
+2716,Iii,[ wal_coex_pta.c : 245 ] COEX_WAL_PTA_COEX_INIT: bdf_flag(0x%x), pta_feature_enabled(%d), disableBTTxConcurrency(%d) 
+2717,iIIIII,[ wal_coex_pta.c : 254 ] COEX_WAL_PTA_COEX_INIT: pta_num(%d) ,pta_mode(0x%x) first_slot_time(0x%x) bt_priority_time(0x%x) pta_algo(0x%x) pta_priority(0x%x) 
+2718,iIIIII,[ wal_coex_pta.c : 266 ] COEX_WAL_PTA_COEX_INIT: pta_num(%d) pta_mode(0x%x) first_slot_time(0x%x) bt_priority_time(0x%x) pta_algo(0x%x) pta_priority(0x%x) 
+2719,IIIIIIII,[ wal_coex_power.c : 394 ] WAL_COEX_SLEEP: status(%u) bm_0(0x%08x) bm_1(0x%08x) [mac|vote|btc|mws|wow](0x%05x) src(%u) [orig|override]reasons(0x%08x) num_2g_vdev(%u) sleep_vote_bt_int(%u) 
+2720,I,[ wal_coex_power.c : 619 ] COEX_LMAC_POWER_CB: W1State_W0State_WlanId_Event:0x%08x,  
+2721,IIIIII,[ wal_coex_power.c : 840 ] WAL_COEX_POWER_CHANGE: Error(0x%x) mac(%u) event_type(%u) cur_state(0x%x) new_state(0x%x) all_mac_sleeping(%u) 
+2722,i,[ wal_coex_power.c : 845 ] WAL_COEX_POWER_CHANGE: Invalid wlan_id from power event, wlan_id=%d 
+2723,i,[ wal_coex_stats.c : 96 ] COEX_STATS_BT: Invalid mac ID %d 
+2724,III,[ wal_coex_gpm.c : 213 ] WAL_MCI_GPM_SENT: UpdatePendingFlag - pending_msg_bm (0x%08x), QFlags (0x%08x) gpm_ack_bm (0x%08x) 
+2725,Ii,[ wal_coex_gpm.c : 406 ] WAL_MCI_GPM_SENT: [0x%x] - CAL GRANT, ret= %d 
+2726,I,[ wal_coex_gpm.c : 421 ] WAL_MCI_GPM_SENT: GPM Sent [0x%x] -  CAL REQ 
+2727,I,[ wal_coex_gpm.c : 436 ] WAL_MCI_GPM_SENT: [0x%x] - CAL DONE 
+2728,IIIIIII,[ wal_coex_gpm.c : 465 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x]- Version query Major(0x%x) Minor(0%x) Cap_cfg(0x%x) pending_msg_bm (0x%x) pending_msg_ack_bm (0x%x) 
+2729,IIIII,[ wal_coex_gpm.c : 490 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - WLAN Version resp. : Major(0x%x) Minor(0x%x) Cap_cfg(0x%x) 
+2730,IIIIIII,[ wal_coex_gpm.c : 537 ] WHAL_MCI_GPM_SENT: WLAN Conn Status Report : 5g_ch_3_2_1_0(0x%08x), 2g_ch_1_0(0x%04x) operating_mode(0x%x) wlm(0x%x) coexLL(%u), war361(0x%x), dbam(%u) 
+2731,IIIIIII,[ wal_coex_gpm.c : 555 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x]- WLAN Unused channels : 0x%x 0x%x 0x%x 0x%x 0x%x 
+2732,IIIIII,[ wal_coex_gpm.c : 581 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x]- Status Query : WLAN QueryType(0x%x) Source 0x%x pending_msg_bm (0x%x) pending_msg_ack_bm (0x%x) 
+2733,III,[ wal_coex_gpm.c : 602 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Disable BT GPM : State(0x%x) 
+2734,IIII,[ wal_coex_gpm.c : 629 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - BT Update flags : Opcode(0x%x) BT Flags(0x%x) 
+2735,IIIII,[ wal_coex_gpm.c : 659 ] WAL_MCI_GPM_SENT: OBSOLETE[0x%x] [0x%x] - BT Pause profile : PauseSlot(0x%x) ProfileBitmap(0x%x) Data(0x%x) 
+2736,IIII,[ wal_coex_gpm.c : 679 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - WLAN set ACL Inactivity Report : InactivityThresh(0x%x) LinkID(0x%x) 
+2737,IIIII,[ wal_coex_gpm.c : 707 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - BT remote registry write : Address(0x%x) Value(0x%x) Op(0x%x) 
+2738,II,[ wal_coex_gpm.c : 725 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Query BT RXSS Minimum Threshold 
+2739,III,[ wal_coex_gpm.c : 746 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Set BT RXSS Minimum Threshold : Threshold(0x%x) 
+2740,IIIIII,[ wal_coex_gpm.c : 777 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Sched info trigger : TriggerEnaNum(0x%x) TriggerType(0x%x) LowerBound(0x%x) UpperBound(0x%x) 
+2741,IIIII,[ wal_coex_gpm.c : 807 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Send priority config : Op(0x%x) Priority(0x%x) IsRead(0x%x) 
+2742,IIiII,[ wal_coex_gpm.c : 862 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Send group priority config : ret(%d) Op(0x%x) Priority(0x%x) 
+2743,IIII,[ wal_coex_gpm.c : 888 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - BT Airtime Stats Req: NumOfDelivery(0x%x) TestInterval(0x%x) 
+2744,IIIIII,[ wal_coex_gpm.c : 912 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - LE Data Len Req : op(%u) id(%u) max_tx(%u) max_rx(%u) 
+2745,IIIIII,[ wal_coex_gpm.c : 935 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - AAID Power measure Req : Freq(%u) Offset(%u) Power(%u) duration(%u) 
+2746,III,[ wal_coex_gpm.c : 957 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - WLAN Status Update : Status(0x%x) 
+2747,III,[ wal_coex_gpm.c : 977 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Read BT TX power : LinkId(0x%x) 
+2748,IIi,[ wal_coex_gpm.c : 998 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Limit BT Max TX power : power(%d)dbm 
+2749,III,[ wal_coex_gpm.c : 1019 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Start BT RSSI Reporting: period(0x%x)second 
+2750,III,[ wal_coex_gpm.c : 1041 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - concurrent TX on chain0(%u) 
+2751,II,[ wal_coex_gpm.c : 1063 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Three-way CoEx Config for WLAN/BT/Zigbee 
+2752,II,[ wal_coex_gpm.c : 1067 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - ERROR sending Three-way CoEx Config for WLAN/BT/Zigbee ! 
+2753,IIIIII,[ wal_coex_gpm.c : 1091 ] WHAL_MCI_GPM_SENT: [0x%x] [0x%x] WLAN Capabilities ctr(0x%x) cap W1(0x%x) cap W2(0x%x) cap B3(0x%x) 
+2754,IIII,[ wal_coex_gpm.c : 1114 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - ASD Status Indication: grant(%u) reason(%u) 
+2755,IIIIII,[ wal_coex_gpm.c : 1135 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - Coex Policy Indication: policy(%u), grant_bt(%u) wlan_dur(%u), bt_dur(%u) 
+2756,I,[ wal_coex_gpm.c : 1189 ] WHAL_MCI_GPM_SENT: GAIN Id error(0x%x) 
+2757,III,[ wal_coex_gpm.c : 1207 ] WHAL_MCI_GPM_SENT: [0x%x] [0x%x] - SET BT GAIN Id(0x%x) 
+2758,IIIIII,[ wal_coex_gpm.c : 1229 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - ISO Priority Update : grpid(%u) config(%u) priority_bmap(%u) mci_prio(0x%x) 
+2759,IIII,[ wal_coex_gpm.c : 1250 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - ISO Subevent Mask : linkid(%u) mask(0x%x) 
+2760,IIII,[ wal_coex_gpm.c : 1273 ] WAL_MCI_GPM_SENT: [0x%x] [0x%x] - DBAM : request (%u), ret (%u) 
+2761,IIIIIII,[ wal_coex_dbs.c : 161 ] WAL_COEX_MODE_CHANGE: new_mode(%u) old_mode(%u) band_mac_map(0x%06x) mac0_settings(0x%x) mac1_settings(0x%x) mac0_2x2(%u) mac1_2x2(%u) 
+2762,III,[ wal_coex_dbs.c : 258 ] WAL_COEX_VDEV_STATE: COEX_VDEV_MIGRATE: old_mac_id %u, new_mac_id %u, old_mac_pwr_state %u 
+2763,IIIIII,[ wal_coex_asd.c : 260 ] WAL_COEX_BT_ML: BT_ASD_STATUS_SYNC_INDICATE: RxRes_TxRes_Pri_Status : 0x%08x, Idx_Rx_Tx-Allow_Rx_Tx : 0x%08x, Result_RxGrn_RxGPM_TxGrn_TxGPM : 0x%08x Rx_Grant-Reason_Code : 0x%04x Tx_Grant-Reason_Code : 0x%04x Wlan_State : 0x%04x 
+2764,IIIIIIIII,[ wal_coex_wifi_tput_monitor.c : 286 ] COEX_WIFI_TPUT_MON_CCA: [mac|prv_wifi_state|curr_wifi_state](0x%03x) [tx_percentage|rx_percentage](0x%02x) cca_busy_usec(%u) my_rx_frame_usec(%u) rx_Frame_usec(%u) cycle_cnt(%u) tx_frame_usec(%u) congestion_percent (%u) ccaObssUsec(%u) 
+2765,II,[ wal_coex_wifi_tput_monitor.c : 406 ] COEX_WIFI_TPUT_SET_STATS_TMR: monitor_period_us(%u) stats_timer_flag(%u) 
+2766,IIIIII,[ wal_coex_wifi_tput_monitor.c : 101 ] COEX_WIFI_TPUT_MON_CONG congestion_raw %u curr_bt_tx_cca_med_usage_cnt_raw %u delta_bt_tx_discount %u congestion_percent %u congestion_percent_wifi %u stuck %u 
+2767,I,[ pktlog.c : 610 ] DEBUG_PKTLOG: _pktlog_enable: already enabled, bmap=0x%x 
+2768,II,[ pktlog.c : 615 ] DEBUG_PKTLOG: _pktlog_enable: enable %u evlist %08x 
+2769,I,[ pktlog.c : 817 ] DEBUG_PKTLOG: _pktlog_disable: already disabled, bmap=0x%x 
+2770,,[ pktlog.c : 1207 ] INVALID TLV TYPE 
+ 
+2771,IIii,[ pktlog.c : 222 ] _pktlog_getbuf: pool_list_alloc failed with size %u type=%u qheap=%d missed=%d 
+2772,i,[ pktlog.c : 373 ] Dropped buffer for pktlog_type:%d 
+2773,IIIII,[ wal_swba.c : 843 ] Staggered beacon drift recover: next_beacon = %u, beacon_period = %u, time_until_next_tbtt = %u, next_hw_tbtt =%u, cur_tsf = %u 
+2774,IIII,[ wal_swba.c : 960 ] Burst beacon drift recover: next_beacon = %u, beacon_period = %u, until_next_tbtt = %u next_hw_tbtt = %u 
+2775,,[ wal_soc_dev.c : 2666 ] _wal_soc_pkt_info_run_algo: No monitored phy mode or device in sleep mode, enabled pktlog.
+ 
+2776,iiiiii,[ wal_soc_dev.c : 2721 ] pktlog from %d to %d: tx_msdu %d, threshold %d, tx_ppdu %d, threshold %d.
+ 
+2777,iiiiii,[ wal_soc_dev.c : 2730 ] pktlog from %d to %d: rx_msdu %d, threshold %d, rx_ppdu %d, threshold %d.
+ 
+2778,iiiiiii,[ wal_soc_dev.c : 2739 ] pktlog from %d to %d: tx_msdu %d, sum_msdu %d, threshold %d, sum_ppdu %d, threshold %d.
+ 
+2779,iiii,[ wal_soc_dev.c : 3695 ] wal_soc_set_gpio_with_txrx_abort: mac_no=%d, tx_stop=%d, rx_stop=%d reset=%d 
+2780,II,[ wal_phy.c : 173 ] wal_phy_debug_MM_cmd_handler: pdev:0x%x, pHandle:0x%x 
+2781,,[ wal_phy.c : 182 ] wal_phy_debug_MM_cmd_handler: pdev is NULL 
+2782,,[ wal_phy.c : 189 ] wal_phy_debug_MM_cmd_handler: pHandle is NULL 
+2783,i,[ wal_phy.c : 248 ] rssi_comb %d 
+2784,,[ wal_phy_dev.c : 641 ] Data stall force reset condition met, cal fdmt 
+2785,i,[ wal_phy_dev.c : 648 ] Data stall force reset condition met, phy_warm_rst=%d 
+2786,iii,[ wal_phy_dev.c : 704 ] DATA_STALL: Type=%d FAIL_CNT[%d]=%d 
+2787,IIIIi,[ wal_phy_dev.c : 1187 ] _wal_dev_global_reset_with_reason: mode=%x reason=%x,c0=%lx,c1=%lx,inprog=%d 
+2788,IIIIIiiI,[ wal_phy_dev.c : 1259 ] DEV_RESET_DBG [%u]: mode=%x reason=%x,c0=%lx,c1=%lx,inprog=%d,dis=%d,en=%x 
+2789,Ii,[ wal_phy_dev.c : 1286 ] DEV_RESET_DBG  mode=%x inprog=%d 
+2790,IIIIi,[ wal_phy_dev.c : 1300 ] DEV_RESET_DBG mode=%x reason=%x,c0=%lx,c1=%lx,inprog=%d 
+2791,,[ wal_phy_dev.c : 1445 ] DMAC is in power down, skip dmac reset 
+2792,IIi,[ wal_phy_dev.c : 1512 ] DEV_RESET_DEBUG [exit]_wal_dev_global_reset: mode=%x reason=%x,inprog=%d 
+2793,i,[ wal_phy_dev.c : 3168 ] wal_pdev_flush_all_non_pause_tids: send msg to SCHED_ALGO, thread_id =%d
+ 
+2794,iiI,[ wal_phy_dev.c : 3275 ] SU PPDU_DURATION %d AMSDU agg_type %d amsdu_factor %f 
+2795,iiI,[ wal_phy_dev.c : 3276 ] MU PPDU_DURATION %d AMSDU agg_type %d amsdu_factor %f 
+2796,iiI,[ wal_phy_dev.c : 3277 ] SU PPDU_DURATION_LARGE %d AMSDU agg_type %d amsdu_factor %f 
+2797,iiI,[ wal_phy_dev.c : 3278 ] SU PPDU_DURATION_MAX %d AMSDU agg_type %d amsdu_factor %f 
+2798,I,[ wal_phy_dev.c : 3540 ] SET_PDEV_PARAM: WAL_PDEV_PARAM_SCAN_RADIO_TX_ON_DFS value=0x%x 
+2799,,[ wal_phy_dev.c : 3566 ] SET_PDEV_PARAM: TXPOWER_LIMIT2G Invalid Band/PowerLimit 
+2800,,[ wal_phy_dev.c : 3578 ] SET_PDEV_PARAM: TXPOWER_LIMIT5G Invalid Band/PowerLimit 
+2801,I,[ wal_phy_dev.c : 3993 ] REG_DOMAIN WAL_PDEV_PARAM_REG_DOMAIN_INFO_CCA reg_domain 0x%x 
+2802,i,[ wal_phy_dev.c : 4062 ] SET_PDEV_PARAM: DATA_STALL flag param=%d 
+2803,,[ wal_phy_dev.c : 4087 ] SET_PDEV_PARAM: TXPOWER_LIMIT2G Invalid Band/PowerLimit 
+2804,,[ wal_phy_dev.c : 4099 ] SET_PDEV_PARAM: TXPOWER_LIMIT5G Invalid Band/PowerLimit 
+2805,,[ wal_phy_dev.c : 4247 ] Reset in progress. Failed to update NAV_OVERRIDE_CTRL 
+2806,i,[ wal_phy_dev.c : 4564 ] NAV offset(%d) is more than 1ms capping it to 1ms 
+2807,i,[ wal_phy_dev.c : 5125 ] BiosDataType %d 
+2808,i,[ wal_phy_dev.c : 5429 ] wal_call_phyrf_ani_SetWeakLo : flag : %d 
+2809,ii,[ wal_phy_dev.c : 5519 ] SMART ANTENNA : config_enable : %d config_mode : %d 
+ 
+2810,ii,[ wal_phy_dev.c : 5530 ] SMART ANTENNA : config_enable : %d rx_antenna : %d 
+ 
+2811,III,[ wal_phy_dev.c : 6039 ] DISPLAY_TPC_STATS: wmi_tpc_config tlv header is %lu, chanFreq is %lu, phyMode is %lu 
+2812,IIiIIIII,[ wal_phy_dev.c : 6041 ] DISPLAY_TPC_STATS: maxAntennaGain is %lu twiceMaxRDPower is %lu userAntennaGain is %d powerLimit is %lu rateMax is %lu numTxChain is %lu cfgctl is %lu flags is %lu 
+2813,II,[ wal_phy_dev.c : 6100 ] DISPLAY_TPC_STATS: wal_pdev_get_ctl_array_len totalSize = %lu whole arr size %lu 
+2814,I,[ wal_phy_dev.c : 6143 ] DISPLAY_TPC_STATS: wal_pdev_get_wmi_tpc_stats_tgt_arr_len:  totalSize = %lu 
+2815,IIIIII,[ wal_phy_dev.c : 6264 ] DISPLAY_TPC_STATS: reg_power_type is %lu reg_power_array_len is %lu d1 is %lu d2 is %lu d3 is %lu d4 is %lu 
+2816,,[ wal_phy_dev.c : 6291 ] DISPLAY_TPC_STATS: Regulatory array contents do not match! 
+2817,,[ wal_phy_dev.c : 6306 ] DISPLAY_TPC_STATS: Regulatory array contents do not match! 
+2818,,[ wal_phy_dev.c : 6323 ] DISPLAY_TPC_STATS: Regulatory array contents do not match! 
+2819,,[ wal_phy_dev.c : 6340 ] DISPLAY_TPC_STATS: Regulatory array contents do not match! 
+2820,II,[ wal_phy_dev.c : 6382 ] DISPLAY_TPC_STATS: rate_array_type is %lu rate_array_len is %lu 
+2821,,[ wal_phy_dev.c : 6548 ] DISPLAY_TPC_STATS: start of ctl event 
+2822,IIIIII,[ wal_phy_dev.c : 6609 ] DISPLAY_TPC_STATS: ctl_array_type is %lu ctl_array_len is %lu d1 is %lu d2 is %lu d3 is %lu d4 is %lu 
+2823,i,[ wal_phy_dev.c : 6635 ] DISPLAY_TPC_STATS: len %d  
+2824,i,[ wal_phy_dev.c : 6677 ] DISPLAY_TPC_STATS: (ch*txbf_enable*ctl_modes*each_nss)+(j*ctl_modes*each_nss)+(k*each_nss)+l) %d 
+2825,,[ wal_phy_dev.c : 6679 ] DISPLAY_TPC_STATS: CTL array contents do not match! 
+2826,,[ wal_phy_dev.c : 7161 ] DISPLAY_AOA_EVT: returned null 
+2827,i,[ wal_phy_dev.c : 7224 ] VOW enable %d 
+2828,i,[ wal_phy_dev.c : 7256 ] Carrier Config features: %d 
+2829,II,[ wal_phy_dev.c : 7372 ] UL_TRAFFIC_LOAD_DBG - Initial ul_heavy_load_sta_rx_ppdu_threshold : ac = %u, ul_heavy_load_sta_rx_ppdu_threshold = %u  
+2830,II,[ wal_phy_dev.c : 7389 ] UL_TRAFFIC_LOAD_DBG - Final ul_heavy_load_sta_rx_ppdu_threshold : ac = %u, ul_heavy_load_sta_rx_ppdu_threshold = %u  
+2831,IIII,[ wal_phy_dev.c : 7401 ] UL_TRAFFIC_LOAD_DBG - Heavy Load STA Count: ac = %u, trig = %u, non_trig = %u, non ul mu trig = %u, 
+2832,IIII,[ wal_phy_dev.c : 7404 ] UL_TRAFFIC_LOAD_DBG - Light Load STA Count: ac = %u, trig = %u, non_trig = %u, non ul mu trig = %u, 
+2833,II,[ wal_phy_dev.c : 7405 ] UL_TRAFFIC_LOAD_DBG : UL OFDMA basic trig response count = %u for ac = %u 
+2834,II,[ wal_phy_dev.c : 7407 ] UL_TRAFFIC_LOAD_DBG - Heavy_TCP Load STA Count: ac = %u, trig = %u 
+2835,III,[ wal_phy_dev.c : 7409 ] UL_TRAFFIC_LOAD_DBG - Light_TCP Load STA Count: ac = %u, trig = %u, non ul mu trig = %u 
+2836,II,[ wal_phy_dev.c : 7412 ] UL_TRAFFIC_LOAD_DBG - 11be Trig capable user count: ac = %u, trig = %u 
+2837,IIII,[ wal_phy_dev.c : 7415 ] UL_TRAFFIC_LOAD_DBG - ac = %u, last_window_active_usr_count = %u, ul_active_sta_max_rx_threshold = %u, last_observation_window_num_rx_ppdus = %u 
+2838,IIi,[ wal_phy_dev.c : 7509 ] TXMODESEL_ULMIMO_DBG udp ingress:%u tcp ingress:%u peer_id:%d  
+2839,III,[ wal_phy_dev.c : 7517 ] UL_TRAFFIC_LOAD_DBG - First time peer activity in observation window - aid = %u , ac = %u, window_idx = %u 
+2840,III,[ wal_phy_dev.c : 7554 ] UL_TRAFFIC_LOAD_DBG - First_TCP activity in observation window - aid = %u , ac = %u, window_idx = %u 
+2841,IIII,[ wal_phy_dev.c : 7569 ] UL_TRAFFIC_LOAD_DBG - Subsequent peer activity in observation window - aid = %u, ac = %u and count = %u and window_idx = %u 
+2842,i,[ wal_phy_dev.c : 8236 ] phyrf_svc_intf:: walReset total time %d us, 
+2843,I,[ wal_phy_dev.c : 8254 ] Update OFDM scrambler seed = 0x%x 
+2844,ii,[ wal_phy_dev.c : 382 ] DATA_STALL: rssi:%d vdev_id:%d 
+2845,,[ wal_vdev.c : 144 ] peer_bitmap POOL ALLOC FAILURE 
+2846,IIIIIII,[ wal_vdev.c : 2343 ] pdev(%x)peer %x,vdev-up for tidLen update,refcnt=%x,htc=%x,remap=%x,security=%x is_master=%x 
+2847,i,[ wal_vdev.c : 2362 ] tid allocation failure status = %d 
+2848,i,[ wal_vdev.c : 2580 ] vdev up: pdev:%d, enable partial ba since 11be SAP is up 
+2849,ii,[ wal_vdev.c : 2932 ] vdev down: pdev:%d, full state ba:%d 
+2850,iiiiii,[ wal_vdev.c : 3522 ] BA_LOG param_val %d vdev_param_buf_size %d bit 64: %d 256: %d 512: %d 1024:%d 
+2851,Ii,[ wal_vdev.c : 3639 ] #### NEW_STATS MGMT_HDR_dbg monitor vdev %x packet_capture_mode %d #### 
+2852,i,[ wal_vdev.c : 3649 ] #### stale_period_sec %d #### 
+2853,i,[ wal_vdev.c : 3654 ] #### mcast_dra_enabled %d #### 
+2854,iiii,[ wal_vdev.c : 3687 ] wal VDEV SR non_srg_en %d non_srg_threshold %d srg_en %d srg_threshold %d 
+2855,iII,[ wal_vdev.c : 3816 ] wal_vdev_set_param: WAL_VDEV_PARAM_FINAL_BMISS_CNT_IN_WOW[%d]=%x->%x 
+2856,ii,[ wal_vdev.c : 3826 ] wal_vdev_set_param: MBSSID_MULTI_GROUP_FLAG %d for vdev_id %d 
+2857,ii,[ wal_vdev.c : 3833 ] wal_vdev_set_param: MBSSID_MULTI_GROUP_ID %d for vdev_id %d 
+2858,I,[ wal_vdev.c : 5415 ] %s: NULL pointer 
+ 
+2859,,[ wal_vdev.c : 6174 ] _wal_vdev_state_publish: Entry  
+2860,ii,[ wal_vdev.c : 6178 ] _wal_vdev_state_publish: bytes is %d, less than output size = %d  
+2861,i,[ wal_vdev.c : 6185 ] _wal_vdev_state_publish: vdev_id_map %d  
+2862,i,[ wal_vdev.c : 6190 ] _wal_vdev_state_publish: vdev  %d  
+2863,ii,[ wal_vdev.c : 6216 ] _wal_vdev_state_publish: vdev_type_state is %d, vdev_id_state = %d  
+2864,iiiiii,[ wal_vdev.c : 6225 ] _wal_vdev_state_publish: mac_address is %d:%d:%d:%d:%d:%d  
+2865,,[ wal_vdev.c : 6230 ] _wal_vdev_state_publish: Exit  
+2866,i,[ wal_vdev.c : 6254 ] wal_add_key_entry: FATAL ERROR group_key_idx is invalid for VDEV_ID:%d 
+2867,ii,[ wal_vdev.c : 6625 ] PEER_DELETE_DBG: vdev = %d, delete_all_peer_in_progress %d 
+ 
+2868,iii,[ wal_vdev.c : 6660 ] wal_vdev_delete_all_peer_resume vdev_id = %d, thread_id = %d, msg_id = %d 
+2869,i,[ wal_vdev.c : 6671 ] PEER_DELETE_DBG: vdev = %d, set WAL_VDEV_DEL_ALL_PEER_CONF_FROM_LOCAL_FRAME_COMPL 
+ 
+2870,ii,[ wal_vdev.c : 6719 ] PEER_DELETE_DBG:  thread_id =%d, vdev_id=%d
+ 
+2871,iiI,[ wal_vdev.c : 6913 ] PEER_DELETE_DBG wal_vdev_free_event_confirmation: vdev_id=%d, flag = %d, vdev_flag_mask = %x
+ 
+2872,iii,[ wal_vdev.c : 6935 ] PEER_DELETE_DBG wal_vdev_free_event_confirmation DEL_ALL_PEER_DEL_CONF: vdev_id=%d, thread_id = %d, msg_id = %d
+ 
+2873,iii,[ wal_vdev.c : 6946 ] vdev_id:%d, prev_channel:%d, current_channel=%d 
+2874,ii,[ wal_vdev.c : 6969 ] SR prohibit timer expired non_srg: %d srg:%d 
+2875,i,[ wal_vdev.c : 6990 ] SR enable prohibit non_srg: %d 
+2876,II,[ wal_vdev.c : 7456 ] EMLSR_BCN_PROT START_TIMER Time_till_tbtt_ms %u cur_time %u
+ 
+2877,IIIii,[ wal_vdev.c : 7482 ] EMLSR_BCN_PROT ENABLE_AID Tstamp %u, tsf:%08x/%08x, bmiss:%d, resume:%d
+ 
+2878,i,[ wal_vdev.c : 7510 ] EMLSR_BCN_PROT Bmiss defer timer, timeout %d
+ 
+2879,I,[ wal_vdev.c : 7541 ] EMLSR_BCN_PROT START_TX_RX_ABORT curr_sys_time %u
+ 
+2880,I,[ wal_vdev.c : 7583 ] EMLSR_BCN_PROT TX_RX ABORT FAIL %u
+ 
+2881,Ii,[ wal_vdev.c : 7653 ] EMLSR_BCN_PROT END_TX_RX_ABORT time %u, config AID timeout %d
+ 
+2882,IIIII,[ wal_vdev.c : 7821 ] wal_vdev_mbssid_update: bss_color|suspended|pdev_id|assoc_id=%x bssid=%x trans_bssid=%x profile_idx(H16)|profile_num(L16)=%x non_trans_bss_id(H16)|trans_bss_id(L16)=%x 
+2883,iIi,[ wal_vdev.c : 322 ] wal_vdev_event_handler: vdev_id=%d event_type=0x%x remote_peer_count=%d 
+2884,,[ wal_vdev.c : 329 ] Add peer handle is NULL 
+2885,,[ wal_vdev.c : 336 ] qcache_peer Add peer handle is NULL 
+2886,,[ wal_vdev.c : 349 ] Delete peer handle is NULL 
+2887,,[ wal_vdev.c : 356 ] qcache_peer Delete peer handle is NULL 
+2888,II,[ wal_vdev.c : 402 ] flow_config: 0x%x 0x%x 
+2889,iIiiii,[ wal_vdev_migrate.c : 1296 ] VDEV migration sync: ba_migrate, thread_id=%d, peer=%p, vdev_id=%d, vdev_type=%d, pdev_id=%d:%d 
+2890,ii,[ wal_vdev_migrate.c : 266 ] vdev migrate: partial BA set:%d, pdev:%d 
+2891,ii,[ wal_thermal.c : 451 ] THERMAL_CHAIN_MASK tx_chain_mask = %d, thermal_tx_chain_mask = %d 
+2892,ii,[ wal_thermal.c : 458 ] THERMAL_CHAIN_MASK GreenAP green_ap_enabled = %d, thermal_tx_chain_mask = %d 
+2893,ii,[ wal_thermal.c : 473 ] THERMAL_CHAIN_MASK GreenAP ret = %d, thermal_tx_chain_mask = %d 
+2894,iii,[ wal_thermal.c : 489 ] thermal_throttle_get_pout_chainmask_change failed pdev_id = %d invalid cur_level = %d prev_level = %d 
+2895,ii,[ wal_thermal.c : 514 ] update pout_tx_chain failed pdev_id = %d invalid level = %d 
+2896,iiii,[ wal_thermal.c : 539 ] TempChange from temp=%d cur_level = %d lw = %d hw = %d   
+2897,iiiII,[ wal_thermal.c : 553 ] WAL_THERMAL_NEW_LAVEL req_level = %d, next_level %d cur_temp = %d lw=%lu hw = %lu  
+2898,iiiII,[ wal_thermal.c : 581 ] WAL_THERMAL_NEW_LAVEL req_level = %d, next_level %d cur_temp = %d lw=%lu hw = %lu  
+2899,ii,[ wal_thermal.c : 607 ] WAL_THERMAL_NEW_LAVEL req_level = %d, next_level %d 
+2900,iiii,[ wal_thermal.c : 658 ] WAL_THERM_TEMP_PER_CHAIN temp_per_chain(0-3) : %d, %d, %d, %d 
+2901,iii,[ wal_thermal.c : 770 ] Thermal Dispatch Stats Event to WMI HOST thrd_id = %d cur_level = %d cur_temp = %d 
+2902,iiiii,[ wal_thermal.c : 813 ] TT_DBG WMI command pdev_id = %d enable = %d tt_level = %d dc_per_event = %d  dc = %d 
+ 
+2903,iiiiiiii,[ wal_thermal.c : 829 ] TT_DBG WMI command throt_levels = %d lw = %d  hw = %d dcoffpercent = %d prio = %d pout_reduction = %d tx_chain_mask = %d duty_cycle =%d
+ 
+2904,iiii,[ wal_thermal.c : 850 ] TT_DBG WMI command throt_levels = %d  put_red_25db = %d
+ tx_chain_mask = %d duty_cycle =%d
+ 
+2905,,[ wal_thermal.c : 903 ] Invalid WMI command
+ 
+2906,i,[ wal_thermal.c : 911 ] initialize wmi service and thermal init timers thrd_id = %d 
+2907,ii,[ wal_thermal.c : 1039 ] WAL_TT_SCHED_SUSPEND_DISPATCH thrd_id = %d pdev_id = %d 
+2908,ii,[ wal_thermal.c : 1081 ] WAL_TT_SCHED_RESUME_DISPATCH thrd_id = %d pdev_id = %d 
+2909,i,[ wal_thermal.c : 1166 ] WAL_TT_LAST_TEMP_UPDATE temp = %d 
+2910,ii,[ wal_thermal.c : 1221 ] WAL_TT_SCHED_SUSPEND_HNDLR thrd_id = %d pdev_id = %d 
+2911,II,[ wal_thermal.c : 1251 ] %s: thread_id=%lx received TT_SUSPEND msg
+ 
+2912,iii,[ wal_thermal.c : 1282 ] WAL_TT_SCHED_RESUME_HNDLR thrd_id = %d pdev_id = %d time_diff %dusec 
+2913,II,[ wal_thermal.c : 1319 ] %s: thread_id=%lx received TT_RESUME msg
+ 
+2914,ii,[ wal_thermal.c : 1406 ] WAL_TT_TIMER thrd_id = %d, time=%dmsec 
+2915,,[ wal_thermal.c : 1666 ] TT_DBG_STATS Thermal Ctxt NULL 
+2916,iiiiiii,[ wal_thermal.c : 1680 ] TT_DBG_STATS  Throt_Level = %d lw = %d  hw = %d dcoffpercent = %d tx_chain_mask = %d pout_reduction = %d duty_cycle =%d
+ 
+2917,iii,[ wal_thermal.c : 1687 ] TT_DBG_STATS  Throt_Level = %d entry_count = %d  duty_cycle spent  = %d 
+2918,ii,[ wal_thermal.c : 1692 ] TT_DBG_STATS Current Temperature = %d Current_Level = %d 
+2919,i,[ wal_thermal.c : 709 ] PPDU completion Temperature Calculation Per Mac thrd_id = %d 
+2920,ii,[ wal_thermal.c : 362 ] TempChange from tx_on=%d to dcoffpercent=%d 
+2921,iIi,[ wal_thermal.c : 375 ] dcoffpercent = %d duty_cycle = % d tt_timer = %d 
+2922,ii,[ wal_thermal.c : 387 ] TempChange from temp=%d cur_level = %d  
+2923,ii,[ wal_thermal.c : 395 ] TempChange from new_level =%d dcoffpercent = %d 
+2924,iIi,[ wal_thermal.c : 410 ] dcoffpercent = %d duty_cycle = % d tt_timer = %d 
+2925,ii,[ wal_thermal.c : 421 ] TempChange from temp1=%d to temp2=%d 
+2926,ii,[ wal_thermal.c : 428 ] TempChange from temp1=%d to temp2=%d 
+2927,iiii,[ wal_channel_change_hw.c : 539 ] WAL_DBGID_CHANNEL_CHANGE_FORCE_RESET: OBW mhz:%d cf1:%d cf2:%d bw:%d 
+2928,IIIiIIII,[ wal_channel_change_hw.c : 550 ] WAL_DBGID_CHANNEL_CHANGE_FORCE_RESET: mhz = %04d cfreq1 = %04d cfreq2 = %04d mac_id = %d phy_mode = %02d flags = 0x%04x rx_stop|tx_stop = 0x%x pf_cnt = %02d 
+2929,IIIiIIII,[ wal_channel_change_hw.c : 561 ] WAL_DBGID_CHANNEL_CHANGE: mhz = %04d cfreq1 = %04d cfreq2 = %04d mac_id = %d phy_mode = %02d flags = 0x%04x pf_cnt = %02d ch_flags=0x%04x 
+2930,i,[ wal_channel_change_hw.c : 672 ] Tx resume check : tx_resumed %d 
+2931,iiiiiiiii,[ wal_channel_change_hw.c : 730 ] wal_channel_change: DPD_AbortSpectral = %d tx_abort = %d rx_suspend = %d pm_pre = %d WhalChanSwitch = %d pm_post = %d rx_resume = %d tx_resume = %d DPD_ResumeSpectral = %d 
+2932,iiiii,[ wal_channel_change_hw.c : 744 ] wal_channel_change: COEX = %d wal_radar = %d POWER = %d MAC_CORE = %d PROTOCOL = %d 
+2933,ii,[ wal_channel_change_hw.c : 759 ] wal_channel_change: mac_ticks = %d halphy_ticks = %d 
+2934,iiii,[ wal_channel_change_hw.c : 838 ] GreenAP wal_set_greenap_channel error tx/rx chainmask: %d/%d, phy_mode: %d, flag: %d 
+2935,iii,[ wal_channel_change_hw.c : 873 ] GreenAP: Clear home channel chan->mhz %d chan->bcf %d phymode:%d
+ 
+2936,iii,[ wal_channel_change_hw.c : 877 ] GreenAP: Set new home channel mhz %d bcf %d phymode:%d
+ 
+2937,iii,[ wal_channel_change_hw.c : 881 ] GreenAP: Set new home channel mhz %d bcf %d phymode:%d
+ 
+2938,,[ wal_phy_dev_hw.c : 3273 ] wifiradar:M3 SSR needed so Abort Wifi Radar Cal if in progress 
+2939,,[ wal_phy_dev_hw.c : 3423 ] SSCAN abort at wlan_rt_thread_pause_hdlr 
+2940,I,[ wal_phy_dev_hw.c : 3589 ] PHY M3 requested WARM reset for PHY: %x 
+ 
+2941,IIII,[ wal_phy_dev_hw.c : 3605 ] PHY M3 SSR is enabled, restarting M3: %x ... M3SSR asserted on pdev:%x  MAC_ID:%x  ts:%x  
+ 
+2942,I,[ wal_phy_dev_hw.c : 3611 ] PHY M3 Assert for PHY: %x 
+ 
+2943,iIIIIIIII,[ wal_phy_dev_hw.c : 4322 ] ucode_stats(%d):rx 11a=%08X,11b=%08X,11n=%08X,11ac=%08X,11ax=%08X,11be=%08X,gf=%08X,aid_mis=%08X 
+2944,iIIIIIII,[ wal_phy_dev_hw.c : 4332 ] ucode_stats(%d):tx 11a=%08X,11b=%08X,11n=%08X,11ac=%08X,11ax=%08X,11be=%08X,gf=%08X 
+2945,iiiIII,[ wal_phy_dev_hw.c : 4390 ] dynamic_cca_algo: pre_rx_bkoff=%d, lt_exp_pre_rx_dis=%d, rx_det_pre_rx_en=%d, consec_lt_exp=%04d, time_since_last_lt_exp_us=%08X:%08X 
+2946,IIIIIIIII,[ wal_phy_dev_hw.c : 4539 ] dynamic_cca_algo: pdev_id=%u, tx= %u, my_rx=%u, rx=%u, pre_rx=%u, cycle_cnt=%u,cca_busy=%u, rx_frame_det_accuracy=%u, virt_cca=%u 
+2947,IIIiIii,[ wal_phy_dev_hw.c : 4543 ] dynamic_cca_algo: num_gi_corr_toggle=%u, num_pre_rx_toggle=%u, a_ms=%u, durxrssi=%d, dur=%u, rssi=%d, ed_cca_thr_p20=%d 
+2948,iiiIIIi,[ wal_phy_dev_hw.c : 4562 ] dynamic_cca_algo: pre_rx_bkoff=%d, lt_exp_pre_rx_dis=%d, rx_det_pre_rx_en=%d, consec_lt_exp=%04d, time_since_last_lt_exp_us=%08X:%08X, trig_phy_reset=%d 
+2949,I,[ wal_phy_dev_hw.c : 4836 ] WAL_DBGID_DEV_TX_TIMEOUT  0x%x 
+2950,,[ wal_phy_dev_hw.c : 6126 ] unit_test_cmd : restart timer at WoW exit 
+2951,iIIIIIII,[ wal_phy_dev_hw.c : 8234 ] ucode_stats(%d):RX 11a=%08X,11b=%08X,11n=%08X,11ac=%08X,11ax=%08X,11be=%08X,gf=%08X 
+2952,iIIIIIII,[ wal_phy_dev_hw.c : 8238 ] ucode_stats(%d):CRC-PASS 11a=%08X,11b=%08X,11n=%08X,11ac=%08X,11ax=%08X,11be=%08X,gf=%08X 
+2953,iIIIIIII,[ wal_phy_dev_hw.c : 8242 ] ucode_stats(%d):TX 11a=%08X,11b=%08X,11n=%08X,11ac=%08X,11ax=%08X,11be=%08X,gf=%08X 
+2954,iIIIIIIII,[ wal_phy_dev_hw.c : 8279 ] ucode_stats(%d):BLK_ERR rxtd_ota=%08X, rxtd_fatal=%08X, demf=%08X,robe=%08X,pmi=%08X,txfd=%08X,txtd=%08X, phyrf=%08X 
+2955,iIIIIIIII,[ wal_phy_dev_hw.c : 8284 ] ucode_stats(%d):TX_ABORT pre_phy_des_tlv=%08X,phy_des_tlv=%08X,lsiga_tlv=%08X,lsigb_tlv=%08X,per_usr_tlv=%08X,hesigb_tlv=%08X,service_tlv=%08X,pkt_end_tlv=%08X 
+2956,II,[ wal_soc_dev_hw.c : 268 ] TCL0 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2957,II,[ wal_soc_dev_hw.c : 279 ] TCL1 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2958,II,[ wal_soc_dev_hw.c : 381 ] TQM0 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2959,II,[ wal_soc_dev_hw.c : 424 ] TQM1 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2960,II,[ wal_soc_dev_hw.c : 516 ] TQM2 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2961,II,[ wal_soc_dev_hw.c : 890 ] APB panic interrupt mask : 0x%x, total count 0x%x
+ 
+2962,II,[ wal_soc_dev_hw.c : 903 ] MEM panic interrupt mask : 0x%x, total count 0x%x
+ 
+2963,II,[ wal_soc_dev_hw.c : 911 ] WBM0 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2964,II,[ wal_soc_dev_hw.c : 933 ] WBM1 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2965,II,[ wal_soc_dev_hw.c : 950 ] WBM2 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2966,II,[ wal_soc_dev_hw.c : 964 ] RE0 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2967,II,[ wal_soc_dev_hw.c : 973 ] REO1 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2968,II,[ wal_soc_dev_hw.c : 982 ] REO2 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2969,II,[ wal_soc_dev_hw.c : 997 ] REO3 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2970,II,[ wal_soc_dev_hw.c : 1032 ] REO4 panic interrupt mask : 0x%x, total count 0x%x
+ 
+2971,II,[ wal_soc_dev_hw.c : 1041 ] GXI panic interrupt mask : 0x%x, total count 0x%x
+ 
+2972,iiii,[ wal_soc_debug_prot.c : 390 ] wal_unit_test: num_args = %d test_cmd = %d arg[1] = %d arg[2] = %d  
+2973,iii,[ wal_soc_debug_prot.c : 537 ] CONGCTRL FW_CONTROL mac_id %d max_msdu_required %d, max_msdu_available %d 
+2974,I,[ wal_soc_debug_prot.c : 632 ] tt_test solution:0x%x 
+2975,ii,[ wal_soc_debug_prot.c : 918 ] Recorded page fault count: %d, reset to 0, Total page fault count: %d 
+2976,ii,[ wal_soc_debug_prot.c : 924 ] Recorded page fault count: %d, Total page fault count: %d 
+2977,IIIII,[ wal_soc_debug_prot.c : 1126 ] pcss_ring_feeder num_interrupts:%u, num_pcss_elem_zero:%u, num_in_elem_zero:%u, num_out_elem_zero:%u, num_elem_moved:%u
+ 
+2978,,[ wal_soc_debug_prot.c : 1306 ] VBSS Debug Command 
+2979,,[ wal_soc_debug_prot.c : 1311 ] VBSS Dump VBSS Info 
+2980,i,[ wal_soc_debug_prot.c : 1332 ] DDR AST Entries - Max Num AST Entries : %d  
+2981,,[ wal_soc_debug_prot.c : 1337 ]  
+2982,i,[ wal_soc_debug_prot.c : 1342 ] OnCHIP AST Entries - Max Num AST Entries : %d  
+2983,,[ wal_soc_debug_prot.c : 1347 ]  
+2984,,[ wal_soc_debug_prot.c : 1374 ] Feature is not supported 
+2985,,[ wal_soc_debug_prot.c : 1592 ] Incorrect args set 
+2986,,[ wal_soc_debug_prot.c : 1607 ] Incorrect args set 
+2987,,[ wal_soc_debug_prot.c : 1624 ] WAL_TWT_MAX_STA_PER_SLOT: Incorrect args set 
+2988,i,[ wal_soc_debug_prot.c : 1629 ] WAL_TWT_MAX_STA_PER_SLOT: Invalid max sta val received %d 
+2989,i,[ wal_soc_debug_prot.c : 1634 ] WAL_TWT_MAX_STA_PER_SLOT set to %d 
+2990,i,[ wal_soc_debug_prot.c : 1669 ] tt_test invalid arg:%d 
+2991,Ii,[ wal_soc_debug_prot.c : 1677 ] tt_test current_time:%llu window_actual_on_percent:%d 
+2992,,[ wal_soc_debug_prot.c : 2244 ] VBSS ---------------------------------------------------- 
+2993,i,[ wal_soc_debug_prot.c : 2245 ] VBSS bssid_id_map pdev VBSS : %d  
+2994,ii,[ wal_soc_debug_prot.c : 2247 ] VBSS pdev BSSID id : %d bss_id_map : %d 
+2995,,[ wal_soc_debug_prot.c : 2249 ] VBSS ---------------------------------------------------- 
+2996,,[ wal_soc_debug_prot.c : 2250 ] VBSS Reset Struct  
+2997,iIIIIIIii,[ wal_soc_debug_prot.c : 2254 ] VBSS BSSID : %d MAC Address : %x:%x:%x:%x:%x:%x ad1 match : %d noack : %d  
+2998,,[ wal_soc_debug_prot.c : 2257 ] VBSS ---------------------------------------------------- 
+2999,,[ wal_soc_debug_prot.c : 2258 ] VBSS VDEV/PEER/TID Info 
+3000,,[ wal_soc_debug_prot.c : 2261 ] VBSS VDEV ---------------------------------------------------- 
+3001,iiiiiii,[ wal_soc_debug_prot.c : 2262 ] VBSS Vdev ID : %d Vdev type: %d subtype : %d bss_id : %d tsf_id : %d vdev_flags : %d  VBSS_ACTIVE : %d   
+3002,,[ wal_soc_debug_prot.c : 2266 ] VBSS PEER ---------------------------------------------------- 
+3003,iiiiiiii,[ wal_soc_debug_prot.c : 2268 ] VBSS peerId : %d is_bss_peer : %d vdev subtype : %d vdev flags : %d bssid : %d tsf_id : %d  peer is_vbss : %d peer vbss active : %d  
+3004,iii,[ wal_soc_debug_prot.c : 2269 ] VBSS PEER OMI : %d PEER EHT OMI : %d OMI updated : %d 
+3005,,[ wal_soc_debug_prot.c : 2271 ] VBSS AST ----------------------------------------------------- 
+3006,iIIIIII,[ wal_soc_debug_prot.c : 2295 ] AST_INDEX : %d MAC Address : %x:%x:%x:%x:%x:%x  [Duplicate Entry] 
+3007,iIIIIII,[ wal_soc_debug_prot.c : 2297 ] AST_INDEX : %d MAC Address : %x:%x:%x:%x:%x:%x  
+3008,iiiii,[ wal_soc_debug_prot.c : 2307 ] next_hop : %d mcast : %d chip_id : %d sw_peer_id : %d ml_peer_id : %d 
+3009,iiii,[ wal_soc_debug_prot.c : 2311 ] next_hop : %d mcast : %d chip_id : %d sw_peer_id : %d 
+3010,iiiiii,[ wal_soc_debug_prot.c : 2316 ] pmac_id : %d vdev_id : %d dest_chip_id : %d dest_chip_pmac_id : %d wds_roaming_detect_en : %d wds_keep_alive_en : %d 
+3011,iiiiiiii,[ wal_soc_debug_prot.c : 2320 ] Intra Bss  : %d MEC : %d monitor_sta : %d monitor_override_sta : %d ad1_match :%d no_ack : %d WDS Roam :%d WDS Keep Alive :%d 
+3012,ii,[ wal_mlo_dev.c : 261 ] TSM: no chip is time_sync_master link_id : %d, chip_id : %d 
+3013,IiIII,[ wal_mlo_dev.c : 353 ] mlo_dbg_ts_sync : wal_mlo_intrachip_fw_time_sync_handler: thread_id=%u, next_link_id:%d mlo_offset_lsb:%x, msb=%x, mlo_time=%u 
+3014,IIiI,[ wal_mlo_dev.c : 385 ] mlo_dbg_ts_sync : periodic_wal_mlo_fw_time_sync_relay: curr_link_id=%u, thread_id=%u, next_link_id:%d, mlo_time=%u 
+3015,ii,[ wal_mlo_dev.c : 448 ]  TSM: wal_mlo_mark_as_invalid_time_sync_master: resetting the master status and setting invalid master for link_id: %d, chip_id: %d  
+3016,ii,[ wal_mlo_dev.c : 560 ] TSM: wal_mlo_make_new_time_sync_master setting new time_sync_master link_id : %d, chip_id : %d 
+3017,,[ wal_mlo_dev.c : 753 ] WAL_MLO_RECOVERY: Power change Partner CHIP OFF 
+3018,,[ wal_mlo_dev.c : 758 ] WAL_MLO_RECOVERY: Power change Partner CHIP ON 
+3019,i,[ wal_mlo_dev.c : 798 ] wal_mlo_recovery ML_TIMER_OFFSET crashed chip is : %d 
+3020,i,[ wal_mlo_dev.c : 871 ] wal_mlo_recovery ML_TIMER_OFFSET crashed chip is : %d 
+3021,IIi,[ wal_mlo_dev.c : 1034 ]  WSI_REMAP MLO_OFFSET curr_mlo_offset_us %u, curr_mlo_offset_clks %u curr_time %d 
+3022,Iii,[ wal_mlo_dev.c : 1233 ] MLO : wal_mlo_handle_mlo_ts_sync_int: compensation period:%lu us:%d clks:%d 
+3023,ii,[ wal_mlo_dev.c : 1337 ] TSM: wal_dev_mlo_handle_partner_chip_crash reset old chip time sync master flag and will make new chip as master_link_id : %d, current_chip_id : %d 
+3024,,[ wal_mlo_dev.c : 1662 ] WSI_DBG WSI connection is bad, End-to-End ping failed 
+ 
+3025,,[ wal_mlo_dev.c : 1688 ] WSI_DBG First ping not done 
+3026,,[ wal_mlo_dev.c : 1802 ] wal_mlo_is_hw_link_id_in_current_chip() - Invalid Hw_link_id 
+3027,,[ wal_mlo_dev.c : 1837 ] MLO : wal_mlo_soc_init return. MLO not supported!! 
+3028,iii,[ wal_mlo_dev.c : 1888 ]  WSI_REMAP MLO: is_mlo_supported = %d is_shared_global_mem_support = %d max_num_chip = %d 
+3029,i,[ wal_mlo_dev.c : 1918 ]  WSI_BYPASS MLO: SLO case max_hw_link_id  = %d 
+3030,,[ wal_mlo_dev.c : 1943 ] WSI_BYPASS start dbell resend timer  
+3031,i,[ wal_mlo_dev.c : 2016 ]  WSI_REMAP Setting Valid Link info valid link to TRUE  for hw_link_id = %d 
+3032,i,[ wal_mlo_dev.c : 2018 ]  WSI_REMAP Resetting Valid Link info for hw_link_id = %d 
+3033,ii,[ wal_mlo_dev.c : 2030 ]  WSI_REMAP who is the time sync master now ? %d [Y=1/N=0] => %d 
+3034,i,[ wal_mlo_dev.c : 2034 ]  WSI_REMAP wal_set_mlo_valid_link valid link bitmap = %d 
+3035,i,[ wal_mlo_dev.c : 2057 ]  WSI_REMAP wal_mlo_reset_wsi_remap_state MLO_READY completed wsi_remap_state = %d 
+3036,,[ wal_mlo_dev.c : 2088 ] MLO : wal_mlo_soc_init return. MLO not supported!! 
+3037,i,[ wal_mlo_dev.c : 2195 ] wal_mlo_recovery PING_REQ crashed chip is : %d 
+3038,III,[ wal_mlo_dev.c : 2237 ] WSI_DBG WSI connection is good , Ping is successful timeStamp_req %llu timeStamp_reply %llu RTT %llu 
+ 
+3039,,[ wal_mlo_dev.c : 2261 ] WSI_REMAP wal_mlo_wsi_remap_teardown : MLO REMAP STARTED 
+3040,,[ wal_mlo_dev.c : 2279 ] WSI_REMAP wal_mlo_wsi_remap_reset : SLO case reset functionality is not required  
+3041,,[ wal_mlo_dev.c : 2286 ] WSI_REMAP wal_mlo_wsi_remap_reset UNTIMEOUT dbell timer 
+3042,,[ wal_mlo_dev.c : 2326 ] wal_mlo_recovery: MLO RECOVERY STARTED 
+3043,ii,[ wal_mlo_dev.c : 1737 ]  WSI_REMAP MLO: num_links = %d valid_link_bmap= %d  
+3044,ii,[ wal_mlo_dev.c : 91 ]  WSI_REMAP hw_link_id = %d is_time_sync_master = %d  
+3045,IIIi,[ offload_common.c : 209 ] wlan_rx_dup_chk_fail: NULL pointer passed 0x%x 0x%x 0x%x %d
+ 
+3046,iii,[ wal_cce.c : 1435 ] _wpm_cce_migrate_vdev_filter_to_new_pdev___RAM: old:%d, new:%d, srule_no:%d
+ 
+3047,iiiI,[ wal_cce.c : 1475 ] _wpm_cce_migrate_vdev_filter_to_new_pdev___RAM: rule_exist:%d, delete_src:%d, rule_no:%d, bitmap:%x
+ 
+3048,i,[ wal_cce_init.c : 776 ] _wpm_cce_get_super_rule_free_slot: position:%d
+ 
+3049,iI,[ wal_cce_init.c : 858 ] _wpm_cce_get_rule_free_slot: mac:%d, bitmap:%llx
+ 
+3050,i,[ wal_cce_init.c : 895 ] _wpm_cce_get_rule_free_slot: position:%d
+ 
+3051,iI,[ wal_cce_init.c : 966 ] _wpm_cce_get_rule_free_slot_total_num: mac:%d, bitmap:%0llX
+ 
+3052,i,[ wal_cce_init.c : 995 ] _wpm_cce_get_rule_free_slot_total_num: total_num:%d
+ 
+3053,IIII,[ wal_ast.c : 780 ] WAL_DBGID_AST_ENTRY_FULL WAL_ENOSPC mac_addr_31_0 0x%x mac_addr_47_32 0x%x sw_peer_id 0x%x orig_ast_index 0x%x 
+3054,,[ wal_ast.c : 827 ]  AST alloc : Mac address is ZERO 
+3055,iIIiI,[ wal_ast.c : 911 ] soc_debug : mcast %d onchip_ast_idx:0x%x onchipmcast idx 0x%x sw_peer_id:%d, sw_peer_key %p 
+3056,IIII,[ wal_ast.c : 1222 ] NRP_DBG ast_search_idx handle:%p mac_add31: 0x%x mac_addr47_32: 0x%x ast_index = 0x%x 
+3057,I,[ wal_ast.c : 1235 ] AST_DBG ast_search_idx invalid ast idx  ast_index = 0x%x 
+3058,Iii,[ wal_ast.c : 1240 ] AST_DBG ast_search_idx invalid ast idx  ast_index = 0x%x ast_valid = %d ast_mac_add_matched = %d 
+3059,III,[ wal_ast.c : 1345 ] NRP_DBG ast_search_idx mac_add31: 0x%x mac_addr47_32: 0x%x ast_index = 0x%x 
+3060,I,[ wal_ast.c : 1353 ] NRP_DBG ast_search_idx invalid ast idx  ast_index = 0x%x 
+3061,Iii,[ wal_ast.c : 1358 ] NRP_DBG ast_search_idx invalid ast idx  ast_index = 0x%x ast_valid = %d ast_mac_add_matched = %d 
+3062,i,[ wal_ast.c : 2022 ] ar_wal_ast_dummy_alloc_peer ast_index = %d 
+3063,III,[ wal_ast.c : 2073 ] ASTALLOC Peer : WAL_DBGID_AST_ENTRY_EXIST WAL_EEXIST for mac 0x%x 0x%x ast_idx 0x%x 
+3064,IIIIIIi,[ wal_ast.c : 2083 ] WAL_AST_ALLOC_PEER Threadid %x : peer_mac:0x%x 0x%x ast_index:0x%x sw_peer_id:0x%x ast_flags:0x%x status:%d 
+3065,iI,[ wal_ast.c : 2186 ] AST_DBG ast_index:%d ar_wal_ast_get_mac_addr called by fn %x when AST ENTRY INVALID 
+3066,I,[ wal_ast.c : 2536 ] AST_UPDATE: SW peer key not found, peer_mac-0x%x 
+3067,IiiIIIII,[ wal_ast.c : 2560 ] Update reorder queue peer_mac-0x%x, sw_peer_id-%d, vdev_id-%d, queue_addr-0x%x:0x%x, queue-%x, ba_win-0x%x:0x%x 
+3068,IIIIII,[ wal_ast_monitor.c : 141 ] TXPEER_FILTER wal_ast_alloc_monitor_override_sta_addr ast_idx 0x%x mac_31_0 0x%x mac_47_32 0x%x pdev_id 0x%x ret_code 0x%x line_id 0x%x 
+3069,IIIII,[ wal_ast_monitor.c : 286 ] TXPEER_FILTER wal_ast_remove_monitor_override_sta_addras_idx 0x%x mac_31_0 0x%x mac_47_32 0x%x peer_null 0x%x status 0x%x 
+3070,III,[ wal_ast_monitor.c : 301 ] TXPEER_FILTER - :vdev:[%x] action:[%x] mac_addr:[%x] 
+3071,IIIII,[ wal_ast_monitor.c : 426 ] WAL_DBGID_AST_ADD_MONITOR_DIRECT_ENTRY ast_idx 0x%x mac_31_0 0x%x mac_47_32 0x%x pdev_id 0x%x ret:0x%x 
+3072,IIIiII,[ wal_ast_monitor.c : 511 ] NRP_DBG WAL_DBGID_AST_ADD_MONITOR_DIRECT_ENTRY offchip, ast_idx 0x%x mac_31_0 0x%x mac_47_32 0x%x pdev_id:%d ret 0x%x line_id 0x%x 
+3073,IIII,[ wal_ast_monitor.c : 582 ] VBSS WAL_DBGID_AST_DEL_MONITOR_DIRECT_ENTRY onchip 0x%x 0x%x 0x%x 0x%x SKIP VBSS  
+3074,IIII,[ wal_ast_monitor.c : 641 ] WAL_DBGID_AST_DEL_MONITOR_DIRECT_ENTRY onchip 0x%x 0x%x 0x%x 0x%x 
+3075,IIIIII,[ wal_ast_monitor.c : 758 ] NRP_DBG WAL_DBGID_AST_DEL_MONITOR_DIRECT_ENTRY offchip 0x%x 0x%x 0x%x 0x%x mac_add31_0:0x%x mac_addr47_32:0x%x 
+3076,II,[ wal_ast_monitor.c : 829 ] WAL_DBGID_AST_DEL_ALL_MONITOR_DIRECT_ENTRY  0x%x 0x%x 
+3077,ii,[ wal_ast_mec.c : 85 ] MEC - UPDATE MEC ENTRY  ast_index : %d  is_active : %d  
+3078,iIIIIII,[ wal_ast_mec.c : 141 ] MEC - ADD MEC ENTRY ast_index : %d mac : %x:%x:%x:%x:%x:%x  
+3079,iIIi,[ wal_ast_mec.c : 243 ] MEC - DELETE MEC ENTRY  ast_index : %d mac : 0x%x 0x%x  is_active : %d  
+3080,IIIIIIII,[ wal_ast_wds.c : 378 ] WAL_DBGID_AST_ADD_WDS_ENTRY Threadid 0x%x ast_idx 0x%x mac_31_0 0x%x mac_47_32 0x%x p_mac_31_0 0x%x p_mac_47_32 0x% pdev_id 0x%x ret_code|line_id 0x%x 
+3081,IIIIIIII,[ wal_ast_wds.c : 545 ] VBSS SKIP KICKOUT WAL_DBGID_AST_UPDATE_WDS_ENTRY Threadid 0x%x  0x%x destmac:0x%x peermac:0x%x flags 0x%x pdev_id|sw_peer_id 0x%x ret_code %x line_id %x 
+3082,IIIIIIII,[ wal_ast_wds.c : 571 ] WAL_DBGID_AST_UPDATE_WDS_ENTRY Threadid 0x%x  0x%x destmac:0x%x peermac:0x%x flags 0x%x pdev_id|sw_peer_id 0x%x ret_code %x line_id %x 
+3083,III,[ wal_ast_wds.c : 625 ] WAL_DBGID_AST_FREE_WDS_ENTRY des_mac is not next_hop or monitor direct Threadid 0x%x 0x%x 0x%x 
+3084,IIIII,[ wal_ast_wds.c : 87 ] WAL_DBGID_AST_DEL_WDS_ENTRY  Threaid 0x%x 0x%x 0x%x 0x%x valid 0x%x 
+3085,i,[ wal_ast_rtt.c : 35 ] rtt 11AZ: matching onchip AST entry:%d found and deleted 
+3086,i,[ wal_ast_rtt.c : 50 ] rtt 11AZ: matching Offchip AST entry:%d found and deleted 
+3087,II,[ wal_peer_control.c : 401 ] wal_peer_set_ptk_m4_sent, peer:%x, peer-flags=%x 
+3088,IIii,[ wal_peer_control.c : 517 ] ar_wal_sw_peer_key_alloc sw_peer_key 0x%x alloc_flag 0x%x remote_sw_peer_key_in_local_mem %d remote_sw_peer_key_cnt_in_local_mem %d 
+3089,,[ wal_peer_control.c : 604 ] Remote sw_peer_key count in local memory is invalid 
+3090,Iii,[ wal_peer_control.c : 613 ] ar_wal_sw_peer_key_free sw_peer_key 0x%x remote_sw_peer_key_in_local_mem %d remote_sw_peer_key_cnt_in_local_mem %d 
+3091,i,[ wal_peer_control.c : 1722 ] ROAMING_DBG WAL_PEER_DISABLE_KICKOUT flag set for peer %d 
+3092,IIii,[ wal_peer_control.c : 1792 ] WAL_ALLOC_PEER_AST_FAIL peer_addr 0x04%x08%x peer_type:%d, error:%d  
+3093,i,[ wal_peer_control.c : 2149 ] PEER_ALLOC: peer_id=%d: Fail to allocate wmm_param 
+3094,IIIIII,[ wal_peer_control.c : 2513 ] FREE_AST_ENTRY: peer=%p sw_peer_id=%umac_addr=0x%x %x  ast_index=0x%x valid_bmap[ast_index]=0x%x 
+3095,,[ wal_peer_control.c : 2735 ] TBD_MLO_TQM: ERROR For RDP441 Miami, freeing flow_q which was not allocated 
+3096,iiI,[ wal_peer_control.c : 2892 ] PEER_DELETE_DBG - _wal_peer_del_msg_hdlr:  thread_id =%d, sw_peer_id=%d, peer->peer_flgs=0x%x
+ 
+3097,ii,[ wal_peer_control.c : 3049 ] PEER_DELETE_DBG - wal_peer_delete_conf_msg_hdlr: peer=%d,num_del_in_pro=%d 
+3098,ii,[ wal_peer_control.c : 3085 ] PEER_DELETE_DBG - wal_peer_delete_conf_msg_hdlr: peer = %d, pdev_peer_deletes_in_progress = %d
+ 
+3099,III,[ wal_peer_control.c : 3115 ] PEER_DELETE_DBG Deleted tid_mask = %x, created tid_mask = %x, tid_mask %x requested for delete 
+3100,i,[ wal_peer_control.c : 3229 ] PEER_DELETE_DBG - wal_peer_free delete already in progress for peer %d 
+3101,i,[ wal_peer_control.c : 3242 ] PEER_DELETE_DBG - wal_peer_free Primary UMAC Migration in progress for %d 
+3102,ii,[ wal_peer_control.c : 3284 ] PEER_DELETE_DBG - _wal_peer_free: peer = %d delete_in_progress %d 
+3103,i,[ wal_peer_control.c : 3289 ] PEER_DELETE_DBG - wal_peer_free delete already in progress for peer %d 
+3104,iii,[ wal_peer_control.c : 3399 ] PEER_DELETE_DBG - wal_peer_delete_resume: peer = %d, delete_in_progress %d pdev_peer_deletes_in_progress = %d
+ 
+3105,i,[ wal_peer_control.c : 3467 ] PPE_DS: unsupported PPE config %d 
+3106,,[ wal_peer_control.c : 5201 ] qdepth_thresh_update_cmd_handler:                     Invalid sw_peer_key 
+3107,,[ wal_peer_control.c : 5208 ] qdepth_thresh_update_cmd_handler:                     Invalid peer 
+3108,,[ wal_peer_control.c : 5218 ] qdepth_thresh_update_cmd_handler:                    is_self_peer or bss_peer 
+3109,,[ wal_peer_control.c : 5228 ] qdepth_thresh_update_cmd_handler:                    peer delete in progress 
+3110,i,[ wal_peer_control.c : 5249 ] qdepth_thresh_update_cmd_handler:                    not valid TID give tidno:%d 
+3111,i,[ wal_peer_control.c : 5261 ] qdepth_thresh_update_cmd_handler:                   not valid tqm tid tidno:%d 
+3112,ii,[ wal_peer_control.c : 5284 ] qdepth_thresh_update_cmd_handler:                        qtype:%d host_drop_th:%d  
+3113,,[ wal_peer_control.c : 5320 ] WMI_PEER_REORDER_QUEUE_SETUP_CMDID vdev NULL  
+3114,iiIIii,[ wal_peer_control.c : 5361 ] Hw error injection: Saving DESC for tid:%d Q:%d Lo:%x Hi:%x WS:%d WSV:%d 
+3115,,[ wal_peer_control.c : 5387 ] WMI_PEER_REORDER_QUEUE_REMOVE_CMDID vdev NULL  
+3116,iiIIii,[ wal_peer_control.c : 5468 ] Hw error injection: Saving DESC for tid:%d Q:%d Lo:%x Hi:%x WS:%d WSV:%d 
+3117,iii,[ wal_peer_control.c : 5894 ] PEER_DELETE_DBG - wal_vdev_delete_all_peer_queue_dummy_frame_into_tqm: vdev = %d, sw_cookie = %d, buffer_id = %d 
+ 
+3118,iii,[ wal_peer_control.c : 5949 ] PEER_DELETE_DBG - wal_vdev_delete_all_peer_queue_dummy_frame_into_tcl: vdev = %d, sw_cookie = %d, buffer_id = %d 
+ 
+3119,III,[ wal_peer_control.c : 6396 ] OMI: Change a_ctrl from 0x%lx to 0x%lx, ULMU Disable is 0x%lx
+ 
+3120,i,[ wal_peer_control.c : 6649 ] wal_peer_alloc_ul_state alloc tid failed for peer %d  
+3121,IiiiII,[ wal_peer_control.c : 6911 ] set_pdg_notify_reg_set %x %d %d %d %x %x 
+3122,IiiiiIi,[ wal_peer_control.c : 6961 ] wal_peer_disable_pdg_notify_acceleration sw_peer_id %x  notify_acc_enabled %d  notify_reg_index %d peer_count %d vdev_type %d rate_code %x update_bss_noti_reg %d 
+3123,,[ wal_peer_key_control.c : 224 ] ar_wal_config_wep_varied_key key_id invalid  
+3124,iIiiiiI,[ wal_peer_key_control.c : 296 ] security: wal_peer_set_key: peer:%d, key_info:%p, key_id:%d is_mcast:%d key_type:%d key_cipher:%d key_flags:%02x  
+3125,iI,[ wal_peer_key_control.c : 957 ] security: postponing set key for peer_id:%d peer_flags:%02x 
+3126,iI,[ wal_peer_key_control.c : 1014 ] security: ML_RECONFIG installing key on newly added link. sw_peer_id:%d key_data:0x%x 
+3127,iIiI,[ wal_peer_key_control.c : 1235 ] security: ar_wal_peer_set_key_block_cb: peer_id:%d  peer_flags:%02x authrized:%d qpeer_flags:%x 
+3128,iIi,[ wal_peer_key_control.c : 1370 ] security: ar_wal_peer_set_mcast_key_block_cb: peer_id:%d  peer_flags:%02x authrized:%d 
+3129,IIII,[ wal_peer_migration.c : 271 ] peer_migrate failed: rx:%x, tx:%x MAC:%x, reset_cause %x 
+3130,i,[ wal_peer_params.c : 252 ] ML_RECONFIG: clearing peer->ml_rcfg_new_peer flag sw_peer_id %d 
+3131,I,[ wal_peer_params.c : 990 ] OMI: Set new nss = 0x%lx
+ 
+3132,I,[ wal_peer_params.c : 997 ] OMI: Set new bw = 0x%lx
+ 
+3133,I,[ wal_peer_params.c : 1003 ] OMI: Set new a_ctrl = 0x%lx
+ 
+3134,,[ wal_peer_tid_control.c : 292 ] wal_soc_get_peer_tid_swap_pool() is NULL 
+3135,ii,[ wal_peer_tid_control.c : 326 ] PEER_DELETE_DBG - wal_peer_tid_free_mem: sw_peer_id=%d, tidno = %d 
+3136,i,[ wal_peer_tid_control.c : 365 ] PEER_DELETE_DBG - delete_all_peer wal_peer_tid_free_mem: WLAN_THREAD_COMM_FUNC_VDEV_DEL_ALL_PEER peer_id:%d 
+3137,ii,[ wal_peer_tid_control.c : 443 ] qos enabled mismatch qcache_peer->qos_enabled %d WAL_IS_TID_QOS_DATA(tidno) %d 
+3138,i,[ wal_peer_tid_control.c : 445 ] Tid %d is of qos data 
+3139,iiI,[ wal_peer_tid_control.c : 587 ] ar_wal_peer_alloc_tid_with_flags: tidno:%d sw_peer_id:%d bmask:0x%08x
+ 
+3140,IiiiI,[ wal_peer_tid_control.c : 662 ] ul_dbg_tid_alloc: peer=0x%x, tidno=%d, ac=%d, timeout_ms=%d, tid_ptr=0x%x 
+3141,,[ wal_peer_tid_control.c : 771 ] Duplicate TID creation 
+3142,ii,[ wal_peer_tid_control.c : 924 ] PEER_DELETE_DBG - _ar_wal_peer_free_tid:                sw_peer_id=%d, tidno=%d 
+3143,ii,[ wal_peer_tid_control.c : 938 ] PEER_DELETE_DBG - _ar_wal_peer_free_tid: sending tid flush cmd to tac thread_id=%d, tidno=%d
+ 
+3144,i,[ wal_peer_tqm_control.c : 61 ] tx header size update failed due to pending sched cmds %d 
+3145,iIIII,[ wal_peer_vbss.c : 67 ] VBSS GET PEER Context Tx PN sw_peer_id : %d pn_128_ptr : %x %x %x %x |  
+3146,ii,[ wal_peer_vbss.c : 77 ] VBSS wal_peer_vbss_get_peer_info tid_num : %d win_ssn : %d  
+3147,IIII,[ wal_peer_vbss.c : 121 ] VBSS SET PEER Context Tx PN  pn_128_ptr : %x %x %x %x |  
+3148,,[ wal_peer_vbss.c : 136 ] VBSS wal_peer_vbss_set_peer_info Set Peer to Active State 
+3149,iiI,[ wal_peer_vbss.c : 182 ] VBSS wal_peer_vbss_set_peer_sn_info tid_num : %d ssn : %d tid_flags : %x  
+3150,iiI,[ wal_peer_vbss.c : 186 ] VBSS wal_peer_vbss_set_peer_sn_info tid_num : %d ssn : %d tid_flags : %x  
+3151,ii,[ wal_peer_vbss.c : 209 ] VBSS wal_peer_update_mpduq_head tid_num : %d ssn : %d  
+3152,iii,[ wal_peer_vbss.c : 232 ] VBSS wal_peer_vbss_set_omi omi : %d eht_omi : %d htctrl : %d   
+3153,Iiiii,[ wal_ml_peer_control.c : 207 ] wal_peer_emlsr_mode_enable_diable  ml_peer = 0x%x en_dis = %d link_idx = %d padding_delay %d tranition_delay %d 
+3154,II,[ wal_ml_peer_control.c : 857 ] ML_RECONFIG: subscribe_tqm_status returning wal_peer 0x%x, ml_peer 0x%x 
+3155,,[ wal_ml_peer_control.c : 869 ] ML_RECONFIG: subscribe_tqm_status returning qpeer NULL / del in prog 
+3156,iIiI,[ wal_ml_peer_control.c : 884 ] ML_RECONFIG: subscribe_tqm_status ml_peer_id:%d st_req:0x%x pri_ch:%d tqm_st_req_bmap:0x%x 
+3157,i,[ wal_ml_peer_control.c : 967 ] ML_RECONFIG: update tqm link info called when num links are %d 
+3158,iII,[ wal_ml_peer_control.c : 990 ] ML_RECONFIG: ml_peer_id:%d valid_hw_link_bmap:0x%x valid_logical_link_bmap:0x%x 
+3159,iIIIIIII,[ wal_ml_peer_control.c : 1106 ] ML_RECONFIG: tid:%d hw_link_bmap_cur/new: (0x%x,0x%x) LTBD:0x%x LTBA:0x%x pend_LTBA:0x%x tx_link_bmap old:0x%x new:0x%x 
+3160,iiiiiiiii,[ wal_ml_peer_control.c : 1111 ] ML_RECONFIG: cur l0,l1,l2: (%d,%d,%d) new l0,l1,l2: (%d,%d,%d) updt l0,l1,l2: (%d,%d,%d) 
+3161,iII,[ wal_ml_peer_control.c : 1166 ] ML_RECONFIG: update tqm link info failed rc:%d wal_peer 0x%x ml_peer 0x%x 
+3162,III,[ wal_ml_peer_control.c : 1200 ] ML_RECONFIG: ASSOC_IPC_HDLR returning wal_peer 0x%x, ml_peer 0x%x, peer_ml_config 0x%x 
+3163,iIiIi,[ wal_ml_peer_control.c : 1263 ] ML_RECONFIG: tlt init from IPC path: notify to SA thread, ml_peer_id:%d sw_peer_id:%u tid_num:%d thread_id:%u tlt_init:%d 
+3164,III,[ wal_ml_peer_control.c : 1325 ] ML_RECONFIG: ML_PEER_UPDT returning wal_peer 0x%x, ml_peer 0x%x, peer_ml_config 0x%x 
+3165,iii,[ wal_ml_peer_control.c : 1386 ] ML_RECONFIG: ML_PEER_UPDT wal_ml_peer_id:%d, new num_links:%d emlsr_supp:%d 
+3166,III,[ wal_ml_peer_control.c : 1398 ] ML_RECONFIG: LINK_UPDT returning wal_peer 0x%x, ml_peer 0x%x, peer_ml_link_config 0x%x 
+3167,iiiiiii,[ wal_ml_peer_control.c : 1414 ] ML_RECONFIG: LINK_UPDT wal_ml_peer_id:%d link_op:%d my_chip:%d src_chip:%d src_hw_link:%d src_LL_idx:%d init:%d 
+3168,iIiIi,[ wal_ml_peer_control.c : 1497 ] ML_RECONFIG: tlt init from WMI path: notify to SA thread, ml_peer_id:%d sw_peer_id:%u tid_num:%d thread_id:%u tlt_init:%d 
+3169,iiiii,[ wal_ml_peer_control.c : 1529 ] ML_RECONFIG: recv link del when num_links is 1; wal_ml_peer_id:%d, chip_id:%d, hw_link_id:%d, LL_idx:%di ll_idx_init:%d 
+3170,iiIIiiII,[ wal_ml_peer_control.c : 1571 ] ML_RECONFIG: PARTNER_LINK_DEL OLD num_links:%d sw_peer_id:%d schd_del_rc:0x%x del_conf_atm:0x%x; NEW num_links:%d sw_peer_id:%d schd_del_rc:0x%x del_conf_atm:0x%x 
+3171,I,[ wal_ml_peer_control.c : 1738 ] wal_ml_peer_post_peer_assoc_msg: Invalid  msg.peer_assoc_msg.ml_peer_idx= %hu
+ 
+3172,I,[ wal_ml_peer_control.c : 1786 ] wal_ml_peer_post_peer_assoc_msg_by_hw_link_id: Invalid  msg.peer_assoc_msg.ml_peer_idx= %hu
+ 
+3173,iiiii,[ wal_ml_peer_control.c : 1790 ] ML_RECONFIG: re send peer assoc IPC to hw_link_id:%d from src:%d ml_peer_id:%d ml_peer_idx:%d is_src_pri:%d 
+3174,iIiIII,[ wal_ml_peer_control.c : 1911 ] tlt_dbg tid_create_send  ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, status_proc_mask=0x%x, dest_idx=%u, mlo_linkidx_bmap=0x%x 
+3175,iiiii,[ wal_ml_peer_control.c : 2055 ] security: wal_ml_set_key_ipc_handler peer_key %d key_type %d set_key_type %d key_id %d set_key_id_flag %d
+ 
+3176,iiiI,[ wal_ml_peer_control.c : 2065 ] security: wal_ml_set_key_ipc_handler mlo->set_key_pending_bmap %d peer_id:%d hw_link_id: %d ml_peer_flag: 0x%08x
+  
+3177,,[ wal_ml_peer_control.c : 2073 ] security: wal_ml_set_key_ipc_handler peer or qpeer is NULL 
+3178,iiiiii,[ wal_ml_peer_control.c : 2173 ] ML_RECONFIG: link_peer_del_ipc_hdlr wal_ml_peer_id:%d, src_link_idx:%d, dst_link_idx:%d, src_hw_idx:%d, dst_hw_idx:%d dst_pri:%d 
+3179,iI,[ wal_ml_peer_control.c : 2266 ] tlt_dbg: link_delete_trigger master link: ml_peer_id:%d, sw_peer_id=%u 
+3180,I,[ wal_ml_peer_control.c : 2313 ] wal_ml_peer_cleanup_msduq_meta_infos: Invalid  peer_idx= %hu
+ 
+3181,II,[ wal_ml_peer_control.c : 2513 ] security: unblock connection through master link: peer:%p  peer_flags:%02x 
+3182,ii,[ wal_ml_peer_control.c : 2529 ] security: run tid flush for master mcast_key_size_update %d ml_peer->num_links %d
+ 
+3183,ii,[ wal_ml_peer_control.c : 2647 ] security: wal_ml_peer_mcast_key_update key_data %d peer id:%d 
+ 
+3184,II,[ wal_ml_peer_control.c : 2739 ] security: setting partner link keys aspects peer:%p  peer_flags:%02x 
+3185,Ii,[ wal_ml_peer_control.c : 3045 ] wal_ml_peer_emlsr_enable emlsr old state = 0x%x new state = %d
+ 
+3186,Ii,[ wal_ml_peer_control.c : 3082 ] wal_ml_peer_emlsr_bcn_protection_enable emlsr state = 0x%x timer state = %d
+ 
+3187,iiiii,[ wal_ml_peer_control.c : 3116 ] msd_config_get: pdev %d, timer %d, ed_thres %d, txop %d, switch %d 
+3188,iIi,[ wal_ml_peer_control.c : 3652 ] ML_RECONFIG: unsubscribe_tqm_status ml_peer_id:%d st_req:0x%x pri_ch:%d 
+3189,iIiI,[ wal_ml_peer_control.c : 3862 ] tlt_dbg send_block_sched_ipc_to_non_master  ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, dest_idx=%u 
+3190,iiIIIII,[ wal_ml_peer_control.c : 4079 ] tlt_dbg: tuple_select ml_peer_id:%d, tid_num:%d, new_tlt_link_bitmap=0x%x,hw_link_id_0=0x%x, valid=%u, hw_link_id_1=0x%x, valid=%u 
+3191,iIIII,[ wal_ml_peer_control.c : 4123 ] tlt_dbg_pm_bitmap: ml_peer_id:%d, hw_link_id=%u, sw_peer=%u, ret_val=%u, pm=%u 
+3192,iiIIIII,[ wal_ml_peer_control.c : 4168 ] tlt_dbg: tuple_select prep: ml_peer_id:%d, tid_num:%d, hw_link_id=%u, sw_peer=%u, ret_val=%u, pm=%u, link_t2lm_state =%u 
+3193,iiIIIIII,[ wal_ml_peer_control.c : 4329 ] tlt_dbg: shortlisted_tuple ml_peer_id:%d, tid_num:%d, active_link_bmap=0x%x, tlt_link_bitmap=0x%x, fw_valid=%u, order=%u:%u:%u 
+3194,ii,[ wal_ml_peer_control.c : 4517 ] tlt_dbg tid_init_hdlr ml_peer_id:%d, tid_num:%d 
+3195,iiIiiii,[ wal_ml_peer_control.c : 4549 ] ML_RECONFIG: tlt_init ml_peer_id:%d tid_num:%d bmap:0x%x l0:%d l1:%d l2:%d loop:%d 
+3196,i,[ wal_ml_peer_control.c : 4609 ] Software peer id for the link :%d is invalid 
+3197,iIiI,[ wal_ml_peer_control.c : 4628 ] tlt_dbg tlt_update_status (SA thread - master) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, tlt_master_link=0x%x 
+3198,iIiI,[ wal_ml_peer_control.c : 4634 ] tlt_dbg activating link for scheduling (master link) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, tlt_master_link=0x%x 
+3199,iIi,[ wal_ml_peer_control.c : 4671 ] tlt_dbg ownership_clear_handler (SA thread) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d 
+3200,iIi,[ wal_ml_peer_control.c : 4684 ] tlt_dbg ownership_clear_handler (SA thread-master link) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d 
+3201,iIiI,[ wal_ml_peer_control.c : 4759 ] tlt_dbg tlt_update_status (SA thread - non master) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, tlt_link_bitmap=0x%x 
+3202,iIiI,[ wal_ml_peer_control.c : 4765 ] tlt_dbg activating link for scheduling (non master link) ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, tlt_link_bitmap=0x%x 
+3203,iIiI,[ wal_ml_peer_control.c : 4841 ] tlt_dbg send_block_sched_conf_ipc_to_master  ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, initiator_link_idx=%u 
+3204,iIi,[ wal_ml_peer_control.c : 4880 ] tlt_dbg block_sched_ipc_hldr  ml_peer_id:%d, sw_peer_id=%u, tid_num:%d 
+3205,iIiI,[ wal_ml_peer_control.c : 4932 ] tlt_dbg block_sched_conf_ipc_hldr  ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, sender_link_idx=%u 
+3206,ii,[ wal_ml_peer_control.c : 4955 ] tlt_dbg update sw_peer_id:%d, tid_num:%d 
+3207,iIIIII,[ wal_ml_peer_control.c : 5093 ] tlt_dbg: process_wmi_tlt_update: ml_peer_id:%d, sw_peer_id=%u, tx_link_bitmap=0x%x, link_prio_order_hw_link_id=%u:%u:%u 
+3208,iII,[ wal_ml_peer_control.c : 5118 ] tlt_dbg trigger_master_tlt_selection ml_peer_id:%d, sw_peer_id=%u, peer_link_idx=%u 
+3209,iI,[ wal_ml_peer_control.c : 5159 ] tlt_dbg trigger_master_tlt_selection_hdlr ml_peer_id:%d, sw_peer_id=%u 
+3210,iIIIIIII,[ wal_ml_peer_control.c : 5293 ] tlt_dbg: compute_link_priority  ml_peer_id:%d, bw_update_pending=%u, bw_max_arr=%u, %u, %u, order=%u:%u:%u 
+3211,iIII,[ wal_ml_peer_control.c : 5299 ] tlt_dbg: compute_link_priority  ml_peer_id:%d hwlink:%u:%u:%u 
+3212,iII,[ wal_ml_peer_control.c : 5315 ] tlt_dbg: compute_link_priority_load_balance  ml_peer_id:%d, curr_bitmap=%x, expected:%x 
+3213,iI,[ wal_ml_peer_control.c : 5359 ] wal_mlo_recovery setting the recovery parameters crashed chip is : %d status_required_bits : %x 
+3214,II,[ wal_ml_peer_control.c : 5438 ] T2LM_DBG_TLT: wal_vdev_trigger_tlt_udpate disabled_link_mask:0x%x link_map:0x%x 
+3215,II,[ wal_ml_peer_control.c : 5625 ] mcast_link: Invalid pointer ml_peer:%p mcast_sw_peer_key:%p 
+3216,ii,[ wal_ml_peer_control.c : 5636 ] mcast_link: cur_link_id:%d new_link:%d 
+3217,I,[ wal_ml_peer_control.c : 452 ] wal_peer_init_ml_peer: Invalid  ml_peer->ml_peer_ext->ml_peer_node_idx[peer_ml_config->setup_link_id]= %hu
+ 
+3218,iiii,[ wal_ml_peer_control.c : 585 ] Set RX BA params for partner links tid %d, seq_st %d, win_sz %d, state %d
+ 
+3219,iIiI,[ wal_ml_peer_control.c : 615 ] tlt_dbg: init from peer_assoc_ipc path: notify to SA thread, ml_peer_id:%d, sw_peer_id=%u, tid_num:%d, thread_id=%u 
+3220,III,[ wal_ml_peer_control.c : 678 ] wal_peer_init_ml_peer peer = 0x%x cfg_ipc_init|cfg_num_links|cfg_ml_peer_id = 0x%08x, peer_assoc_ipc_revd_bmap=0x%x 
+3221,III,[ wal_ml_peer_control.c : 698 ] wal_peer_init_ml_peer link_info valid|active|primary|vdev_id = 0x%08x, assoc|master|anchor|hw_link_id = 0x%08x, sw_peer_id|ml_peer_id=0x%08x 
+3222,iiIIIIII,[ wal_ml_peer_control.c : 4393 ] tlt_dbg: final_tuple_select ml_peer_id:%d, tid_num:%d, curr_tlt_link_bitmap=0x%x, next_tlt_link_bitmap=0x%x, time_ms=%u, pending_conf=0x%x, hw_link_ids:%u:%u 
+3223,ii,[ wal_ml_peer_umac_migration.c : 168 ] PRI_UMAC_MIG : SM : wal_pri_umac_mig_abort_migration sw_peer_id %d, abort_status %d 
+3224,i,[ wal_ml_peer_umac_migration.c : 178 ] PRI_UMAC_MIG : SM : wal_pri_umac_mig_abort_migration pending peer delete resumed sw_peer_id %d 
+3225,ii,[ wal_ml_peer_umac_migration.c : 302 ] PRI_UMAC_MIG : SM : wal_mlo_pri_umac_mig_tqm_sync_ipc_hdlr src_link_id %d num_links_rcvd %d 
+3226,iiIiiii,[ wal_ml_peer_umac_migration.c : 658 ] ML_RECONFIG: migr ml_peer_id:%d tid_num:%d bmap:0x%x l0:%d l1:%d l2:%d loop:%d 
+3227,iii,[ wal_ml_peer_umac_migration.c : 798 ] PRI_UMAC_MIG : SM : wal_ml_peer_pri_umac_mig_notify_partner_links link_idx_src %d link_idx_dest %d msg %d 
+3228,iiIi,[ wal_ml_peer_umac_migration.c : 878 ] PRI_UMAC_MIG : SM : wal_ml_peer_pri_umac_mig_notify_partner_link_handler link_idx %d sw_peer_id %d peer_ptr %x msg %d 
+3229,,[ wal_ml_peer_umac_migration.c : 892 ] PRI_UMAC_MIG : SM : wal_ml_peer_pri_umac_mig_notify_partner_link_handler - HANDSHAKE completed 
+3230,i,[ wal_ml_peer_umac_migration.c : 929 ] PRI_UMAC_MIG : SM : wal_ml_peer_pri_umac_mig_notify_partner_link_handler ppe_src_info %d 
+3231,i,[ wal_ml_peer_umac_migration.c : 968 ] PRI_UMAC_MIG : SM : wal_rx_primary_peer_migrate_msg_hdlr ppe_src_info %d 
+3232,Iiii,[ wal_ml_peer_umac_migration.c : 1252 ] PRI_UMAC_MIG : SM : old primary prev RxPt Info fp_uc_mc_1000 %x, src_ring %d dest_ring %d reo_dest %d 
+3233,Iiii,[ wal_ml_peer_umac_migration.c : 1313 ] PRI_UMAC_MIG : SM : New primary Prev RxPt Info fp_uc_mc_1000 %x, src_ring %d dest_ring %d reo_dest %d 
+3234,ii,[ wal_ml_peer_umac_migration.c : 1347 ] PRI_UMAC_MIG : SM : hw_link_id %d Duration_us %d 
+3235,iIiIi,[ wal_ml_peer_umac_migration.c : 1401 ] ML_RECONFIG: tlt init from umac migr: notify to SA thread, ml_peer_id:%d sw_peer_id:%u tid_num:%d thread_id:%u tlt_init:%d 
+3236,iIiIi,[ wal_ml_peer_umac_migration.c : 1409 ] ML_RECONFIG: tlt updt done from umac migr: notify to SA thread, ml_peer_id:%d sw_peer_id:%u tid_num:%d thread_id:%u tlt_init:%d 
+3237,iiIi,[ wal_ml_peer_umac_migration.c : 1441 ] PRI_UMAC_MIG : SM : curr_state %d next_state %d flags %x cur_primary_link %d 
+3238,i,[ wal_ml_peer_umac_migration.c : 1462 ] PRI_UMAC_MIG : WMI_CMD : There is no ml_peer with ml_peer_id %d 
+3239,i,[ wal_ml_peer_umac_migration.c : 1470 ] PRI_UMAC_MIG : WMI_CMD : Invalid link id:  %d 
+3240,ii,[ wal_ml_peer_umac_migration.c : 1485 ] PRI_UMAC_MIG : WMI_CMD : There is no link peer in ml_peer %d with sw_peer_id %d 
+3241,,[ wal_ml_peer_umac_migration.c : 1493 ] PRI_UMAC_MIG : WMI_CMD : All Links are not initialized 
+3242,iiii,[ wal_ml_peer_umac_migration.c : 1510 ] PRI_UMAC_MIG : WMI_CMD : Invalid config : ml_peer %d with sw_peer_id %d cur_pri %d, new_pri %d 
+3243,i,[ wal_ml_peer_umac_migration.c : 1521 ] PRI_UMAC_MIG : WMI_CMD : Invalid link id:  %d 
+3244,ii,[ wal_ml_peer_umac_migration.c : 1530 ] PRI_UMAC_MIG : WMI_CMD : New primary hw_link_id for ml_peer %d is %d 
+3245,i,[ wal_ml_peer_umac_migration.c : 1588 ] PRI_UMAC_MIG : WMI_EVT : WMI event for ml_peer_id %d 
+3246,iiii,[ wal_rtt.c : 239 ] rtt_compute_distance num_meas: %d mean_rtt: %d median_rtt: %d distance_cm: %d 
+3247,III,[ wal_rtt.c : 1366 ] _wal_rtt_attach() pdev = %p rtt_pdev_ctxt = %p wal_rtt_ctxt = %p 
+3248,iIIIi,[ wal_rtt.c : 1403 ] _wal_rtt_init() pdev_id = %d rtt_ctxt: %p  alloc_buff = %p buff = %p max_buff_len = %d 
+3249,iiiiII,[ wal_rtt.c : 1544 ] _wal_rtt_ctxt_init() :freq: %d is_qca: %d force_legacy_ack: %d enable_ht_vht_ack :%d self_mac: %08x%04x 
+3250,Ii,[ wal_rtt.c : 1733 ] rtt: update_last_meas: peer_head:%p, is_last_meas:%d 
+3251,iiiiiii,[ wal_rtt.c : 1924 ] wal_rtt_ctxt_clean: rxoffld_under_cnt: %d rxoffld_alloc_cnt: %d rxind_under_cnt: %d rxind_alloc_cnt: %d tm_rx_comp_cnt: %d rxoffld_drop_cnt: %d rxind_drop_cnt: %d 
+3252,I,[ wal_rtt.c : 1976 ] rtt_local_send() Not a valid rtt frame type, retrun error! txrx_cb_flags: 0x%x 
+3253,iIIIi,[ wal_rtt.c : 2039 ] _wal_rtt_local_frame_send_with_rate: acks%d tid_num 0x%x rate_info 0x%08x%08x report %d 
+3254,,[ wal_rtt.c : 2481 ] DISCARDING MEASUREMENT!! T3 not captured 
+3255,iIiiIIII,[ wal_rtt.c : 2621 ] _wal_report_type2_collect_report_info: rtt_ps: %d rssi=0x%x tx_preamble=%d tx_bw=%d tx_rate_info1 = 0x%x tx_rate_info2= 0x%x rx_rate_info1=0x%x, rx_rate_info2 = 0x%x 
+3256,II,[ wal_rtt.c : 2624 ] tx_rate_info3=0x%x, rx_rate_info3 = 0x%x 
+3257,IIiIIiiiI,[ wal_rtt.c : 2671 ] RTT_INITR_TSTAMP: t2=%u, t3=%u  t3_del=%d t1=%u t4=%u t4_del=%d rtt=%d meas_count=%d num_rtt_per_frame_info_saved: %u 
+3258,,[ wal_rtt.c : 2799 ] TX completion message was dropped. Report failure 
+3259,,[ wal_rtt.c : 2805 ] _wal_rtt_null_ack_hdl() is called after RTT session is completed !!! 
+3260,II,[ wal_rtt.c : 2812 ] Ignore NULL ack for stale entry: ath_buf: %p: last queued NULL frame ath_buf: %p 
+3261,,[ wal_rtt.c : 2858 ] TX completion message was dropped. Report failure 
+3262,,[ wal_rtt.c : 2864 ] _wal_rtt_tm_ack_hdl() is called after RTT session is completed !!! 
+3263,II,[ wal_rtt.c : 2871 ] Ignore TM ack for stale entry: ath_buf: %p: last queued TM frame ath_buf: %p 
+3264,,[ wal_rtt.c : 3131 ] _wal_rtt_tm_rx_hdl: TM frame not directed to me. Don't process 
+3265,,[ wal_rtt.c : 3143 ] _wal_rtt_tm_rx_hdl: Not a valid TM frame. Don't process 
+3266,III,[ wal_rtt.c : 3226 ] _wal_rtt_tm_rx_hdl: rx_ts %10u now_ts %10u rx_proc_delay %10u 
+3267,i,[ wal_rtt.c : 3292 ] _wal_rtt_tm_rx_hdl: HT_VHT ack enable RTT_TM_FTM1 %d 
+3268,iii,[ wal_rtt.c : 3297 ] _wal_rtt_tm_rx_hdl:  expect_token=%d, dia_token=%d, follow_token=%d 
+3269,II,[ wal_rtt.c : 3430 ] CFR/CIR report queue full; CFR/CIR data at 0x%04x%04x will be dropped 
+3270,i,[ wal_rtt.c : 3434 ] no CFR/CIR pending for report type %d 
+3271,iII,[ wal_rtt.c : 3441 ] CFR/CIR pending for report type %d; CFR/CIR data at 0x%04x%04x will be dropped 
+3272,Ii,[ wal_rtt.c : 3577 ] wal_rtt_11mc_send_rsta_meas_report cur_p = %p report_type = %d 
+3273,II,[ wal_rtt.c : 3598 ] wal_rtt_11mc_send_rsta_meas_report for %08x%02x 
+3274,i,[ wal_rtt.c : 3631 ] wal_rtt_11mc_send_rsta_meas_report BUF_LEN_ERROR %d 
+3275,,[ wal_rtt.c : 3688 ] wal_rtt_tx_ppdu_done(): rx_location_info is found to be invalid 
+3276,II,[ wal_rtt.c : 3740 ] CFR/CIR report queue full; CFR/CIR data at 0x%04x%04x will be dropped 
+3277,i,[ wal_rtt.c : 3744 ] no CFR/CIR pending for report type %d 
+3278,iII,[ wal_rtt.c : 3751 ] CFR/CIR pending for report type %d; CFR/CIR data at 0x%04x%04x will be dropped 
+3279,II,[ wal_rtt.c : 3808 ] CFR/CIR report queue full; CFR/CIR data at 0x%04x%04x will be dropped 
+3280,i,[ wal_rtt.c : 3812 ] no CFR/CIR pending for responder report type %d 
+3281,iII,[ wal_rtt.c : 3819 ] CFR/CIR pending for responder report type %d; CFR/CIR data at 0x%04x%04x will be dropped 
+3282,IIIIIIIIi,[ wal_rtt.c : 3904 ] _wal_rtt_tx_ppdu_done(%u-sided): abf: 0x0 tx_preamble=%u, retries=%u tod_32=%u tod_0=%u toa_32=%u toa_0=%u fac_valid: %u fac=%d 
+3283,ii,[ wal_rtt.c : 4066 ] wal_rtt_unit_test: debug_cnt[%d] = %d 
+3284,iii,[ wal_rtt.c : 156 ] Detected Outlier. i: %d rtt: %d bw: %d 
+3285,i,[ wal_rtt.c : 751 ] wal_rtt_get_per_frame_info: input rx_bw goes beyond valid config - %d 
+3286,i,[ wal_rtt.c : 654 ] wal_rtt_get_per_frame_info_send_sta: input tx_bw goes beyond valid config - %d 
+3287,iII,[ wal_rtt_init.c : 84 ] _wal_rtt_psoc_init() wal_rtt_ctxt idx in rtt_psoc_handle: %d rtt_ctxt: %p alloc_buff_p: %p 
+3288,Iiii,[ wal_rtt_init.c : 93 ] _wal_rtt_psoc_init() psoc_rtt handle: %p sizes rtt_tx_pool: %d rtt_rx_pool handle: %d, rtt_rx_ofld_pool: %d 
+3289,I,[ wal_cfir.c : 94 ] wal_cfir_req_unregister: req %p already unregistered 
+3290,iIIi,[ wal_cfir.c : 51 ] wal_cfir_resolve: pdev %d cfg 0x%08x => 0x%08x status %d 
+3291,III,[ wal_rtt_11az.c : 46 ] wal_rtt_init_11az_context: rtt_ctxt:%p, rtt_11az_ctxt:%p, rtt_11az_ctxt_buff_pool:%p 
+3292,IIII,[ wal_rtt_11az.c : 95 ] wal_rtt_11az_local_frame_send_with_rate: tid_num 0x%x rate_info 0x%08x%08x txrx_cb_flags 0x%x 
+3293,IIIIIIIII,[ wal_rtt_11az.c : 138 ] 11AZ:%cchainRssi: 0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x,0x%08x 
+3294,Iiiiiiii,[ wal_rtt_11az.c : 155 ] RTT 11AZ CTXT 1: sequence_id:0x%x, sta_type:%d, bb_cap_chn:%d, loc_info_valid:%d, integrity_data_valid:%d, rssi_info_valid:%d, tx_ts_valid:%d, lmr_valid:%d 
+3295,IIIIIIIII,[ wal_rtt_11az.c : 165 ] RTT 11AZ CTXT 2: ndpa_sounding_dia_tkn:%u, tx_bw:%u, rx_bw:%u, tx_nss:%u, rx_nss:%u, tx_nrep:%u, rx_nrep:%u, sch_cmd_result_fes_tx_status:%u, phytx_abort_reason:%u 
+3296,II,[ wal_rtt_11az.c : 181 ] 11AZ: RAW_TOD (T1 in clock cycle): start_ts:0x%x, end_ts:0x%x 
+3297,ii,[ wal_rtt_11az.c : 241 ] rtt_11az_type2_collect_report_info: add_ie_data:%d, ie_data_collected:%d 
+3298,IIIIIIII,[ wal_rtt_11az.c : 320 ] 11AZ: RTT_TSTAMP: t1: 0x%x%08x, t2: 0x%x%08x t3: 0x%x%08x, t4: 0x%x%08x 
+3299,iiii,[ wal_rtt_11az.c : 324 ] 11AZ: TIME_STAMPS: t4_del=%d 3_del=%d RTT_PS=%d meas_count=%d 
+3300,IIIiiiii,[ wal_rtt_11az.c : 351 ] 11AZ: max_tod_toa_error:0x%08x, tx_chain_mask:0x%x, rx_chain_mask:0x%x, tx_bw:%d, tx_nss:%d, tx_nrep:%d, tx_ndpa_dia_tkn:%d, coex_based_ant_mask:%d 
+3301,iIiiii,[ wal_rtt_11az.c : 375 ] 11AZ: rx_preamble_type:%d, rx_chainmask:0x%x, rx_bw:%d, rx_nss:%d, rx_nrep:%d, is_secure_ltf:%d 
+3302,Iiiiii,[ wal_rtt_11az.c : 423 ] wal_rtt_11az_lmr_rx_hdl: buf:0x%p, imdt_r2i_fdbk:%d, cur_dia_tkn:%d, lmr_dia_tkn:%d, lmr_inv_meas:%d curr_ctxt_loc_inf_valid:%d 
+3303,,[ wal_rtt_11az.c : 436 ] wal_rtt_11az_lmr_rx_hdl: ERROR:  IMMEDIATE_FEEDBACK: Invalid Measurement or DiaTkn mismatch 
+3304,,[ wal_rtt_11az.c : 464 ] wal_rtt_11az_lmr_rx_hdl: lmr->invalid_measurement: 1 save ctxt buff and return 
+3305,,[ wal_rtt_11az.c : 476 ] wal_rtt_11az_lmr_rx_hdl: INFO: DELAYED_FEEDBACK: DiaTkn match with prev sequence collect measmt and save new ctxt 
+3306,,[ wal_rtt_11az.c : 487 ] wal_rtt_11az_lmr_rx_hdl: ERROR:  DELAYED_FEEDBACK: DiaTkn match with current sequence, collect report and clear prev ctxt 
+3307,,[ wal_rtt_11az.c : 496 ] wal_rtt_11az_lmr_rx_hdl: INFO:  save ctxt buff to prev ctxt buff 
+3308,II,[ wal_rtt_11az.c : 552 ] wal_rtt_11az_ctxt_clean:  peer_mac %08x%04x  
+3309,ii,[ wal_rtt_11az.c : 578 ] wal_rtt_11az_trigger_ntb_ranging: for sw_peer_id:%d, ndpa_dia_tkn:%d 
+3310,II,[ wal_rtt_11az.c : 652 ] rtt_11az_process_sequence_status: ERROR: mt_msg:%p, pdev:%p 
+3311,II,[ wal_rtt_11az.c : 676 ] rtt_11az_process_sequence_status: ERROR: sw_peer_id:%u, wal_peer:%p 
+3312,IIii,[ wal_rtt_11az.c : 760 ] rtt_11az_unsecure_ranging_peer_alloc: allocating AST for %08x%04x ast_index:%d, status:%d 
+3313,iiiiiII,[ wal_rtt_11az.c : 854 ] wal_rtt_11az_alloc_and_setup_bssid_rsid: pdev_id:%d vdev_id:%d type:%d allocated bss_reg_id:%d, rsid:%d, bssid:%08x%04x 
+3314,i,[ wal_rtt_11az.c : 878 ] rtt_11az_free_and_setup_bssid_rsid: ERR: Invalid bss_reg_id:%d  
+3315,iiii,[ wal_rtt_11az.c : 898 ] wal_rtt_11az_free_and_setup_bssid_rsid: pdev_id:%d vdev_id:%d type:%d freed bss_reg_id:%d 
+3316,II,[ wal_rtt_11az.c : 999 ] wal_rtt_11az_process_ndpa_rx: ERR: wal_peer:%p, pdev:%p 
+3317,Ii,[ wal_rtt_11az.c : 1036 ] rtt_11az_tb_peer_register: wal_peer:%p, sw_peer_id:%d 
+3318,Ii,[ wal_rtt_11az.c : 1050 ] rtt_11az_tb_peer_unregister: wal_peer:%p, sw_peer_id:%d 
+3319,IIIIIIIi,[ wal_rtt_11az.c : 1110 ] RTT tbr_get_next_unified_sp: peer:%p, sw_peer_id:%u, periodicity_us:%u, last_start_time_us:0x%x%08x, tsf_time_now_us:0x%x%08x tsf_diff:%d 
+3320,iiii,[ wal_rtt_11az.c : 1174 ] rtt_11az_update_session_status: pdev_id:%d, activate:%d, state_change:%d, new active_11az_session_cnt:%d 
+3321,Ii,[ wal_rtt_11az.c : 95 ] wal_rtt_11az_alloc: rtt_11az_hw_info 0x%x ranging_idx %d 
+3322,ii,[ wal_rtt_11az.c : 473 ] wal_rtt_11az_install_security_keys: key_type:%d, keyid_octet:%d 
+3323,i,[ wal_rx_control.c : 1028 ] RXMON UploadCfg [%d]
+ 
+3324,iii,[ wal_rx_control.c : 1564 ] rx_src_ring_setup ring_id:%d ring_sz : %d max_entries:%d 
+3325,iii,[ wal_rx_control.c : 1872 ] rx_dest_ring_setup ring_id:%d ring_sz:%d max_entries:%d 
+3326,IIIIII,[ wal_rx_control.c : 2650 ] WAL_DBGID_RX_BA_SETUP  0x%x 0x%x 0x%x 0x%x 0x%x MAC:%x 
+3327,III,[ wal_rx_control.c : 2928 ] %s: filter0 (0x%x) filter1 (0x%x)
+ 
+3328,ii,[ wal_rx_recovery_control.c : 262 ] wal_rx_rings_reset pdev:%d, cnt:%d 
+3329,I,[ wal_rx_recovery_control.c : 292 ] restart remote timers for pdev:%x 
+3330,iII,[ wal_rx_recovery_control.c : 621 ] UL OFDMA usr index: %d, HE Control value: 0x%x, HE Control count: 0x%x
+ 
+3331,iII,[ wal_rx_recovery_control.c : 648 ] UL OFDMA usr index: %d, Qos Control value: 0x%x, Qos Control count: 0x%x
+ 
+3332,IIi,[ wal_rx_recovery_control.c : 1041 ] SFM_PENDING_RXPCU DETECTION_TYPE: 0x%x RECOVERY_TYPE = 0x%x NUM_RESETS : %d 
+3333,,[ wal_tx_send_halphy_control.c : 251 ] SSCAN abort at wal_phy_TurnPhyOff 
+3334,iiiii,[ wal_tx_send_halphy_control.c : 287 ] PAPRD Total PHY OFF %d Tx suspend fail %d Rx suspend fail %d Tx suspend %d, Tx suspend %d 
+3335,iii,[ wal_tx_send_halphy_control.c : 440 ] PAPRD: phyId %d thread_id %d mem_dpd_thread_active_status %d 
+3336,iiiii,[ wal_tx_send_halphy_control.c : 481 ] PAPRD: schedule_mem_dpd_post_processing: phyId %d thread_id %d g_edpd_rt_thread_id %d BG thread status %d start time %d 
+3337,iiiiii,[ wal_tx_send_halphy_control.c : 521 ] PAPRD: halphy_signal_mem_dpd_post_processing_complete: PHY id %d thread_id %d rt_thread_id %d BG thread status %d end time %d post proc time %d 
+3338,i,[ wal_tx_send_halphy_control.c : 525 ] PAPRD: halphy_signal_mem_dpd_post_processing_complete: exit() and phyId %d 
+3339,iI,[ wal_tx_send_halphy_control.c : 541 ] PAPRD: halphy_start_mem_dpd_post_processing() Entering thread_id %d pHandle 0x%x 
+3340,iII,[ wal_tx_send_halphy_control.c : 554 ] PAPRD: wal_mem_dpd_rt_exchange received ctx received from MEM DPD phyid is %d phyrf_fw_intf_init_GetPhyBase(pHandle) %x current time  %lu 
+3341,ii,[ wal_tx_send_halphy_control.c : 602 ] PAPRD: wal_mem_dpd_thread_hdlr phyId %d, thread_id %d 
+3342,i,[ wal_tx_send_halphy_control.c : 692 ]  thread id %d 
+3343,i,[ wal_tx_send_halphy_control.c : 704 ]  wal_check_ppdu_status invalid phyId %d 
+3344,i,[ wal_tx_send_halphy_control.c : 710 ]  wal_check_ppdu_status DPD ppdu is stuck in the hardware queue %d 
+3345,I,[ wal_tx_control.c : 776 ] TX_ABORT FAILED 0x%x 
+3346,IIIIIIII,[ wal_tx_control.c : 966 ] update_hw_wmm_params: ac:%x,ul_resp=%x,txqid=%x,cw_min/cw_max:%x,aifs:%x,type=%x,txop_limit=%x %x 
+3347,iIi,[ wal_tx_control.c : 1069 ] update pdev(%d) vdev(%p) wmm params, type=%d 
+3348,IIIIIIIi,[ wal_tx_control.c : 1139 ] config_ul_resp: pdev:%p(%u,ul_mu:%u,ul-vdev:%p), en:%u, vdev:%p(ul_mu:%u), vdev_falgs: %d 
+3349,iiii,[ wal_tx_control.c : 1416 ] mu_edca_count_down_timer, pdev:%d, AC:%d, Cnt=%d, lmac_active=%d, MU-EDCA switch to Legacy 
+3350,III,[ wal_tx_control.c : 1521 ] pdev:%u, RING(%x) pause WAR triggered(%x) 
+3351,,[ wal_tx_control.c : 1858 ] tx_ctxt is NULL 
+3352,Ii,[ wal_tx_control.c : 4064 ] tx_send_attach failed 0x%x, line:%d 
+3353,Ii,[ wal_tx_control.c : 5912 ] WAL_DBGID_STA_KICKOUT:                     peer=0x%x consecutive_null_failure=%d 
+3354,iii,[ wal_tx_control.c : 5916 ] WAL_DBGID_STA_KICKOUT:                     null_ppdu_fail_time:%dms delta:%dms vdev_type:%d 
+3355,iIiIIIIII,[ wal_tx_control.c : 5998 ] WAL_DBGID_STA_KICKOUT: KICKOUT_REASON_NULL_PER_CHECK_FAILURE_TH null_per= %d% wake_per= %d% null_fail_count= 0x%x, null_pass_count= 0x%x cumulative_wake_time_ps_sta_ms= 0x%x , null_per_stats_start_time = 0x%x, curr_time= 0x%x  
+3356,ii,[ wal_tx_msdu_control.c : 648 ] HW overwritten tx_flow_number:%d and corressponding sw_peer_id:%d 
+3357,I,[ wal_tx_msdu_control.c : 747 ] wal_tx_msdu_flow_alloc_init: Invalid ml_peer_idx  = %hu
+ 
+3358,iIIIII,[ wal_tx_msdu_control.c : 1172 ] pdev_id: %d ar_wal_peer_clean_up_flow:%x,%x,%x,%x,%x, 
+3359,I,[ wal_tx_msdu_control.c : 1302 ] wal_tx_msdu_flowq_ptr_free: Invalid ml_peer_idx = %hu
+ 
+3360,IiI,[ wlan_buf_internal.c : 915 ] wlan_internal_buf_recycle_buffers abf:0x%x, thread:%d, cb flags:0x%x 
+3361,ii,[ wlan_buf_internal.c : 1169 ] MGMT_BUF_GET_BCN_REQ  mac_id:%d, rsvd:%d 
+3362,,[ wlan_buf_internal.c : 1374 ] wlan_buf_mac_buffer_dispatcher no buffers available in chain 
+3363,,[ wlan_buf_internal.c : 1389 ] wlan_buf_mac_buffer_dispatcher oops 
+3364,,[ wlan_buf_internal.c : 1402 ] wlan_buf_mac_buffer_dispatcher oops 
+3365,,[ wlan_buf_internal.c : 1413 ] wlan_buf_large_buffer_dispatcher no buffers available in chain 
+3366,,[ wlan_buf_internal.c : 1418 ] wlan_buf_large_buffer_dispatcher oops 
+3367,,[ wlan_buf_internal.c : 1463 ] wlan_buf_mac_buffer_dispatcher oops 
+3368,,[ wlan_buf_internal.c : 1488 ] wlan_buf_mac_buffer_dispatcher oops 
+3369,III,[ wal_wmm_prot.c : 52 ] WMMAC_PAUSE_CB: peer=0x%x blocked tids=0x%x/0x%x 
+3370,Iiii,[ wal_wmm_prot.c : 81 ] WMMAC_Q_REPRIO: peer=0x%x tid=%d qid:%d->%d 
+3371,iI,[ wal_wmm_prot.c : 87 ] WMMAC_PAUSE_CB: unblock tid(%d)=0x%x 
+3372,IIII,[ wal_wmm_prot.c : 193 ] WMMAC_PERIODIC_UPDATE 0x%x 0x%x 0x%x 0x%x 
+3373,I,[ wal_wmm_prot.c : 203 ] WMMAC_NO_DOWNGRADE: unblock tid mask=0x%x 
+3374,Iii,[ wal_wmm_prot.c : 224 ] WMMAC_PERIODIC_UPDATE (VO): peer=0x%x, used=%d, admitted=%d 
+3375,Iii,[ wal_wmm_prot.c : 234 ] WMMAC_PERIODIC_UPDATE (VI): peer=0x%x, used=%d, admitted=%d 
+3376,Iiiiii,[ wal_wmm_prot.c : 124 ] WMMAC_STATUS: peer=0x%x, used=%d, admitted=%d, txq_sts=%d/%d, downgrade=%d 
+3377,iIiii,[ wal_wmm_prot.c : 155 ] WMMAC_TXQ_STATUS ac=%d txq_status=0x%02x used=%d admitted=%d downgrade=%d 
+3378,Iii,[ blockack.c : 217 ] TX_BA_LOG: delay post BA timer complete peer 0x%x tid %d thread %d 
+3379,IIi,[ blockack.c : 959 ] BA_LOG: ba_peer_handle NULL: peer 0x%x, mac %x, tid %d 
+3380,IIiii,[ blockack.c : 979 ] BA_LOG: skipped wal_ba_tx_sm: peer 0x%x, mac %x, tid %d, is data tid %d, addba mode %d 
+3381,IIII,[ blockack.c : 1354 ] peer:%x BA tx %p complete status %x, %x bufs 
+3382,ii,[ blockack.c : 1397 ] action_hdr->ia_action:%d completion_status:%d 
+3383,iii,[ blockack.c : 1612 ] RX Update BA Win Size: SW peer ID = %d, tid_num = %d, buf_size = %d 
+3384,iiii,[ blockack.c : 1705 ] UL_MUMIMO_QDEPTH: AID = %d, ac = %d, ba_bitmap = %d, buf_size = %d 
+3385,Ii,[ blockack.c : 1730 ] RX setup block-ack peer:0x%x ba_event type:%d 
+3386,iii,[ blockack.c : 1755 ] RX_BA_LOG our_buf_size %d their_buf_size %d buf_size %d 
+3387,i,[ blockack.c : 2146 ] Error: ba_handle is NULL for wal_peer_id = %d 
+3388,iiii,[ blockack.c : 2201 ] BA_TX_SM: peerid=%d tid_num=%d state=%d event=%d 
+3389,IIiiii,[ blockack.c : 2215 ] TX_BA_LOG: return from EV_START: peer 0x%x, mac %x, tid %d, aggr %d, qos_en %d, conn_st %d 
+3390,IIiIi,[ blockack.c : 2232 ] TX_BA_LOG: defer BA setup: peer 0x%x, mac %x, tid %d, ba->tx_st_bmap 0x%x, active_tid_no_ba_setup %d 
+3391,IIi,[ blockack.c : 2238 ] TX_BA_LOG: alloc context when BA neg in prog: peer 0x%x, mac %x, tid %d 
+3392,iI,[ blockack.c : 2244 ] TX_BA_LOG: ADDBA request pending in frameQ: tid=%d bmap=0x%x 
+3393,IIi,[ blockack.c : 2312 ] TX_BA_LOG: tx_sm_ctxt NULL: peer 0x%x, mac %x, tid %d 
+3394,IIiii,[ blockack.c : 2346 ] TX_BA_LOG: addba_req queued: peer 0x%x, mac %x, tid %d, ssn %d, win_sz %d 
+3395,IIiIii,[ blockack.c : 2374 ] TX_BA_LOG: send_addba_req ERR: peer 0x%x, mac %x, tid %d, ba->tx_st_bmap 0x%x, actv_tid_no_ba %d, wal_soc %d 
+3396,IIii,[ blockack.c : 2416 ] TX_BA_LOG: addba_req Tx success: peer 0x%x, mac %x, tid %d, resp timeout %d 
+3397,ii,[ blockack.c : 2446 ] TX_BA_LOG send WAL_BA_TX_SM_EV_SUCCESS buffersize %d ext_buffersize %d 
+3398,IIiiii,[ blockack.c : 2477 ] TX_BA_LOG: Tx BA setup complete: peer 0x%x, mac %x, tid %d, win_sz %d, amsdu_sup %d, delayed unblock %d 
+3399,Iiii,[ blockack.c : 2486 ] TX_BA_LOG:delay post BA timer started: peer 0x%x tid %d thread_id %d unblock delay %dms 
+3400,IIi,[ blockack.c : 2591 ] TX_BA_LOG: delba sent. tearing down session: peer 0x%x, mac %x, tid %d 
+3401,IIi,[ blockack.c : 2673 ] TX_BA_LOG: BA_NOT_SETUP state: peer 0x%x, mac %x, tid %d 
+3402,iiii,[ blockack.c : 2827 ] BA_RX_SM: Entry :peerid=%d tid_num=%d state=%d event=%d 
+3403,iiii,[ blockack.c : 2832 ] BA_RX_SM: EV_START : buffersize:%d ba_policy:%d dialog_token:%d seq_num:%d 
+3404,ii,[ blockack.c : 2835 ] BA_RX_SM: EV_SEND_COMPLETE : addba_rsp:%d delba:%d 
+3405,ii,[ blockack.c : 2838 ] BA_RX_SM: EV_SEND_FAIL : addba_rsp:%d delba:%d 
+3406,ii,[ blockack.c : 2841 ] BA_RX_SM: EV_TEARDOWN : send_delba:%d reasoncode:%d 
+3407,,[ blockack.c : 2871 ] BA_RX_SM: BA ignored as QPEER is not in connected state 
+3408,ii,[ blockack.c : 2885 ] BA_RX_SM: their_buf_size:%d, our_buf_size:%d 
+3409,IIiiiii,[ blockack.c : 2901 ] BA_RX_SM: BA refused: peer 0x%x, mac %x, tid %d, aggr %d, qos_en %d, rsp_code %d ba_policy %d 
+3410,IIiii,[ blockack.c : 2915 ] BA_RX_SM: addba_resp queued: peer 0x%x, mac %x, tid %d, ssn %d, rc %d 
+3411,IIiii,[ blockack.c : 2932 ] BA_RX_SM: addba_resp gen failed: peer 0x%x, mac %x, tid %d, ssn %d, rc %d 
+3412,IIi,[ blockack.c : 2965 ] RX_BA_LOG: ADDBA rsp send successful: peer 0x%x, mac %x, tid %d 
+3413,IIi,[ blockack.c : 2991 ] BA_RX_SM: ADDBA rsp fail: peer 0x%x, mac %x, tid %d 
+3414,IIi,[ blockack.c : 2998 ] BA_RX_SM: BA restarting: peer 0x%x, mac %x, tid %d 
+3415,IIi,[ blockack.c : 3017 ] BA_RX_SM: DELBA send successful: peer 0x%x, mac %x, tid %d 
+3416,i,[ blockack.c : 3057 ] BA_RX_SM : Exit : state=%d 
+3417,,[ blockack.c : 3508 ] BA-Link-Monitor implementation Start 
+3418,II,[ blockack.c : 3523 ] add 0x%p  ba_abf_list to peer 0x%p 
+3419,II,[ blockack.c : 3538 ] BA peer 0x%p migrate %x buffer 
+3420,ii,[ blockack.c : 3625 ] BA_LOG wal_ba_get_win_size ADDBA_REQUEST buffer_size %d frame_len %d 
+3421,iii,[ blockack.c : 3662 ] VBSS wal_ba_vbss_peer_setup buffer_size %d tid_num %d sn %d 
+3422,iii,[ blockack.c : 474 ] RX_BA_LOG drop dup frame: type %d peer %d dropped %d 
+3423,ii,[ blockack.c : 520 ] wal_ba_event_peer_rx IEEE80211_ACTION_BA_ADDBA_RESPONSE: amsdusupported=%d,buffersize=%d 
+3424,IIiiii,[ blockack.c : 541 ] TX_BA_LOG addba response recieved: peer 0x%x, mac %x, tid %d, frm seq %d, buffersize %d, amsdusupport %d 
+3425,IIiiii,[ blockack.c : 560 ] TX_BA_LOG addba response recieve failure: peer 0x%x, mac %x, tid %d, frm seq %d, buffersize %d, amsdusupport %d 
+3426,IIii,[ blockack.c : 621 ] TX_BA_LOG delba RX success: peer 0x%x, mac %x, tid %d, frm seq %d 
+3427,Ii,[ blockack.c : 644 ] RX_BA_LOG ADDBA RESP for this tid is already queued: resp bmap 0x%x tid %d 
+3428,i,[ blockack.c : 670 ] wal_ba_event_peer_rx IEEE80211_ACTION_BA_ADDBA_REQUEST: buffersize=%d 
+3429,ii,[ blockack.c : 902 ] ADDBA Req dropped WEP:%d MFP_SUPPORT:%d 
+3430,I,[ blockack.c : 1079 ] wal_ba_event_retry_timeout peer:%x 
+3431,i,[ blockack.c : 1926 ] send_addba_req: after wal_get_configured_ba_size %d 
+3432,ii,[ blockack.c : 2064 ] wal_ba_send_addba_rsp: amsdusupported=%d, buffersize=%d 
+3433,,[ wal_lp_bar.c : 45 ] LP_BAR_DBG: Local frame completion 
+3434,,[ wal_lp_bar.c : 76 ] LP_BAR_DBG: Alloc failed 
+3435,,[ wal_lp_bar.c : 88 ] LP_BAR_DBG: BA session not established 
+3436,Iiiii,[ wal_lp_bar.c : 110 ] LP_BAR_DBG: Resp_ctxt info = %x, peer_id = %d,tid_num = %d, session_id = %d, repeat_cnt = %d 
+3437,iii,[ wal_lp_bar.c : 187 ] LP_BAR_DBG: lp_complete_cnt=%d,tid_num = %d, session_id = %d 
+3438,,[ wal_tdma.c : 339 ] TDMA: slot pool allocation failure 
+3439,i,[ wal_tdma.c : 463 ] TDMA: Updating an existing schedule, ID: %d, is not supported 
+3440,,[ wal_tdma.c : 472 ] TDMA: Cannot add beyond a maximum of 10 active schedules 
+3441,,[ wal_tdma.c : 478 ] TDMA: slot pool allocation failure 
+3442,,[ wal_tdma.c : 490 ] TDMA: slot pool allocation failure 
+3443,,[ wal_tdma.c : 494 ] TDMA: Schedule added 
+3444,iii,[ wal_tdma.c : 523 ] TDMA: Switching from slot %d to slot %d at start time %d 
+3445,i,[ wal_tdma.c : 573 ] TDMA_EDCA: EDCA config update for slot : %d 
+3446,i,[ wal_wifi_radar.c : 220 ] WIFI_RADAR_DBG cal_complete pdev_id:%d 
+3447,,[ wal_wifi_radar.c : 252 ] WIFI_RADAR_DBG: Local frame completion 
+3448,Iiiii,[ wal_wifi_radar.c : 297 ] WIFI_RADAR_DBG: Busy, wr_peer_ctxt:%x, tid_paused:%d, vdev_up:%d, scan_radio:%d, next_tbtt_nearby:%d 
+3449,,[ wal_wifi_radar.c : 303 ] WIFI_RADAR_DBG: Alloc failed 
+3450,Iii,[ wal_wifi_radar.c : 331 ] WIFI_RADAR_DBG: Resp_ctxt info = %x, peer_id = %d,tid_num = %d 
+3451,ii,[ wal_wifi_radar.c : 433 ] WIFI_RADAR_DBG: tid_num = %d, success:%d 
+3452,Ii,[ mlo_blockack.c : 69 ] MLO_BA_LOG wal_ml_peer_ipc_ba_start_setuplink_ids 0x%x dest_hw_link_id %d 
+3453,I,[ mlo_blockack.c : 81 ] MLO_BA_LOG wal_ml_peer_ipc_ba_start_setup calling wal_ba_start peer 0x%x 
+3454,,[ mlo_blockack.c : 338 ] MLO_BA_LOG num_bytes less then the sizeof ml_ba_rx_setup_ipc_msg + ipc_msg_hdr 
+3455,,[ mlo_blockack.c : 349 ] MLO_BA_LOG link_idx is greater than the MAX_MLO_LINKS 
+3456,i,[ mlo_blockack.c : 460 ] MLO_BA_LOG wal_ml_ba_ipc_recv_handler msg_type %d 
+3457,,[ mlo_blockack.c : 558 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_start_setup_to_master_link send ML_BA_TX_START_REQUEST 
+3458,i,[ mlo_blockack.c : 629 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_tx_sm_event_to_master_link send ML_BA_TX_SM_EVENT event %d 
+3459,,[ mlo_blockack.c : 704 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_tx_send_setup send ML_BA_TX_SEND_SETUP 
+3460,iiiii,[ mlo_blockack.c : 737 ] ML_RECONFIG: replay ML_BA_TX_SETUP FAILED link_idx:%d !! to ml_peer_id:%d dest_hw_link_id:%d tid:%d win_sz:%d 
+3461,iiii,[ mlo_blockack.c : 758 ] ML_RECONFIG: replay ML_BA_TX_SETUP FAILED ipc NULL !! to ml_peer_id:%d dest_hw_link_id:%d tid:%d win_sz:%d 
+3462,iiiiii,[ mlo_blockack.c : 768 ] ML_RECONFIG: replay ML_BA_TX_SETUP to ml_peer_id:%d dest_hw_link_id:%d tid:%d ssn:%d win_sz:%d en_amsdu:%d 
+3463,,[ mlo_blockack.c : 817 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_rx_setup do not send ML_BA_RX_SETUP as all links not initialized 
+3464,,[ mlo_blockack.c : 847 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_rx_setup send ML_BA_RX_SETUP 
+3465,iiiii,[ mlo_blockack.c : 878 ] ML_RECONFIG: replay ML_BA_RX_SETUP FAILED link_idx:%d !! to ml_peer_id:%d dest_hw_link_id:%d tid:%d win_sz:%d 
+3466,iiii,[ mlo_blockack.c : 901 ] ML_RECONFIG: replay ML_BA_RX_SETUP FAILED ipc NULL!! to ml_peer_id:%d dest_hw_link_id:%d tid:%d win_sz:%d 
+3467,iiii,[ mlo_blockack.c : 907 ] ML_RECONFIG: replay ML_BA_RX_SETUP to ml_peer_id:%d dest_hw_link_id:%d tid:%d win_sz:%d 
+3468,,[ mlo_blockack.c : 940 ] MLO_BA_LOG link_idx is greater than the MAX_MLO_LINKS 
+3469,,[ mlo_blockack.c : 959 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_rx_setup_in_rt do not send ML_BA_RX_SETUP as all links not initialized 
+3470,,[ mlo_blockack.c : 985 ] MLO_BA_LOG ipc_cfg is NULL  
+3471,,[ mlo_blockack.c : 995 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_rx_setup_in_rt send ML_BA_RX_SETUP 
+3472,,[ mlo_blockack.c : 1050 ] MLO_BA_LOG wal_ml_peer_send_ipc_ba_tear_down send ML_BA_TEARDOWN 
+3473,Ii,[ mlo_blockack.c : 1072 ] MLO_BA_LOG wal_ml_ba_start peer 0x%x 0x%d -- skip, null ba handle 
+3474,Ii,[ mlo_blockack.c : 1076 ] MLO_BA_LOG wal_ml_ba_start peer 0x%x tid_num=%d 
+3475,,[ mlo_blockack.c : 1087 ] MLO_BA_LOG Do not start the BA negotiation till all links are created 
+3476,I,[ mlo_blockack.c : 1121 ] MLO_BA_LOG wal_ml_ba_tx_sm_trigger peer 0x%x 
+3477,I,[ mlo_blockack.c : 1147 ] MLO_BA_LOG wal_ml_ba_tx_send_setup_block_ack peer 0x%x 
+3478,I,[ mlo_blockack.c : 1164 ] MLO_BA_LOG wal_ml_rx_setup_block_ack calling wal_ml_peer_send_ipc_ba_rx_setup peer 0x%x 
+3479,I,[ mlo_blockack.c : 1180 ] MLO_BA_LOG wal_ml_ba_tear_down peer 0x%x 
+3480,iIIII,[ data_rx.c : 509 ] DATA_TXRX_DBGID_DUP_CHECK vdev_id = %d tcp_info=0x%x SN=0x%x last_pn_valid=0x%x offset_winsize=0x%x 
+3481,II,[ data_rx.c : 638 ] DATA_TXRX_DBGID_DUP_CHECK da_is_mcbc=%x, da_is_valid=%x 
+3482,III,[ data_rx_pn.c : 156 ] DATA_TXRX_DBGID_REPLAY_CHECK_WAR KeyId=0x%x oldPN=0x%llx newPN=0x%llx 
+3483,IIII,[ data_rx_pn.c : 193 ] DATA_TXRX_DBGID_REPLAY_CHECK 0x%x KeyId=0x%x oldPN=0x%x newPN=0x%x 
+3484,,[ wal_tx_de_fast.c : 805 ] wal_tx_de_tcl_proc_sawf_frame_fail: mlo_invalid_routing_dup_entry 
+3485,,[ wal_tx_de_fast.c : 815 ] wal_tx_de_tcl_proc_sawf_frame_fail: mld_ast_entry invalid sw_peer 
+3486,iii,[ wal_tx_de_fast.c : 1850 ] ar_wal_tx_de_input CCE classify match super rule : %d meta data : %d rule ind : %d 
+3487,i,[ wal_tx_de_fast.c : 1869 ] tx_de_input stats: exception path invoked while PRI_UMAC_MIG in-progress  ret=%d 
+3488,IIIiIiII,[ wal_tx_de_fast.c : 2488 ] DE enq: sw_peer_id|tid=0x%08x fc|type=0x%08x msdu_flags=0x%x len=%d id=0x%x svc_class_id=%d buf_ts=0x%x svc_ts=0x%x 
+3489,iIiIiIIii,[ wal_tx_de_fast.c : 2508 ] security: WAL_DBGID_TX_EAPOL_PKT DE enq: sw_peer_id:%d peer_flags:0x%x tid:%d tid_flags:0x%x is_rc4:%d, fc:0x%x msdu_flags:0x%x len:%d enq_status:%d 
+3490,iiii,[ wal_tx_de_fast.c : 2546 ] DE enq from_host: pdev=%d, tot_enq=%d, tot_compl=%d, tot_wbm2sw=%d 
+3491,iiiiii,[ wal_tx_de_fast.c : 2548 ] DE enq from_host: enq_tqm/bypass=%d/%d, enq_disc=%d, compl_tqm/bypass/reinject=%d/%d/%d 
+3492,ii,[ wal_tx_de_fast.c : 2573 ] security: WAL_DBGID_TX_EAPOL_PKT lookup failed: enq_discard ret:%d, reason %d 
+3493,i,[ wal_tx_de_fast.c : 2607 ] WAL DBG TX DE DISCARD ERROR_CODE=%d 
+3494,IiIii,[ wal_tx_de_fast.c : 4333 ] DE wbm2fw: cookie=0x%x sw_peer_id=%d flags=0x%x msdu_len=%d rel_md=%d 
+3495,IiiiIiii,[ wal_tx_de_fast.c : 4366 ] security: WAL_DBGID_TX_EAPOL_PKT completion: cookie=0x%x sw_peer_id=%d rc4_cnt=%d 1x_rekey=%d flags=0x%x msdu_len=%d rel_md=%d rel_reason=%d 
+3496,iiii,[ wal_tx_de_fast.c : 4387 ] DE wbm2fw from_host: pdev=%d, tot_enq=%d, tot_compl=%d, tot_wbm2sw=%d 
+3497,iiiiii,[ wal_tx_de_fast.c : 4389 ] DE wbm2fw from_host: enq_tqm/bypass=%d/%d, enq_disc=%d, compl_tqm/bypass/reinject=%d/%d/%d 
+3498,IiiiiIiii,[ wal_tx_de_fast.c : 4462 ] security: WAL_DBGID_TX_EAPOL_PKT completion: cookie=0x%x sw_peer_id=%d eapol_key_type=%d rc4_cnt=%d 1x_rekey=%d flags=0x%x msdu_len=%d rel_md=%d rel_reason=%d 
+3499,,[ wal_tx_de_fast.c : 4539 ] invalid_msdu - about to free to FW 
+3500,,[ wal_tx_de_fast.c : 4544 ] invalid_msdu - about to free to host 
+3501,,[ wal_tx_de_fast.c : 2717 ] DE classify: invalid bcast mcast 
+3502,,[ wal_tx_de_fast.c : 2726 ] tx_de_input_tx_classify fail: peer delete in progress/deleted 
+3503,iiiI,[ wal_tx_de_fast.c : 2870 ] DE enq: ARP req|actual_tid_num = %d %d arp_debug_cnt = %d arp_type = %x 
+3504,ii,[ wal_tx_de_fast.c : 2930 ] DE enq: DHCP|actual_tid_num = %d %d 
+3505,,[ wal_tx_de_fast.c : 2965 ] tx_de_input_tx_classify status: DHCP frame needs host inspection 
+3506,,[ wal_tx_de_fast.c : 3037 ] tx_de_input_tx_classify classify_failed : bcast_mcast, No peer for the vdev 
+3507,,[ wal_tx_de_fast.c : 3065 ] tx_de_input_tx_classify interbss traffic should be blocked 
+3508,,[ wal_tx_de_fast.c : 3074 ] tx_de_input_tx_classify avoid bcast/mcast storm, use_4addr is set 
+3509,,[ wal_tx_de_fast.c : 3087 ] tx_de_input_tx_classify MCAST frame needs host inspection 
+3510,,[ wal_tx_de_fast.c : 3093 ] tx_de_input_tx_classify: invalid MC/BC EAPOL 
+3511,,[ wal_tx_de_fast.c : 3107 ] tx_de_input_tx_classify: vdev bss_peer not found 
+3512,,[ wal_tx_de_fast.c : 3191 ] tx_de_input_tx_classify bss peer does not exist 
+3513,,[ wal_tx_de_fast.c : 3216 ] tx_de_input_tx_classify_fail: invalid_vdev_type 
+3514,,[ wal_tx_de_fast.c : 3229 ] tx_de_input_tx_classify_fail: mlo_invalid_routing_dup_entry_discard  
+3515,,[ wal_tx_de_fast.c : 3247 ] tx_de_input_tx_classify_fail: mld_ast_entry invalid sw_peer  
+3516,,[ wal_tx_de_fast.c : 3261 ] tx_de_input_tx_classify_fail: mlo_invalid_routing_discard  
+3517,,[ wal_tx_de_fast.c : 3270 ] tx_de_input_tx_classify fail: qcache peer entry is invalid 
+3518,,[ wal_tx_de_fast.c : 3281 ] tx_de_input_tx_classify fail: peer delete in progress 
+3519,,[ wal_tx_de_fast.c : 3287 ] tx_de_input_tx_classify fail: unicast on AP bss qcache peer 
+3520,,[ wal_tx_de_fast.c : 3319 ] tx_de_input_tx_classify fail: AP vdev is invalid 
+3521,,[ wal_tx_de_fast.c : 3349 ] tx_de_input_tx_classify stats: DE frame needs host inspection 
+3522,,[ wal_tx_de_fast.c : 3356 ] tx_de_input_tx_classify fail: ast peer entry is invalid 
+3523,,[ wal_tx_de_fast.c : 3363 ] tx_de_input_tx_classify fail: ethertype is not ip 
+3524,,[ wal_tx_de_fast.c : 3371 ] tx_de_input_tx_classify fail: peer entry is not valid 
+3525,,[ wal_tx_de_fast.c : 3395 ] tx_de_input_tx_classify fail: mlo_invalid_routing_discard 
+3526,,[ wal_tx_de_fast.c : 3449 ] WAL_DBGID_TX_EAPOL_PKT qpeer is not valid 
+3527,,[ wal_tx_de_fast.c : 3538 ] _tx_de_input_tx_classify: pdev, vdev and peer are invalid 
+3528,,[ wal_tx_de_fast.c : 3543 ] _tx_de_input_tx_classify: assoc flag is not set 
+3529,,[ wal_tx_de_fast.c : 3548 ] _tx_de_input_tx_classify: allow data is not set 
+3530,iiiii,[ wal_tx_de_fast.c : 3622 ] SAWF: EXP discarded! peer %d is_bss %d is_qos %d tid %d svc_class_id %d 
+3531,ii,[ wal_tx_de_fast.c : 3644 ] SAWF: ERROR Mapping flow to MSDUQ TX_DE fail on tid %d svc_class_id %d 
+3532,IiIiiIiii,[ wal_tx_de_fast.c : 3797 ] security: WAL_DBGID_TX_EAPOL_PKT typeorlen:0x%x sw_peer_id:%d peer_mac:0x%x encap_type:%d hdr_len:%d msdu_ethertype:0x%x eapol_pkt_type:%d len:%d is_vlan_tagged:%d 
+3533,iiIIII,[ wal_tx_de_fast.c : 3863 ] security: sw_peer_id=%d WAL_DBGID_TX_EAPOL_PKT PEER_MISMATCH Non-key EAPOL packet type=%d MSDU MAC= 0x%x, 0x%x PEER_MAC=0x%x, 0x%x 
+3534,iiiiIii,[ wal_tx_de_fast.c : 4011 ] security: WAL_DBGID_TX_EAPOL_PKT sw_peer_id:%d  M%d or G%d  key_type:%d key_val:0x%x packet type %d, eapol_type %d 
+3535,iII,[ wal_tx_de_fast.c : 571 ] RXDMA buffer leak :  Count : %d  current_time_stamp_in_ms : %u sw_buffer_cookie : %x 
+3536,ii,[ wal_tx_de_fast.c : 663 ] wal_tx_de_wbm_complete_handler vdev_id = %d, buffer_id = %d 
+3537,ii,[ wal_tx_de_fast.c : 669 ] wal_tx_de_wbm_complete_handler WAL_BUFFERID_TX_DELETE_ALL_PEER_TCL_DUMMY_FRAME vdev_id = %d, peer_id = %d 
+3538,i,[ wal_tx_de_fast.c : 681 ] wal_tx_de_wbm_complete_handler WAL_VDEV_DEL_ALL_PEER_TCL_DUMMY_FRAME_DONE vdev_id = %d 
+3539,ii,[ wal_tx_de_fast.c : 686 ] wal_tx_de_wbm_complete_handler WAL_BUFFERID_TX_DELETE_ALL_PEER_TQM_DUMMY_FRAME vdev_id = %d, peer_id = %d 
+3540,i,[ wal_tx_de_fast.c : 698 ] wal_tx_de_wbm_complete_handler WAL_VDEV_DEL_ALL_PEER_TQM_DUMMY_FRAME_DONE vdev_id = %d 
+3541,i,[ wal_tx_de_fast.c : 713 ] wal_tx_de_wbm_complete_handler WAL_VDEV_DEL_ALL_PEER_TCL_DUMMY_FRAME_DONE & WAL_VDEV_DEL_ALL_PEER_TQM_DUMMY_FRAME_DONE vdev_id = %d 
+3542,iii,[ wal_tx_de_fast.c : 716 ] wal_tx_de_wbm_complete_handler vdev_id = %d, thread_id = %d, msg_id = %d 
+3543,i,[ wal_tx_de_mgmt.c : 457 ] _wal_tx_tcl_lce_config  TCL Special rate skip LCE programming for rule %d 
+3544,i,[ wal_tx_de_mgmt.c : 702 ] _wal_tx_tcl_cce_custom_config packet_bitmap : %d  
+3545,,[ wal_tx_de_mgmt.c : 709 ] _wal_tx_tcl_cce_custom_config enable filter for ARP  
+3546,,[ wal_tx_de_mgmt.c : 713 ] _wal_tx_tcl_cce_custom_config enable filter for EAPOL  
+3547,,[ wal_tx_de_mgmt.c : 717 ] _wal_tx_tcl_cce_custom_config enable filter for DHCP  
+3548,,[ wal_tx_de_mgmt.c : 721 ] _wal_tx_tcl_cce_custom_config enable filter for DNS  
+3549,,[ wal_tx_de_mgmt.c : 725 ] _wal_tx_tcl_cce_custom_config enable filter for ICMP  
+3550,III,[ wal_tx_de_mgmt.c : 879 ] TQM SSN sync cb tickle, peer=%u, tid=%u, tickle=%u 
+3551,II,[ wal_tx_de_mgmt.c : 896 ] MLO TQM set primary hw link id in wow exit: peer=%u, tid=%u 
+3552,ii,[ wal_tx_de_mgmt.c : 921 ] Un-block non_anchor tid, non_anchor peer=%d, pending_frames=%d 
+3553,iIIIII,[ wal_tx_de_mgmt.c : 1019 ] restore SN (skip=%d): tid=%x, mpdu_last_seq_num=%X, next_sn=%X frameq=%p %x 
+3554,i,[ wal_tx_de_mgmt.c : 1055 ] wal_tx_de_delete_all_peer_handler vdev_id = %d 
+3555,ii,[ wal_tx_dm.c : 560 ] hcm_vdev_id already allocated vdev_id %d hcm_vdev_id %d 
+3556,i,[ wal_tx_dm.c : 601 ] hcm_vdev_id already deallocated for vdev_id %d 
+3557,ii,[ wal_phy_dev_hw_mgmt.c : 350 ] wal_htt_sring_name_publish ring_name is null for ring_id:%d, group_id:%d
+ 
+3558,II,[ wal_phy_dev_hw_mgmt.c : 2195 ] ctrl_path_stats_dbg: mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x
+ 
+3559,ii,[ wal_phy_dev_hw_mgmt.c : 3181 ] wal_htt_sring_cfg_publish sring is null for ring_id:%d, group_id:%d
+ 
+3560,III,[ wal_umac_recovery_htt.c : 208 ] MLO_U.R Host completed Handshake with FW for t2h-msg-mask %u state %u handshake_delta_ms %u 
+3561,III,[ wal_umac_recovery.c : 195 ] MLO_U.R UMAC recovery triggered reason %u last_trigger_request_ms %u last_start_ms %u 
+3562,IIIIII,[ wal_umac_recovery.c : 289 ] MLO_U.R : footprint: %u, start_ms: %u, end_ms: %u, val1: %u Delta ms: %u tqm_ref_ts : %u 
+3563,III,[ wal_umac_recovery_ssr.c : 387 ] MLO_U.R UMAC recovery completed last delta ms %u max delta ms %u total done %u 
+3564,iiiiii,[ wal_hif_prio_mgr.c : 411 ] htt_in %d, wmi_drop %d, htt_drop %d, max_hif_ele %d, max_full_per %d bp_time:%d 
+3565,iiiiii,[ wal_hif_prio_mgr.c : 420 ] Inc msg cnt bp:%d, stats:%d, add_del_ba%d, string_setup:%d, peer_add_del:%d, unknown:%d 
+3566,iiiiii,[ wal_hif_prio_mgr.c : 428 ] Dec msg cnt bp:%d, stats:%d, add_del_ba%d, string_setup:%d, peer_add_del:%d, unknown:%d 
+3567,Ii,[ wal_hif_prio_mgr.c : 432 ] WMI_Event 0x%x	Drop_cnt %d 
+3568,Iiiiiiiii,[ wal_hif_prio_mgr.c : 448 ] bp_dur %u, drop_cnt %d, hp_ingress %d, lp_ingress %d, ce1 %d, ce2 %d, fifo_ele_max %d, fifo_max %d, evt_enqd_cnt %d 
+3569,iiiiii,[ htt_tgt_rx.c : 75 ] TX_MON htt_tgt_sring_setup [%d] [%d] [%d] [%d] [%d] [%d]
+ 
+3570,iiiiii,[ htt_tgt_rx.c : 229 ] htt_tgt_sring_setup [%d] [%d] [%d] [%d] [%d] [%d]
+ 
+3571,ii,[ htt_tgt_rx.c : 277 ] htt_tgt_sring_setup RXMON SRC ring [%d] [%d]
+ 
+3572,ii,[ htt_tgt_rx.c : 283 ] htt_tgt_sring_setup RXMON dest ring [%d] [%d]
+ 
+3573,iiiIIi,[ htt_tgt_rx.c : 578 ] htt_tgt_fse_setup:[%d] [%d] [%d] [0x%lx] [0x%lx] RT: [%d]
+ 
+3574,iiiii,[ htt_tgt_rx.c : 641 ] htt_tgt_fse_operation pdev,ipsec,src/dest ports,proto:[%d][%d] [%d][%d] [%d]
+ 
+3575,IIIIIIII,[ htt_tgt_rx.c : 651 ] IP src [%x][%x][%x][%x] dest [%x][%x][%x][%x]
+ 
+3576,III,[ htt_tgt_rx.c : 756 ] 3-tuple Configuration value rcvd : 
+ flow_id_toeplitz_enable : [%x]
+ toeplitz_2_or_4_field_enable : [%x]
+ 3_tuple_flow_classification_field_enable : [:%x]
+ 
+3577,i,[ htt_tgt_rx.c : 1012 ] htt_tgt_sring_setup_done -[%d]
+ 
+3578,IIII,[ htt_tgt_rx.c : 1259 ] ring_selection_cfg RXMON enable: [%x] hdr_len: [%x], fpmo1[%x], fpmo2[%x]
+ 
+3579,IIIIIII,[ htt_tgt_rx.c : 1271 ] ring_selection_cfg mpdu_s:0x%x mpdu_e:0x%x msdu_e:0x%x mpdu_s_v2:0x%x mpdu_e_v2:0x%x msdu_e_v2:0x%x ppdu_e_v2:0x%x
+ 
+3580,iii,[ htt_tgt_rx.c : 1362 ] htt_tgt_msi_setup [%d] [%d] [%d]
+ 
+3581,IIIII,[ htt_tgt_rx.c : 1421 ] umac_recovery setup failed due to Host args msg_type %u t2h %u h2t %u htt_setup_completed %u msg_shared_mem size %u 
+3582,IIII,[ htt_tgt_rx.c : 1486 ] UMAC_WKK H2T htt_tgt_umac_recovery_soc_start_pre_reset tstmp-ms:%u cnt:%u to trigger WAL UMAC recovery (dbg umac_hang %u initiator %u) 
+3583,iiii,[ htt_tgt_rx.c : 1511 ] PRI_UMAC_MIG: htt_tgt_rx_primary_peer_migrate [%d] [%d] [%d] [%d] 
+ 
+3584,iii,[ htt_tgt_rx.c : 1533 ] PRI_UMAC_MIG: htt_tgt_rx_primary_peer_migrate [%d] [%d] [%d] 
+ 
+3585,III,[ htt_tgt_rx_event.c : 682 ] RX event msg buf_len type[%x] peer_id [%x] vdev_id [%x]
+ 
+3586,II,[ htt_tgt_tx.c : 314 ] TX_MON after tx_monitor_cfg [%x] [%x]
+ 
+3587,iiiii,[ htt_tgt_tx.c : 432 ] PRI_UMAC_MIG : SM : htt_tgt_tx_pri_peer_migrate_msg_handler : chip_id %d pdev_id %d vdev_id %d sw_peer_id %d, ml_peer_id %d 
+3588,iiiii,[ htt_tgt_tx_latency.c : 56 ] GQL: htt cfg: enable %d interval %d grain %d vdev %d reset %d 
+3589,IIIiIiiII,[ wal_local_frames.c : 275 ] CONN_DBG_TX: subtype=%x to MAC_addr %04x%08x seq_num=%d pdev_vdev_buffer_id=0x08%x tx_status=%d last_ok_bcn_seq=%d, flags = 0x%x, fc = 0x%x 
+3590,iii,[ wal_local_frames.c : 506 ] local_frame_handle_completion: thread=%d/%d, status=%d 
+3591,iiii,[ wal_local_frames.c : 594 ] local_frame_completion_tqm_tx_de_ipc_msg_handler: abf_thread=%d, current_thread=%d, hw_link_id:%d, tx_status:%d
+ 
+3592,iiI,[ wal_local_frames.c : 728 ] local_frame_handle_completion_tqm ipc_send: src_chip_id=%d, my_chip_id=%d, cookie:0x%x
+ 
+3593,iiIiIIIi,[ wal_local_frames.c : 1120 ] wal_local_frame_send vdev_id=%d peer_id=%d FC=0x%x cur_ch=%d ppdu_rate=0x%x ppduinfo_H32=0x%x ppduinfo_L32=0x%x tid=%d 
+3594,ii,[ wal_local_frames.c : 1281 ] WAL_DBGID_TX_MGMT_ENQUEUE_FAILED vdev_id = %d tid:%d 
+3595,iiIiIII,[ wal_local_frames.c : 1569 ] DBG WAL_DBGID_TX_MGMT_DESCID_SEQ_TYPE_LEN vdev_id=%d mac_id=%d cookie=0x%x seq_num=%d type=0x%x len=0x%x tid_flg=0x%x 
+3596,III,[ wal_local_frames.c : 1894 ] Local EAPOL M4 duplicated, peer:%x, qpeer-flag=%x peer-flags=%x 
+3597,III,[ wal_local_frames.c : 1904 ] Local EAPOL with M4 SENT flag, peer:%x, qpeer-flag=%x peer-flags=%x 
+3598,III,[ wal_local_frames.c : 1931 ] Local EAPOL M4 after key installation, peer:%x, qpeer-flag=%x peer-flags=%x 
+3599,iiIII,[ wal_local_frames.c : 2041 ] local_data_frame_send  vdev_id=%d mac_id=%d seq_num=0x%x type=0x%x status =0x%x 
+3600,iiIiIIIi,[ wal_local_frames.c : 2154 ] wal_mgmt_frame_send vdev_id=%d peer_id=%d FC=0x%x cur_ch=%d ppdu_rate=0x%x ppduinfo_H32=0x%x ppduinfo_L32=0x%x tid=%d 
+3601,IIIII,[ wal_local_frames.c : 2222 ] wal_mgmt_frame_send: unpause the mgmt tid for powersave client peer=0x%x, tid_num=0x%x, fc[0]=0x%x mac_addr_47_32=0x%x, mac_addr_31_0=0x%x 
+3602,ii,[ wal_local_frames.c : 2274 ] WAL_DBGID_TX_MGMT_ENQUEUE_FAILED vdev_id = %d tid:%d 
+3603,iiIiIII,[ wal_local_frames.c : 2557 ] DBG WAL_DBGID_TX_MGMT_DESCID_SEQ_TYPE_LEN vdev_id=%d mac_id=%d cookie=0x%x seq_num=%d type=0x%x FC=0x%x len=0x%x 
+3604,iIiiI,[ wal_local_frames.c : 2616 ] WAL_DBGID_MGMT_TX_FAIL vdev_id=%d, err_code=%x, cookie=%d, status=%d, fc[0]=%x 
+3605,IIII,[ wal_local_frames.c : 2694 ] local_mgmt, peer(%p, sw_peer_id:%x) pdev mismatch(%p:%p) 
+3606,,[ wal_local_frames.c : 2748 ] local_data drop , abf null 
+3607,i,[ wal_local_frames.c : 2758 ] local_data drop , allow data is not set tid_num %d 
+3608,iII,[ wal_local_frames.c : 2812 ] send local buffer fail: sw_peer_id=%d migration in progress mac_addr_31_0=%x mac_addr_47_32=%x 
+3609,II,[ wal_local_frames.c : 2842 ] send local buffer fail: status=%x, flags=%x 
+3610,IIIiII,[ wal_local_frames.c : 2906 ] Deliver LOCAL buffer sending msg failure: tid=%x,peer=%x,abf=%x,flag=%d,target_thread=%x, is_data:%x 
+3611,II,[ wal_local_frames.c : 3016 ] abf=0x%x, target_thread changed to %x 
+3612,I,[ wal_mlo_glb_api.c : 49 ] wal_ml_peer_get_glb_sawf_peer_info: Invalid ml_peer_idx = %hu
+ 
+3613,iiii,[ wal_mlo_tx.c : 134 ] TID_FLUSH_DBG: tid flush not required - sw peer id = %d, tidnum = %d, current flush reasons = %d, req flush reason = %d
+ 
+3614,iiii,[ wal_mlo_tx.c : 518 ] TID_FLUSH_DBG: proc_request - sw peer id = %d, tidnum = %d, curr reasons = %d, requested_reasons = %d 
+3615,iiii,[ wal_mlo_tx.c : 606 ] TID_FLUSH_DBG: proc_response - sw peer id = %d, tidnum = %d, curr reasons = %d, requested_reasons = %d 
+3616,iIi,[ wal_mlo_tx.c : 745 ] MLO_STAKO_LOG: Xretry detected already - ml peer id = %d, sw peer id = %x, tidno = %d
+ 
+3617,iIi,[ wal_mlo_tx.c : 753 ] MLO_STAKO_LOG: Sta recovered - ml peer id = %d, sw peer id = %x, tidno = %d
+ 
+3618,iIi,[ wal_mlo_tx.c : 759 ] MLO_STAKO_LOG: Num sched cmds pending = 0, - ml peer id = %d, sw peer id = %x, tidno = %d
+ 
+3619,iIi,[ wal_mlo_tx.c : 765 ] MLO_STAKO_LOG: Deferring to cmd cmpl for master cmds to go to 0 - ml peer id = %d, sw peer id = %x, tidno = %d
+ 
+3620,iii,[ wal_mlo_tx.c : 974 ] TID_FLUSH_DBG: setting flush reason and sending messages to partners - sw peer id = %d, tidnum = %d, flush reason = %d
+ 
+3621,iiii,[ wal_mlo_tx.c : 992 ] TID_FLUSH_DBG: is_ipc_sent = %d - sw peer id = %d, tidnum = %d, flush reason = %d
+ 
+3622,,[ wal_mlo_tx.c : 1036 ] MLO_STAKO_LOG: connection block successful; call func to queue BAR frame
+ 
+3623,,[ wal_mlo_tx.c : 1062 ] MLO_STAKO_LOG: cancel BAR enqueue, anchor link is invalid
+ 
+3624,IiIi,[ wal_mlo_tx.c : 1106 ] MLO_STAKO_LOG: wal_tqm_sync_seq_num_ipc_hdlr - sw_peer_id=%u, tidno=%d (ptid=%p), pdev id = %d 
+3625,iii,[ wal_mlo_tx.c : 1228 ] MLO_STAKO_LOG: pdev id = %d - sw peer id = %d, tidno = %d
+ 
+3626,,[ wal_mlo_tx.c : 1232 ] MLO_STAKO_LOG: master link calling block enable
+ 
+3627,ii,[ wal_mlo_tx.c : 1347 ] MLO_STAKO_LOG: MLO MGMT BAR : completion_hdlr - completion_status = %d, peer id = %d 
+3628,i,[ wal_mlo_tx.c : 1378 ] MLO_STAKO_LOG: MLO MGMT BAR Frame: calling block disable, pdev->sendbar_in_progress = %d 
+ 
+3629,ii,[ wal_mlo_tx.c : 1384 ] MLO_STAKO_LOG: MLO MGMT BAR Frame failed sw peer id %d num_bar_retries %d
+ 
+3630,,[ wal_mlo_tx.c : 1433 ] MLO_STAKO_LOG: queuing MLO mgmt frame
+ 
+3631,i,[ wal_mlo_tx.c : 1474 ] MLO_STAKO_LOG: Sending stako msg to master - sw peer id = %d
+ 
+3632,ii,[ wal_mlo_tx.c : 1512 ] MLO_STAKO_LOG: Stako detected already - sw peer id = %d, ml peer id = %d
+ 
+3633,ii,[ wal_mlo_tx.c : 1518 ] MLO_STAKO_LOG: Sta recovered before kickout - sw peer id = %d, ml peer id = %d
+ 
+3634,ii,[ wal_mlo_tx.c : 1521 ] MLO_STAKO_LOG: STAKO from IPC CTXT - sw peer id = %d, ml peer id = %d
+ 
+3635,iiiiii,[ wal_mlo_tx.c : 1662 ] mlo_link_ownership: gen list ptid count=%d gen list partner count/fail=%d/%d peer=%d tid=%d trig_type=%d 
+3636,,[ wal_mlo_tx.c : 1701 ] mlo_link_ownership: emlsr beacon protection in prog: defer LOR 
+3637,iiiiiI,[ wal_mlo_tx.c : 1737 ] mlo_link_ownership: clear is started, peer=%d tid=%d cons_cnt=%d trig_type=%d qdepth=%d start_us=%u 
+3638,iiiiii,[ wal_mlo_tx.c : 1753 ] mlo_link_ownership: clear is denied, peer=%d tid=%d peer_del=%d/%d xretry=%d in-prog=%d 
+3639,i,[ wal_mlo_tx.c : 1775 ] mlo_link_ownership: failed on posting tqm cmd due to tqm %d 
+3640,iiI,[ wal_mlo_tx.c : 1792 ] mlo_link_ownership: flush req done, posting tqm remove mpdu, peer=%d tid=%d time_us=%u 
+3641,iiii,[ wal_mlo_tx.c : 1814 ] mlo_link_ownership: clear requested from RT/SCHED, peer=%d tid=%d, list count=%d, recipe in-prog=%d 
+3642,iii,[ wal_mlo_tx.c : 1903 ] mlo_link_ownership: TQM command retry=%d UNSET due to unavailable partner tid, peer=%d tid=%d 
+3643,iii,[ wal_mlo_tx.c : 1915 ] mlo_link_ownership: TQM command retry=%d, peer=%d tid=%d 
+3644,i,[ ar_wal_mlo_ipc.c : 977 ] MLO : wal_mlo_producer_sw_ipc_init return. Src link %d not valid!! 
+3645,ii,[ ar_wal_mlo_ipc.c : 996 ]  WSI_REMAP  MLO : wal_mlo_producer_sw_ipc_init sw_ipc_is already initialized fr src_link_id = %d hw_link_id = %d  
+3646,ii,[ ar_wal_mlo_ipc.c : 1239 ] MLO : WSI_REMAP hw_ipc_init ipc already exists src_link_id %d dest_link_id = %d 
+3647,,[ ar_wal_mlo_ipc.c : 1535 ] MLO : wal_mlo_consumer_sw_ipc_init return. MLO not supported!! 
+3648,i,[ ar_wal_mlo_ipc.c : 1541 ] MLO : wal_mlo_consumer_sw_ipc_init return. Self link ID %d not valid!! 
+3649,,[ ar_wal_mlo_ipc.c : 1656 ] MLO : wal_mlo_consumer_hw_ipc_init return. MLO not supported!! 
+3650,,[ ar_wal_mlo_ipc.c : 2720 ] FTM_MLO Ping failure - reply has exceeded the time limit of 100 milli seconds 
+3651,i,[ ar_wal_mlo_ipc.c : 2436 ] MLO : wal_mlo_doorbell_process_bcast_msg %d 
+3652,IiiI,[ wal_monitor.c : 1295 ] PEER_DELETE_QUEUED_UP peer_id = %u peer_delete_sm_state = %d  qpeer->flags = %d del_all_peer_sched_batched = %u  
+3653,ii,[ wal_monitor.c : 1322 ] PRI_UMAC_MIG : SM : wal_monitor_get_peer_from_sw_peer_id 4 secs timeout sw_peer_id %d delay %d 
+3654,iiiiiii,[ wal_monitor.c : 1391 ] CONGCTRL HOST_CONTROL peer_id:%d tid_num:%d traffic_enq:%d drop:%d deq:%d old_threshold:%d new_threshold:%d 
+3655,iiii,[ wal_monitor.c : 1588 ] CONGCTRL HOST_CONTROL UPDATE aid:%d tid_num:%d threshold_1:%d threshold_2:%d
+ 
+3656,iii,[ wal_monitor.c : 1613 ] CONGCTRL HOST_CONTROL UPDATE aid:%d tid_num:%d new drop_threshold:%d  
+3657,iii,[ wal_monitor.c : 1667 ] CONGCTRL FW_CONTROL UPDATE aid:%d tid_num:%d new drop_threshold:%d  
+3658,iiI,[ wal_monitor.c : 1805 ] CONGCTRL peer_id:%d tid_num:%d msduq_mask:0x%08x 
+3659,ii,[ wal_monitor.c : 2156 ] EMLSR_DBG: MAX BW link idx:%d Link_state%d 
+3660,IIIIIIII,[ wal_monitor.c : 2280 ] tlt_dbg: monitor_link_stats  free/tx/rx/my_rx percent=%u, %u, %u, %u, mlo_ts_ms= %u, act_clients=%x, tx_avail_curr/new=%u:%u 
+3661,ii,[ wal_monitor.c : 2389 ] tlt_dbg monitor_ctxt sw_peer_id:%d, tid_num:%d 
+3662,Ii,[ wal_monitor.c : 2516 ] SAWF_SCHED_OPT: idx %u Idle time exhausted reset! curr delta %d 
+3663,,[ wal_connection_pause.c : 274 ] qcache_peer is NULL 
+3664,,[ wal_connection_pause.c : 295 ] qcache_peer is NULL 
+3665,,[ wal_connection_pause.c : 316 ] qcache_peer is NULL 
+3666,i,[ wal_connection_pause.c : 572 ] TID not present for tid num %d, Create new tid 
+3667,ii,[ wal_connection_pause.c : 578 ] MLO BA Block tid requested TID:%d, tid_alloc_status=%d 
+3668,II,[ wal_connection_pause.c : 836 ] Tx_Pause: wal_connection_pause_en_dis_ext: NULL peer list, mod=%u, is_en=%u 
+3669,II,[ wal_connection_pause.c : 843 ] Tx_Pause: wal_connection_pause_en_dis_ext: (qpeer == NULL), mod=%u, is_en=%u 
+3670,i,[ wal_connection_pause.c : 2297 ] sendn_pending is not valid: qpeer->sendn_pending = %d  
+3671,,[ wal_connection_pause.c : 3399 ] Tx_Pause: ar_wal_tx_pause_check_pending_pdev_cmd_completions: (qpeer == NULL) 
+3672,,[ wal_connection_pause.c : 3712 ] POOL ALLOC FAILURE 
+3673,i,[ wal_connection_pause.c : 3792 ] Tx_Pause: unsupported pdev request id:%d 
+3674,i,[ wal_connection_pause.c : 3851 ] Tx_Pause: unsupported vdev request id:%d 
+3675,i,[ wal_connection_pause.c : 4032 ] Tx_Pause: unsupported peer request id:%d 
+3676,,[ wal_connection_pause.c : 4164 ] Tx_Pause: WAL_TX_PAUSE_HWQ_EMPTY rcvd for deleted/delete_in_progress peer 
+3677,i,[ wal_connection_pause.c : 4222 ] Tx_Pause: unsupported no-resp request id:%d 
+3678,i,[ wal_connection_pause.c : 4279 ] Tx_Pause: unsupported request id:%d 
+3679,,[ wal_connection_pause.c : 4358 ] wal_tx_pause_alloc_handle POOL ALLOC FAILURE 
+3680,iiiI,[ wal_connection_pause.c : 4483 ] tid_pause_data_stall tid_num:%d pause_module_id_map:%d block_module_id_map:%d peer:0x%x 
+3681,IIIII,[ wal_connection_pause.c : 4530 ] PM_STATE_DBG: PEER_STATE: peer:0x%p, all_tids_pause_module_bitmap:0x%x, all_tids_block_module_bitmap:0x%x data_tids_pause_module_bitmap:0x%x, data_tids_block_module_bitmap:0x%x 
+3682,IiIIII,[ wal_connection_pause.c : 4537 ]  PM_STATE_DBG: TID_STATE: peer:0x%p, tid_num:%d, flags:0x%x, ext_flags:0x%x, pause_module_id_map:0x%x, block_module_id_map:0x%x 
+3683,III,[ wal_connection_pause.c : 4568 ] ar_wal_connection_pause_rtwt_notify: peer=%u, b_start=%u, rtwt_tidmask=0x%x 
+3684,I,[ wal_ml_connection_pause.c : 187 ] Attach failed - Invalid ml_peer_entries: %lu 
+3685,Ii,[ wal_ml_connection_pause.c : 320 ] wal_ml_connection_pause_block_free_requests: wal_peer=0x%x, thread_id=%d 
+3686,IIiIiIII,[ wal_ml_connection_pause.c : 392 ] wal_ml_connection_pause_block_enable_disable: peer_id:%u, is_enable:%u, module_id:%d, tid_bitmap:0x%lx, filter:%d, cb_func:%p, cb_data:%p, thread_id:%u 
+3687,iiiiiiiii,[ wal_ml_connection_pause.c : 740 ] wal_ml_non_iniator_link_assemble_response_ipc_msg: ml_request_id=%d, ml_peer_id=%d, module_id=%d, src_ll_id=%d, dest_ll_id=%d, dest_hw_link_id=%d, non_initiator_hw_link_id=%d, initiator_hw_link_id=%d, thread_id=%d 
+3688,II,[ wal_ml_connection_pause.c : 1015 ] post_request_completed_event: ml_req_id=%u wal_peer=0x%x 
+3689,,[ wal_ml_connection_pause.c : 1342 ] wal_ml_handle_non_initiator_pause_unpause_request ml_peer is NULL 
+3690,,[ wal_ml_connection_pause.c : 1352 ] wal_ml_handle_non_initiator_pause_unpause_request wal_peer is NULL 
+3691,,[ wal_ml_connection_pause.c : 1381 ] wal_ml_handle_non_initiator_block_unblock_request wal_peer is NULL 
+3692,,[ wal_ml_connection_pause.c : 1391 ] wal_ml_handle_non_initiator_block_unblock_request wal_peer is NULL 
+3693,,[ wal_ml_connection_pause.c : 1524 ] wal_ml_connection_pb_handle_non_initiator_link_request ml_peer is NULL 
+3694,,[ wal_ml_connection_pause.c : 1532 ] wal_ml_connection_pb_handle_non_initiator_link_request ml_peer_ext is NULL 
+3695,,[ wal_ml_connection_pause.c : 1591 ] wal_ml_connection_pb_handle_non_initiator_link_request wal_peer is NULL 
+3696,I,[ wal_peer_fast.c : 198 ] wal_tx_classify_info_free: TCL Special rate flow  NON_UDP 0x%X 
+3697,,[ wal_ml_peer_fast.c : 43 ] mlo_dbg : wal_ml_peer_get_logical_link_idx_from_hw_link_id Invalid link ID 
+3698,IiI,[ wal_ml_peer_fast.c : 82 ] mlo_dbg tlt_dbg: tid_create_ipc_hldr_entry ml_peer=%u tid=%d,  link_idx_bmap=0x%x 
+ 
+3699,IiIII,[ wal_ml_peer_fast.c : 179 ] mlo_dbg tlt_dbg: tid_create_ipc_hldr peer=%u tid=%d, ba_params_tid=%u, ba_param_set=0x%x, link_idx=%u 
+ 
+3700,iII,[ wal_peer_mgmt.c : 575 ] [wal_get_qcache_peer] : sw_peer_id %d qcache_peer NULL caller %x caller1 %x 
+3701,,[ wal_peer_mgmt.c : 689 ] wal_htt_peer_stats_reset: Peer pointer is NULL  
+3702,I,[ wal_peer_mgmt.c : 1536 ] qpeer is NULL for sw_peer_id: %u 
+3703,II,[ wal_peer_mgmt.c : 1543 ] Htt stats is requested without setting in_progress: Caller 0 %x Caller 1 %x 
+3704,II,[ wal_peer_mgmt.c : 1719 ] PRESEND_WLAN_PS, peer=%u, event_handler=%p 
+3705,,[ wal_peer_mgmt.c : 2118 ] peer_delete_in_progress do NOT register event 
+3706,II,[ wal_peer_mgmt.c : 2291 ] TRIGGER PDEV MISMATCH, thread:%x, tid:%x 
+3707,IIIIIII,[ wal_peer_mgmt.c : 2447 ] security:pdev(%x)peer %x,flag %x, unblocked for tidLen update,refcnt=%x,htc=%x,remap=%x,security=%x 
+3708,,[ wal_peer_mgmt.c : 763 ] Memory ERROR: Cannot retrieve peer stats
+ 
+3709,,[ wal_peer_mgmt.c : 767 ] Invalid stats. Please try again
+ 
+3710,I,[ wal_ml_peer_mgmt.c : 136 ] wal_get_ml_peer_idx_from_ml_peer_id: Invalid ml_peer_id = %hu
+ 
+3711,iiiiiI,[ wal_ml_peer_mgmt.c : 249 ] ML_RECONFIG: sched_peer_del_ipc_hdlr wal_ml_peer_id:%d src_ll_id:%d, dst_ll_id:%d, dst_pri:%d src_val:%d schd_del_rc:0x%x 
+3712,ii,[ wal_peer.c : 47 ] _ar_wal_peer_tidq_empty: thread_id =%d,tidq->tid_num=%d
+ 
+3713,iIIi,[ wal_peer.c : 251 ] security: WAL_DBGID_SECURITY_PM4_SENT peer_id:%d, peer_flag:0x%x, qpeer_flag:0x%x tx_status:%d 
+3714,iII,[ wal_peer.c : 290 ] security: call ptk handler for master link peer_id:%d, peer_flag:0x%x, qpeer_flag:0x%x 
+3715,I,[ pktgen.c : 1762 ] pktgen_data_tx_start_msg_send  dev->running=0x%x 
+3716,iii,[ pktgen.c : 210 ] pktgen_calc_aggr_size: adjust pkt len: orig=%d adjust=%d mpdu=%d 
+3717,Iii,[ wal_rc_peer.c : 499 ] FIXED_RATE_ADJUST: adjust nss from tx_chain_mask:0x%x old_nss:%d new_nss:%d 
+ 
+3718,III,[ wal_rc_peer.c : 1197 ] wal_rc_peer_non_data_rc_param_setup: rc_flags=0x%x, notify=%x, phy_mode=0x%x 
+3719,ii,[ wal_rc_peer.c : 2359 ] tx mcs 3d Stats publish :: input buffer size = %d 3d stats buffer size = %d 
+3720,ii,[ wal_rc_peer.c : 2401 ] rx mcs 3d Stats publish :: input buffer size = %d 3d stats buffer size = %d 
+3721,iiI,[ wal_rc_peer.c : 2450 ] tx mcs Stats publish :: input buffer size = %d mcs stats buffer size = %d, nss:8/bw:8 0x%08x 
+3722,iiI,[ wal_rc_peer.c : 2497 ] rx mcs Stats publish :: input buffer size = %d mcs stats buffer size = %d, nss:8/bw:8 0x%08x 
+3723,ii,[ wal_rc_peer.c : 2593 ] rx cck Stats publish :: input buffer size = %d ofdm stats buffer size = %d 
+3724,ii,[ wal_rc_peer.c : 2649 ] tx ofdm Stats publish :: input buffer size = %d ofdm stats buffer size = %d 
+3725,ii,[ wal_rc_peer.c : 2685 ] tx cck Stats publish :: input buffer size = %d ofdm stats buffer size = %d 
+3726,Ii,[ wal_rc_vdev.c : 194 ] RATECTRL_DBGID wal_vdev_set_non_data_rc_pdg_notify vdev non data notify rc %x phy_mode %d 
+3727,II,[ wal_rc_vdev.c : 545 ] RATECTRL_DBGID_WAL_SET_VDEV_DATA_RX: rc=0x%x data_rc=0x%x 
+3728,,[ wal_rc_pdev.c : 350 ] RATECTRL_DBGID_WAL_RCUPDATE  rc_tid is null 
+3729,,[ wal_rc_pdev.c : 360 ] RATECTRL_DBGID_WAL_RCUPDATE  vdevf is null 
+3730,IIi,[ wal_rc_pdev.c : 367 ] RATECTRL_DBGID_WAL_RCUPDATE  NumTxDnElem=0x%x SwPpduFlags=0x%x autorate:%d 
+3731,iiiI,[ wal_rc_pdev.c : 1026 ] SET tx_chain_mask[%d]: new=%d old=%d, pdev=%u 
+3732,iiiii,[ wal_rc_pdev.c : 2739 ] UL_TPC_DBG: AID: %d, min_tx_power: %d, power_headroom: %d, target_rssi: %d, fd_rssi: %d 
+3733,iiiiii,[ wal_rc_pdev.c : 2749 ] UL_TPC_DBG: AID: %d, mcs: %d, nss %d delta_p_mcs_100x: %d, chain_adjust_100x: %d, rssi_ref_inst_100x: %d,  
+3734,iiiii,[ wal_rc_pdev.c : 2757 ] UL_TPC_DBG:rssi_ref_100x: %d, ulmumimo_rssi_ref_100x %d target_rssi_error_100x:%d target_ulmumimo_rssi_error_100x:%d  ulmumimo_fd_rssi_100x %d 
+3735,iIIIIIIii,[ wal_rc_pdev.c : 2993 ] UL Rate update, sta_resp_cnt: %d, ptx_rc %x, mpdu_tried %x, mpdu_failed %x, aid %x, num_user %x, usr idx %x, rc_mode %d, rx_done %d
+ 
+3736,,[ wal_rc_pdev.c : 1751 ] exclude rate update due to antenna training 
+3737,Iii,[ wal_rc_pdev.c : 1890 ] rate_sched:bw_mask:8/max_bw:8=0x%08x,flags=%d rix=%d 
+3738,I,[ wal_rc.c : 266 ] Phy rate=0, rix=%x 
+3739,Iiii,[ wal_rc.c : 414 ] CHAINMASk_DBG overwrite tx chainmask, peer%p, sw_peer_id:%d  rate_Sched_chainmask %d tx_mask %d 
+3740,iIi,[ wal_rc.c : 1685 ] evm channel %d  padding 0x%x phyId %d 
+3741,iii,[ wal_rc.c : 1687 ] wal_rc_rx_get_pilot_evm rx_evm_nss_count = %d, rx_evm_pilot_count = %d, number_of_data_sym =%d 
+3742,iIiI,[ wal_rc.c : 1692 ] Check tlv data. acc_linear_evm_0_%d = 0x%8x, acc_linear_evm_1_%d = 0x%8x 
+3743,iii,[ wal_rc.c : 1721 ] pilot_evm warning: strem_idx: %d pilot_idx %d pilot_evm_dB %d 
+3744,iiiii,[ wal_rc.c : 1831 ] RX pilot evm. channel %d pkt_type %d bw %d MCS%d ppdu duration %dus 
+3745,iiiii,[ wal_rc.c : 1833 ] rx stream%d. RX pilot evm_dB  mean enable %d mean_evmx10 %d, max_evm %d, min_evm %d 
+3746,iIIIIIIII,[ wal_rc.c : 1834 ] rx stream%d. RX pilot evm_dB  pilots 0~3: 0x%8x     4~7:0x%8x     8~11:0x%8x     12~15:0x%8x     16~19:0x%8x     20~23:0x%8x     24~27:0x%8x     28~31:0x%8x 
+3747,iiiiii,[ wal_rc.c : 2926 ] FDRSSI: ul_mu_type %d, user %d, nss %d, min_total_gain %d, Raw %d, Final %d.
+ 
+3748,ii,[ wal_rc.c : 3215 ] [HT Sig]MCS value is not correct (%d) or rate_table_index is  not correct (%d) 
+3749,i,[ wal_rc.c : 3272 ] MCS value is not correct (%d) 
+3750,i,[ wal_rc.c : 3405 ] [he_sig_b2_ofdma]MCS value is not correct (%d) 
+3751,i,[ wal_rc.c : 3491 ] [he_sig_a]MCS value is not correct (%d) 
+3752,IIII,[ wal_rc.c : 4356 ] MU_EDCA_DEBUG: total_msdu: %lu, tcp_msdu: %lu, udp_msdu: %lu, other_msdu: %lu 
+3753,ii,[ wal_rc.c : 2152 ] user id didn't match (%d %d) 
+3754,i,[ wal_rc.c : 2265 ] [HT Sig]MCS value is not correct (%d) 
+3755,iiiIiiI,[ wal_rc.c : 2302 ] pk_11be_rx_ppdu_stats: mcs: %d nss: %d rix: %d rx_rate: %lu bw: %d punctured_mode: %d punctured_pattern: 0x%x 
+3756,iiiiiiiii,[ wal_rc_ul.c : 626 ] UL_TPC_DBG: AID: %d, bw: %d, ru_size: %d, mcs: %d, delta_p_mcs_100x: %d, delta_p_ru_100x: %d, rssi_ref_100x: %d, target_rssi_error_100x: %d => target_rssi_100x: %d 
+3757,IiI,[ wal_rx_recovery.c : 97 ] pdev %x, rx empty recovery sq %d, buffer[%x] 
+3758,IiI,[ wal_rx_recovery.c : 127 ] pdev %x, rx reap recovery sq %d, buffer[%x] 
+3759,,[ wal_rx_recovery.c : 288 ] SFM_PENDING_RXPCU ignored.. 
+3760,IIII,[ wal_rx_recovery.c : 314 ] SFM_PENDING_RXPCU (SFM_REG) detected dev_id:0x%x,rxpcu_sfm_num_dwords=0x%x,MCMN_R0_MCMN_MAC_IDLE=0x%x,detection_type= 0x%x 
+3761,iII,[ wal_rx_recovery.c : 504 ] PDEV id - %d, TPC stuck counter - %u, reset_counter - %u 
+3762,i,[ wal_rx_mgmt.c : 177 ] wal_rx_delete_all_peer_hdlr vdev_id = %d 
+3763,iiIIII,[ wal_rx_mgmt.c : 370 ] rx_suspend_resume_msg on pdev:%d, data_value:%d, status ring flag %x, head %x, tail %x, ms:%x 
+3764,i,[ wal_rx_refill.c : 121 ] Skip host ring TP updating for inactive pdev %d 
+3765,i,[ wal_rx_refill.c : 218 ] Skip monitor ring HP updating for inactive pdev %d 
+3766,i,[ wal_rx_refill.c : 338 ] Skip refill ring HP updating on pdev %d 
+3767,,[ wal_rx_refill.c : 1666 ] Buffer leaked! 
+3768,ii,[ wal_rx_refill.c : 2252 ] pdev %d CE pending in refill ring %d  
+3769,ii,[ wal_rx_refill.c : 2261 ] pdev %d CE pending in dest ring %d  
+3770,ii,[ wal_rx_refill.c : 2269 ] pdev %d CE pending in dest ring %d  
+3771,ii,[ wal_rx_refill.c : 2278 ] pdev %d CE pending in src ring %d  
+3772,iiI,[ wal_rx_uplink.c : 1084 ] smart_basic_trig_log_buf_depletion_time in rx_reset_ul_qdepth : ac=%d flags=%d buffer_depletion_time=%lu 
+3773,iiiiiiIii,[ wal_rx_uplink.c : 1616 ] ul_mlo_proc_qdepth_params src_hw_link=%d dest_hw_link=%d ppdu_id=%d aid=%d sw_peer_id=%d ul_resp_type=%d received_psdu_ok_bytes=%u qos_ctrl_qsize_valid_ac_bitmask=%d bsr_ctrl_qsize_valid_ac_bitmask=%d
+ 
+3774,iiII,[ wal_rx_uplink.c : 1619 ] ul_mlo_proc_qdepth_params qos_control_info_valid=%d ht_control_info_null_valid=%d ul_psdu_proc_timestamp=%lu ul_mlo_psdu_proc_timestamp=%lu
+ 
+3775,III,[ wal_rx_uplink.c : 1674 ] ul_mlo_proc_qdepth_params ac=%u qdepth_bytes_tid1_or_bytes_ac=%u qdepth_bytes_tid2=%u
+ 
+3776,iIIii,[ wal_rx_uplink.c : 2139 ] ul_dbg_update_peer_ul_data: peer_aid=%d, peer=0x%x, ul_rate_info=0x%x, ul_resp_type=%d bsr_recvd=%d 
+3777,IIIIIIII,[ wal_rx_uplink.c : 2148 ] ul_dbg_update_peer_ul_data: fc_valid:%x, fc_field:0x%x, ht_ctrl_valid=%x, ht_control_field=0x%x,ht_ctrl_null_valid=%x, ht_control_null_field=0x%x,qos_data_tid_bitmap=0x%x, qos_data_tid_eosp_bitmap=0x%x 
+3778,II,[ wal_rx_uplink.c : 2152 ] ul_dbg_update_peer_ul_data: qos_control_info_valid=0x%x, qos_control_field=0x%x 
+3779,I,[ wal_rx_uplink.c : 2354 ] ul_dbg_fake_qdepth_timer_handler:  pdev=0x%x 
+3780,Ii,[ wal_rx_uplink.c : 2392 ] ul_dbg_fake_qdepth_updated:  peer=0x%x, ac=%d 
+3781,iiiiiiii,[ wal_rx_uplink.c : 2586 ] UL_ACTIVITY_DBG: TRIG_TYPE=%d, NUM_USER=%d, RX_DONE=%d, TX_DONE=%d, RX_FLUSH_TIMEOUT=%d CMD_RESULT=%d TSF=%d TSTAMP_MS=%d 
+3782,iiiiiiiii,[ wal_rx_uplink.c : 2672 ] UL_ACTIVITY_DBG_USR: PEER_AID=%d, USER_INDEX=%d, BASIC_FAIL=%d, BASIC_SUCCESS=%d, QDEPTH_RESET=%d, BASIC_TRIG=%d, BSR_TRIG=%d, RX_DONE=%d, UL_MPDU_OK=%d 
+3783,iiiiiiiii,[ wal_rx_uplink.c : 3077 ] UL_MUMIMO_DBG, EVM, mu_type %d, user %d, stream %d, pilot %d, raw_evm %d, sig_pwr_db4 %d, evm_pwr_db4 %d, pilot_evm_dB %d, mean_pilot_evm %d 
+3784,III,[ wal_rx_uplink.c : 3132 ] FDRSSI Skip: Alloc count check failed - Alloc cnt : %x Alloc cnt from uCode : %x, num_ul_user = %u 
+ 
+3785,IIII,[ wal_rx_uplink.c : 1520 ] latency_metric aid=%u ac=%u qdepth_curr=%u cur_hw_link_id=%u 
+3786,IIIIIiI,[ wal_rx_uplink.c : 1524 ] latency_metric ul_resp_type=%u, received_ok_bytes_quantized=%u, flags=%u, time_now_us=%lx, last_deter_basic_trig_tstamp_us=%lx, service_interval=%d, delay=%lx 
+3787,IIII,[ wal_rx_uplink.c : 1550 ] latency_metric aid=%u ac=%u qdepth_curr=%u cur_hw_link_id=%u 
+3788,IIIIIiI,[ wal_rx_uplink.c : 1555 ] latency_metric not_eligible ul_resp_type=%u, received_ok_bytes_quantized=%u, flags=%u, time_now_us=%lx, last_deter_basic_trig_tstamp_us=%lx, service_interval=%d, delay=%lx 
+3789,iiiiiiI,[ wal_rx_uplink.c : 434 ] smart_basic_trig_log_buf_depletion_time : link_idx=%d ppdu_id=%d ul_resp_type=%d ac=%d aid=%d flags=%d buffer_depletion_time=%lu
+ 
+3790,iiiiiiiiI,[ wal_rx_uplink.c : 471 ] smart_basic_trig_log_buf_filling_params : link_idx=%d ppdu_id=%d ul_resp_type=%d ac=%d aid=%d flags=%d sample_count=%d qdepth=%d buffer_depletion_time_us=%lu
+ 
+3791,iiIiIii,[ wal_rx_uplink.c : 479 ] smart_basic_trig_log_buf_filling_params : received_psdu_ok_bytes=%d ignore_rcvd_bytes=%d buff_filling_interval_us=%lu buff_filling_interval_bytes=%d cal_buff_filling_interval_us=%lu cal_buff_filling_interval_bytes=%d smart_basic_trigger=%d
+ 
+3792,IIII,[ wal_rx_uplink.c : 567 ] ul_dbg_update_peer_queue_stats_from_HT_CTRL: aci_bitmap=0x%x, aci_high=0x%x, qsize_all=%u, qsize_high=%u 
+3793,iIi,[ wal_rx_uplink.c : 626 ] UL_MUMIMO_DBG: update from_htctrl. aid %d,  queue size %u, ptid_tidno=%d reset UL implicit 
+3794,iIIIIII,[ wal_rx_uplink.c : 673 ] ul_dbg_update_peer_queue_stats_from_HT_CTRL ac=%d, time_delta=%u, qdepth_prev=%u, qdepth_curr=%u, time_now_ms=%u, bsr timeout=%u, last_non_zero_qdepth_ts=%u 
+3795,iiIIIIIii,[ wal_rx_uplink.c : 947 ] ul_dbg_update_peer_ul_data QOS_BITMAP: peer_aid=%d, tid_num=%d, ul_tid_state=0x%x, tid_bitmap=0x%x, eosp_bitmap=0x%x, qsize=%u, qos_ctrl_15_8=%u, ul_resp_type=%d, reception_type_ofdma=%d 
+3796,IIIIII,[ wal_rx_uplink.c : 959 ] ul_dbg_update_peer_ul_data_for_bsr: time_delta=%u,qdepth_prev=%u, qdepth_curr=%u, time_now_ms=%u, bsr_timeout_ms=%u, last_non_zero_update_ts=%u 
+3797,iiIIIII,[ wal_rx_uplink.c : 971 ] ULMU_QUEUE_TRACK: peer_aid=%d ,peer_aid=%d, rx_mpdu_ok: %lu, rx_mpdu_fail: %lu, rx_mpdu_bytes_count: %lu, tcp_ack_msdu_cnt=%lu, ppdu_dur_us=%u 
+3798,iIIIIII,[ wal_rx_uplink.c : 980 ] ul_dbg_efficiency: peer_aid=%d,rx_mpdu_ok: %lu, rx_mpdu_fail: %lu, rx_mpdu_bytes_count: %lu, extra_delim_bytes: %lu, tcp_ack_msdu_cnt=%lu, ppdu_dur_us=%u 
+3799,iIIIII,[ wal_rx_uplink.c : 1009 ] UL_MAX_PPDU_SIZE_DBG_1: aid: %d,average_mpdu_len: %lu, rx_mpdu_count: %lu, rx_mpdu_bytes_count: %lu, rx_null_delim_bytes: %lu, sum_qdepth_bytes: %lu 
+3800,iIIi,[ wal_rx_uplink.c : 1048 ] UL_MAX_PPDU_SIZE_DBG_2: aid: %d, rx_mpdu_bytes_count: %lu, ul_ofdma_estimated_max_ppdu_bytes: %lu g_dbg_min_no_of_mpdus_before_padding : %d 
+3801,ii,[ wal_rx_uplink.c : 1908 ] smart_basic_trig : unreliable basic trig reset smart basic trig params for all ACs ppdu_id=%d aid=%d
+ 
+3802,ii,[ wal_rx_uplink.c : 1957 ] smart_basic_trig : reset parameters due to consecutive QOS NULLs ppdu_id=%d aid=%d
+ 
+3803,IIIIIII,[ wal_rx_uplink.c : 1120 ] latency_metric unreliable_check aid=%u, ac=%u, last_deter_basic_trig_tstamp_us=%lx, null_resp_count=%u, flags=%u, service_interval=%u, hw_time_now_us=%lx 
+3804,III,[ wal_rx_uplink.c : 1136 ] latency_metric unreliable_check deterministic_trig ON flags=%u, null_resp_count=%u, null_response=%u 
+3805,III,[ wal_rx_uplink.c : 1147 ] latency_metric unreliable_check deterministic_trig OFF flags=%u, null_resp_count=%u, null_response=%u 
+3806,iiiiIiiii,[ wal_rx_uplink.c : 1761 ] ul_mlo_send_qdepth_params src_hw_link=%d ppdu_id=%d aid=%d ul_resp_type=%d received_psdu_ok_bytes=%u qos_ctrl_qsize_valid_ac_bitmask=%d bsr_ctrl_qsize_valid_ac_bitmask=%d qos_control_info_valid=%d ht_control_info_null_valid=%d
+ 
+3807,iii,[ wal_rx_uplink.c : 1822 ] ul_mlo_send_qdepth_params send ipc_msg from link = %d to link = %d sw_peer_id = %d
+ 
+3808,iiii,[ wal_rx_uplink.c : 2772 ] EARLY_RX_TERM: num_user/resp: [%d/%d], cmd_result/abort: %d/%d 
+ 
+3809,iii,[ wal_rx_uplink.c : 2807 ] FDRSSI: rx done %d, ipc done %d, flush out %d.
+ 
+3810,ii,[ wal_rx_fast.c : 358 ] RSSI :%d packet %d 
+3811,ii,[ wal_rx_fast.c : 1060 ] RX_DBG_DATA Ring_EMPTY_DBG Reset intitated at %d value of counter for pdev %d  
+3812,iiIiI,[ wal_rx_fast.c : 1748 ] rx_process_recv_status: 11AZ: loc_inf_valid:%d, is_ranging_ndp:%d, peer:%p, peer->keyid0_ast_index:%d, pdev:%p 
+3813,iIII,[ wal_rx_fast.c : 2138 ] RX PhyErr: dev=%d, pkt_type=%x, err=%x, rx_err_cnt=%x 
+3814,,[ wal_rx_fast.c : 2160 ] ULOFDMA_MANUAL_TRIG - Peer handle not present in PPDU state due to FCS error - unable to extract RX PPDU info for this peer 
+3815,ii,[ wal_rx_fast.c : 2543 ] PMLO_DEBUG_V5: UL ppdu_duration_us = %d peer_id = %d 
+3816,iI,[ wal_rx_fast.c : 2550 ] PMLO_DEBUG_V5: UL num_users = %d ppdu_duration_us_corrected = %u 
+3817,II,[ wal_rx.c : 119 ] rx_is_ipv4_wai_frame ether_type:0x%x, WAI swap:0x%x 
+3818,IiI,[ wal_rx.c : 646 ] pdev %x, rx reap error sq %d, buffer 0x%x 
+3819,IIIIi,[ wal_rx.c : 728 ] Rx_bp_dbg consecutive_ppdu_id_mismatch %u dst_ring->mpdu_info.ppdu_id %u expected_ ppdu_id %u buf %x buf_seq %d 
+3820,iI,[ wal_rx.c : 1197 ] peer_rx_event: sw_peer_id=%d, FC=%x ATIM is received for AP VAP and dropping it
+ 
+3821,iIIiiI,[ wal_rx.c : 1652 ] PN_LOG err status: %d last PN: 0x%x  Cur PN: 0x%x type: %d subtype:%d IEEE80211_IS_WEP_FRAME(wh->i_fc[1]) : 0x%x 
+3822,iI,[ wal_rx.c : 1752 ] peer_rx_event: sw_peer_id=%d, FC=%x ATIM is received for AP VAP and dropping it
+ 
+3823,IIIIII,[ wal_rx.c : 1810 ] rxdma_error_code: %x, sw_peer_id =%x ,sw group_id %x, %x,%x, ts= %u 
+3824,i,[ sawf.c : 629 ] svc class %d disabled
+ 
+3825,ii,[ sawf.c : 629 ] svc classes %d-%d disabled
+ 
+3826,i,[ sawf.c : 632 ] svc class %d:
+ 
+3827,I,[ sawf.c : 634 ] %s: na
+ 
+3828,Ii,[ sawf.c : 634 ] %s: %d
+ 
+3829,I,[ sawf.c : 635 ] %s: na
+ 
+3830,Ii,[ sawf.c : 635 ] %s: %d
+ 
+3831,I,[ sawf.c : 636 ] %s: na
+ 
+3832,Ii,[ sawf.c : 636 ] %s: %d
+ 
+3833,I,[ sawf.c : 637 ] %s: na
+ 
+3834,Ii,[ sawf.c : 637 ] %s: %d
+ 
+3835,I,[ sawf.c : 638 ] %s: na
+ 
+3836,Ii,[ sawf.c : 638 ] %s: %d
+ 
+3837,I,[ sawf.c : 639 ] %s: na
+ 
+3838,Ii,[ sawf.c : 639 ] %s: %d
+ 
+3839,I,[ sawf.c : 640 ] %s: na
+ 
+3840,Ii,[ sawf.c : 640 ] %s: %d
+ 
+3841,I,[ sawf.c : 641 ] %s: na
+ 
+3842,Ii,[ sawf.c : 641 ] %s: %d
+ 
+3843,I,[ sawf.c : 642 ] %s: na
+ 
+3844,Ii,[ sawf.c : 642 ] %s: %d
+ 
+3845,I,[ sawf.c : 643 ] %s: na
+ 
+3846,Ii,[ sawf.c : 643 ] %s: %d
+ 
+3847,I,[ sawf.c : 644 ] %s: na
+ 
+3848,Ii,[ sawf.c : 644 ] %s: %d
+ 
+3849,I,[ sawf.c : 645 ] %s: na
+ 
+3850,Ii,[ sawf.c : 645 ] %s: %d
+ 
+3851,I,[ sawf.c : 646 ] %s: na
+ 
+3852,Ii,[ sawf.c : 646 ] %s: %d
+ 
+3853,i,[ sawf.c : 649 ] svc class %d disabled
+ 
+3854,ii,[ sawf.c : 649 ] svc classes %d-%d disabled
+ 
+3855,i,[ sawf.c : 1083 ] SAWF:======== Error all queues used for peer %d=======
+ 
+3856,iiii,[ sawf.c : 1090 ] SAWF:======== Queue %d on tid %d used for peer %d error %d=======
+ 
+3857,iiii,[ sawf.c : 1098 ] SAWF_ALLOC:======== New queue allocated svc_class_id=%d htt_msduq_idx=%d orig service tid=%d hlost_tid %d======= 
+3858,IiiiI,[ sawf.c : 1155 ] SAWF_ALLOC:======== New MSDUQ meta %p svc_class_id=%d NO_remap_tid=%d hlostid in tcl_res=%d tx_flow_num=%u 
+3859,iiiiI,[ sawf.c : 1180 ] wal_sawf_send_htt_indication: flow_override=%d flow_override_enable=%d who_classify_info_sel=%d tid=%d tidno_real=%x 
+3860,IIIIII,[ sawf_htt.c : 1042 ] SDWF_FLOW_DEP: sawf_htt_h2t_sdwf_msduq_recfg_req_hdlr: MLO link handled!! ml_peer_id %u sw_peer_id %u link_idx %u is_deactivate %u error_code %u request_cookie %u 
+3861,IIII,[ sawf_htt.c : 1062 ] SDWF_FLOW_DEP: sawf_htt_h2t_sdwf_msduq_recfg_req_hdlr: SLO link handled!! sw_peer_id %u is_deactivate %u error_code %u request_cookie %u 
+3862,ii,[ sawf_htt.c : 1129 ] SAWF : *msg_ptr %d msg_dword_2 %d  
+3863,i,[ sawf_htt.c : 1181 ] SAWF : flow number %d  
+3864,IIIII,[ sawf_htt.c : 1212 ] SAWF_AST: HTT IND NEW event msg buf_len type[%x] peer_id [%x] vdev_id [%x] ast_1 [%x] ast_2 [%x]
+ 
+3865,,[ sawf_mlo.c : 48 ] SAWF: sawf ipc message is null 
+3866,I,[ sawf_mlo.c : 57 ] SAWF:IPC: invalid peer id: %x  
+3867,I,[ sawf_mlo.c : 72 ] wal_sawf_mlo_svcid_ipc_msg_handler: Invalid  ml_peer_idx= %hu
+ 
+3868,i,[ sawf_mlo.c : 320 ] SAWF: ptid is NULL for tid  %d 
+3869,iiIii,[ wal_htt_stats.c : 561 ] wal_htt_stats_report_error : Skipping wifistats %d for pdev_id %d reset_in_progress = 0x%x chan_change_status = %d curr_time_us %d 
+3870,iiIii,[ wal_htt_stats.c : 575 ] wal_htt_stats_report_error : Skipping wifistats %d for pdev_id %d reset_in_progress = 0x%x chan_change_status = %d curr_time_us %d 
+3871,,[ wal_htt_ppdu_stats.c : 569 ] Dropped ppdu stats due to full QHEAP 
+3872,,[ wal_htt_ppdu_stats.c : 651 ] Dropped ppdu stats due to ring full 
+3873,,[ wal_htt_ppdu_stats.c : 765 ] Dropped ppdu stats due to full QHEAP 
+3874,,[ wal_htt_ppdu_stats.c : 930 ] Dropped ppdu stats due to full QHEAP 
+3875,,[ wal_htt_ppdu_stats.c : 1044 ] Dropped ppdu stats due to full QHEAP 
+3876,,[ wal_htt_ppdu_stats.c : 1104 ] Dropped ppdu stats due to full QHEAP 
+3877,,[ wal_htt_ppdu_stats.c : 1165 ] Dropped ppdu stats due to full QHEAP 
+3878,,[ wal_htt_ppdu_stats.c : 1285 ] Dropped ppdu stats due to full QHEAP 
+3879,,[ wal_htt_ppdu_stats.c : 1577 ] Dropped ppdu stats due to full QHEAP 
+3880,,[ wal_htt_ppdu_stats.c : 1719 ] Dropped tqm ppdu stats due to ring full 
+3881,,[ wal_htt_ppdu_stats.c : 1733 ] Dropped tqm ppdu stats due to full QHEAP 
+3882,,[ wal_htt_ppdu_stats.c : 1822 ] Dropped ppdu stats due to full QHEAP 
+3883,,[ wal_htt_ppdu_stats.c : 2117 ] Dropped tac ppdu stats due to full QHEAP 
+3884,,[ wal_htt_ppdu_stats.c : 2321 ] Dropped ppdu stats due to full QHEAP 
+3885,,[ wal_htt_ppdu_stats.c : 2384 ] Dropped ppdu stats due to full QHEAP 
+3886,,[ wal_htt_ppdu_stats.c : 2445 ] Dropped ppdu stats due to full QHEAP 
+3887,,[ wal_htt_ppdu_stats.c : 2515 ] Dropped mgmt ppdu tlv due to ring full 
+3888,,[ wal_htt_ppdu_stats.c : 2576 ] Dropped ppdu stats due to full QHEAP 
+3889,,[ wal_htt_ppdu_stats.c : 2603 ] Dropped ppdu stats due to full HTT RING 
+3890,,[ wal_htt_ppdu_stats.c : 2620 ] Dropped ppdu stats due to full QHEAP 
+3891,i,[ wal_htt_ppdu_stats.c : 2688 ] Dropped self gen ppdu tlv due to ring full ring_id:%d 
+3892,,[ wal_htt_ppdu_stats.c : 2737 ] Dropped ppdu stats due to full QHEAP 
+3893,,[ wal_htt_ppdu_stats.c : 2795 ] Dropped flush stats due to ring full 
+3894,,[ wal_htt_ppdu_stats.c : 2806 ] Dropped flush stats due to full QHEAP 
+3895,I,[ wal_tqm_cmn.c : 223 ] TQM_DBG:  wal_tqm_dbg_dump_acked_mpdu TQM CMD Number: 0x%08X 
+3896,I,[ wal_tqm_cmn.c : 227 ] TQM_DBG:      ptid: 0x%08X 
+3897,i,[ wal_tqm_cmn.c : 228 ] TQM_DBG:      thread_id: %d 
+3898,I,[ wal_tqm_cmn.c : 229 ] TQM_DBG:      cb_func: 0x%08X 
+3899,I,[ wal_tqm_cmn.c : 230 ] TQM_DBG:      cb_ctxt: 0x%08X 
+3900,I,[ wal_tqm_cmn.c : 234 ] TQM_DBG:      acked_mpdu_info->bmap_start_addr: 0x%08X 
+3901,i,[ wal_tqm_cmn.c : 235 ] TQM_DBG:      acked_mpdu_info->ssn: %d 
+3902,ii,[ wal_tqm_cmn.c : 567 ] wal_tqm_process_gen_mpdu_length_list_status:List stopped due to semi hard notify tid_num %d peer_id %d 
+3903,i,[ wal_tqm_cmn.c : 696 ] mlo_link_ownership: failed to find ptid, can't update gen list counter, link id=%d 
+3904,,[ wal_tqm_cmn.c : 981 ] Bank and Bank Sub type are not valid 
+3905,IIIIi,[ wal_tqm_cmn.c : 1036 ] REMOVE_MPDU_TID_FLUSH_DBG : sw_peer_id = %lx, tidnum = %lx, flush_reason = %lx src_hw_link_id = %lx src_logical_link_id=%d 
+3906,IIIII,[ wal_tqm_cmn.c : 1090 ] DROP wal_tqm_process_remove_mpdu_status peer_id:%u tid:%u msdu_removed: %u mpdu_removed: %u flush_reason:%u 
+3907,ii,[ wal_tqm_cmn.c : 1162 ] wal_tqm_process_remove_mpdu_status:head is notify tid_num %d peer_id %d 
+3908,,[ wal_tqm_cmn.c : 1236 ] tqm: wal_tqm_process_remove_mpdu_status_wrapper: failure tqm_cmd_execution_status 
+3909,iii,[ wal_tqm_cmn.c : 1298 ] tqm_dbg/tlt_dbg: remove_mpdu_status: ownership clear is done, sts=%d code=%d rmv=%d 
+3910,iIi,[ wal_tqm_cmn.c : 1310 ] tlt_dbg: tqm_remove_mpdu_status:ownership clear is done: ml_peer_id:%d, sw_peer_id=%u, tid_num:%d 
+3911,,[ wal_tqm_cmn.c : 1738 ] wal_tqm_process_acked_mpdu_status:List stopped due to semi hard notify  
+3912,IIIi,[ wal_tqm_cmn.c : 1860 ] TQM_DBG: ACKED_MPDU_STATUS: Calling function 0x%08X with ctxt 0x%08X, data 0x%llx, in thread %d
+ 
+3913,ii,[ wal_tqm_cmn.c : 2047 ] wal_tqm_process_get_mpdu_head_info_status  mpdu_head_notify_frame_type tid_num %d peer_id %d 
+3914,iIi,[ wal_tqm_cmn.c : 2492 ] tlt_dbg: tqm_update_status ml_peer_id:%d, sw_peer_id=%u, tid_num:%d 
+3915,I,[ wal_tqm_cmn.c : 2593 ] UMAC_WKK low_prio_status_cmd_infra num_processed %u 
+3916,IIIIII,[ wal_tqm_cmn.c : 4009 ] wal_tqm_alloc_cmd cmd_type 0x%x src 0x%x dst 0x%x dev_id 0x%x chip_id 0x%x status_0 0x%x  
+3917,IIIII,[ wal_tqm_cmn.c : 4013 ] wal_tqm_alloc_cmd 0x%X for thread = 0x%X status_1 0x%x status_2 0x%x src_logical_id 0x%x  
+3918,II,[ wal_tqm_cmn.c : 5063 ] WSI_REMAP: wal_tqm_remove_cmdq_post_remap 0x%X for thread = 0x%X  
+3919,ii,[ wal_tqm_cmn.c : 5209 ] mlo_tqm_dbg: link ownership cmd enqueue, peer=%d tid=%d 
+3920,iiiII,[ wal_tqm_cmn.c : 7176 ] TQM_DBG: wal_tqm_acked_mpdu: thread=%d,cmdq=%d,owner=%d,ring=0x%x,pdng_enq=0x%x 
+3921,iiiI,[ wal_tqm_cmn.c : 7227 ] TQM_DBG: wal_tqm_ack_mpdus: sw_peer_id: %d, tid_num: %d, tid_ssn: %d(0x%x) 
+3922,iIIII,[ wal_tqm_cmn.c : 7242 ] TQM_DBG: wal_tqm_cleaup_transmitted_mpdus_cb_func: curr thread_id: %d, *ctxt[ptid]: 0x%08X, data_val: %ld, tqm_cmd_execution_status: %ld, cmd_execution_code: %ld 
+3923,i,[ wal_tqm_cmn.c : 7261 ] TQM_DBG: wal_tqm_test_tqm_ack_mpdus: tid_tx->win_size_o: %d 
+3924,II,[ wal_tqm.c : 210 ] wal_tqm_flow_update_helper not_init, fw_initialized:%x, counter:%x 
+3925,ii,[ wal_tqm.c : 449 ] _wal_tqm_process_update_tx_msdu_flow_status tx_flow_number:%d update_requirements_not_met:%d  
+3926,ii,[ wal_tqm.c : 562 ] wal_tqm_process_add_msdu_status: peer_id %d TSF %d
+ 
+3927,i,[ wal_tqm.c : 866 ] tqm tickle pending due to assoc_flag=0 peer %d 
+3928,IIII,[ wal_tqm.c : 1059 ] SAWF_ERR: svc stats allocation FAILED for peer %u tid %u qtype %u svc_id %u 
+3929,III,[ wal_tqm.c : 1463 ] SAWF_ERR: svc stats is null for peer %u tid %u qtype %u 
+3930,IIIIIIIII,[ wal_tqm.c : 1480 ] SAWF_STATS generating aggr stats qtype=%u, qpeer_id=%u, mix_ratio_this_queue=%u, mix_ratio_sum=%u,avg_msdu_len=%u, used_msdus=%u, used_msdus_this_queue=%u, used_msduq_bytes=%u, tx_bytes_over_burst_act=%u 
+3931,,[ wal_tqm.c : 1808 ] wal_tqm_process_gen_mpdus_status: Null ptid or tid->_state is NULL 
+3932,IIIIII,[ wal_tqm.c : 1953 ] SAWF_STATS flow0_valid=%u, flow1_valid=%u, flow2_valid=%u, flow3_valid=%u, cur_link=%u, src_link=%u 
+3933,IIIIII,[ wal_tqm.c : 1956 ] SAWF_STATS sum_msdu_mix_ratios=%u, ratio_idx=%u, ratio0=%u, ratio1=%u, ratio2=%u, ratio3=%u 
+3934,iiii,[ wal_tqm.c : 2128 ] wal_tqm_process_gen_mpdus_status:head_notify %d semi_hard_notify_frame_generated %d tid_num %d peer_id %d 
+3935,III,[ wal_tqm.c : 2537 ] peer_id= 0x%x, wal_tqm_process_remove_msdu_status:%x,%x 
+3936,III,[ wal_tqm.c : 2607 ] DROP wal_tqm_process_remove_msdu_status peer_id:%u tid:%u msdu_removed: %u 
+3937,iii,[ wal_tqm.c : 3304 ] soft_msduq_delete: msduq got deleted sw_peer_id:%d, tid_num=%d, qtype:%d 
+3938,iii,[ wal_tqm.c : 3308 ] soft_msduq_delete: delete req dropped sw_peer_id:%d, tid_num=%d, qtype:%d 
+3939,IIII,[ wal_tqm.c : 3760 ] peer_id= 0x%x, wal_tqm_process_flush_cache_status:%x,%x,%x 
+3940,iiii,[ wal_tqm.c : 3872 ] Fired timer and paused TCL rings             ring link descriptor counters mac0:%d mac1:%d mac2:%d sum:%d 
+3941,,[ wal_tqm.c : 4724 ] TCL rings unpaused 
+3942,i,[ wal_tqm.c : 4730 ] Fired timer again             TQM link descriptor counter:%d 
+3943,IIIIIIII,[ wal_tqm.c : 5105 ] tqm_dbg: populate_gen_mpdu sw_peer_id=%u, mpdu_gen_cnt=%u, tgt_mpdu_cnt=%u, max_msdu_in_mpdu=%u, max_mpdu_size=%u, amsdu_size=%u, qbyte_cnt_size=%u, ppdu_bytes=%u 
+3944,ii,[ wal_tqm.c : 6671 ] wal_tqm_peer_qos_update_helper() sw_peer_id:%d qos:%d 
+3945,I,[ wal_tqm.c : 7055 ] wal_tqm_get_msduq_meta_from_flow_number: Invalid  ml_peer_idx= %hu
+ 
+3946,IIII,[ wal_tqm.c : 524 ] peer_id=0x%x, _set_flow_to_be_cleanup:%x, tx_flow_number:%x,caller:%x 
+3947,IIIII,[ wal_tqm.c : 3506 ] SAWF_MLO_SYNC_RATIO recieving n_usrs=%u mpdu_queue_number=%u bits_used=%u dword=%u rem_bits_this_dword=%u 
+3948,IIIIIIII,[ wal_tqm.c : 3536 ] SAWF_MLO_SYNC_RATIO recieving on hw_link=%u aid=%u src_hw_link_id=%u bits_used=%u dword=%u rem_bits_this_dword=%u queue_num=%u ratio_idx=%u 
+3949,IIIIII,[ wal_tqm.c : 3554 ] SAWF_MLO_SYNC_RATIO recieving qtype=%u mix_ratio=%u drain_ratio_self_adj_links=%u bits_used=%u dword=%u rem_bits_this_dword=%u 
+3950,I,[ wal_tqm_mlo.c : 457 ] wal_tqm_alloc_mlo_msduq_meta: Invalid  ml_peer_idx= %hu
+ 
+3951,ii,[ wal_tx_dbg.c : 372 ] TQM_DBG: sw_peer_id: %d, tid_num: %d BMAP:  
+3952,I,[ wal_tx_dbg.c : 377 ] TQM_DBG:    0x%08X 
+3953,i,[ wal_tx_dbg.c : 385 ] TQM_DBG: wal_dbg_test_acked_mpdu_cmd: ret: %d 
+3954,iiiI,[ wal_tx_dbg.c : 425 ] TSF_DBG: tsf_op_cmd: %d, <Get[0]/Set[1]>, is_absolute: %d <offset[0]/absoulte[1]>, tsf_id: %d <TSF_ID[0,1]>, tsf_offset: %016llX <tsf_offset>  
+3955,iII,[ wal_tx_dbg.c : 431 ] TSF_DBG: TSF_ABSOLUTE: ret: %d, Read value: 0x%08llX %08llX 
+3956,iII,[ wal_tx_dbg.c : 434 ] TSF_DBG: TSF_OFFSET: ret: %d, Read value: 0x%08llX %08llX 
+3957,iII,[ wal_tx_dbg.c : 439 ] TSF_DBG: TSF_OFFSET: AFTER SET, ret: %d, Read value: 0x%08llX %08llX 
+3958,iiii,[ wal_tx_dbg.c : 452 ] CW_DBG: wal_config_cw_param: ret: %d, txq_id: %d, cw_min: %d, cw_max: %d 
+3959,iI,[ wal_tx_dbg.c : 461 ] NAV_DBG: wal_control_nav: ret: %d, nav: 0x%08X 
+3960,iii,[ wal_tx_dbg.c : 471 ] CCA_DBG: wal_control_hwsch_cca: ret: %d, hwq_id: %d, cca_enable: %d 
+3961,iii,[ wal_tx_dbg.c : 528 ] RXPCU_BA_DBG: ba_win_type: %d [0: 64 ba, 1: 256, 2: 512, 3: 1024], max_ta_tid: %d, rxpcu_ba_reg_dump_enable : %d 
+3962,III,[ wal_tx_dbg.c : 812 ] data_stall debug support is not allowed as the vdev_type is not            STA pdev_id:8/vdev_id:8 0x%08x vdev:0x%x pdev:0x%x 
+3963,I,[ wal_tx_dbg.c : 940 ] tx_unit_test : pdev:0x%x 
+3964,,[ wal_tx_dbg.c : 951 ] tx_unit_test : pdev is NULL 
+3965,iii,[ wal_tx_dbg.c : 1184 ] %dms Burst: avg_txop_burst(ms) = %d,txop_on_burst_complete(ms) = %d 
+ 
+3966,iiiiiiii,[ wal_tx_dbg.c : 1424 ] sched_cmd_result[0] to sched_cmd_result[6] for HWQ id %d = {%d,%d,%d,%d,%d,%d,%d}
+ 
+3967,iiiiiii,[ wal_tx_dbg.c : 1434 ] sched_cmd_result[7] to sched_cmd_result[12] for HWQ id %d = {%d,%d,%d,%d,%d, %d}
+ 
+3968,iiiiiiii,[ wal_tx_dbg.c : 1548 ] WHAL_STATS for pdev id =  %d: last_unpause_ppdu_id = %d hwsch_unpause_wait_tqm_write = %d hwsch_dummy_tlv_skipped = %d hwsch_misaligned_offset_received = %d hwsch_reset_count = %d hwsch_dev_reset_war = %d hwsch_delayed_pause = %d 
+3969,iiiiiiii,[ wal_tx_dbg.c : 1568 ] hwsch_long_delayed_pause = %d sch_rx_ppdu_no_response = %d sch_selfgen_response = %d sch_rx_sifs_resp_trigger = %d sch_mpdu_info_bitmap_missed = %d hwsch_qcdd03911334 = %d hwsch_qcdd04031456 = %d hwsch_qcdd03955078 = %d 
+3970,iiiiiii,[ wal_tx_dbg.c : 1586 ] hwsch_backpressure_wdog = %d hwsch_pause_wdog = %d hwsch_fes_start_wdog = %d hwsch_life_time_expiry_valid_fes_offset = %d crypto_wdog_tmout = %d pdg_sfm_leak_rst_cnt = %d hwsch_cmd_ring_reset_war_dummy_completions = %d 
+3971,iiiiiiii,[ wal_tx_dbg.c : 1606 ] hwsch_flush_not_done = %d flush_tx_not_idle = %d hwsch_wd_unknown_reset = %d hwsch_mtu_wrap_wdog = %d crypto_fatal_unknown = %d txdma_fatal_unknown = %d sfm_fatal_unknown = %d mcmn_fatal_unknown = %d 
+3972,iiiiiiii,[ wal_tx_dbg.c : 1626 ] txpcu_wdog_tout = %d txpcu_recd_lt_mpdu = %d txpcu_recd_gt_mpdu= %d pdg_fatal_unknown = %d hwsch_fatal_unknown = %d hwsch_wdog_unknown = %d mxi_fatal_unknown = %d txole_fatal_unknown = %d 
+3973,iiiiiii,[ wal_tx_dbg.c : 1666 ] tx_flush_tlv_tag_oor_err = %d tx_flush_tlv_len_oor_err = %d tx_flush_tlv_taglen_mismatch_err = %d tx_flush_unexpected_tlv_end_err = %d tx_steer_frm_cnt = %d tx_flush_txdma_sfm_busy = %d phy_warm_reset = %d 
+3974,,[ wal_tx_dbg.c : 1693 ] No ul_resp_vdev assigned !! 
+3975,II,[ wal_tx_dbg.c : 1697 ] ac:%x already in MU mode, reset timer to %x 
+3976,I,[ wal_tx_dbg.c : 1700 ] ac:%x switch to MU mode 
+3977,I,[ wal_tx_dbg.c : 1864 ] flush hwq mask:%x, if hwq >= 16, flush is not initiated 
+3978,i,[ wal_tx_dbg.c : 1924 ] TPCDBG logging flag is %d 
+3979,IIIIIII,[ wal_tx_dbg.c : 2035 ] TXDEWDOG TCL1:%u full_ignore:%u dummy_queued:%u last_time:%u , TQM1:%u dummy_queued:%u last_time:%u 
+3980,iiI,[ wal_tx_dbg.c : 2074 ] No ul_resp_vdev:%d or BSS-peer not assigned:%d or invalid ACTRL:%x !! 
+3981,iiiiii,[ wal_tx_dbg.c : 2152 ] fudge_txtime=%d, legacy_burst=%d, vht_burst=%d, short_pkt_min_msdu_size=%d, legacy_burst_per=%d, vht_burst_per=%d 
+3982,iii,[ wal_tx_dbg.c : 2228 ] mu_mimo_ppdu_dur_hist_200us_bin_%d (Nr_%d) : %d 
+3983,iiiiiiiii,[ wal_tx_dbg.c : 2248 ] 11be_mu_mimo_total_txop_ms_hist_MU%d_bin_%d - %d (Nr_%d) : %d, %d, %d, %d, %d 
+3984,iiiiiiiii,[ wal_tx_dbg.c : 2272 ] mu_mimo_total_txop_ms_hist_MU%d_bin_%d - %d (Nr_%d) : %d, %d, %d, %d, %d 
+3985,iiii,[ wal_tx_dbg.c : 2282 ] mu_mimo_mpdus_failed_hist_%d - %d (Nr_%d) : %d 
+3986,iiii,[ wal_tx_dbg.c : 2287 ] mu_mimo_mpdus_failed_hist_%d - %d (Nr_%d) : %d 
+3987,iii,[ wal_tx_dbg.c : 2296 ] mu_mimo_mpdus_tried_hist_%d (Nr_%d) : %d 
+3988,iiii,[ wal_tx_dbg.c : 2301 ] mu_mimo_mpdus_tried_hist_%d - %d (Nr_%d) : %d 
+3989,iiii,[ wal_tx_dbg.c : 2306 ] mu_mimo_mpdus_tried_hist_%d - %d (Nr_%d) : %d 
+3990,II,[ wal_tx_dbg.c : 2419 ] read addr: 0x%x, value = 0x%x 
+3991,Ii,[ wal_tx_dbg.c : 2789 ] sifs burst enable: 0x%x, pdev=%d
+ 
+3992,i,[ wal_tx_dbg.c : 2814 ] # of MU-RTS : %d 
+ 
+3993,IIIIII,[ wal_tx_dbg.c : 2912 ] flush_38_hist: %02d %02d %02d %02d %02d %02d 
+3994,i,[ wal_tx_dbg.c : 2982 ] WAL_PPDU: MU PPDU VAL:%d 
+3995,IIIII,[ wal_tx_dbg.c : 3250 ] twt_dbg_leak_hist_dl: Bins0-4: %u, %u, %u, %u, %u 
+3996,IIIII,[ wal_tx_dbg.c : 3255 ] twt_dbg_leak_hist_dl: Bins5-9: %u, %u, %u, %u, %u 
+3997,IIIII,[ wal_tx_dbg.c : 3261 ] twt_dbg_leak_hist_ul: Bins0-4: %u, %u, %u, %u, %u 
+3998,IIIII,[ wal_tx_dbg.c : 3267 ] twt_dbg_leak_hist_ul: Bins0-4: %u, %u, %u, %u, %u 
+3999,i,[ wal_tx_dbg.c : 3674 ] SelfGenResp: Dev id %d is in power saving state, not able to print. 
+4000,iiii,[ wal_tx_dbg.c : 3739 ] LOCAL/REMOTE: msduq_pool_ctxt total_alloc_cnt:%d/%d cur_alloc_cnt:%d/%d 
+4001,iiii,[ wal_tx_dbg.c : 3751 ] LOCAL/REMOTE: tid_state_pool total_alloc_cnt:%d/%d cur_alloc_cnt:%d/%d 
+4002,iiii,[ wal_tx_dbg.c : 3756 ] LOCAL/REMOTE: ul_tid_state_pool total_alloc_cnt:%d/%d cur_alloc_cnt:%d/%d 
+4003,iiii,[ wal_tx_dbg.c : 3762 ] LOCAL/REMOTE: sawf_ul_delay_tuple_pool total_alloc_cnt:%d/%d cur_alloc_cnt:%d/%d 
+4004,ii,[ wal_tx_dbg.c : 3963 ]  Profile Enabled : %d   hist_intvl : %d 
+4005,iiiiiiiii,[ wal_tx_dbg.c : 4001 ]  Profile ID : %d  Count: %d  Min : %d  Max : %d  Profile ID : %d  hist_intvl: %d  hist[0] : %d  hist[1] : %d  hist[2] : %d  
+4006,,[ wal_tx_dbg.c : 4064 ] wal_tqm_update_msdu_txflow skipped as hw_msduq Null.  
+4007,,[ wal_tx_dbg.c : 4147 ] ctrl_path_stats_dbg : Disabling peer_dbg logs
+ 
+4008,,[ wal_tx_dbg.c : 4154 ] ctrl_path_stats_dbg : Error seen 
+ Usage 
+ctrl_path_stats_dbg: To Enable  Stats: wifitool athX setUnitTestCmd 0x48 8 244 1 <mac_addr_0> <mac_addr_1> <mac_addr_2>  <mac_addr_3> <mac_addr_4> <mac_addr_5>
+ctrl_path_stats_dbg: To Disable Stats: wifitool athX setUnitTestCmd 0x48 2 244 0
+ 
+4009,IIIIIIII,[ wal_tx_dbg.c : 4178 ] ctrl_path_stats_dbg : args[2] = 0x%x args[3] = 0x%x args[4] = 0x%x args[5] = 0x%x args[6] = 0x%x args[7] = 0x%x mac_addr_31_0 = 0x%x mac_addr_47_32 = 0x%x
+ 
+4010,,[ wal_tx_dbg.c : 4180 ] ctrl_path_stats_dbg: SW Peer ID Check
+ 
+4011,i,[ wal_tx_dbg.c : 4183 ] ctrl_path_stats_dbg: vdev %d 
+ 
+4012,iiiII,[ wal_tx_dbg.c : 4193 ] ctrl_path_stats_dbg: bss/self %d/%d, peer %d, mac %x %x
+ 
+4013,iII,[ wal_tx_dbg.c : 4195 ] ctrl_path_stats_dbg: sw_peer_id found peer %d, mac %x %x
+ 
+4014,II,[ wal_tx_dbg.c : 4294 ] s_stats: dbg_num_bufs: %u, dbg_num_evt: %u 
+ 
+4015,III,[ wal_tx_dbg.c : 4295 ] s_stats: HOST_ring_HI : %u, TI : %u, S_TI : %u  
+4016,IIII,[ wal_tx_dbg.c : 4296 ] s_stats: IN/SHADOW_ring_HI : %u, TI : %u, S_TI : %u, S_HI : %u 
+4017,IIII,[ wal_tx_dbg.c : 4297 ] s_stats: OUT_ring_HI : %u TI : %u, S_TI : %u, S_HI : %u 
+4018,IIIII,[ wal_tx_dbg.c : 4300 ] s_stats: IPC_ring_%u : HI : %u TI : %u, S_TI : %u, S_HI : %u 
+4019,,[ wal_tx_dbg.c : 4303 ] s_stats: VREG_DET0 : 
+ 
+4020,III,[ wal_tx_dbg.c : 4304 ] s_stats: ScanPri : %u, SCount : %u, SPrd : %u 
+ 
+4021,III,[ wal_tx_dbg.c : 4305 ] s_stats: ChnMask : %u, SEna : %u, SUpdtMask : 0x%x 
+ 
+4022,IIII,[ wal_tx_dbg.c : 4306 ] s_stats: SRdyIntrpt : %u, SPfmd : %u, IntrptsSent : %u, Scanpending : %u 
+
+ 
+4023,IIII,[ wal_tx_dbg.c : 4307 ] s_stats: ScanNoIpcBufAvail : %u ScanFFTdiscardCount %u ScanRecaptureFFTdiscardCount %u ScanRecaptureCount %u 
+4024,,[ wal_tx_dbg.c : 4308 ] s_stats: DET0 - FW Debug stats 
+4025,IIII,[ wal_tx_dbg.c : 4309 ] s_stats: num_pcss_elem_zero : %u num_in_elem_zero : %u num_out_elem_zero : %u num_elem_moved : %u  
+4026,,[ wal_tx_dbg.c : 4314 ] s_stats: VREG_DET1: 
+ 
+4027,III,[ wal_tx_dbg.c : 4315 ] s_stats: ScanPri : %u, SCount : %u, SPrd : %u 
+ 
+4028,III,[ wal_tx_dbg.c : 4316 ] s_stats: ChnMask : %u, SEna : %u, SUpdtMask : 0x%x 
+ 
+4029,IIII,[ wal_tx_dbg.c : 4317 ] s_stats: SRdyIntrpt : %u, SPfmd : %u, IntrptsSent : %u , Scanpending : %u 
+ 
+4030,,[ wal_tx_dbg.c : 4318 ] s_stats: DET1 - FW Debug stats 
+4031,IIII,[ wal_tx_dbg.c : 4319 ] s_stats: num_pcss_elem_zero : %u num_in_elem_zero : %u num_out_elem_zero : %u num_elem_moved : %u  
+4032,IIiIiiIiI,[ wal_tx_dbg.c : 4565 ] Exception stats min/max time %x/%x, service_time_below%d_count %x, service_time_above%d_below%d_count %x, service_time_above%d_count %x 
+4033,iiii,[ wal_tx_dbg.c : 4670 ] delimiter user track: Number of total MU PPDU %d, MU PPDUs with delimiter users: %d, Percent:%d                    Average MU number of delimiter users %d 
+4034,i,[ wal_tx_dbg.c : 5055 ] NOC_PENDING_TRANSACTIONS lmac_noc_transaction_pending_cnt %d 
+4035,iiiii,[ wal_tx_dbg.c : 5162 ] CONG_CTRL Multicast_DBG buf_id:%d hcm_bin_idx:%d cur:%d, min:%d, max:%d 
+4036,iiiiii,[ wal_tx_dbg.c : 5364 ] tqm_sync_pipeling_stats: tqm_sync_sent = %d, tqm_sync_proc = %d, TAC/IST post = %d, tqm_sync_not_proc = %d, tqm_ist post = %d, hwsch_trigger_lots = %d 
+4037,i,[ wal_tx_dbg.c : 5386 ] MAC clock gating: %d 
+4038,IIIIIIi,[ wal_tx_dbg.c : 5434 ] PM_STATE_DBG: for %2x:%2x:%2x:%2x:%2x:%2x, DUMP_CONN_PAUSE_PEER_STATE: Peer found = %d 
+4039,II,[ wal_tx_dbg.c : 5452 ] twt_debug: g_dbg_stop_seq_cnt:%u,stop_burst_seq_for_twt:%u 
+4040,iiii,[ wal_tx_dbg.c : 5487 ] Custom Basic trigger null_response %d null_term %d trig_count %d cust_basic_trig_err %d
+ 
+4041,i,[ wal_tx_dbg.c : 5508 ] err injection omitted due to mac-%d test ongoing 
+4042,ii,[ wal_tx_dbg.c : 5520 ]  unit_test_cmd : TX flush interval %d enable %d 
+4043,iii,[ wal_tx_dbg.c : 5538 ]  unit_test_cmd : Host2HW Ring %d Duration  %d is_on %d 
+4044,,[ wal_tx_dbg.c : 5541 ]  HW_ERR_REINJECTION : Invalid host ring id during host ring bkpressure err injection 
+4045,iii,[ wal_tx_dbg.c : 5559 ]  unit_test_cmd : FW2HW Ring %d Duration  %d is_on %d 
+4046,,[ wal_tx_dbg.c : 5562 ]  HW_ERR_REINJECTION : Invalid fw ring id during fw ring bkpressure err injection 
+4047,iii,[ wal_tx_dbg.c : 5580 ]  unit_test_cmd : HW2HW Ring %d Duration  %d is_on %d 
+4048,,[ wal_tx_dbg.c : 5583 ]  HW_ERR_REINJECTION : Invalid hw ring id during hw ring bkpressure err injection 
+4049,ii,[ wal_tx_dbg.c : 5598 ]  unit_test_cmd : RX abort interval %d enable %d 
+4050,,[ wal_tx_dbg.c : 5617 ]  HW_ERR_REINJECTION : Invalid no of arguements 
+4051,,[ wal_tx_dbg.c : 5627 ]  HW_ERR_REINJECTION : Invalid no of arguements for axi 
+4052,,[ wal_tx_dbg.c : 5633 ]  HW_ERR_REINJECTION : Invalid module for axi read latency injection 
+4053,ii,[ wal_tx_dbg.c : 5659 ]  unit_test_cmd : RX flush interval %d enable %d 
+4054,ii,[ wal_tx_dbg.c : 5700 ]  unit_test_cmd : PDG Latency Error interval %d enable %d 
+4055,,[ wal_tx_dbg.c : 5705 ]  HW_ERR_REINJECTION : PDG Latency Error can't be injected 
+4056,,[ wal_tx_dbg.c : 5738 ] UMAC_SSR : unit_test_cmd : REO Wdog error injection 
+4057,,[ wal_tx_dbg.c : 5749 ] UMAC_SSR : unit_test_cmd : TQM cache controller error injection 
+4058,ii,[ wal_tx_dbg.c : 5759 ] HW_ERR_REINJECTION : Invalid no. of arguments on args[1]=%d num_args=%d 
+4059,i,[ wal_tx_dbg.c : 5808 ] g_debug_arp_assert set %d 
+4060,III,[ wal_tx_dbg.c : 5827 ] g_debug_mgmt_fail_assert set %08x %08x %08x 
+4061,i,[ wal_tx_dbg.c : 6305 ] TX_BA_LOG:delay post BA is %d 
+4062,i,[ wal_tx_dbg.c : 6315 ] TX_BA_LOG: delay post BA timer value is %d ms 
+4063,i,[ wal_tx_dbg.c : 6347 ] tx_dbg: tx resume timeout %d ms is requested. Valid range = 100<timeout<1000 
+4064,ii,[ wal_tx_dbg.c : 6385 ] tx_dbg: set=%d msdu_drop for peer %d 
+4065,ii,[ wal_tx_dbg.c : 6399 ] tx_dbg: txq stuck is set to %d %d 
+4066,ii,[ wal_tx_dbg.c : 6407 ] Set OFDM scrambler seed=%d pdev_id=%d 
+4067,ii,[ wal_tx_dbg.c : 6431 ] DEBUG_PKTLOG: Pktlog enabled:%d Pktlog-decode-info-WMI-event sent with valid contents:%d 
+4068,I,[ wal_tx_dbg.c : 6450 ] Total PDG_WRNG_TLV_ORD occurences : %x 
+4069,iii,[ wal_tx_dbg.c : 6468 ] SUBRING_PAUSE_DBG: g_subring_pause_war_timeout = %d, g_subring_pause_war_filter_start = %d g_subring_pause_war = %d
+ 
+4070,I,[ wal_tx_dbg.c : 6589 ] SAWF_DBG: qpeer is null, INCORRECT peer id %u 
+4071,I,[ wal_tx_dbg.c : 6595 ] SAWF_DBG: peer %u deleted 
+4072,I,[ wal_tx_dbg.c : 6601 ] SAWF_DBG: No valid peer %u 
+4073,i,[ wal_tx_dbg.c : 6605 ]                   SAWF QUEUES FOR SW Peer ID: %d 
+4074,,[ wal_tx_dbg.c : 6606 ] ======================================================================= 
+4075,,[ wal_tx_dbg.c : 6607 ]  HLOS_TID|   TID          | HTT_MSDUQ_IDX    | SVC_CLASS_ID | FLOW NUM  
+4076,,[ wal_tx_dbg.c : 6608 ] ======================================================================= 
+4077,IIIII,[ wal_tx_dbg.c : 6646 ]   %02d     |   %02d           | %02d               | %02d           | %02d          
+4078,,[ wal_tx_dbg.c : 6672 ] SAWF_DBG: Please input either 1 or 0 to either enable dummy ast allocation or not 
+4079,,[ wal_tx_dbg.c : 6680 ] SAWF_DBG: Enabling Dummy ast allocations for all peers 
+4080,,[ wal_tx_dbg.c : 6684 ] SAWF_DBG: Disabling Dummy ast allocations for all peers 
+4081,i,[ wal_tx_dbg.c : 6714 ] g_whal_mac_core_cfg.dbg.crash_on_OOO_int : %d 
+4082,I,[ wal_tx_dbg.c : 6753 ] g_enable_rxole_sm_state_check : %x 
+4083,i,[ wal_tx_dbg.c : 6850 ] QOS Ring Switch Low AC terminated count : %d 
+4084,iii,[ wal_tx_dbg.c : 7419 ] BEACON_DIAG: consecutive beacon life span expiry threshold is set to %d for pdev id %d and force crash on reaching this threshold flag is %d 
+4085,i,[ wal_tx_dbg.c : 7423 ] BEACON_DIAG: force assert on consecutive beacon life span expiry threshold is disabled at pdev id %d 
+4086,IIIII,[ wal_tx_dbg.c : 7441 ] wal_tx_dbg: WMI_REQUEST_LINK_STATS_CMD: stats_type=%u, vdev_id=%u, request_id=%u, peer_macaddr31to0=%u, peer_macaddr48to32=%u 
+4087,,[ wal_tx_dbg.c : 7463 ] Crash for UL Trigger packet sent in SIFS - Tx-BA --> SIFS --> Tx-Trigger --> TB-PPDU-Rx 
+4088,i,[ wal_tx_dbg.c : 7533 ] mlo_link_ownership: consecutive tx failure threshold changed: %d 
+4089,iiiii,[ wal_tx_dbg.c : 7577 ] FILS_DEBUG_UTC vdev_id %d FILS enq_cnt %d tx_cmpl OK %d tx cmpl fail %d FILS not queued cnt %d  
+4090,iiiiii,[ wal_tx_dbg.c : 7578 ] FILS_DEBUG_UTC vdev_id %d bcn cmpl cnt %d #3_FILS_bw_bcns: %d  #2_FILS_bw_bcns: %d #1_FILS_bw_bcns: %d #0_FILS_bw_bcns: %d 
+4091,II,[ wal_tx_dbg.c : 7643 ] SAWF: g_local_ipc_count = 0x%x g_sawf_stats_alloc_failed = 0x%x 
+4092,Iiii,[ wal_tx_dbg.c : 7665 ] SAWF: sawf_mlo_msduq_detailed_info = 0x%x ml_peer_id = %d tid = %d htt_msduq_idx = %d 
+4093,I,[ wal_tx_dbg.c : 7705 ] SAWF_DBG: qpeer is null, INCORRECT peer id %u 
+4094,I,[ wal_tx_dbg.c : 7711 ] SAWF_DBG: peer %u deleted 
+4095,I,[ wal_tx_dbg.c : 7717 ] SAWF_DBG: No valid peer %u 
+4096,,[ wal_tx_dbg.c : 7722 ] SAWF_DBG: ptid is null 
+4097,iiIii,[ wal_tx_dbg.c : 7726 ] SAWF_DBG: peer %d tid %d svc_class_flags=0x%x latency idx=%d get_lat_idx = %d 
+4098,II,[ wal_tx_dbg.c : 7730 ] SAWF_DBG: cust_bank_idx %u sawf_msduq2tid_alloc_bmap %u 
+4099,I,[ wal_tx_dbg.c : 7732 ] SAWF_DBG: sawf_ul_ac_en_bmap %u  
+4100,iiii,[ wal_tx_dbg.c : 7746 ] SAWF_DBG: sifs_disable_svc_interval_limit_ms = %d ultra_low_lat_idx_delay_ms %d low_lat_idx_delay_ms %d mid_lat_idx_delay_ms %d 
+4101,ii,[ wal_tx_dbg.c : 7916 ] OBSS SPATIAL REUSE: wrong args[2]=%d, num_args=%d 
+4102,I,[ wal_tx_dbg.c : 7975 ] UMAC_WKK pre_mlo_ur_tqm_status_intentionally_dropped %u 
+4103,,[ wal_tx_dbg.c : 7982 ] UMAC_WKK enabled post sync cmd to TQM  
+4104,I,[ wal_tx_dbg.c : 8008 ] TDMA: Adding a schedule at %lx us 
+4105,III,[ wal_tx_dbg.c : 8044 ] global_dev_reset waiting for dev reset success_count:%u is_waiting:%u  waiting not_req count = %u  
+4106,II,[ wal_tx_dbg.c : 8096 ] MU BAR RETRY MECHANISM setting parameter:%u %u 
+4107,II,[ wal_tx_dbg.c : 8109 ] UMAC_WKK umac_recovery htt_setup_completed %u unit test opt %u 
+4108,II,[ wal_tx_dbg.c : 8161 ] tlt_dbg monitor_ctxt_settings: arg1=%u, arg2=%u 
+4109,,[ wal_tx_dbg.c : 8196 ] tlt_dbg, peer data inconsistent 
+4110,,[ wal_tx_dbg.c : 8203 ] tlt_dbg unit_test_num_args_incorrect 
+4111,II,[ wal_tx_dbg.c : 8221 ] force_fake_power_save peer_id=%u, qpeer=0x%x 
+4112,,[ wal_tx_dbg.c : 8223 ] force_fake_power_save, peer data inconsistent 
+4113,ii,[ wal_tx_dbg.c : 8265 ]  TQM_MSDU_AGE g_dbg_msdu_latency_debug_ac %d g_dbg_assert_on_max_latency %d  
+4114,iiiii,[ wal_tx_dbg.c : 8273 ] TQM_MSDU_AGE  0-10: %d 10-20 %d 20-30 %d 30-40 %d 40-50 %d  
+4115,iiiii,[ wal_tx_dbg.c : 8275 ] TQM_MSDU_AGE  50-60: %d 60-70 %d 70-80 %d 80-90 %d >90 %d  
+4116,i,[ wal_tx_dbg.c : 8276 ] TQM_MSDU_AGE g_dbg_max_msdu_latency %d  
+4117,I,[ wal_tx_dbg.c : 8312 ] ULMU_PRINT: sequences_terminated: %u 
+4118,I,[ wal_tx_dbg.c : 8313 ] ULMU_PRINT: ul_mumimo_seq_term_low_tx_time_efficiency: %u 
+4119,I,[ wal_tx_dbg.c : 8314 ] ULMU_PRINT: ul_mumimo_seq_term_per_peer_low_qdepth: %u 
+4120,IIIIII,[ wal_tx_dbg.c : 8353 ] PRIMARY_UMAC_MIGRATION: for %2x:%2x:%2x:%2x:%2x:%2x 
+4121,iii,[ wal_tx_dbg.c : 8364 ] PRIMARY_UMAC_MIGRATION : Peer found : ml_peer_id %d, cur_hw_link_id %d, new_pri_hw_link_id %d 
+4122,,[ wal_tx_dbg.c : 8366 ] PRIMARY_UMAC_MIGRATION : Peer not found 
+4123,i,[ wal_tx_dbg.c : 8370 ] PRIMARY_UMAC_MIGRATION : state %d 
+4124,,[ wal_tx_dbg.c : 8372 ] PRIMARY_UMAC_MIGRATION : Invalid args 
+4125,iii,[ wal_tx_dbg.c : 8437 ] emlsr: change observation period: pdev = %d, period = %d, final period = %d 
+4126,ii,[ wal_tx_dbg.c : 8441 ] emlsr: change observation period ERR: pdev = %d, power = %d 
+4127,i,[ wal_tx_dbg.c : 8451 ] enable_sawf_def_queue %d  
+4128,I,[ wal_tx_dbg.c : 8476 ] UMAC_WKK g_whal_umac_reset.opt.enable_umac_ssr_wdiag : %u 
+4129,i,[ wal_tx_dbg.c : 8494 ] MLO_U.R: t2h_msi_data: %d 
+4130,I,[ wal_tx_dbg.c : 8503 ] UMAC_WKK enable_kpi_e2e_delta_threshold_exceed_crash : %u 
+4131,I,[ wal_tx_dbg.c : 8515 ] UMAC_WKK g_wal_mac_core_ctrl.opt.enable_umac_recovery_on_reo_hang: %u 
+4132,II,[ wal_tx_dbg.c : 8560 ] tlt_dbg monitor_ctxt_settings: num_args=%u, arg1=%u 
+4133,II,[ wal_tx_dbg.c : 8575 ] tlt_dbg monitor_ctxt_settings: num_args=%u, arg1=%u 
+4134,I,[ wal_tx_dbg.c : 8615 ] SAWF_DBG: g_sawf_opt_sample_thold %u 
+4135,iiiIII,[ wal_tx_dbg.c : 8634 ] mu_mode:%d curr_ftype:%d prev_ftype:%d g_ppdu_cycles_accum:%lu g_dbg_ppdu_count:%lu avg_ppdu_cycles:%lu 
+4136,I,[ wal_tx_dbg.c : 8661 ] MU_DBG_FILS_OPT: fils_threshold:%u 
+4137,I,[ wal_tx_dbg.c : 8664 ] MU_DBG_FILS_OPT: fils_tid_delay_threshold:%u 
+4138,IIIIII,[ wal_tx_dbg.c : 8814 ] 11AZ TBR SU Stats :(POLL  = %lu)(SOUND = %lu)(NDPA  = %lu)(NDP   = %lu)(LMR   = %lu)(TF_REPORT = %lu) 
+4139,IIIIII,[ wal_tx_dbg.c : 8830 ] 11AZ TBR MU Stats(POLL  = %lu)(SOUND = %lu)(NDPA  = %lu)(NDP   = %lu)(LMR   = %lu)(TF_REPORT = %lu) 
+4140,i,[ wal_tx_dbg.c : 8841 ] Tbr Frame %d SU Cmd Result : 
+4141,IIIIIIIII,[ wal_tx_dbg.c : 8845 ] %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu 
+4142,IIIIIIIII,[ wal_tx_dbg.c : 8858 ] %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu 
+4143,i,[ wal_tx_dbg.c : 8865 ] Tbr Frame %d MU Cmd Result : 
+4144,IIIIIIIII,[ wal_tx_dbg.c : 8869 ] %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu 
+4145,IIIIIIIII,[ wal_tx_dbg.c : 8882 ] %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu %2lu 
+4146,I,[ wal_tx_dbg.c : 8893 ] MLO_U.R syssw_wmi_h2t_reap_deferred %u 
+4147,II,[ wal_tx_dbg.c : 8901 ] MLO_U.R pre_mlo_ur_aborted_seq  : %u  discarded_pre_mlo_ur_seq_completions : %u 
+4148,I,[ wal_tx_dbg.c : 8908 ] MLO_U.R  seq_repost_stop_due_to_umac_recovery : %u 
+4149,I,[ wal_tx_dbg.c : 8915 ] MLO_U.R tx_send_purge_mpdus_skipped_for_no_pending_or_stale_mpdus %u 
+4150,,[ wal_tx_dbg.c : 8967 ] SAWF_WFA: Previous_state:  
+4151,I,[ wal_tx_dbg.c : 8968 ] SAWF_WFA: 	disable_qos_null_trig_terminate: %u 
+4152,I,[ wal_tx_dbg.c : 8973 ] SAWF_WFA: 	enable_low_lat_peer_su_cts_burst : %u 
+4153,I,[ wal_tx_dbg.c : 8974 ] SAWF_WFA: 	g_dbg_disable_check_ppdu_fail_thr: %u 
+4154,I,[ wal_tx_dbg.c : 8975 ] SAWF_WFA: 	dbg_enable_low_latency           : %u 
+4155,I,[ wal_tx_dbg.c : 8976 ] SAWF_WFA: 	g_enable_aggressive_dl_schedule : %u 
+4156,,[ wal_tx_dbg.c : 8984 ] SAWF_WFA: Current_state:  
+4157,I,[ wal_tx_dbg.c : 8985 ] SAWF_WFA: 	disable_qos_null_trig_terminate: %u 
+4158,I,[ wal_tx_dbg.c : 8990 ] SAWF_WFA: 	enable_low_lat_peer_su_cts_burst : %u 
+4159,I,[ wal_tx_dbg.c : 8991 ] SAWF_WFA: 	g_dbg_disable_check_ppdu_fail_thr: %u 
+4160,I,[ wal_tx_dbg.c : 8992 ] SAWF_WFA: 	dbg_enable_low_latency           : %u 
+4161,I,[ wal_tx_dbg.c : 8993 ] SAWF_WFA: 	g_enable_aggressive_dl_schedule : %u 
+4162,III,[ wal_tx_dbg.c : 9272 ] ml_mpdu_limit updated : 
+g_ml_mpdu_limit[ML_MPDU_PROFILE_MIN] : %x, 
+g_ml_mpdu_limit[ML_MPDU_PROFILE_NOMINAL] : %x, 
+g_ml_mpdu_limit[ML_MPDU_PROFILE_HI_PERF] : %x 
+4163,,[ wal_tx_dbg.c : 9324 ] LED-Blink-Index: Format: wifitool athX setUnitTestCmd 0x48 1 830 
+4164,,[ wal_tx_dbg.c : 9334 ] LED-Blink-Index: Config-CONFIG_DATA_RATE_TXRX_BLINK_LED not enable in FW 
+4165,iii,[ wal_tx_dbg.c : 9361 ] FTM_MLO arg[0] =%d arg[1]=%d chip_id=%d  
+4166,,[ wal_tx_dbg.c : 9364 ] FTM_MLO WSI FTM PING stats 
+4167,ii,[ wal_tx_dbg.c : 9367 ] FTM_MLO g_wsi_ftm_ping_request_recv_count[%d] = %d 
+4168,ii,[ wal_tx_dbg.c : 9368 ] FTM_MLO g_wsi_ftm_ping_response_recv_count[%d] = %d 
+4169,,[ wal_tx_dbg.c : 9375 ] FTM_MLO WSI FTM PING stats reset 
+4170,,[ wal_tx_dbg.c : 9500 ] WIFI_RADAR_DBG peer not found 
+4171,,[ wal_tx_dbg.c : 9504 ] WIFI_RADAR_DBG invalid sw peer id 
+4172,i,[ wal_tx_dbg.c : 9607 ] TX_PPDU Cleanup: %d 
+4173,i,[ wal_tx_dbg.c : 9646 ] seq_reposted: %d 
+4174,ii,[ wal_tx_dbg.c : 9668 ] tqm_gen_list_pipeling_stats: queued_cnt = %d, filled_cnt = %d 
+4175,IIII,[ wal_tx_dbg.c : 9679 ] SDWF_FLOW_DEP: calling sawf_htt_h2t_sdwf_msduq_recfg_req_gen() %u %u %u %u 
+4176,,[ wal_tx_dbg.c : 9694 ] 
+ 
+4177,i,[ wal_tx_dbg.c : 9695 ] Number of deactivates: %d 
+4178,i,[ wal_tx_dbg.c : 9696 ] Number of reactivates: %d 
+4179,,[ wal_tx_dbg.c : 9706 ] ===========================REQEUEST==================================== 
+4180,iI,[ wal_tx_dbg.c : 9707 ]  idx %d | timestamp %u MS 
+4181,,[ wal_tx_dbg.c : 9708 ]  request_cookie | tgt_opaque_msduq_id | activation type | svc_class_id  
+4182,IIII,[ wal_tx_dbg.c : 9709 ]  %15d|  %19d| %16d| %12d 
+4183,,[ wal_tx_dbg.c : 9711 ] ===========================RESPONSE==================================== 
+4184,,[ wal_tx_dbg.c : 9712 ]  request_cookie | tgt_opaque_msduq_id |    error_code   | svc_class_id  
+4185,IIII,[ wal_tx_dbg.c : 9713 ]  %15d|  %19d| %16d| %12d 
+4186,,[ wal_tx_dbg.c : 9714 ]  peer_id        |      hlos_tid       |    remap_tid    | who_classify  
+4187,IIII,[ wal_tx_dbg.c : 9715 ]  %15d|  %19d| %16d| %12d 
+4188,,[ wal_tx_dbg.c : 9716 ]  ast_list_idx   |      htt_qtype      |  flow_override  |               
+4189,III,[ wal_tx_dbg.c : 9717 ]  %15d|  %19d| %16d| 
+4190,,[ wal_tx_dbg.c : 9718 ] 
+ 
+4191,,[ wal_tx_dbg.c : 9738 ] ======================================================================= 
+4192,i,[ wal_tx_dbg.c : 9773 ] RXPCU_BA_DBG: HALT_RX: Failed: stop_status: %d 
+4193,I,[ wal_tx_dbg.c : 9871 ] SAWF_DBG_LOG: num_service_class supported = %u 
+4194,,[ wal_tx_dbg.c : 10003 ] platform_update_ctc_array_dump: CONFIG_CTC_BITCOV not Enabled for this Chip 
+4195,,[ wal_tx_dbg.c : 10036 ] platform_update_ctc_array: CONFIG_CTC_BITCOV not Enabled for this Chip 
+4196,I,[ wal_tx_dbg.c : 10165 ] Templated ppdu cnt %u 
+4197,i,[ wal_tx_dbg.c : 10188 ] mcast_tclres_tid_nonbss_peer cnt %d 
+4198,i,[ wal_tx_dbg.c : 10205 ] configured wds_aging_timeout = %d 
+4199,i,[ wal_tx_dbg.c : 10219 ] LPI_DBG: AFTER g_wal_mac_core_ctrl.opt.disable_lpi_for_beacon %d 
+4200,ii,[ wal_tx_dbg.c : 10245 ]  WSI_REMAP who is the time sync master now ? %d [Y=1/N=0] => %d 
+4201,I,[ wal_tx_dbg.c : 10257 ] enabl_tac_opt %u 
+4202,ii,[ wal_tx_dbg.c : 10329 ] RX_DBG_DATA enable_early_recovery %d rx_ring_empty_threshold : %d 
+4203,iii,[ wal_tx_dbg.c : 10342 ] MDSB_DBG sw genmpdu %d part2 %d part2_compens %d 
+4204,i,[ wal_tx_dbg.c : 10350 ] MDSB_DBG disable_mdsb_atomic_posting %d 
+4205,i,[ wal_tx_dbg.c : 10359 ] [ANI_OPTIMIZATION] Minimum RSSI: %d 
+4206,II,[ wal_tx_dbg.c : 10370 ] NON_PRIMARY_DBG g_dbg_max_active_peer_non_primary_link : %u, g_dbg_max_msdu_drained_non_primary_link :%u 
+4207,i,[ wal_tx_dbg.c : 10436 ] ML_RECONFIG: getting sta_ml_reconfig_support = %d 
+4208,i,[ wal_tx_dbg.c : 10443 ] ML_RECONFIG: setting sta_ml_reconfig_support = %d 
+4209,i,[ wal_tx_dbg.c : 10458 ]  MLO_SWBA_DBG Invalid arguments Expected Num args: 3 Observed Num args: %d 
+4210,ii,[ wal_tx_dbg.c : 10464 ]  MLO_SWBA_DBG enable_mlo_ts_sync_swba_logs  %d enable_bcn_swba_logs %d 
+4211,,[ wal_tx_dbg.c : 10489 ] Stats printed for each AC in the order of | AC:0 WAL_TXQ_ID_WMM_BK | AC:1 WAL_TXQ_ID_WMM_BE | AC:2 WAL_TXQ_ID_WMM_VI | AC:3 WAL_TXQ_ID_WMM_VO | 
+4212,i,[ wal_tx_dbg.c : 10493 ] -----TAC_TC FR stats for AC = %d----- 
+4213,i,[ wal_tx_dbg.c : 10495 ] -----TAC_TC: AC = %d | TXOP END INDICATION STATUS----- 
+4214,ii,[ wal_tx_dbg.c : 10498 ] TAC_TC: AC = %d | ist_txop_end_indicated_cnt to sched algo: %d 
+4215,ii,[ wal_tx_dbg.c : 10501 ] TAC_TC: AC = %d | ist_txop_end_inidication_cnt at cmd_status_end: %d 
+4216,ii,[ wal_tx_dbg.c : 10504 ] TAC_TC: AC = %d | ist_txop_end_indication_cnt at isr_end: %d 
+4217,ii,[ wal_tx_dbg.c : 10507 ] TAC_TC: AC = %d | ist_txop_end_skip_on_mpdu_ownership: %d 
+4218,i,[ wal_tx_dbg.c : 10509 ] -----TAC_TC: AC = %d | THROTTLE STATUS----- 
+4219,ii,[ wal_tx_dbg.c : 10512 ] TAC_TC: AC = %d | tac_post_skip_cnt due to seq pool full: %d 
+4220,ii,[ wal_tx_dbg.c : 10515 ] TAC_TC: AC = %d | ist_txop_end_skip_on_seq_unavail_cnt: %d 
+4221,i,[ wal_tx_dbg.c : 10517 ] -----TAC_TC: AC = %d | EARLY SCHEDULE SKIPPED DUE TO PER STATUS----- 
+4222,ii,[ wal_tx_dbg.c : 10519 ] TAC_TC: AC = %d | Skipped due to PER: %d 
+4223,i,[ wal_tx_dbg.c : 10521 ] -----TAC_TC: AC = %d | SCHED_CMD_POSTED STATUS----- 
+4224,ii,[ wal_tx_dbg.c : 10524 ] TAC_TC: AC = %d | sched_cmd_posted_at_hw_txop_end: %d 
+4225,ii,[ wal_tx_dbg.c : 10527 ] TAC_TC: AC = %d | sched_cmd_missed_at_hw_txop_end: %d 
+4226,ii,[ wal_tx_dbg.c : 10530 ] TAC_TC: AC = %d | sched_cmd_posted_at_sched_cmd_end: %d 
+4227,ii,[ wal_tx_dbg.c : 10533 ] TAC_TC: AC = %d | sched_cmd_missed_at_sched_cmd_end: %d 
+4228,ii,[ wal_tx_dbg.c : 10536 ] TAC_TC: AC = %d | num_QoS_runs: %d 
+4229,i,[ wal_tx_dbg.c : 10538 ] -----TAC_TC: AC = %d | INSTANTANEOUS SEQ_CTRL STATS----- 
+4230,i,[ wal_tx_dbg.c : 10540 ] TAC_TC: AC = %d | TAC pending seq ctrl histogram 
+4231,iii,[ wal_tx_dbg.c : 10544 ] TAC_TC: AC = %d | tac_seq_pending[%d]: %d 
+4232,i,[ wal_tx_dbg.c : 10547 ] TAC_TC: AC = %d | ISR pending seq ctrl histogram 
+4233,iii,[ wal_tx_dbg.c : 10551 ] TAC_TC: AC = %d | isr_active_seq_hist[%d]: %d 
+4234,i,[ wal_tx_dbg.c : 10554 ] TAC_TC: AC = %d | DSR pending seq ctrl histogram 
+4235,iii,[ wal_tx_dbg.c : 10558 ] TAC_TC: AC = %d | dsr_active_seq_hist[%d]: %d 
+4236,i,[ wal_tx_dbg.c : 10616 ] allow_rate_feedback_threshold: %d
+ 
+4237,IIIIII,[ wal_tx_dbg.c : 10688 ] HTT Stream Stats global. stats_enabled %u, upload_successes %u, err_no_buf %u, err_no_msg_to_hif %u, err_no_qheap_buf %u, timer initialized %u 
+4238,iii,[ wal_tx_dbg.c : 10860 ] ULMU_PRINT UL MUMIMO partial trigger response for %d user user_response:%d count:%d  
+4239,ii,[ wal_tx_dbg.c : 10863 ] ULMU_PRINT UL MUMIMO partial trigger response for %d user:%d 
+4240,ii,[ wal_tx_dbg.c : 10878 ] MDSB_DBG [%d] : %d 
+4241,IiI,[ wal_tx_dbg.c : 10935 ] wal_rx_health_check_timeout_war: WAR count %u, WAR enable %d, WAR threshold %u 
+4242,IIIIIII,[ wal_tx_send_selfgen.c : 1782 ] NTBR_NDPA: TA: %02x:%02x:%2x, RA: %02x:%02x:%2x, sac:0x%x 
+4243,ii,[ wal_tx_send_selfgen.c : 4570 ] UL_MUMIMO_DBG, seq_type %d, is_ul_mumimo: %d 
+4244,ii,[ wal_tx_send_selfgen.c : 7170 ] MLO_STAKO_LOG: Xretry qos null response received - tidno = %d, sw peer id = %d
+ 
+4245,IIIIIII,[ wal_tx_send_selfgen.c : 7951 ] TBR_NDPA: TA: %02x:%02x:%2x, RA: %02x:%02x:%2x, sac:0x%x 
+4246,IIIII,[ wal_tx_send_selfgen.c : 6028 ] MU BAR Retry Set reenable time:curr:%lu re-enable:%lu reenable_cnt:%u reset_cnt:%u peer_id:%u 
+4247,IIII,[ wal_tx_send_selfgen.c : 6044 ] MU BAR Retry reenable MU BAR: curr:%lu re-enable:%lu reenable_cnt:%u sw_peer_id:%u 
+4248,iIIII,[ wal_tx_flush.c : 677 ] _wal_peer_flush_tids: send msg to SCHED_ALGO, thread_id =%d tid_bitmap=0x%x sw_peer_id=0x%x reason=0x%x ctrl_flags=0x%x 
+4249,ii,[ wal_tx_flush.c : 1011 ] dtim_type is %d :	 power_state : %d 	 Flushing the MGMT frames in IMPS 
+4250,III,[ wal_tx_mon.c : 79 ] TX_MON thread id : %u pdev_id : %u tx_ctxt->tx_mon_src_ring_hp_update_timer_running : %u 
+4251,IIIII,[ wal_tx_mon.c : 99 ] TX_MON TX Mon Src ring [%lx] setup: hdword [%ld] buffer_size [0x%lx] max_entries [0x%lx] pdev [%p]
+ 
+4252,II,[ wal_tx_mon.c : 232 ] TX_MON TX Mon Dest ring setup max_entries [0x%lx] pdev [%p]
+ 
+4253,IIIII,[ wal_tx_mon.c : 328 ] TX_MON TX Mon setup msg ring_msg [0x%p] idx[0x%lx] bs[0x%lx] hr[0x%lx] flags[0x%x]
+ 
+4254,IIIII,[ wal_tx_mon.c : 413 ] TX_MON TX Mon setup pkt tlv [0x%p] idx[0x%lx] bs[0x%lx] hr[0x%lx] flags[0x%x]
+ 
+4255,i,[ wal_tx_mon_refill.c : 44 ] TX_MON tx_mon_dest_ring_tp_update_timeout %d 
+4256,i,[ wal_tx_mon_refill.c : 55 ] TX_MON Skip Dest ring TP updating for inactive pdev %d 
+4257,i,[ wal_tx_mon_refill.c : 123 ] TX_MON tx_mon_src_ring_hp_update_timeout %d 
+4258,i,[ wal_tx_mon_refill.c : 133 ] TX_MON Skip Dest ring TP updating for inactive pdev %d 
+4259,iIi,[ wal_tx_send.c : 2248 ] tx_send_process_compl_status_hdlr: tid_num %d, ppdu_id 0x%x tx_comp_status %d 
+4260,I,[ wal_tx_send.c : 3709 ] ht_ctrl after OM field %x 
+4261,I,[ wal_tx_send.c : 3716 ] ht_ctrl after EHT OM field %x 
+4262,I,[ wal_tx_send.c : 3753 ] after omi clear bitmap val %x 
+4263,I,[ wal_tx_send.c : 4218 ] legacy frame with HT-ctrl, tid=%x 
+4264,II,[ wal_tx_send.c : 6870 ] post_user_data_ppdu %x %x 
+4265,iiiIiiii,[ wal_tx_send.c : 7331 ] vdev_id %d tid_num %d seq_num %d allow_n_flags 0x%x sendn_frms_allowed %d sendn_frms_tried %d subfrms_max %d encap_type %d 
+4266,IIII,[ wal_tx_send.c : 8829 ] tqm_dbg: mpdu_scheduler rc_subfrm_max=%u, subfrms_max=%u, amsdu_size=%u, win_credit=%u 
+4267,IIII,[ wal_tx_send.c : 8961 ] tqm_dbg: mpdu_scheduler rc_subfrm_max=%u, subfrms_max=%u, amsdu_size=%u, win_credit=%u 
+4268,,[ wal_tx_send.c : 10132 ] Anchor_Link BAR frame 
+4269,iii,[ wal_tx_send.c : 10185 ] Anchor_Link old cnt %d migrated mpdus %d total mpdus %d
+ 
+4270,ii,[ wal_tx_send.c : 10259 ] Anchor_Link Frameq movement for tid %d num_mpdus %d 
+4271,ii,[ wal_tx_send.c : 10288 ] Anchor_Link Empty Data Frameq tid %d num_mpdus %d 
+4272,,[ wal_tx_send.c : 10342 ] MLO_U.R tx_send_purge_mpdus skipped for MLO U.R Session ID mismatch. 
+4273,iii,[ wal_tx_send.c : 10701 ] _dsr_hdlr: generate_tx_status: thread_id=%d, comp=%d tid_num %d
+ 
+4274,III,[ wal_tx_send.c : 11109 ] WAL_DBGID_XCESS_FAILURES  %p 0x%x MAC:%x 
+4275,IIIIiiIIi,[ wal_tx_send.c : 11149 ] pdev_vdev_id=0x%x, peer=0x%x,tid=0x%x (flags=0x%x), consecutive failure=%d, kickout thresh=%d rate_code=0x%x, tsRate flags=0x%x, ppdu_mprot_type:%d 
+4276,IIIIIii,[ wal_tx_send.c : 11153 ] pdev_vdev_id =0x%08x, peer=0x%x,tid=0x%x (flags=0x%x %x), consecutive failure=%d, kickout thresh=%d  
+4277,IIiIIII,[ wal_tx_send.c : 11170 ] pdev:8/vdev:8 0x%08x peer=0x%x consecutive_failure:%d cur_time:%x elapsed_ppdu_fail_time:%x tid_retryfailure:%x vdevtype:%x 
+4278,iii,[ wal_tx_send.c : 11228 ] MLO_STAKO_LOG: ml level stako tx_send_is_mlo_stako_reached - ml_peer->consec_ppdu_fail = %d cnt = %d mlo_stako_th %d
+ 
+4279,iii,[ wal_tx_send.c : 11274 ] MLO_STAKO_LOG: Link stako cond reached - sw peer id = %d, is ml peer = %d, consec failure count = %d
+ 
+4280,iiiii,[ wal_tx_send.c : 11292 ] MLO_STAKO_LOG: ml level stako not reached.. link %d going to fakeps (AP VAP ONLY) - sw peer id = %d, is ml peer = %d, consec failure count = %d ml consecutive cnt = %d
+ 
+4281,iiiii,[ wal_tx_send.c : 11301 ] MLO_STAKO_LOG: ml level stako - link_idx = %d,sw peer id = %d, is ml peer = %d, consec failure count = %d ml consecutive cnt = %d
+ 
+4282,II,[ wal_tx_send.c : 11315 ] WAL_DBGID_STA_KICKOUT  0x%x 0x%x 
+4283,IIII,[ wal_tx_send.c : 11319 ] ppdu_fail_time:%x current_time:%x delta:%x type:%x  
+4284,iiii,[ wal_tx_send.c : 11362 ] MLO_STAKO_LOG: non master (link %d) STA KO Reached - sw peer id = %d, is ml peer = %d, consec failure count = %d
+ 
+4285,iiii,[ wal_tx_send.c : 11369 ] MLO_STAKO_LOG: master (link %d) STA KO Reached - sw peer id = %d, is ml peer = %d, consec failure count = %d
+ 
+4286,II,[ wal_tx_send.c : 11411 ] MLO_STAKO_LOG: consec_ppdu_fail = %ld, mlo_xretry_th = %ld
+ 
+4287,I,[ wal_tx_send.c : 11460 ] MLO_STAKO_LOG: Master link xretry - AMPDU = %x
+ 
+4288,I,[ wal_tx_send.c : 11463 ] MLO_STAKO_LOG: Non master link xretry - AMPDU = %x
+ 
+4289,,[ wal_tx_send.c : 11614 ] MLO_STAKO_LOG: Link xretry condition reached 
+ 
+4290,,[ wal_tx_send.c : 11620 ] MLO_STAKO_LOG: Master link xretry
+ 
+4291,,[ wal_tx_send.c : 11623 ] MLO_STAKO_LOG: Non master link xretry
+ 
+4292,iiiIIiii,[ wal_tx_send.c : 11849 ] twt_dbg/ul_tcp: dsr_proc_ppdu_done txqid=%d, sched_id=%d, tx_status=%d, peer=%u, ftype=%u, queued=%d, tried=%d, failed=%d 
+ 
+4293,iiiI,[ wal_tx_send.c : 13528 ] mlo_link_ownership: hwsch will be reset, unset flush pending flg, pdev=%d peer=%d tid=%d time_us=%u 
+4294,i,[ wal_tx_send.c : 14324 ] delimiter user track: peer_aid:%d runs out of data 
+4295,i,[ wal_tx_send.c : 14384 ] delimiter user track: peer_aid:%d runs out of data 
+4296,iiI,[ wal_tx_send.c : 18053 ] tx_send_completion_dsr_hdlr: rtt 11AZ: TXSEND_FTYPE_SGEN_NTBR_NDP sch_cmd_result:%d, abort_reason:%d, 11az_obj_ptr:%p 
+4297,IIIiiI,[ wal_tx_send.c : 18090 ] tx_send_completion_dsr_hdlr: rtt 11AZ: TXSEND_FTYPE_SGEN_NTBR_NDP: sched_id %x start_ts:%x, end_ts:%x, fes_tx_result:%d, phytx_pkt_end_info_valid:%d, resptype_tlf_chmk_bw:0x%x 
+4298,III,[ wal_tx_send.c : 18094 ] tx_send_completion_dsr_hdlr: 11AZ: TXSEND_FTYPE_SGEN_NTBR_NDP: fes_end:%p, fes_start:%p, ppdu_start:%p 
+4299,iiiiIi,[ wal_tx_send.c : 18122 ] dsr_hdlr: 11AZ TBR:  num_users:%d, valid_users:%d, ftype:%d, sch_cmd_result:%d location_info:%p, NDPA sndtoken:%d 
+4300,IIII,[ wal_tx_send.c : 18134 ] dsr_hdlr: 11AZ TBR:  fes_end:%p, fes_start:%p, ppdu_start:%p, rtt_11az_ctxt_buff:%p 
+4301,IIIiiI,[ wal_tx_send.c : 18165 ] tx_send_completion_dsr_hdlr: rtt 11AZ: TXSEND_FTYPE_SGEN_TBR_NDP: sched_id %x start_ts:%x, end_ts:%x, fes_tx_result:%d, phytx_pkt_end_info_valid:%d, resptype_tlf_chmk_bw:0x%x 
+4302,,[ wal_tx_send.c : 18200 ] dsr_hdlr: 11AZ TBR: ERR: NULL wal peer 
+4303,,[ wal_tx_send.c : 18548 ] VBSS tx_completion BAR Successful 
+4304,i,[ wal_tx_send.c : 18560 ] Retried BAR for %d times, clear BAR flag
+ 
+4305,iI,[ wal_tx_send.c : 18573 ] BAR tx failure tid_num: %d, tid_flags:0x%x
+ 
+4306,iiii,[ wal_tx_send.c : 19465 ] MSDUTTL TQM peer_id:%d deq:%d tid_num:%d qtype:%d 
+4307,iiiiiIII,[ wal_tx_send.c : 19650 ] TTL tid:%d ppdu:%d %d,cmd:%d txq_id:%d,flg:%x %x,caller:%x 
+4308,I,[ wal_tx_send.c : 20508 ] Received GTK frame for Qpeer=%p, but PTK not set 
+4309,ii,[ wal_tx_send.c : 21040 ] pdev=%d, MAC Reset on pause ring failure:%d 
+4310,III,[ wal_tx_send.c : 21152 ] pdev:%u, RING(%x) pause finished(%x) 
+4311,III,[ wal_tx_send.c : 21257 ] pdev:%u, pause ring(%x:%x) 
+4312,IiiIII,[ wal_tx_send.c : 8697 ] SAWF_MLO_SYNC_RATIO mpdu_queue_number=%u qtype=%d mix_ratio=%d bits_used=%u dword=%u rem_bits_this_dword=%u 
+4313,IIIIIIIII,[ wal_tx_send.c : 8729 ] SAWF_MLO_SYNC_RATIO sending drain ratio from hw_link_id=%u aid=%u status_proc_mask=%u bits_used=%u dword=%u rem_bits_this_dword=%u 1st_dword=%u 2nd_dword=%u tid_status_proc_mask=%u 
+4314,IIII,[ wal_tx_send.c : 788 ] STA_KICKOUT: ppdu_fail_time: %x current_time: %x delta: %x type: %x
+ 
+4315,iiIIii,[ wal_tx_send.c : 792 ] STA_KICKOUT: non master (link %d), sw peer id = %d, schedule_id = %x, sch_cmd_result %u, is ml peer = %d, consec failure count = %d
+ 
+4316,iiIIii,[ wal_tx_send.c : 794 ] STA_KICKOUT: master (link %d), sw peer id = %d, schedule_id = %x, sch_cmd_result %u, is ml peer = %d, consec failure count = %d
+ 
+4317,i,[ wal_tx_send.c : 799 ] STA_KICKOUT: ack_rssi = %d
+ 
+4318,iiii,[ wal_tx_send.c : 12997 ] BEACON_DIAG: BEACON Stuck due to LSE reached %d on pdev id %d force crash flag %d and threshold configured is %d 
+4319,iIII,[ wal_tx_send.c : 13273 ] CONSECUTIVE_FLUSH9 dmac_reset: pdev id %d, reset_cnt=%u, flush_9_reset_cnt=%u, res_in_progress=%u 
+4320,iiii,[ wal_tx_send.c : 13309 ] CONSECUTIVE_FLUSH9: pdev id %d,reset_mode %d consecutive flush 9 happen for %d times.Total WAR trigger %d times. 
+4321,II,[ wal_tx_send.c : 17058 ] tx_send_compl_sig_sched_algo: exclude rate update for flush or short TBD (%x, %x) 
+4322,IIii,[ wal_tx_send.c : 17137 ] tx_send_compl_sig_sched_algo: SCHED_TX_COMPL_STATUS generated, sched_cmd=0x%x, ppdu_id=0x%x, tid_num=%d, tx_comp_status=%d 
+4323,IIIIIII,[ wal_tx_send.c : 15400 ] code-fail-info: flags:0x%x start bt_tx:%u wan_tx:%u, end bt_txtx:%u bt_txrx:%u wan_txtx:%u wan_txrx:%u 
+4324,IIIII,[ wal_tx_send.c : 15406 ] code-fail-info: flags:0x%x end bt_txtx:%u bt_txrx:%u wan_txtx:%u wan_txrx:%u 
+4325,IIIIIIIII,[ wal_tx_send.c : 15471 ] TXPPDU_0 peerid_tidnum_hwq:0x%08x ppdu_id:0x%08x wait_dur:%5u tstamp:%10u dur:%5u sw_sched_id__mpdutried__failed:0x%08x mcs_nss_bw_pream:0x%08x seqnum__sifs__sch:0x%08x tries__fes__flush:0x%08x 
+4326,I,[ wal_tx_send.c : 15474 ] SW_LATENCY_CNT:0x%08x 
+4327,IIIII,[ wal_tx_send.c : 15493 ] TXPPDU_1_064 ssn__basn:0x%08x enq_bitmap:%08x_%08x compl_bitmap:%08x_%08x 
+4328,IIIIIIIII,[ wal_tx_send.c : 15507 ] TXPPDU_1_256 ssn__basn:0x%08x enq_bitmap:%08x_%08x_%08x_%08x_%08x_%08x_%08x_%08x 
+4329,IIIIIIIII,[ wal_tx_send.c : 15521 ] TXPPDU_1_256 ssn__basn:0x%08x compl_bitmap:%08x_%08x_%08x_%08x_%08x_%08x_%08x_%08x 
+4330,IIIIIIIII,[ wal_tx_send.c : 15592 ] TXPPDU_2 sched_id:%08x sch_flg:%08x swppdu_flg:%08x msdu_mpdu:%08x tpc_lb1_lb0_cmndpwr1_pwr0:%08x txppdu_debug_event_0:%08x txppdu_debug_event_1:%08x txppdu_debug_event_2:%08x txppdu_debug_event_3:%08x 
+4331,IIIIIIIII,[ wal_tx_send.c : 15608 ] TXPPDU_3 seq_ctrl:%08x:flags:%08x, last_mpdu_msdu:%08x, amsdu_params:%08x %08x, sch_eval:start:%08X:end:%08X:delta:%08d:ssn:%04X: 
+4332,,[ wal_tx_send.c : 15190 ] enter per ppdu logggin 
+4333,,[ wal_tx_send.c : 15201 ] exit per ppdu logging 
+4334,iiIiiiiII,[ wal_tx_send.c : 15762 ] twt_dbg: update_dl_stats txqid=%d, sched_id=%d, ftype=%u, tx_status=%d, queued=%d, tried=%d, failed=%d,sched_ref_time_start=%u, sched_ref_time_end=%u 
+ 
+4335,IIIII,[ wal_tx_send.c : 15798 ] twt_dbg_leak: update_dl_stats: start_tsTstamp=%u, duration_us=%u, sch_eval_end_ts=%u, twt_sp_end=%u, offset_tsf2=%u 
+ 
+4336,I,[ wal_tx_send.c : 15802 ] twt_dbg_leak: update_dl_stats twt_sp leakage detected by %u us 
+4337,iiiIIIII,[ wal_tx_send.c : 15834 ] twt_dbg_leak_ul: update_ul_stats: txqid=%d, sched_id=%d, tx_sw_status=%d, fes_start=%u, fes_end=%u, fes_duration=%u, sched_ref_time_start=%u, sched_ref_time_end=%u 
+ 
+4338,IIII,[ wal_tx_send.c : 15869 ] twt_dbg_leak_ul: update_ul_stats: sch_eval_start_ts=%u, sch_eval_end_ts=%u, twt_sp_end=%u, offset_tsf2=%u 
+ 
+4339,I,[ wal_tx_send.c : 15873 ] twt_dbg_leak_ul: update_ul_stats twt_sp leakage detected by %u us 
+4340,III,[ wal_tx_seq.c : 454 ] tx_seq_trace_sched_complete: TX_SEQ_SCHED_COMPLETE_EVENTID sched_cmd=0x%x, queue_id=0x%x, flags=0x%x 
+4341,ii,[ wal_tx_seq.c : 3842 ] tx_seq_send_post_ppdu: peer_id %d tid_num %d
+ 
+4342,,[ wal_tx_seq.c : 5693 ] CW reset 
+4343,ii,[ wal_tx_seq.c : 7091 ] SCHED CMD is not allowed due to WAL_TID_COMMON_CLEANUP_NOTIF, peer=%d, tid=%d 
+4344,ii,[ wal_tx_seq.c : 7731 ] mlo_link_ownership: seq repost is not allowed due to hwq is paused by other tid, peer=%d, tid=%d 
+4345,,[ wal_tx_seq.c : 8649 ] tx bw dropping, disable dpd for ETSI 
+4346,,[ wal_tx_seq.c : 8687 ] tx bw recover, enable dpd for ETSI 
+4347,iiii,[ wal_tx_seq.c : 8715 ] 6G FCC: BW recipe state: max_bw_restricted - %d, max_queued_bw - %d, current_transmitted_bw - %d, resp_bw - %d 
+4348,ii,[ wal_tx_seq.c : 8718 ] 6G FCC: BW recipe state: num_intereference_at_sec[%d] : %d 
+4349,,[ wal_tx_halphy_send.c : 82 ]  HALPHY_TX_TBTT_FLUSH : DPD packet is flushed out  
+4350,IIIIIIII,[ wal_tx_q_enque.c : 784 ] pn_alloc:fc=%x,comp_type=%x,flen=%lx,msdu_flags=%lx,id=%x,buffer_id=%x,enque_id=%x,pending_local=%x 
+4351,,[ wal_tx_q_enque.c : 868 ] pn_alloc: invalid PN assigned 
+4352,IIIIIII,[ wal_tx_q_enque.c : 910 ] pn_alloc_complete:fc=%x,flen=%lx,msdu_flags=%lx,tid_num=%x,enque_id=%x,pn_idx=%x,pn=%llx 
+4353,IIIIII,[ wal_tx_q_enque.c : 1022 ] pn_alloc failed: id:%x,flags:%x,tid_no:%x,fc:%x,enqeu_id=%x,pending_local=%x 
+4354,IIii,[ wal_tx_q_enque.c : 1076 ] tx_enq ar_wal_tx_q_enque_ipc_msg_handler tq: %p, info: s%p, chip_id:%d, primary_chip_id:%d
+ 
+4355,iIIii,[ wal_tx_q_enque.c : 1274 ] ar_wal_tx_q_enque_ipc_send tid_num %d, tq: %p, info: s%p, chip_id:%d, primary_chip_id:%d
+ 
+4356,iIIIIIIII,[ wal_tx_q_enque.c : 1404 ] tx_q_enque tid_num %d, %p, sw_peer_id=0x%x, msdu_flags=0x%x tid_flags=0x%x tid_ext_flags=0x%x, tid_ext2_flags=0x%x, tid_flush_reason=0x%x TS %u 
+4357,iIIiiii,[ wal_tx_q_enque.c : 1411 ] WDS_OFFLOAD: NULL or EAPOL frame enqueued: tid_num %d, %p, sw_peer_id=0x%x, len %d, msdu_flags %d, flags: %d, frm_ctrl %d 
+4358,IIIIII,[ wal_tx_q_enque.c : 1533 ] WAL_DBGID_TX_DISCARD id: %x, flag:%lx, flags %x, frame cntrl %x, tid %x, type %x 
+ 
+4359,i,[ wal_tx_q_enque.c : 1568 ] WAL_DBGID_TX_DISCARD local frame discarded error_code=%d 
+4360,iI,[ wal_tx_send_isr.c : 503 ] isr_hdlr (pdev=%d): req=%x
+ 
+4361,i,[ wal_tx_send_isr.c : 1062 ] tx_send_update_isr_status_head_and_trigger_tac: num_elem %d 
+4362,i,[ wal_tx_send_isr.c : 2280 ] tx_send_isr_trigger_dsr: recycle_ring=%d 
+4363,iii,[ wal_tx_send_isr.c : 3124 ] 6G FCC: resp block state: resp_block - %d, LT cnt - %d, recover - %d 
+4364,IIIIII,[ wal_tx_sch_status.c : 3972 ] NAV_INFO, pkt_type_inbss_obss:0x%08x,new_nav:0x%08x,cur_oibss_nav:0x%08x,gtime:0x%08x,updated_blacklisted_color_bssid:0x%08x,lsig_ab:0x%08x 
+4365,ii,[ wal_tx_sch_status.c : 3417 ] Spatial_Reuse opportunity: 0x1 dur: %d rssi: %d 
+4366,Iiiiiii,[ tx_cong_ctrl.c : 56 ] CONG_CTRL_%02x(01=ALLOC,02=FREE,03=DROP,04=DISC): sw_pid:%d tid_num:%d buf_id:%d desc_id:%d bin_idx:%d cur:%d 
+4367,iiiiiiiii,[ tx_cong_ctrl.c : 283 ] CONGCTRL FW_CONTROL *OVERRIDE* peer_id:%d tid_num:%d traffic_enq:%d drop:%d deq:%d tot_deq:%d rate_max_allowed:%d old_threshold:%d max_extra:%d 
+4368,iiiiiiiii,[ tx_cong_ctrl.c : 298 ] CONGCTRL FW_CONTROL *DISABLED* peer_id:%d tid_num:%d traffic_enq:%d drop:%d deq:%d tot_deq:%d rate_max_allowed:%d old_threshold:%d max_extra:%d 
+4369,iIiiiiiii,[ tx_cong_ctrl.c : 316 ] CONGCTRL FW_CONTROL peer_id:%d tid_num__qtype__msduq_masks:0x%08x traffic_enq:%d drop:%d deq:%d tot_deq:%d rate_max_allowed:%d old_threshold:%d max_extra:%d 
+4370,iiiII,[ wal_wmm.c : 50 ] WMMAC_ADD_DELTS: ac=%d admitted=%d acm=%d block=0x%x downgrade=0x%x 
+4371,iii,[ wal_wmm.c : 98 ] WMMAC_UPDATE: used_time=%d admitted_time=%d, downgrade=%d 
+4372,Iiii,[ wal_wmm.c : 282 ] WMMAC_Q_DEPRIO: peer=0x%x tid=%d qid:%d->%d 
+4373,IiI,[ wal_wmm.c : 292 ] WMMAC_Q_DROP: peer=0x%x tid(%d)=0x%x 
+4374,iii,[ wal_wmm.c : 123 ] WMMAC_USED_TIME_EXCEED: used=%d admitted=%d wmmac_q=%d 
+4375,I,[ mac_core_main.c : 151 ] mac_core_work_loop_init: invalid wlan_driver_mode 0x%x 
+4376,III,[ mac_core_main.c : 229 ] assert:r0=0x%x, r1=0x%x, line:0x%x
+ 
+4377,iii,[ wal_dfs.c : 70 ]  DFS_DBG dbw channel mhz:%d cf1:%d cf2:%d 
+4378,iii,[ wal_dfs.c : 76 ] DFS_DBG current channel mhz:%d cf1:%d cf2:%d 
+4379,,[ wal_dfs.c : 424 ] WAL_DFS_SCHED_SUSPEND_HNDLR PDEV NULL 
+4380,i,[ wal_regulatory.c : 125 ] TPC_DBG TX suspend Status=%d 
+4381,i,[ wal_regulatory.c : 141 ] TPC_DBG TX Resume Status=%d 
+4382,iiii,[ wal_spectral.c : 226 ] SSCAN mac_id = %d: num_bufs %d forceAbortCount %d forceResumeCount %d 
+4383,iiiiI,[ wal_spectral.c : 228 ] SSCAN_DUMP mac_id = %d: trigger = %d enable = %d scan_mode = %d timestamp %ld 
+4384,I,[ wal_spectral.c : 240 ] SSCAN_DUMP: wal_spectral_scan_get_config  called %p 
+4385,,[ wal_spectral.c : 359 ] Report Mode 1 does NOT generate FFT Bins. Please use Report Mode 2 or 3 
+4386,iiiii,[ wal_spectral.c : 382 ] wal_get_spur_bin_indices bin center_freq = %d, spur_freq = %d, bw_hz = %d, fft_size = %d, report_mode = %d 
+4387,ii,[ wal_spectral.c : 407 ] wal_get_spur_bin_indices bin start_idx = %d, end_idx = %d 
+4388,ii,[ wal_spectral.c : 408 ] wal_get_spur_bin_indices absolute bin start_idx = %d, end_idx = %d 
+4389,ii,[ wal_spectral.c : 1188 ] Pdev id : %d WMI event with reset_delay %d 
+4390,iIIi,[ wal_spectral.c : 1199 ] <%d>: WMI event called %p with %u buffers for module %d  
+4391,ii,[ wal_spectral.c : 1296 ] out_ring reap : Before read shadow_tail_idx %d & After read shadow_tail_idx %d 
+4392,iIi,[ wal_spectral.c : 1461 ] SSCAN wal_abort_spectral_scan : mac_id = %d timestamp_us %ld forceAbortCount %d 
+4393,i,[ wal_spectral.c : 1478 ] SSCAN: Spectral mode %d aborted 
+4394,,[ wal_spectral.c : 1497 ] SSCAN: Spectral Force disabled flag set 
+4395,,[ wal_spectral.c : 1508 ] SSCAN: Spectral Force disable flag cleared 
+4396,i,[ wal_spectral.c : 1549 ] Resume SSCAN : pending elements in out_ring %d 
+4397,i,[ wal_spectral.c : 1576 ] SSCAN: Spectral mode %d RESUMED 
+4398,iiII,[ wal_spectral.c : 1583 ] SSCAN wal_resume_spectral_scan : mac_id = %d forceResumeCount %d timestamp_us %ld time_delta = %ld 
+4399,i,[ wal_spectral.c : 1609 ] SSCAN: Invalid HIF event received with Id: %d 
+4400,i,[ wal_spectral.c : 1953 ] wifiradar: pdev_id = %d: wifiradar sig handler 
+4401,,[ direct_dma_wmi.c : 222 ] Direct DMA is not attached 
+4402,i,[ direct_dma_wmi.c : 227 ] pdev_id = %d: DMA is not attached 
+4403,,[ direct_dma_wmi.c : 244 ] Direct DMA is not attached 
+4404,i,[ direct_dma_wmi.c : 249 ] pdev_id = %d: DMA is not attached 
+4405,,[ wal_wmac_pm.c : 125 ] error on wlan_log_save_module_level 
+4406,,[ wal_powersave_ap.c : 328 ] error: no WAL_PEER_EVENT_SEND_COMPLETE for BUF_STA 
+4407,iii,[ wal_powersave_ap.c : 643 ] PS_STATE_CHANGE wal_ps_buf_peer_rx_event_handler assoc_id:%d, ps_enabled_mirror:%d pwrmgmt:%d 
+4408,II,[ wal_powersave_ap.c : 778 ] PS_STATE_CHANGE wal_ps_ap_sa_thread_msg_handler(STATE_CHANGE): cmd_id | assoc_id:%x, peer_enabled | ps_enabled:%x 
+4409,II,[ wal_powersave_ap.c : 795 ] PS_STATE_CHANGE wal_ps_ap_sa_thread_msg_handler (EXCESS_RETRIES): cmd_id | assoc_id:%x, peer_enabled | pause_enabled:%x 
+4410,Ii,[ wal_powersave_ap.c : 816 ] PS_STATE_CHANGE wal_ps_ap_sa_thread_msg_handler(OUT_OF_SYNC_STA): cmd_id | assoc_id:%x, peer_enabled:%d 
+4411,,[ wal_powersave_ap.c : 852 ] WAL_AP_PS_DBGID wal_peer is NULL 
+4412,,[ wal_powersave_ap.c : 1959 ] wal_peer is NULL 
+4413,iI,[ wal_ml_powersave_ap.c : 249 ] tlt_dbg: update_ps_state: ml_peer_id:%d, sw_peer_id=%u 
+4414,IiII,[ wal_powersave_buf_peer_sm.c : 476 ] WAL_AP_PS_DBGID_PSPOLL_ERROR vdev_id | AssocID = %x TidPaused = %d AllowdLegacyTidMask = 0x%x LegacyTidMask = 0x%x 
+4415,iii,[ wal_powersave_buf_peer_sm.c : 673 ] AP_PS TID_UNPAUSE_ERROR AssocID = %d Tid = %d Peer_id = %d 
+4416,IIIII,[ wal_powersave_buf_peer_sm.c : 702 ] WAL_AP_PS_DBGID_UAPSD_RESPONSE_ERROR vdev_id | AssocID = %x Tid/Paused = 0x%x AllowedUAPSDTidMask = 0x%x PendingTidMap = 0x%x SPLength = 0x%x 
+4417,iIi,[ wal_powersave_buf_peer_sm.c : 1236 ] PS_STATE_CHANGE wal_ps_buf_peer_state_active_event next state is sleep, next_state = %d vdev_id | assoc_id = %x peer_enabled = %d 
+4418,ii,[ wal_powersave_buf_peer_sm.c : 1357 ] PS_STATE_CHANGE wal_ps_buf_peer_state_sleep_doze_event next state is active vdev_id | assoc_id = %d peer_enabled = %d  
+4419,,[ twt_protocol.c : 67 ] twt_power_2_mantissa wrong parameters  
+4420,II,[ twt_protocol.c : 247 ] twt_i_ie_2_d_param_set: twt_ie->len(%u) != GET_I_TWT_IE_SIZE(%u) - IEEE80211_IE_HDR_LEN(2) 
+4421,II,[ twt_protocol.c : 309 ] twt_b_param_set_2_d_param_set: param_set_len(%u) < GET_B_TWT_PARAM_SET_SIZE(%u) 
+4422,i,[ twt_protocol.c : 390 ] twt_b_param_set_2_d_param_set: !is_restricted:%d 
+4423,II,[ twt_protocol.c : 395 ] twt_b_param_set_2_d_param_set: param_set_len(%u) < GET_B_TWT_PARAM_SET_SIZE(%u) 
+4424,II,[ twt_protocol.c : 402 ] twt_b_param_set_2_d_param_set: param_set_len(%u) < GET_B_TWT_PARAM_SET_SIZE(%u) 
+4425,I,[ twt_protocol.c : 411 ] twt_b_param_set_2_d_param_set: param_set_len(%u) != 0 
+4426,,[ twt_ap.c : 261 ] POOL ALLOC FAILURE 
+4427,iiiii,[ twt_ap.c : 392 ] ap_twt_send_del_event Error: %d %d %d %d %d 
+4428,ii,[ twt_ap.c : 452 ] ap_twt_check_send_del_all_frame FAIL for peer:%d after %d attempts 
+4429,iiIi,[ twt_ap.c : 487 ] ap_twt_check_send_del_frame FAIL for peer:%d session:%d flags:%x after %d attempts 
+4430,,[ twt_ap.c : 625 ] ap_twt_setup_done error: Unexpected Broadcast flag set in iTWT setup IE 
+4431,i,[ twt_ap.c : 742 ] %d: ap_twt_setup_tx_completion: parse_setup_frame error 
+4432,ii,[ twt_ap.c : 746 ] ap_twt_setup_tx_completion: status=%d, comp_ctxt=%d 
+4433,ii,[ twt_ap.c : 855 ] ap_twt_teardown_tx_completion err: status=%d, comp_ctxt=%d 
+4434,i,[ twt_ap.c : 1030 ] twt_ap_twt_session_t == NULL, session_id=%d 
+4435,i,[ twt_ap.c : 1045 ] twt_ap_twt_session_t == NULL, session_id=%d 
+4436,i,[ twt_ap.c : 1062 ] twt_ap_twt_session_t == NULL, session_id=%d 
+4437,iii,[ twt_ap.c : 1278 ] %d: Mismatch between reported number ofsessions %d and actual number of sessions %d 
+4438,ii,[ twt_ap.c : 1347 ] %d: AP TWT not initialized on this MAC %d 
+4439,ii,[ twt_ap.c : 1357 ] %d: AP TWT enable on MAC %d 
+4440,i,[ twt_ap.c : 1460 ] %d: AP TWT not initialized on this MAC 
+4441,ii,[ twt_ap.c : 1472 ] %d: AP TWT disable on MAC:%d 
+4442,i,[ twt_ap.c : 1524 ] %d: AP TWT not initialized on this MAC 
+4443,i,[ twt_ap.c : 1530 ] %d: AP TWT: disable cmd cannot find SOC handle 
+4444,i,[ twt_ap.c : 1548 ] %d: AP TWT not initialized on this MAC 
+4445,i,[ twt_ap.c : 1554 ] %d: AP TWT: disable cmd cannot find SOC handle 
+4446,i,[ twt_ap.c : 1572 ] %d: AP TWT not initialized on this MAC 
+4447,i,[ twt_ap.c : 1578 ] %d: AP TWT: disable cmd cannot find SOC handle 
+4448,iIii,[ twt_ap.c : 1763 ] %d: DUPLICATE REQ twt_ap_vdev_pre_migrate for vdev:%x migrating from MAC%d to MAC%d 
+4449,iii,[ twt_ap.c : 1823 ] twt_ap_vdev_migrate: vdev %d migrating from MAC %d to MAC %d 
+4450,,[ twt_ap.c : 2092 ] twt_ap_vdev_config_cmd_handler error: beacon not supported for this vdev  
+4451,ii,[ twt_ap.c : 2098 ] twt_ap_vdev_config_cmd_handler: current twt value=%d,incoming twt value=%d 
+4452,i,[ twt_ap.c : 2243 ] %d: UAPSD+TWT Not allowed 
+4453,i,[ twt_ap.c : 2279 ] ap_twt_add_i_session(send_failed): status=%d 
+4454,ii,[ twt_ap.c : 2333 ] ap_twt_del_dialog[unknown dialog_id]: peer=%d, dialog_id=%d 
+4455,iii,[ twt_ap.c : 2402 ] twt_ap_add_dialog_cmd_handler: vdev id %d curr_state %d error code %d 
+4456,ii,[ twt_ap.c : 2423 ] %d: AP TWT not enabled on this vdev %d 
+4457,i,[ twt_ap.c : 2447 ] %d: TWT not enabled on this peer 
+4458,i,[ twt_ap.c : 2467 ] %d: TWT not enabled on this peer 
+4459,i,[ twt_ap.c : 2486 ] %d: TWT not enabled on this peer 
+4460,i,[ twt_ap.c : 2520 ] %d: AP TWT not enabled on this vdev 
+4461,i,[ twt_ap.c : 2525 ] %d: AP TWT already enabled on this peer 
+4462,i,[ twt_ap.c : 2532 ] %d: AP TWT peer memory not available on this peer 
+4463,i,[ twt_ap.c : 2598 ] %d: TWT not enabled on this peer 
+4464,i,[ twt_ap.c : 2604 ] %d: AP TWT not enabled on this vdev 
+4465,i,[ twt_ap.c : 2985 ] %d: TWT not enabled on this peer 
+4466,i,[ twt_ap.c : 3016 ] TWT AP Unexpected command %d 
+4467,i,[ twt_ap.c : 3030 ] %d: TWT not enabled on this peer 
+4468,i,[ twt_ap.c : 3058 ] %d: TWT not enabled on this peer 
+4469,ii,[ twt_ap.c : 3070 ] %d: session not found: session_id=%d 
+4470,i,[ twt_ap.c : 3360 ] %d: TWT AP, setup frame details is NULL 
+4471,i,[ twt_ap.c : 3650 ] TWT AP Unexpected frame type %d 
+4472,i,[ twt_ap.c : 3832 ] %d: AP TWT not initialized on this MAC 
+4473,i,[ twt_ap.c : 3884 ] %d: TWT not enabled on this peer 
+4474,iiiI,[ twt_ap_session_sm.c : 501 ] ap_twt_session_state_renegotiating_event failed after %d attempts for peer=%d session:%d flags:%x 
+4475,i,[ twt_ap_session_sm.c : 615 ] sending pause frame failed: status=%d 
+4476,i,[ twt_ap_session_sm.c : 808 ] sending resume frame failed: status=%d 
+4477,,[ twt_ap_adaptor.c : 1393 ] Error: Exceeded MAX_TWT_SESSION_PER_STA in BTWT session slot allocation.
+ 
+4478,,[ twt_ap_adaptor.c : 1413 ] Error: Exceeded MAX_TWT_SESSION_PER_STA in BTWT session slot allocation.
+ 
+4479,i,[ twt_ap_btwt.c : 302 ] %d: AP TWT not initialized on this MAC 
+4480,,[ twt_ap_btwt.c : 490 ] POOL ALLOC FAILURE 
+4481,I,[ twt_ap_btwt.c : 831 ] ap_btwt_check_persist error: b_twt_persistence(%u) > 254 
+4482,II,[ twt_ap_btwt.c : 838 ] ap_btwt_check_persist error: reducing more than 1, cur=%u, new=%u 
+4483,i,[ twt_ap_btwt.c : 871 ] ap_btwt_session == NULL, session_id=%d 
+4484,,[ twt_ap_btwt.c : 900 ] btwt get session failure 
+4485,,[ twt_ap_btwt.c : 927 ] Error: ap_btwt_update_session_done:Failed to allocate memory for cmd_data 
+4486,,[ twt_ap_btwt.c : 965 ] Error: ap_btwt_delete_session_done:Failed to allocate memory for cmd_data 
+4487,ii,[ twt_ap_btwt.c : 1084 ] %d: session not found: session_id=%d 
+4488,i,[ twt_ap_btwt.c : 1131 ] ap_btwt_send_twt_resp_compl reject for vdev id %d 
+4489,,[ twt_ap_btwt.c : 1142 ] btwt get session failure 
+4490,i,[ twt_ap_btwt.c : 1205 ] ap_btwt_invite_sta session %d null 
+4491,i,[ twt_ap_btwt.c : 1210 ] ap_btwt_invite_sta session %d peer not joined 
+4492,i,[ twt_ap_btwt.c : 1216 ] ap_btwt_invite_sta: R-TWT not enabled on this peer:%d 
+4493,i,[ twt_ap_btwt.c : 1243 ] ap_btwt_remove_sta: R-TWT not enabled on this peer:%d 
+4494,ii,[ twt_ap_btwt.c : 1331 ] ap_btwt_setup_frame_handler(!twt_peer->flags.cap_rtwt): peer=%d, session_id=%d 
+4495,ii,[ twt_ap_btwt.c : 1369 ] ap_btwt_setup_frame_handler(!ap_btwt_session): peer=%d, session_id=%d 
+4496,iii,[ twt_ap_btwt.c : 1381 ] ap_btwt_setup_frame_handler(!ap_btwt_session): session has max peers[%d] already! peer=%d, session_id=%d 
+4497,i,[ twt_ap_btwt.c : 1419 ] twt_ap_btwt_invite_sta_cmd_handler cap btwt not set for session %d 
+4498,i,[ twt_ap_btwt.c : 1490 ] sending pause frame failed: status=%d 
+4499,i,[ twt_ap_btwt.c : 1526 ] sending resume frame failed: status=%d 
+4500,IIiI,[ twt_ap_smartwt.c : 34 ] <pdev%u-slot%u>: num_peer=%d, flags=0x%x 
+4501,IiiI,[ twt_ap_smartwt.c : 40 ] [slot%u]   peer=%d, session=%d, flags=0x%x 
+4502,III,[ twt_ap_smartwt.c : 266 ] ap_smartwt_get_slot_idx_start_time_end_time last_slot_extra_dur_us %llu temp %llu diff_in_time %llu 
+4503,ii,[ twt_ap_smartwt.c : 429 ] twt_slot POOL ALLOC FAILURE total slots %d pending slots to alloc %d 
+4504,,[ twt_ap_smartwt.c : 499 ] twt_assign_peer POOL ALLOC FAILURE 
+4505,,[ twt_ap_smartwt.c : 523 ] twt_assign_peer POOL ALLOC FAILURE 
+4506,i,[ twt_ap_smartwt.c : 700 ] ap_smartwt_setup_comp(slot_match failed): slot_id=%d 
+4507,i,[ twt_ap_smartwt.c : 1645 ] ap_smartwt_setup_teardown_peers(send_failed): status=%d 
+4508,,[ direct_dma_config.c : 128 ] ddma_error: invalid module ID 
+4509,Ii,[ direct_dma_config.c : 361 ] dma_prepare %p status %d 
+4510,I,[ host_ring_reader.c : 293 ] host ring reader %p stop request 
+4511,IIIIIIII,[ host_ring_reader.c : 343 ] host ring reader %p has base address 0x%08x%08x, %u elements, tail address 0x%08x%08x, head address 0x%08x%08x 
+4512,IIIi,[ host_ring_reader.c : 41 ] host ring reader %p failed to copy from address 0x%08x%08x with status %d 
+4513,ii,[ pcss_ring_feeder.c : 81 ] SSCAN: Stale buffers discarded for IPC ring id %d: %d 
+4514,iii,[ pcss_ring_feeder.c : 332 ] SSCAN : PHY %d PCSS ring %d wrap around condition hit pcss_re_reap %d 
+4515,iiI,[ pcss_ring_feeder.c : 338 ] SSCAN : PHY %d ring %d has %u elements remaining 
+4516,III,[ pcss_ring_feeder.c : 374 ] pcss_ring_feeder_handle_ipc : head = %u shadow_head = %u and num_elems = %u for out_ring 
+4517,I,[ pcss_ring_feeder.c : 385 ] pcss_ring_feeder_handle_ipc : num elems_dmaed = %u for out_ring 
+4518,iiII,[ pcss_ring_feeder.c : 484 ] PHY %d ring %d needs %u elements; have %u 
+4519,I,[ ratectrl.c : 7565 ] SEC_RETRY skip PER update flags:0x%x 
+4520,iiiii,[ ratectrl.c : 7815 ] Prot failure:%d(%d,%d),rts_en(%d,%d) 
+4521,,[ ratectrl.c : 8200 ] Set INVALID!!! RTS Rate Index 
+4522,ii,[ ratectrl.c : 8210 ] _RATE_SetRtsCtsRate: Def RTS Rate Rix %d Alt RTS Rate Rix %d  
+4523,iI,[ ratectrl.c : 9868 ] RateBasedRAswitch ra_reactivity_level = %d, currRateKbps = %u 
+4524,iIIII,[ ratectrl.c : 10235 ] pdev_id:%d rc_leg_rate_allowed=0x%x rc_legacy_mask=0x%x temp_cck_rate_bitmap=0x%x module_id=0x%x 
+4525,iIIIII,[ ratectrl.c : 10266 ] FINAL: pdev_id:%d rc_leg_rate_allowed=0x%x rc_legacy_mask=0x%x  rc_pdev->rc_legacy_mask: BT=0x%x LTE_COEX=0x%x HE_ASSOC=0x%x
+ 
+4526,II,[ ratectrl.c : 3062 ] rc_validate_rateset/NON_HT:  Before mask update ni_legacy_rate_set 0x%x validTxRateMask 0x%x 
+4527,II,[ ratectrl.c : 3104 ] rc_validate_rateset/NON_HT:  After mask update ni_legacy_rate_set 0x%x validTxRateMask 0x%x 
+4528,iiIiiI,[ ratectrl.c : 3256 ] NSS Mismatch: 160nss %d, 160_mcs_nss_set %d, 160_mcs_nss_map %x, 80nss %d, 80_mcs_nss_set %d, 80_mcs_nss_map %x 
+4529,iii,[ ratectrl.c : 6523 ] legacy rate is disabled, pdev leg allow=%d, pdev cck allow=%d, peer cck disable=%d 
+4530,I,[ ratectrl_if.c : 119 ] is_rc_peer_mem_optimized: peer is invalid vdev:0x%x 
+4531,III,[ ratectrl_if.c : 1704 ] LOWQ_LOW_LAT_RA_DBG : peer_high_qdepth_tid_mask = 0x%x goodput_prob_rix = 0x%x lat_probe_rix = 0x%x 
+4532,,[ ratectrl_if.c : 1928 ] RATE_EnableCCKRatesInHTMode: No vdev's attached to pdev, rejecting WLAN_PDEV_ENABLE_CCK_RATE !
+ 
+4533,IiiIiii,[ ratectrl_if.c : 1985 ] Enabling coex restriction (pdev - 0x%x) enable %d min_rate:%d on wlan_peer:0x%x rc_mode:%d rateMax:%d bestRate:%d 
+4534,IiiIiii,[ ratectrl_if.c : 1998 ] Enabling coex restriction (pdev - 0x%x) enable %d min_rate:%d on wlan_peer:0x%x rc_mode:%d rateMax:%d bestRate:%d 
+4535,i,[ ratectrl_if.c : 2008 ] vdev[%d] is NULL, rejecting WLAN_PDEV_ENABLE_CCK_RATE !
+ 
+4536,IIi,[ ratectrl_if.c : 2237 ] AUTORATE_RESET_USER_START_RATE: peer  phymode:8/ht:8/vht:8 : 0x%08x ni_flags 0x%x  user_start_rate %d 
+4537,IIiII,[ ratectrl_if.c : 2410 ] 
+org_rc_mask_null pdev_rc_mask[0]:%x pdev_rc_mask[1]:%x phymode:%d ni_legacy_rate_set:%x rc_legacy_mask_final:%llx 
+4538,IIIIIIII,[ ratectrl_debug.c : 225 ] ratectrl_unit_test, case=%u,num_args=%u,args=0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 
+4539,Ii,[ ratectrl_debug.c : 361 ] RTS_DEBUG: vdev id:8/rts cts type:8/rts cts profile:16 0x%08x rts_rix %d
+ 
+4540,I,[ ratectrl_debug.c : 409 ] RA_DBG_CMDID_TEST_PER_CONV_UL_MUMIMO:  ltPer:8/stPer:8/curr_per:8 : 0x%08x 
+4541,iiiiiiii,[ ratectrl_debug.c : 501 ] MCAST_RC: vdev_id: %d, Is mcast dra enabled: %d
+MCAST_RC: stale_period_sec: %d
+MCAST_RC: Number of stale clients: %d
+MCAST_RC: Default Mcast rate: %d Mbps, rix: %d
+MCAST_RC: Auto Mcast rate: %d Mbps, rix: %d
+ 
+4542,iiii,[ ratectrl_debug.c : 504 ] MCAST_DBG_RC: RC queries %d, RC updates %d, RIX error: %d, Peer count error: %d
+ 
+4543,iii,[ ratectrl_debug.c : 509 ] MCAST_DBG_RC: Last stale peer id %d, current time %d, stale tx time %d
+ 
+4544,ii,[ ratectrl_debug.c : 516 ] MCAST_DBG_RC: %d Mbps - %d
+ 
+4545,iiiii,[ ratectrl_debug.c : 532 ] MCAST_DBG_RC: peer id: %d, rate kbps: %d, mcast rate kbps: %d, rix:%d, mcast rix:%d
+ 
+4546,i,[ ratectrl_debug.c : 885 ] PEER_CAPS: low_latency %d 
+4547,I,[ ratectrl_debug.c : 889 ] PEER_CAPS: dyn_nss_mask %x
+ 
+4548,IIIII,[ ratectrl_debug.c : 897 ] PEER_CAPS: aid 0x%x, sw_peer_id: 0x%x, ni_flags: 0x%x, phymode: 0x%x, peer_nss :0x%x
+ 
+4549,I,[ ratectrl_debug.c : 902 ] PEER_CAPS: ni_flags_ext: 0x%x
+ 
+4550,I,[ ratectrl_debug.c : 908 ] PEER_CAPS: peer_nss_160: 0x%x
+ 
+4551,I,[ ratectrl_debug.c : 913 ] PEER_CAPS: peer_ul_nss: 0x%x
+ 
+4552,I,[ ratectrl_debug.c : 917 ] PEER_CAPS: ni_legacy_rate_set: 0x%x
+ 
+4553,iI,[ ratectrl_debug.c : 922 ] PEER_CAPS: ni_ht_mcs_set[%d]: 0x%x
+ 
+4554,I,[ ratectrl_debug.c : 926 ] PEER_CAPS: ht_caps: 0x%x
+ 
+4555,II,[ ratectrl_debug.c : 930 ] PEER_CAPS: ni_vht_mcs_set: 0x%x,  vht_caps: 0x%x
+ 
+4556,I,[ ratectrl_debug.c : 934 ] PEER_CAPS: he_cap_info: 0x%x
+ 
+4557,iI,[ ratectrl_debug.c : 938 ] PEER_CAPS: he_cap_phy[%d]: 0x%x
+ 
+4558,iIiI,[ ratectrl_debug.c : 945 ] PEER_CAPS: he_mcs_nss_set.map[%d].rx: 0x%x, he_mcs_nss_set.map[%d].tx: 0x%x
+ 
+4559,i,[ ratectrl_debug.c : 951 ] PEER_CAPS: eht_cap_ops_mcs15: %d, 
+ 
+4560,I,[ ratectrl_debug.c : 956 ] PEER_CAPS:  eht_cap_phy: %x, 
+ 
+4561,iIiI,[ ratectrl_debug.c : 963 ] PEER_CAPS: eht_mcs_nss_set.map[%d].rx: 0x%x, eht_mcs_nss_set.map[%d].tx: 0x%x
+ 
+4562,ii,[ ratectrl_debug.c : 972 ] PEER_CAPS: ml_peer->link_info[%d].emlsr: %d
+ 
+4563,I,[ ratectrl_debug.c : 1037 ] NSS_CLAMP: dyn_nss_mask %x
+ 
+4564,iiiiII,[ ratectrl_debug.c : 1050 ] rate_ctrl_unit_test use fixed TPC args[0]:%d args[1]:%d args[2]:%d args[3]:%d wal_vdev:0x%x pdev:0x%x 
+4565,,[ ratectrl_debug.c : 1141 ] DBG_RATE_CFG ERROR: PDEV is NULL 
+4566,iiii,[ ratectrl_debug.c : 1173 ] DBG_RATE_CFG after:nss_cap: %d, nss_valid: %d mcs_cap: %d, mcs_valid: %d 
+4567,iiii,[ ratectrl_debug.c : 1176 ] DBG_RATE_CFG after:ul_nss_cap: %d, ul_nss_valid: %d, ul_mcs_cap: %d, ul_mcs_valid: %d 
+4568,i,[ ratectrl_debug.c : 1196 ] DBG_RA_BW_PROBE_CHECK_ON_ALL_BW decision_changed cnt :%d  
+4569,i,[ ratectrl_debug.c : 1209 ] SAWF_DBG_LOG rc_rate_max_per_thr: %d 
+4570,i,[ ratectrl_debug.c : 1231 ] SAWF_DBG_LOG beta_exp_avg: %d 
+4571,i,[ ratectrl_debug.c : 1239 ] SAWF_DBG_LOG rc_probe_period_cur_nss_min %d 
+4572,i,[ ratectrl_debug.c : 1247 ] SAWF_DBG_LOG rc_probe_period_cur_nss_max: %d 
+4573,i,[ ratectrl_debug.c : 1255 ] SAWF_DBG_LOG rc_probe_period_alt_nss_min: %d 
+4574,i,[ ratectrl_debug.c : 1263 ] SAWF_DBG_LOG : rc_probe_period_alt_nss_max %d 
+4575,i,[ ratectrl_debug.c : 1271 ] SAWF_DBG_LOG rc_probe_succ_per_thr: %d 
+4576,i,[ ratectrl_debug.c : 1280 ] SAWF_DBG_LOG g_rc_probe_msdu_limit: %d 
+4577,i,[ ratectrl_debug.c : 1288 ] SAWF_DBG_LOG default_no_ack_wifi_thr: %d 
+4578,i,[ ratectrl_debug.c : 1296 ] SAWF_DBG_LOG rc_reduce_num_mcs: %d 
+4579,i,[ ratectrl_debug.c : 1308 ] *****SAWF_DBG_LOG RC_PROFILE: %d*****
+ 
+4580,i,[ ratectrl_debug.c : 1311 ] SAWF_DBG_LOG rc_rate_max_per_thr: %d 
+4581,i,[ ratectrl_debug.c : 1314 ] SAWF_DBG_LOG beta_exp_avg: %d 
+4582,i,[ ratectrl_debug.c : 1317 ] SAWF_DBG_LOG rc_probe_period_cur_nss_min %d 
+4583,i,[ ratectrl_debug.c : 1320 ] SAWF_DBG_LOG rc_probe_period_cur_nss_max: %d 
+4584,i,[ ratectrl_debug.c : 1323 ] SAWF_DBG_LOG rc_probe_period_alt_nss_min: %d 
+4585,i,[ ratectrl_debug.c : 1326 ] SAWF_DBG_LOG rc_probe_period_alt_nss_max %d 
+4586,i,[ ratectrl_debug.c : 1329 ] SAWF_DBG_LOG rc_probe_succ_per_thr: %d 
+4587,i,[ ratectrl_debug.c : 1332 ] SAWF_DBG_LOG g_rc_probe_msdu_limit: %d 
+4588,i,[ ratectrl_debug.c : 1335 ] SAWF_DBG_LOG default_no_ack_wifi_thr: %d 
+4589,i,[ ratectrl_debug.c : 1338 ] SAWF_DBG_LOG rc_reduce_num_mcs: %d 
+4590,ii,[ ratectrl_debug.c : 1508 ] RA_DBG_MCS_BASED_RA  pdev id:%d, enable:%d 
+4591,II,[ ratectrl_debug.c : 1514 ] RA_BDG_MCS_BASED_RA HystMin:%u, HystMax:%u 
+4592,,[ ratectrl_debug.c : 1516 ] RA_BDG_MCS_BASED_RA Invalid Choice 
+4593,i,[ ratectrl_debug.c : 1532 ] SAWF_DBG_LOG :: g_ratectrl_cfg.opt.en_small_pkt_per_support = %d 
+4594,ii,[ ratectrl_debug.c : 1547 ] SAWF_DBG_LOG :: per :: per_thr_mpdu = %d accumilation_mpdu = %d 
+4595,i,[ ratectrl_debug.c : 1559 ] SAWF_DBG_LOG: enable rts collision stats = %d 
+4596,i,[ ratectrl_debug.c : 1572 ] SAWF_DBG_LOG: g_enable_cap_phyrate_support = %d 
+4597,i,[ ratectrl_debug.c : 1584 ] SAWF_DBG_LOG: en_clear_on_rate_mismatxh = %d 
+4598,i,[ ratectrl_debug.c : 1731 ] RATE_CTRL_DBG: avoid_rate_alg_for_lower_bw: %d 
+4599,ii,[ ratectrl_debug.c : 1957 ] PROBE_COUNTER Total probe:%d Consecutive Failure Change Enablement: %d
+ 
+4600,iiii,[ ratectrl_debug.c : 1973 ] ADAPTIVE_CCK_CHAINMASK: Enablement: %d CCK 1M with Nchain failure:%d Probe 1M with 1chain:%d Switch to 1 chain TX for CCK:%d
+ 
+4601,IIIIII,[ ratectrl_ofdma.c : 890 ] OFDMA_MIN_STAY_TIME: sw_id %u fail %u, total %u cur_time %u cur_rate_start_time %u last_min_stay_update %u 
+4602,IIII,[ ratectrl_ofdma.c : 924 ] OFDMA_MIN_STAY_TIME: min stay time %u  cur_time %u cur_rate_start_time %u last_min_stay_update %u 
+4603,iiiiii,[ ratectrl_ofdma.c : 1426 ] OFDMA_RC_DBG: aid: %d, ref_rix: %d, trialBaseRate: %d, complMismatchCnt: %d, ru_size: %d, rc_mode: %d 
+4604,iiiiiii,[ ratectrl_ofdma.c : 1899 ] UL_PSD_BOOST_DBG: AID: %d, bw: %d, ref_mcs: %d, ref_nss: %d, ru_try: %d, boosted mcs: %d, boosted nss: %d 
+4605,iiiIIi,[ ratectrl_ofdma.c : 2165 ] UL_PSD_BOOST_DBG: idx: %d, AID: %d, MRU RU Size: %d, Out of Date Bmap: 0x%08x, Invalid RU Size Bmap: 0x%08x, Lgest uptodate ru: %d 
+4606,IiiiiiI,[ ratectrl_ofdma.c : 2188 ] UL_PSD_BOOST_DBG: cur_time: %u, ru_size: %d, dst_mcs: %d, dst_nss: %d, src_mcs: %d, src_nss: %d, src_tstamp: %u 
+4607,IIIII,[ sched_algo.c : 598 ] DET_SCHED_PROBE: vdev_id: %u, time: %u, state %u->%u, re-arm timeout (ms): %u 
+4608,I,[ sched_algo.c : 627 ] DET_SCHED_PROBE: ignored probe request, current state: %u 
+4609,,[ sched_algo.c : 822 ] 11AZ NTBR: tidq is NUL cannot post message to sched 
+4610,ii,[ sched_algo.c : 1612 ] SCHED_DBG : SAWF enable %d, sched_scheme_cnt %d 
+4611,i,[ sched_algo.c : 1806 ] SAWF_SCHED_OPT: Enable/Disable: %d 
+4612,I,[ sched_algo.c : 3029 ] SCHED_ALGO_ERR: Tid register is called by fn %x when TID is marked for delete 
+4613,iii,[ sched_algo.c : 3102 ] SCHED_ALGO_DBG: sched_algo_tid_register sw_peer_id: %d, tid_num: %d, num_frames: %d 
+4614,iiiIi,[ sched_algo.c : 3164 ] TID REG:peer %d tidnum %d txqid %d flags %x num active %d
+ 
+4615,iii,[ sched_algo.c : 3260 ] SCHED_ALGO_DBG: sched_algo_tid_unregister sw_peer_id: %d, tid_num: %d, num_frames: %d 
+4616,,[ sched_algo.c : 3496 ] smart_basic_trig : reset smart basic trig due to zero service_interval or zero exp_bytes 
+ 
+4617,iiIIii,[ sched_algo.c : 3504 ] smart_basic_trig : skip_no_ul_data service_interval=%d, exp_bytes=%d, time_diff=%lu, last_sched_tsmp=%lu, aid=%d, tid_num=%d 
+ 
+4618,iiIIii,[ sched_algo.c : 3510 ] smart_basic_trig : allow_ul_tid service_interval=%d, exp_bytes=%d, time_diff=%lu, last_sched_tsmp=%lu, aid=%d, tid_num=%d 
+ 
+4619,IIIIIIII,[ sched_algo.c : 3571 ] MLO_DLMUMIMO ml_peer_id %u, emlsr %u, link_idx %u, primary %u, active %u, chip_id %u, num_links %u, current_chip_id %u. 
+4620,I,[ sched_algo.c : 3727 ] ul_dbg_check_eligibility: No UL Trig: is_wmm_txq_ul_trig_disabled=%u 
+4621,IiiiIIII,[ sched_algo.c : 3837 ] ul_dbg_check_eligibility: tid_q=%x, tid_num=%d, is_bsr_timeout=%d, num_frms=%d, curr_time = %u, tsf_now=%u, bsr_ts=%u, bsr_timeout_ms=%u 
+4622,i,[ sched_algo.c : 3844 ] ul_dbg_check_eligibility: trigger_state=%d 
+4623,iiiiiIIi,[ sched_algo.c : 3862 ] freq_bsrp_dbg: bsr_elig : aid=%d, tid_num=%d, is_bsr_timeout=%d, qdepth_bytes=%d, est_qdepth=%d, curr_time = %u, pdev_bsr_tstamp =%u, bsr_trigger_in_flight =%d 
+4624,iiii,[ sched_algo.c : 3941 ] OFDMA_SCHED_DECISION: aid: %d, tid_num: %d, unreliable_basic_trigger: %d, unreliable_metric: %d 
+4625,iiii,[ sched_algo.c : 4349 ] sched_algo_get_max_usr_possible: txqid=%d, resv / max_desc_credits %d max_desc_credits_extra %d in_use %d 
+4626,iii,[ sched_algo.c : 4518 ] GRP_SSID_DBG: local_sched_cmd_space %d txq_id %d total_sched_cmds %d  
+4627,i,[ sched_algo.c : 4529 ] GRP_SSID_DBG: sched_cmd_space %d 
+4628,I,[ sched_algo.c : 4615 ] SCHED_ALGO_DEBUG: sched_algo_run_scheduler_all_active_txqs active_txq_id_bmask: %u 
+4629,iiii,[ sched_algo.c : 4782 ] UL_MU_DISABLE_DBG - trig_capable_user_count_tcp:%d, rx_loading_pct:%d, avg_chan_lat:%d, ac:%d 
+4630,,[ sched_algo.c : 4794 ] UL_MU_DISABLE_DBG - UL OFDMA Triggers disabled due to low TCP user count 
+4631,,[ sched_algo.c : 4803 ] UL_MU_DISABLE_DBG - UL OFDMA Triggers disabled due to high TCP user count 
+4632,iiiii,[ sched_algo.c : 4845 ] UL_MU_DISABLE_DBG - Final - total_active_client_count_ulmu:%d, trig_capable_user_count:%d, non_ulmu_trig_count:%d, other_trig_count:%d, disabled_txmode_mask:%d 
+4633,i,[ sched_algo.c : 4990 ] sched_algo_run_scheduler_start: txq_id=%d 
+4634,IIIIII,[ sched_algo.c : 5043 ] twt_dbg: twt_sched_algo_return (slot ended):txqid=%u, tsf_now_msb=%u, lsb=%u, curr_slot_end msb=%u, lsb=%u slot_valid:%u 
+4635,i,[ sched_algo.c : 5055 ] sched_algo_run_scheduler: SCHED ALGO is in paused state, txqid=%d 
+4636,i,[ sched_algo.c : 5081 ] sched_algo_run_scheduler: Either current or some other sched txq ctxt's run scheduler is already running, num_sched_recursive_calls=%d 
+4637,iiI,[ sched_algo.c : 5150 ] ul_dbg_sched_new_run: txqid=%d, sched_cmd_space=%d, flags=0x%x 
+4638,i,[ sched_algo.c : 5169 ] sched_algo_run_scheduler: no avail desc for q=%d 
+4639,iiI,[ sched_algo.c : 5228 ] twt_dbg: twt_sched_algo_run_policy: txqid=%d, sched_cmd_space=%d, flags=%x 
+4640,iii,[ sched_algo.c : 5372 ] sched_algo_run_scheduler_done: txq_id=%d, sched_policy=%d, multi_ac_qos_sched_enable=%d 
+4641,II,[ sched_algo.c : 5897 ] sched_algo_cmd_update_user_info: g_qnull_peer_id%x %x 
+4642,,[ sched_algo.c : 5903 ] NEW_STATS: qnull set 
+4643,i,[ sched_algo.c : 6292 ] STANDALONE:sched_algo_cmd_update_user_info NDPA FLAG NOT SET $$$tid_num=%d 
+4644,iiiiiiii,[ sched_algo.c : 6397 ] SCHED_ALGO_DBG: rc_subfrms_max: txtime_us %d rate_kbps %d required_bytes %d amsdu size %d required_mpdu %d rc_subfrms_max %d rix %d  IS_SET_SVC_CLASS_PRESENT_ON_TID(ptid) %d  
+4645,Iii,[ sched_algo.c : 7439 ] smart_basic_trig : last_sched_tsmp=%lu aid=%d, tid_num=%d 
+ 
+4646,iiIII,[ sched_algo.c : 7920 ]     SAWF: idx %d optimize %d diff %x, time_delta_prxmity_upr_tshold  %x time_delta_prximty_lwr_tshold %x 
+4647,iiii,[ sched_algo.c : 10095 ] UL_SU_PROBE: tx_mode:%d, probe_flag:1, rix:%d, rate_kbps:%d, ppdu_dur:%d 
+ 
+4648,ii,[ sched_algo.c : 10306 ] TTL dropped count:%d, tid:%d 
+4649,iii,[ sched_algo.c : 10387 ] UL_SU_PROBE: gen_list_worth_txtime_us=%d max_num_mpdu_info_over_wsi=%d sched_cmd->txtime_us=%d 
+4650,IIIIIIII,[ sched_algo.c : 10502 ] tcp_ul_dbg_sched_dispatch_result: tx_mode=%u, peer_sw_id=%u, sched_id=0x%x, qdepth_adv =%u, qdepth_implicit=%u, qdepth_implicit_final=%u, ru_size=%u, ru_idx=%u 
+4651,IIII,[ sched_algo.c : 10861 ] sched_algo_configure_ul_rts_protection: t_success_rts: %u, t_success_no_rts: %u, t_fail_no_rts: %u, t_fail_rts: %u 
+4652,iiIIiiiii,[ sched_algo.c : 11007 ] EARLY_RX_TERM: user_ru26_cnt=%d, user_ru_size=%d, rix=%x, rc_flags=%x, n_dbps=%d,total_num_bits=%d, num_data_symbols=%d, total_num_delims_across_users=%d mcs=%d
+ 
+4653,iiiiiiiii,[ sched_algo.c : 11035 ] EARLY_RX_TERM: total_num_delims_across_users=%d, min_mcs=%d, cmn_gi=%d, max_bw=%d,num_data_symbols=%d, ul_single_null_delim_dur_us=%d, ru_rate_kbps=%d, user_ru_size=%d, num_users=%d 
+ 
+4654,iIIIIII,[ sched_algo.c : 11106 ] sched_algo_configure_ul_rts_protection: ac: %d, num_users: %u, tb_ppdu_duration: %u, trig_rix: %u, mba_rix: %u, min_coll_prob_to_enable_rts_cts: %u, cur_fail_pct: %u 
+4655,IIi,[ sched_algo.c : 12266 ] sched_algo_dispatch_result failure: sched_param=0x%x, sched_cmd=0x%x, ring_ctxt_valid=%d 
+4656,i,[ sched_algo.c : 12319 ] sched_algo_dispatch_result failure: seq_type=%d 
+4657,IiiiiII,[ sched_algo.c : 12352 ] ul_dbg_sched_dispatch_result: tsf_lsb=%u, sched_mode=%d, tx_mode=%d, seq_type=%d, num_users=%d, tx_time_us=%u, txop_time_us=%u 
+4658,i,[ sched_algo.c : 12466 ] sched_algo_dispatch_result failure: update_user_info with error code=%d 
+4659,ii,[ sched_algo.c : 12478 ] freq_bsrp_dbg: Freq BSRP enabled : AC : %d num_entries : %d 
+4660,ii,[ sched_algo.c : 12488 ] COMB_UL_TRIG_DBG: Combined UL trig enabled : AC : %d num_entries : %d 
+4661,II,[ sched_algo.c : 12549 ] sched_algo_dispatch_result failure: flags=0x%x 0x%x 
+4662,,[ sched_algo.c : 12614 ] ULOFDMA_MANUAL_TRIG WAL_SCHED_CMD_EXT2_FLAG_MANUAL_ULOFDMA_TRIG_ENABLED set 
+4663,i,[ sched_algo.c : 12637 ] MISSING_BSR_DEBUG: aid: %d, trigger in flight=true 
+4664,,[ sched_algo.c : 12786 ] MBSSID_CTRL_FRM_DBG MBSSID Ctrl Frame Feature is in use 
+4665,,[ sched_algo.c : 12800 ] MBSSID_CTRL_FRM_DBG MBSSID Ctrl Frame Feature for Freq BSRP frames is in use 
+4666,,[ sched_algo.c : 12849 ] sched_algo_configure_ul_rts_protection: using shorter RTS duration for non-repeater environment 
+4667,,[ sched_algo.c : 12877 ] sched_algo_dispatch_result failure: descriptor allocation failed 
+4668,iiiI,[ sched_algo.c : 13100 ] sched_algo_dispatch_result: sched_id=%d txqid=%d posted_commands=%d, sched_cmd_flags=0x%x 
+4669,iiiIiIII,[ sched_algo.c : 13224 ] twt_dbg_eosp / ul_dbg: sched_dispatch_sched_cmd txqid=%d, sched_id=%d, posted_commands=%d,sched_cmd_flags=0x%x, is_partial=%d, tsf_low=%u, start_time=%u, end_time=%u 
+ 
+4670,iII,[ sched_algo.c : 13501 ] sched_algo_completion_hdlr: status_type %d sched_id 0x%x ppdu_id 0x%x 
+4671,IIII,[ sched_algo.c : 13644 ] PMLO CHAN_ACC_LAT_DBG window : ac = %u , tot_latency = %u, samples = %u , avg = %u 
+4672,,[ sched_algo.c : 13804 ] CHAN_ACC_LAT_DBG - Enabling OFDMA since new chan acc lat is greater than prior value 
+4673,III,[ sched_algo.c : 13815 ] CHAN_ACC_LAT_DBG : chan_acc_lat_based_dlofdma_state = %u, average channel latency = %u , ac = %u 
+4674,iiiiiii,[ sched_algo.c : 13879 ] OBSS_EDCA_TUNING: free_channel: %d, my_rx_time: %d, my_tx_time: %d, obss_rx_airtime: %d, in_bss_airtime:%d, non_wifi_cu:%d , total_rx %d 
+4675,iiiiiiII,[ sched_algo.c : 14154 ] SCHED_ALGO_DBG: sched_algo_user_completion_hdlr curr_time_us: %d, ppdu_duration_us: %d, sw_peer_id: %d, ptid->tid_num: %d, num_enqued: %d, num_failed: %d, ratecode: 0x%x, flags: 0x%x 
+4676,i,[ sched_algo.c : 14362 ] ULOFDMA_MANUAL_TRIG WMI_MANUAL_UL_OFDMA_TRIG_FEEDBACK_EVENT sent for num peers = %d 
+4677,i,[ sched_algo.c : 14502 ] ULOFDMA_MANUAL_TRIG WMI_MANUAL_UL_OFDMA_TRIG_RX_PEER_USERINFO_EVENTID sent for num peers = %d 
+4678,iII,[ sched_algo.c : 14632 ] PMLO_DEBUG_V5: DL num_users = %d ppdu_duration_us = %u ppdu_duration_us_corrected = %u 
+4679,III,[ sched_algo.c : 14886 ] SCHED_ALGO_DBG: sched_algo_cmd_completion_hdlr debug: cur_time_in_us= %u sched_id=0x%x flush=0x%x 
+4680,iIi,[ sched_algo.c : 15003 ] MISSING_BSR_DEBUG: aid: %d, trigger in flight=false, updated_ac_bmap: 0x%08x, miss_count: %d 
+4681,iIi,[ sched_algo.c : 15019 ] MISSING_BSR_DEBUG2: aid: %d, trigger in flight=false, updated_ac_bmap: 0x%08x, miss_count: %d 
+4682,iiii,[ sched_algo.c : 15050 ] MISSING_BSR_DEBUG: aid: %d, trigger in flight=false, ac=%d, orig_timeout: %d, new_timeout: %d 
+4683,iiIIiIII,[ sched_algo.c : 15166 ] twt_dbg/ul_dbg: sched_cmd_completion txqid=%d, sched_id=%d, seq_type=%u, peer_id=%u, pending_commands=%d,compl_ts=%u, user_resp=%u, seq_compl_flags=0x%x 
+ 
+4684,IIIII,[ sched_algo.c : 15178 ] twt_dbg: sched_cmd_completion peer_id=%u, tid_num=%u, sched_flags=0x%x, trigger_state=%u, eosp_state=%u 
+ 
+4685,,[ sched_algo.c : 15253 ] DL_OFDMA_PERF_DBG - Keeping OFDMA disabled 
+4686,,[ sched_algo.c : 15260 ] DL_OFDMA_PERF_DBG - Re-enabling OFDMA 
+4687,ii,[ sched_algo.c : 15306 ] ULOFDMA_MANUAL_TRIG trigger status = %d, trigger type = %d 
+4688,ii,[ sched_algo.c : 15536 ] MLO_STAKO_LOG: Cmd_compl: superset_flush_reason = xretry. sw peer id = %d, tidnum = %d
+ 
+4689,Iii,[ sched_algo.c : 15541 ] MLO_STAKO_LOG: Cmd_compl: xretry_reached=%u, sw_peer_id = %d, tidnum+ %d 
+4690,ii,[ sched_algo.c : 15549 ] MLO_STAKO_LOG: Cmd_compl: nonmaster.. we shouldn't be here. sw peer id = %d, tidnum = %d
+ 
+4691,i,[ sched_algo.c : 15722 ] sched_algo_sched_cmd_done_user data before allow data txq_id %d 
+4692,iiIIi,[ sched_algo.c : 15765 ] TTL tid:%d txq_id:%d, flg-clr:%x %x ttl_st:%d 
+4693,ii,[ sched_algo.c : 15818 ] MLO_STAKO_LOG: cmd cmpl: non-master link notifying master of xretry condn. sw peer id = %d, tidnum = %d
+ 
+4694,,[ sched_algo.c : 15900 ] GEN MPDU command not sent 
+4695,ii,[ sched_algo.c : 16659 ] sched_algo_process_trigger: sw_peer_id mismatch = %d/%d 
+4696,iII,[ sched_algo.c : 16849 ] sched_algo_process_trigger: qos_enabled=%d, tid=0x%x, g_dbg_non_qos_tid_trigger=0x%x 
+4697,IIIII,[ sched_algo.c : 16858 ] discard trigger msg as pdev mismatch peer_id=%x,tid=%x,pdev=%x:%x,flag=%x 
+4698,Iii,[ sched_algo.c : 16880 ] sched_algo_process_trigger: qpeer is in migration, flags=0x%x peer=%d tid=%d 
+4699,IIIIIIIII,[ sched_algo.c : 17022 ] sched_algo_process_trigger: TID is paused, peer_tid=0x%x flags=0x%x 0x%x pause/block bmap 0x%x 0x%x, event_bitmap=0x%x, trig-flags=0x%x, vdev_evt_bmap=0x%x, presend_pending=%u 
+4700,,[ sched_algo.c : 17211 ] sched_algo_tqm_trigger_hdlr 
+4701,,[ sched_algo.c : 17231 ] sched_algo_de_trigger_hdlr 
+4702,,[ sched_algo.c : 17251 ] sched_algo_rt_trigger_hdlr 
+4703,,[ sched_algo.c : 17272 ] sched_algo_be_trigger_hdlr 
+4704,i,[ sched_algo.c : 18131 ] sched_algo_send_trigger  thread_id=%d 
+4705,III,[ sched_algo.c : 18498 ] migrate peer in delete prog %p, flags:%x, sw_peer_id:%x 
+4706,iII,[ sched_algo.c : 18533 ] migrate peer %d, already on MAC(%u %u) 
+4707,iIII,[ sched_algo.c : 18568 ] migrate peer %d, tid(%u) isnot paused! pdev=%u, total_cnt=%u 
+4708,i,[ sched_algo.c : 19266 ] sched_algo_req_handler: unsupported msg type:%d 
+4709,iI,[ sched_algo.c : 19852 ] tx_sched_check_tid_eligible: data before allow data tid_num %d, qpeer flags = %x 
+4710,IiiIII,[ sched_algo.c : 20060 ] twt_dbg_eosp: sched_algo_dl_eligible_check peer_id=%u, is_announced=%d, is_ul_received=%d,tidq->tid_num=%u, tid_ext_flags=0x%x, eosp_state=%u 
+4711,ii,[ sched_algo.c : 20414 ] GRP_SSID_DBG: txq_id %d sched_cmd_space %d  
+4712,i,[ sched_algo.c : 20433 ] GRP_SSID_DBG: sched_pdev_ctxt->atf_total_sched_cmds_pending %d  
+4713,iiiii,[ sched_algo.c : 21462 ] OFDMA_SCHED_DECISION: top level eligibility: aid: %d, tid_num: %d, sta_is_lowq: %d, avg_txtime_us: %d, average_ul_qdepth_bytes: %d 
+4714,IIIIiIII,[ sched_algo.c : 21726 ] AGGR_DBG: aid: %u avg_msdu_bytes: %u, avg_mpdu_bytes: %u, new_mpdu_bytes_estimate: %u, required_bytes: %d, required_mpdu: %u, ppdu duration: %u, phy_rate_kbps: %u 
+4715,II,[ sched_algo.c : 21800 ] AGGR_DBG: aid: %u, final target_mpdu: %u 
+4716,iiiii,[ sched_algo.c : 21875 ] AGGR_DBG: user %d: assigned: %d, rate_kbps: %d, qdepth: %d, target_mpdu: %d
+ 
+4717,ii,[ sched_algo.c : 21958 ] freq_bsrp_dbg: check_bw : pri_max_bw : %d sec_max_bw : %d 
+4718,iii,[ sched_algo.c : 22068 ] RTT ntbr sequence bw rtt_bw: %d full_bw: %d selected_bw: %d 
+4719,iiii,[ sched_algo.c : 22426 ] freq_bsrp_dbg: Combined_Freq_BSRP_Disabled due to Pattern mismatch : pri_punc : %d sec_punc : %d pri_pat_mask : %d sec_pat_mask : %d 
+4720,II,[ sched_algo.c : 22532 ] MBSSID_CTRL_FRM_DBG peer_a RXCFM cap = %u, peer_b RXCFM cap = %u 
+4721,,[ sched_algo.c : 22547 ] MBSSID_CTRL_FRM_DBG Using MBSSID Control Frame - Triggering peers on different vdevs 
+4722,,[ sched_algo.c : 22564 ] MBSSID_CTRL_FRM_DBG Using MBSSID Control Frame - Triggering peers on different vdevs 
+4723,,[ sched_algo.c : 22581 ] MBSSID_CTRL_FRM_DBG Primary Peer not on TX BSS and candidate peer supports this feature and on the same non TX BSS 
+ 
+4724,,[ sched_algo.c : 22590 ] MBSSID_CTRL_FRM_DBG Primary Peer not on TX BSS and candidate peer supports this feature and connected to the TX BSS 
+ 
+4725,,[ sched_algo.c : 22598 ] MBSSID_CTRL_FRM_DBG Primary Peer and candidate peer are on the same non TX BSS 
+ 
+4726,iII,[ sched_algo.c : 22727 ] sched_algo_disable_sched_mode_bmap_update: IN: txq_id: %d, disabled_sched_mode_bmap_req: 0x%08x, disabled_sched_mode_bmap: 0x%08x 
+4727,iII,[ sched_algo.c : 22782 ] sched_algo_disable_sched_mode_bmap_update: OUT: txq_id: %d, disabled_sched_mode_bmap_req: 0x%08x, disabled_sched_mode_bmap: 0x%08x 
+4728,IIiiiIII,[ sched_algo.c : 7500 ] SCHED_ALGO_DBG: sched_algo_post_sched_cmd PPDU Duration debug: sched_id=0x%x sched_seq_type=0x%x txop_us=%d txtime_us=%d max_ppdus=%d flags=0x%x 0x%x tx_ctxt_flags=0x%x 
+4729,IIIII,[ sched_algo.c : 7508 ] SCHED_ALGO_DBG: sched_algo_post_sched_cmd num_users = 0x%x peer_tid[0] = 0x%x peer_tid[1] = 0x%x peer_tid[2] = 0x%x peer_tid[3] = 0x%x  
+4730,IIIII,[ sched_algo.c : 13726 ] PMLO CHAN_ACC_LAT_DBG : ac = %u , chan_latency = %u, tot_latency = %u, samples = %u , avg = %u 
+4731,IIII,[ sched_algo.c : 13757 ] CHAN_ACC_LAT_DBG : Prev. avg_chan_lat = %u , new_value = %u, Curr. avg_chan_lat = %u ,ac = %u 
+4732,iiii,[ sched_algo.c : 21140 ] UL_MU_MIMO_MLO_PARAMS: aid:%d, ml_peer_id:%d, num_links:%d, emlsr_client:%d 
+ 
+4733,iii,[ sched_algo.c : 21230 ] UL_FD_RSSI_DBG:sw peer id %d ulmumimo_fd_rssi_100x %d dbg_ulmumimo_fd_rssi_threshold_100x %d 
+ 
+4734,iiiIiii,[ sched_algo.c : 21262 ] UL_MU_MIMO_TX_PARAMS: AID %d: NSS %d: MCS: %d, qdepth bytes: %lu, txtime  %d, num frames: %d tidq_ul_mumimo_eligible %d
+ 
+4735,,[ sched_algo.c : 21284 ] UL_MU_DISABLE_DBG - Disabling UL MU-MIMO Triggers 
+4736,I,[ sched_algo.c : 21317 ] UL_MU_DISABLE_DBG - UL MU-MIMO Trig Eligibility = %u 
+4737,I,[ sched_algo.c : 21436 ] UL_MU_DISABLE_DBG - UL OFDMA Trig Eligibility = %u 
+4738,ii,[ sched_algo_rr.c : 426 ] twt_dbg: sched_algo_run_rr_scheduler_tidq0 skip tid tid:%d elgble: %d 
+4739,II,[ sched_algo_qos.c : 330 ] SCHED_ALGO_DBG: QOS Sched list type %u num entries %lu 
+ 
+4740,Ii,[ sched_algo_qos.c : 334 ] SCHED_ALGO_DBG: peer 0x%lu.%d  
+4741,,[ sched_algo_qos.c : 336 ] SCHED_ALGO_DBG: null 
+
+ 
+4742,iII,[ sched_algo_qos.c : 341 ] SCHED_ALGO_DBG: tidq container list type %d num entries %lu  super_cycle: %x 
+ 
+4743,Iiiiiii,[ sched_algo_qos.c : 356 ] SCHED_ALGO_DBG: sched_algo_dump_candidate_list() sw_peer_id: 0x%lu, tid_num: %d, weight[0]: %d, weight[1]: %d, weight[2]: %d, weight[3]: %d, rtxop: %d  
+4744,,[ sched_algo_qos.c : 363 ] SCHED_ALGO_DBG: null 
+
+ 
+4745,iI,[ sched_algo_qos.c : 368 ] SCHED_ALGO_DBG: candidate tid list type %d num entries %lu 
+ 
+4746,Ii,[ sched_algo_qos.c : 373 ] SCHED_ALGO_DBG: peer 0x%lu.%d 
+4747,,[ sched_algo_qos.c : 375 ] SCHED_ALGO_DBG: null 
+
+ 
+4748,iiiiii,[ sched_algo_qos.c : 610 ] FORCE_SU_UL_TRIG: peer aid: %d, force_single_user_ul_ofdma: %d, cur_peer_requires_su_trigger: %d, force_2users_in_160_trigger %d, primary peer aid: %d, cur_time: %d 
+4749,,[ sched_algo_qos.c : 644 ] MBSSID_CTRL_FRM_DBG Option 1 is selected since the peers selected from option 1 is high 
+ 
+4750,,[ sched_algo_qos.c : 654 ] MBSSID_CTRL_FRM_DBG Option 2 is selected since the peers selected from option 2 is high 
+ 
+4751,,[ sched_algo_qos.c : 662 ] MBSSID_CTRL_FRM_DBG Peer is not removed since it is a part of both the options 
+ 
+4752,II,[ sched_algo_qos.c : 1047 ] DL_OFDMA_HISTORY_DBG: num_dl_ofdma_txop = %u, ac = %u 
+4753,iiii,[ sched_algo_qos.c : 1232 ] freq_bsrp_dbg: AC : %d num_ax_bsr_elig_users : %d num_be_bsr_elig_users : %d primary_tx_mode : %d 
+4754,ii,[ sched_algo_qos.c : 1328 ] freq_bsrp_dbg: standalone_type : AC : %d candidate_list_entries : %d  
+4755,III,[ sched_algo_qos.c : 1437 ] COMB_UL_TRIG_DBG - Curr avg_chan_lat: %u, avg_txop_dur: %u, ac: %u 
+4756,,[ sched_algo_qos.c : 1475 ] freq_bsrp_dbg: Puncturing enabled, combining 11be BSRP with 11be sequence 
+4757,,[ sched_algo_qos.c : 1540 ] COMB_UL_TRIG_DBG: Puncturing enabled, combining 11be trigger with 11be sequence 
+4758,III,[ sched_algo_qos.c : 1571 ] COMB_UL_TRIG_DBG - sched_tx_mode: %u, comb_ul_basic_trig_sched: %u, combined_freq_bsrp_trig_en: %u 
+4759,,[ sched_algo_qos.c : 1576 ] COMB_UL_TRIG_DBG: Skipping DL+UL sequence since sec sched_tx_mode is not UL data 
+4760,,[ sched_algo_qos.c : 1584 ] COMB_UL_TRIG_DBG: Skipping DL+UL sequence since UL MU-MIMO combined triggers are disabled 
+4761,,[ sched_algo_qos.c : 1592 ] COMB_UL_TRIG_DBG: Skipping combined UL MU-MIMO trig due to enforced delay 
+4762,,[ sched_algo_qos.c : 1599 ] COMB_UL_TRIG_DBG: Skipping combined UL MU-MIMO trig due to cd list selection failure 
+4763,,[ sched_algo_qos.c : 1635 ]  COMB_UL_TRIG_DBG, freq_bsrp_dbg: Selected sched_tx_mode not 11ax/11be UL, hence not doing combined trigger 
+4764,iii,[ sched_algo_qos.c : 1661 ] freq_bsrp_dbg: combined_type : AC: %d candidate_list_entries : %d, sched_tx_mode = %d  
+4765,I,[ sched_algo_qos.c : 2515 ] SCHED_ALGO_DBG: inside ACTIVE sched_pdev_ctxt->active_ac_bmask 0x%x  
+4766,IIIII,[ sched_algo_qos.c : 2689 ] SCHED_TID_WEIGHT_DBG - SCHED_CMDS_PENDING_TXQ: %u, ac:%u, avg_pdev_rx_dur:%u, avg_pdev_tx_dur_qos_sched: %u, rx_greater: %u 
+4767,III,[ sched_algo_qos.c : 2691 ] SCHED_TID_WEIGHT_DBG - num_active_tids_with_partial_txop:%u, monitor_num_active_tids: %u, is_majority_tids_with_partial_txop: %u 
+4768,,[ sched_algo_qos.c : 2696 ] SCHED_TID_WEIGHT_DBG - Skip DL Scheduler set 
+4769,,[ sched_algo_qos.c : 2777 ] SCHED_TID_WEIGHT_DBG - No valid DL candidates, or BSRP timeout. So running UL scheduler also 
+4770,,[ sched_algo_qos.c : 2793 ] SCHED_TID_WEIGHT_DBG - No valid UL candidates, so running the DL scheduler also 
+4771,i,[ sched_algo_qos.c : 2910 ] twt_dbg: twt_sched_algo_qos returned (CL empty): txqid=%d 
+4772,IiIiIIIII,[ sched_algo_qos.c : 3958 ] ul_dbg_check_eligibility_master: aid=%u, tid_num=%d, ul_tid_inactive_time=%u, ul_qdepth=%d, curr_time = %u, bsr_ts=%u, bsr_timeout_ms=%u, flags=%u, pending_cmds=%u 
+4773,III,[ sched_algo_qos.c : 3986 ] ul_dbg_check_eligibility_master : remove UL TID aid=%u, tid_num=%u, ul_tid_inactive_time=%u 
+4774,iiii,[ sched_algo_qos.c : 4199 ] SCHED_ALGO_DBG: Master sort eligibility:: peer_id: %d, tid_num: %d, is_skip_tid: %d, sched_eligible: %d 
+4775,IIIIIII,[ sched_algo_qos.c : 4998 ] SCHED_ALGO_DBG: check_eligibility:curr_time_us=%u, txqid=%u, pdev_id=%u, peer_id=%u, tid_num=%u, is_skip_tid=%u, sched_eligible=%u 
+4776,iiii,[ sched_algo_qos.c : 5084 ] TX_MODE_SEL Secondary peer grouping skipped with primary, primary_txtime %d lower_thresh %d upper_thresh %d sec_txtime %d 
+4777,iiiiiii,[ sched_algo_qos.c : 5128 ] TX_MODE_SEL sched_algo_find_tx_mode txtime_us=%d, primary_user=%d, local_enabled_txmode_mask=%d, default_txmode_mask=%d, list_type=%d, txmode_mask=%d, txmode_num_users_maxed_out=%d 
+4778,iiiiii,[ sched_algo_qos.c : 5203 ] TX_MODE_SEL primary_user_txmode_mask=%d, local_enabled_txmode_mask=%d, default_txmode_mask=%d, primary_txtime_us=%d, list_type=%d, mdsb_eligible=%d 
+4779,ii,[ sched_algo_qos.c : 5243 ] SCHED_DBG : Latency enable %d, sched_scheme_cnt %d 
+4780,iiiiiiii,[ sched_algo_qos.c : 5515 ] SCHED_DBG is_ul %d, peer %d, weight0 %d, weight1 %d, weight2 %d, weight3 %d, weight4 %d, weight5 %d 
+4781,IIii,[ sched_algo_qos.c : 5707 ] SCHED_ALGO_DBG: sched_algo_check_window switching atf window from %llu to %llu, dyn_window_switch: %d, time_based_win_switch: %d 
+4782,iii,[ sched_algo_qos.c : 5840 ] SCHED_ALGO_DBG: sched_algo_tid_reset_txop_on_window_switch peerid: %d, tid_num: %d, rtxop: %d 
+4783,ii,[ sched_algo_qos.c : 6886 ] GRP_SSID_DBG: num_active_private_grp_tid_cnt: %d, num_active_public_grp_tid_cnt: %d 
+4784,Ii,[ sched_algo_qos.c : 6940 ] ul_dbg_tid_unregister_qos: qpeer=0x%x, tid_num=%d 
+4785,ii,[ sched_algo_qos.c : 7039 ] GRP_SSID_DBG: num_active_private_grp_tid_cnt: %d, num_active_public_grp_tid_cnt %d 
+4786,ii,[ sched_algo_qos.c : 1134 ] SCHED_DBG : sched_scheme change pdev_ctxt_scheme_cnt %d, pdev_scheme_cnt %d 
+4787,iiiI,[ sched_algo_qos.c : 1424 ] freq_bsrp_dbg - Freq.BSRP mode for current txq_id_%d is : %d, num_ul_tids_assoc = %d, freq_bsrp_trig_timed_out=%u 
+4788,ii,[ ru_allocator.c : 522 ] Dropping Static RU Unit Test Cmd - Num Args %d : Max Users: %d 
+4789,ii,[ ru_allocator.c : 543 ] Invalid Static RU allocation - ru_size: %d : ru_map_type: %d 
+4790,iii,[ ru_allocator.c : 558 ] RU idx exceeds max idx - ru_idx: %d : ru_size: %d : tx_bw: %d 
+4791,iii,[ ru_allocator.c : 565 ] Incorrect Static RU allocation - ru_idx: %d : ru_size: %d : tx_bw: %d 
+4792,iii,[ ru_allocator.c : 617 ] Config not applied: Static RU allocation - user_count: %d : ru_map_type: %d, max_bw: %d
+ 
+4793,,[ ru_allocator.c : 10115 ] Dropping user from DL OFDMA grouping - dissimilar MCS 
+4794,i,[ ru_allocator.c : 10245 ] ULOFDMA_MANUAL_TRIG target_rssi = %d 
+4795,IIII,[ ru_allocator.c : 10904 ] RU_ALLOC_DBG: Dyn PPDU Duration -  min_dur = %u, min_bytes_ppdu_dur = %u, max_dur = %u, final_selected_dur = %u 
+4796,iii,[ ru_allocator.c : 11083 ] RU Power imbalance Adjust: pre mcs %d, per_tone_pwr %d, interference_from_pre %d 
+4797,iii,[ ru_allocator.c : 11123 ] RU Power imbalance Adjust: next mcs %d, per_tone_pwr %d, interference_from_next %d 
+4798,iiiiii,[ ru_allocator.c : 11182 ] RU Power imbalance Adjust: mcs %d, pre mcs %d per_tone_pwr %d, interference_from_neigbor %d, margin %d, num_notches %d 
+4799,iIIii,[ ru_allocator.c : 12554 ] RU_ALLOC DBG: id: %d, ru_input: flags: 0x%08x, pat_mask 0x%08x, ppdu_time: %d, input user count: %d 
+4800,iiiIiii,[ ru_allocator.c : 12574 ] RU_ALLOC DBG: aid: %d, max_pat_idx: %d, rix: %d, queue_depth: %u, qos_weight: %d, consec_no_mpdu_tried: %d, consec_skip_cnt: %d 
+4801,iiiIiii,[ ru_allocator.c : 12595 ] RU_ALLOC DBG: id: %d, ru_result: ret_val: %d, num_users: %d, pat_mask 0x%08x, data_ppdu_dur[0]: %d, data_ppdu_dur[1]: %d, data_ppdu_dur[2]: %d 
+4802,iiii,[ ru_allocator.c : 12608 ] RU_ALLOC DBG: id: %d, ru_result: ul_ba_ppdu_duration_us[0]: %d, ul_ba_ppdu_duration_us[1]: %d, ul_ba_ppdu_duration_us[2]: %d 
+4803,i,[ ru_allocator.c : 12617 ] RU_ALLOC DBG: DROPPED_USER: aid: %d 
+4804,iIIii,[ ru_allocator.c : 12922 ] M_VS_N: num_users: %d, mba_bits: %lu, trigger bits: %lu, trigger_dur_us %d mba_dur_us %d 
+ 
+4805,iiIIiI,[ ru_allocator.c : 13018 ] M_VS_N: user_info(AID - %d) : mcs: %d, user_actual_bytes: %lu, max_trig_bytes: %lu, user_ru_size: %d, queue_bytes: %lu 
+ 
+4806,iiIIiI,[ ru_allocator.c : 13131 ] M_VS_N: user_info(AID - %d) : mcs: %d, user_actual_bytes: %lu, su_ul_max_ppdu_bytes: %lu, ul_su_ru_size: %d, su_ul_queue_bytes: %lu 
+ 
+4807,IIIIiii,[ ru_allocator.c : 13207 ] M_VS_N: total_n_user_ul_bytes: %llu, n_user_ppdu_duration: %lu, estimated_n_user_overhead_us: %lu, total_n_user_txop_duration: %lu, num_ul_n_users: %d trig_rc %d, mba_rc %d 
+ 
+4808,IIIIIiii,[ ru_allocator.c : 13219 ] M_VS_N: total_m_user_ul_bytes: %llu, m_user_ppdu_duration: %lu, estimated_m_user_overhead_us: %lu, total_m_user_txop_duration: %lu, biasfor2users: %lu trig_rc %d, mba_rc %d m_vs_n %d
+ 
+4809,,[ ru_allocator_ftm.c : 1104 ] FTM_DBG : there is a issue with pattern index 
+4810,,[ ru_allocator_ftm.c : 1129 ] FTM_DBG : there is a issue with pattern inde 
+4811,ii,[ ru_allocator_ftm.c : 1143 ] FTM_DBG : num_mc_peers %d  list->num_entries %d 
+4812,,[ ru_allocator_ftm.c : 1149 ] FTM_DBG : cannot do ftm allocation as no of peers differ 
+4813,iiiii,[ ru_allocator_ftm.c : 1183 ] FTM_DBG sta id %d ru_size %d  -- ru_index %d content channel no %d contet channel index %d 
+4814,ii,[ sched_algo_atf.c : 264 ] SCHED_DBG :BWF enable %d, sched_scheme_cnt %d 
+4815,iiiiiiiii,[ sched_algo_atf.c : 630 ] GRP_PRI_DBG,PeerID, %d,tid->tid_num, %d, se->num_msdus, %d, time diff, %d, se->cur_metric, %d, se->best_metric, %d, se->cur_coeff, %d, se->good_coeff, %d, se->bad_coeff, %d
+ 
+4816,iiiii,[ sched_algo_atf.c : 650 ] GRP_PRI_DBG: PeerID: %d, tid->tid_num: %d, flush_type: %d, user_info->txop_usr_us: %d probe_rix: %d  
+4817,iiiiII,[ sched_algo_atf.c : 711 ] GRP_PRI_DBG: Peer ID: %d, tid_num: %d, num_samples: %d, max_mpdus_in_ppdu: %d, sch_tid_info->txop_avg_us: %u, user_info->txop_usr_us: %u 
+4818,iiiiIIIIi,[ sched_algo_atf.c : 746 ] GRP_PRI_DBG: PeerID: %d, tid_num: %d, num_samples: %d, max_mpdus_in_ppdu: %d, min_sched_delay_us: %u, time_diff_us: %u, txop_sum_us: %u, user_info->txop_usr_us: %u, sch_eff->cur_coeff %d 
+4819,ii,[ sched_algo_atf.c : 1196 ] SCHED_DBG :ATF enable %d, sched_scheme_cnt %d 
+4820,ii,[ sched_algo_dbg.c : 299 ] STANDALONE : TICKLE SCHEDULER %d thread id %d  
+4821,II,[ sched_algo_dbg.c : 372 ] MLO_SENDBAR_DBG: wal_sendbar_dummy_completion(%u) result=%x 
+4822,IIIIIIII,[ sched_algo_dbg.c : 390 ] sched_algo_unit_test, case=%u,num_args=%u,args=0x%x 0x%x 0x%x 0x%x 0x%x 0x%x 
+4823,,[ sched_algo_dbg.c : 514 ] SCHED_DBG_LOGS: AirTime + Scheduler stats 
+ 
+4824,iii,[ sched_algo_dbg.c : 521 ] SCHED_DBG_LOGS pdev %d tx resource consumption %d, rx resource consumption %d 
+ 
+4825,i,[ sched_algo_dbg.c : 524 ] vdev %d 
+ 
+4826,,[ sched_algo_dbg.c : 547 ] bss  
+4827,,[ sched_algo_dbg.c : 549 ] self  
+4828,ii,[ sched_algo_dbg.c : 558 ] SCHED_DBG_LOGS: Peer AID %d: num_schedules = %d
+ 
+4829,iIIIIii,[ sched_algo_dbg.c : 569 ] SCHED_DBG_LOGS : peer %d, mac %x %x, tx resource consumption %u, rx resource consumption %u, atf units: expected %d actual %d 
+ 
+4830,iii,[ sched_algo_dbg.c : 579 ] SCHED_DBG_LOGS: ppdus_queued = %d, mpdus_enqueued = %d, mpdus_failed = %d
+ 
+4831,,[ sched_algo_dbg.c : 599 ] Resetting AirTime stats 
+ 
+4832,iiiii,[ sched_algo_dbg.c : 649 ] SCHED_LOGS: Num active tids in txq %d %d, %d, %d, %d 
+ 
+4833,ii,[ sched_algo_dbg.c : 655 ] SCHED_LOGS: Registered tids in txq %d list %d 
+ 
+4834,i,[ sched_algo_dbg.c : 659 ] SCHED_LOGS: peer id %d 
+ 
+4835,ii,[ sched_algo_dbg.c : 666 ] SCHED_LOGS: Pdev id %d, last sched order idx %d 
+ 
+4836,IIIII,[ sched_algo_dbg.c : 675 ] SCHED_LOGS: last scheduled txqid and peer ids (global): 0x%08x, 0x%08x, 0x%08x, 0x%08x, 0x%08x 
+4837,iiiii,[ sched_algo_dbg.c : 1044 ] SCHED_LOGS: Peer AID %d: num_schedules = %d, ppdus_queued = %d, mpdus_enqueued = %d, mpdus_failed = %d
+ 
+4838,I,[ sched_algo_dbg.c : 1120 ] SCHED_LOGS: Tx_SCHEDULE_CMD Tx mode = %u 
+ 
+4839,IIiI,[ sched_algo_dbg.c : 1129 ] SCHED_LOGS: peer_aid = %u, weight = %u, OFDMA_status = %d, ru_width = %u 
+ 
+4840,,[ sched_algo_dbg.c : 1134 ] SCHED_LOGS: PPDU_COMPLETION 
+ 
+4841,IIIIII,[ sched_algo_dbg.c : 1143 ] SCHED_LOGS: peer_aid = %u, ru_size = %u, rtxop = %u, ppdu_duration = %u, nss_usr = %u, BW = %u 
+ 
+4842,II,[ sched_algo_dbg.c : 1150 ] SCHED_LOGS: Last populated index TxScheduleCmd = %u, PPDUCompletion = %u 
+  
+4843,i,[ sched_algo_dbg.c : 1281 ] ULMU_PRINT, ulmu_not_allowed_sch %d 
+4844,i,[ sched_algo_dbg.c : 1859 ] SCHED_RU_ALLOC_DBG: g_sched_algo_cfg.dbg.cnt.dl_mode_allocation_failed: %d 
+4845,i,[ sched_algo_dbg.c : 1863 ] SCHED_RU_ALLOC_DBG: g_sched_algo_cfg.dbg.cnt.ul_mode_allocation_failed: %d 
+4846,ii,[ sched_algo_dbg.c : 1872 ] SCHED_RU_ALLOC_DBG: g_sched_algo_cfg.dbg.cnt.sched_mode_disabled[%d]: %d 
+4847,ii,[ sched_algo_dbg.c : 2115 ] pdev %d rx_ps_fifo_drop %d 
+ 
+4848,,[ sched_algo_dbg.c : 2468 ] ATF Throughput improvement related variables are removed as they are enabled by default in the code 
+4849,iiiiiii,[ sched_algo_dbg.c : 2573 ] ATM: group_id %d, group_units %d, flags %d, wmm_be_units %d, wmm_bk_units %d, wmm_vo_units %d, wmm_vi_units %d 
+4850,iiiii,[ sched_algo_dbg.c : 2580 ] ATM: ERR_STATS Ivalid grp_id %d, Invalid group %d, Invalid group units %d, Invalid peer %d Invalid atf cmd %d 
+4851,iiii,[ sched_algo_dbg.c : 2588 ] ATM: Eligibility counters 0: %d, 1: %d, 2: %d, 3: %d 
+4852,,[ sched_algo_dbg.c : 2657 ] ATF Throughput improvement related variables are removed as they are enabled by default in the code 
+4853,IIIII,[ sched_algo_dbg.c : 2760 ] UL_SCHED_DEC_STATS: ac: %u, count: %u, latency_sensitive: %u, psd_boost: %u, collision_reduction: %u 
+4854,II,[ sched_algo_dbg.c : 2792 ] PARTIAL_SND_STATS: : MU2  1:%u 2:%u  
+4855,III,[ sched_algo_dbg.c : 2797 ] PARTIAL_SND_STATS: : MU3  1:%u 2:%u 3:%u 
+4856,IIII,[ sched_algo_dbg.c : 2803 ] PARTIAL_SND_STATS: : MU4  1:%u 2:%u 3:%u 4:%u 
+4857,II,[ sched_algo_dbg.c : 2807 ] PARTIAL_SND_STATS: Prefetch_CV_NDPA_Cnt: 1:%u 2:%u 
+4858,iiiiii,[ sched_algo_dbg.c : 3028 ] SCHED_CMD_DBG: AVG Tx: %d, AVG legacy Rx %d, AVG HE Rx: %d                      rx < tx | rx < ax_rx: %d, rx > tx -> 1. With pending sched cmds %d 2. No sched cmd %d 
+4859,,[ sched_algo_dbg.c : 3079 ] SU_STATS_DBG: ---Cleared all SU Multi Destination and SU Only stats--- 
+4860,iiii,[ sched_algo_dbg.c : 3085 ] SU_STATS_DBG: num_su_multi_dest_scheduled: BK: %d | BE = %d | VI = %d | VO = %d 
+4861,iiii,[ sched_algo_dbg.c : 3091 ] SU_STATS_DBG:       num_su_only_scheduled: BK: %d | BE = %d | VI = %d | VO = %d 
+4862,i,[ sched_algo_dbg.c : 3149 ] STANDALONE INVALID SW PEER ID %d 
+4863,,[ sched_algo_dbg.c : 3155 ] STANDALONE SEND MSG SUCCESSFUL 
+4864,,[ sched_algo_dbg.c : 3157 ] STANDALONE SEND MSG FAILED  
+4865,iiii,[ sched_algo_dbg.c : 3178 ] AC_DBG: Requests BE: %d, BK: %d, VI: %d, VO: %d 
+4866,iiii,[ sched_algo_dbg.c : 3179 ] AC_DBG: Counters Data Txq : %d, Other Txq: %d, i/p max_sched_cmd < pending sched_cmds: %d, default %d 
+4867,I,[ sched_algo_dbg.c : 3315 ] DYN_MIMO_PS num_seq_posted: %u 
+4868,II,[ sched_algo_dbg.c : 3320 ] DYN_MIMO_PS num_dyn_mimo_ps_users [%u]: %u 
+4869,II,[ sched_algo_dbg.c : 3326 ] DYN_MIMO_PS num_users_posted [%u]: %u 
+4870,II,[ sched_algo_dbg.c : 3391 ] ULMU_PRINT: Num Triggers %u: %u 
+4871,II,[ sched_algo_dbg.c : 3394 ] ULMU_PRINT: Total Txop %u: %u 
+4872,III,[ sched_algo_dbg.c : 3399 ] ULMU_PRINT: PPDU Duration[%u us] Total trigger %u:%u 
+4873,II,[ sched_algo_dbg.c : 3403 ] ULMU_PRINT: ineligibility counter = %u history based ineligibility = %u 
+4874,iiiiiiii,[ sched_algo_dbg.c : 3511 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_grp_best_grp_size -> (%d, %d, %d, %d, %d, %d, %d, %d )
+  
+4875,iiiii,[ sched_algo_dbg.c : 3534 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_mimo_tputs_observed (0-1500Mbps)> (%d, %d, %d, %d, %d )
+  
+4876,iiiii,[ sched_algo_dbg.c : 3541 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_mimo_tputs_observed (1500-3000Mbps) (%d, %d, %d, %d, %d)
+  
+4877,iiiiiiiii,[ sched_algo_dbg.c : 3550 ] ULMU_PRINT : ulmu_mimo_grp_stats:num_mu_mimo_candidate(0-8 users)-> ( %d, %d, %d, %d, %d, %d, %d, %d, %d )
+  
+4878,iiiiiiii,[ sched_algo_dbg.c : 3558 ] ULMU_PRINT: ulmu_mimo_grp_stats:num_mu_mimo_candidate(9-16 users)-> (%d, %d, %d, %d, %d, %d, %d, %d )
+  
+4879,ii,[ sched_algo_dbg.c : 3572 ] ULMU_PRINT: ulmu_mimo_grp_stats:Group_id: %d, Group entry_id:%d  
+4880,,[ sched_algo_dbg.c : 3575 ] ULMU_PRINT: ulmu_mimo_grp_stats:candidate_sched_compatibility ->
+ 
+4881,iiiiiiiii,[ sched_algo_dbg.c : 3583 ] ULMU_PRINT: ulmu_mimo_grp_stats:user %d -> ( %d, %d, %d, %d, %d, %d, %d, %d) 
+4882,,[ sched_algo_dbg.c : 3602 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_group_eligible_skip ->
+ 
+4883,iiiiiiiii,[ sched_algo_dbg.c : 3610 ] ULMU_PRINT: ulmu_mimo_grp_stats:user %d ->( %d, %d, %d, %d, %d, %d, %d, %d) 
+4884,iiiiiiii,[ sched_algo_dbg.c : 3619 ] ULMU_PRINT: ulmu_mimo_grp_stats: mu_grp_invalid [0-7] -> (%d, %d, %d, %d, %d, %d, %d, %d ) 
+ 
+4885,iiiii,[ sched_algo_dbg.c : 3624 ] ULMU_PRINT: ulmu_mimo_grp_stats: mu_grp_invalid [8-12] -> (%d, %d, %d, %d, %d ) 
+ 
+4886,i,[ sched_algo_dbg.c : 3629 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_grp_ineligible -> %d 
+ 
+4887,i,[ sched_algo_dbg.c : 3635 ] ULMU_PRINT: ulmu_mimo_grp_stats:mu_grp_eligible -> %d 
+ 
+4888,iiiiii,[ sched_algo_dbg.c : 3645 ] ULMU_PRINT: ulmu_mimo_grp_stats: mu_sched_type-> (%d, %d, %d, %d, %d, %d) 
+ 
+4889,IIIIIIII,[ sched_algo_dbg.c : 3799 ] TID_FLUSH_DBG: flush reasons = 0x%lx, waiting_on_reply_lo = 0x%lx, waiting_on_reply_hi = 0x%lx, mlo_flush_any_resp_lo = 0x%lx, mlo_flush_any_resp_hi = 0x%lx,                     tqm_status_pending_lo = %lx, tqm_status_pending_hi = %lx, tid flags2 = %lx
+ 
+4890,II,[ sched_algo_dbg.c : 3854 ] DYN_MIMO_PS sw_peer_id: %u, dyn_mimo_ps_enabled: %u. 
+4891,I,[ sched_algo_dbg.c : 4027 ] twt_dbg: g_dbg_disable_triggers_from_wmm_txq = %u 
+4892,I,[ sched_algo_dbg.c : 4139 ] dbg: g_dbg_disable_timeout_based_bsr_trigger = %u 
+4893,iiiii,[ sched_algo_dbg.c : 4156 ] LATENCY_DBG:Invalid latency info %d, tid alloc failure %d, invalid state %d, invalid tid_num %d, invalid AC %d 
+4894,i,[ sched_algo_dbg.c : 4248 ] Partial failure schedule count :%d
+ 
+4895,,[ sched_algo_dbg.c : 4269 ] Usage: wifitool athX setUnitTestCmd 0x47 6 356 <ppdu_dur> <ppdu_per_tid> <min_bound> <weight_limit> <min_SI_th> OR 
+4896,,[ sched_algo_dbg.c : 4270 ] Usage: wifitool athX setUnitTestCmd 0x47 8 356 <ppdu_dur> <ppdu_per_tid> <min_bound> <weight_limit> <min_SI_th> <min_SAWFSI_th> <min_SAWFDB_th> 
+4897,i,[ sched_algo_dbg.c : 4298 ] MBO txmode current AC : %d 
+ 
+4898,ii,[ sched_algo_dbg.c : 4300 ] MBO txmode %d : %d
+ 
+4899,I,[ sched_algo_dbg.c : 4325 ] Updated Idle condition trigger count as value = %u 
+4900,iii,[ sched_algo_dbg.c : 4344 ] Custom Basic trigger g_dbg_trig_sched_count = %d, g_dbg_trig_out_of_sync = %d, g_dbg_trig_fake_sched = %d
+ 
+4901,iiii,[ sched_algo_dbg.c : 4371 ] LATENCY_DBG: Latency Config Enable : %d, Min service_interval_set : %d, Num active non-Latency Tid: %d, Num Sched Non-Latency tid: %d  
+4902,i,[ sched_algo_dbg.c : 4373 ] LATENCY_DBG: VDEV ID : %d 
+4903,iiiIIII,[ sched_algo_dbg.c : 4394 ] LATENCY_DBG: SW Peer ID : %d, AID : %d, Tid : %d, service_interval : %u, burst_size: %u, delay_bound %u avg delay: %u 
+4904,iiiii,[ sched_algo_dbg.c : 4405 ] LATENCY_DBG: Peer AID : %d, SW Peer ID : %d, tid_num %d, estimated avg scheduling latency %d, estimated avg bytes transmitted in si %d 
+4905,I,[ sched_algo_dbg.c : 4586 ] Updated PPDU Max-Min delta threshold as value = %u 
+4906,i,[ sched_algo_dbg.c : 4622 ] MU Sched Delay: Number of schedules delayed waiting for MU2 = %d 
+4907,i,[ sched_algo_dbg.c : 4624 ] MU Sched Delay: Number of schedules delayed waiting for MU3 = %d 
+4908,i,[ sched_algo_dbg.c : 4626 ] MU Sched Delay: Number of schedules delayed waiting for MU4 = %d 
+4909,I,[ sched_algo_dbg.c : 4662 ] Updated MU-MIMO Idle condition trigger count as value = %u 
+4910,iiii,[ sched_algo_dbg.c : 4708 ] freq_bsrp : updated : en_ul_comb_bsrp : %d timeout : %d max_users : %d min_users_thr : %d 
+4911,i,[ sched_algo_dbg.c : 4801 ] SCH_LATENCY : sw_peer_id = %d 
+4912,ii,[ sched_algo_dbg.c : 4877 ] SCHED_ALGO_LATENCY: Num outstanding Pending SchedCmd %d : %d 
+ 
+4913,iii,[ sched_algo_dbg.c : 4882 ] SCHED_ALGO_LATENCY: SCHED2TAC Latency BIN %d - %d : %d 
+ 
+4914,ii,[ sched_algo_dbg.c : 4885 ] SCHED_ALGO_LATENCY: SCHED2TAC Latency BIN > %d : %d 
+ 
+4915,iii,[ sched_algo_dbg.c : 4891 ] SCHED_ALGO_LATENCY: TAC2SCHED Latency BIN %d - %d : %d 
+ 
+4916,ii,[ sched_algo_dbg.c : 4894 ] SCHED_ALGO_LATENCY: TAC2SCHED Latency BIN  > %d : %d 
+ 
+4917,I,[ sched_algo_dbg.c : 5123 ] INCORRECT peer id %u 
+4918,I,[ sched_algo_dbg.c : 5130 ] SAWF_DBG: peer %u sw_peer_id mismatch between qcache_peer and wal_peer 
+4919,I,[ sched_algo_dbg.c : 5137 ] SAWF_DBG: peer %u deleted/delete is in progress 
+4920,ii,[ sched_algo_dbg.c : 5146 ] ==SAWF_DBG: [peer %d tid_num %d] SUMMARY== 
+4921,ii,[ sched_algo_dbg.c : 5148 ]     SAWF_DBG%d: rtxop %d NO end-to-end SET_SVC_CLASS_PRESENT 
+4922,iiIIIIiI,[ sched_algo_dbg.c : 5176 ]     SAWF_DBG: qtype %d, svc_class_id %d cfg_delay %u, avg_delay %u, cfg_service_interval %u, avg_sched_delay %u, rtxop %d msduq_de_prioritized = %u 
+4923,II,[ sched_algo_dbg.c : 5177 ]     SAWF_DBG: ingress_bytes_over_win %0x%x 
+4924,ii,[ sched_algo_dbg.c : 5179 ]     SAWF_DBG: qtype %d, rtxop %d NO SVC class config 
+4925,iiiiii,[ sched_algo_dbg.c : 5184 ]     SAWF_DBG: svc_class_set:%d db_set:%d low_latency:%d lat_idx:%d is_ultra_low:%d peer_low_latency:%d 
+4926,II,[ sched_algo_dbg.c : 5209 ] SAWF: dur_based_tx_mode_selection %u dur_based_tx_mode_sel_override %u 
+4927,iiiii,[ sched_algo_dbg.c : 5212 ] SAWF_DBG pdev %d sawf_sched_en %d ul_sawf_sched_en %d sawf_tput_sched_en %d number of SAWF peers %d 
+4928,iiii,[ sched_algo_dbg.c : 5213 ] SAWF_DBG: tid count ultra_low_lat = %d low_lat = %d mid_lat = %d tput_cfg = %d 
+4929,II,[ sched_algo_dbg.c : 5214 ] SAWF_DBG: num_active_svc_instances %u num_active_svc_inst_with_only_tid_cfg %u 
+4930,,[ sched_algo_dbg.c : 5220 ] ================================== SAWF STATS =================================== 
+4931,iiiii,[ sched_algo_dbg.c : 5223 ] 		SAWF_DBG: Invalid delay %d, Invalid service interval %d, delay not within limits %d, svc_interval not within limits %d, invalid_fairness_metric %d 
+4932,,[ sched_algo_dbg.c : 5225 ] 	============================ TPUT STATS ============================= 
+4933,i,[ sched_algo_dbg.c : 5227 ] 		SAWF_DBG: max_tput_achieved_cnt_dl %d 
+4934,,[ sched_algo_dbg.c : 5228 ] 	============================ MSDUQ STATS ============================= 
+4935,iii,[ sched_algo_dbg.c : 5229 ] 		SAWF_DBG: Drain ratio histogram 0-5 %d, 5-10 %d, >10 %d 
+4936,,[ sched_algo_dbg.c : 5230 ] 	============================ TxOP STATS ============================= 
+4937,,[ sched_algo_dbg.c : 5231 ] 		====================== Scheduler STATS ======================= 
+4938,IiIiIii,[ sched_algo_dbg.c : 5236 ] 		SAWF_DBG: TXOP duration histogram %uus: %d %uus: %d %uus: %d 8000us: %d 
+4939,iiii,[ sched_algo_dbg.c : 5239 ] 		SAWF_DBG: New sched opt count BIN[UL] %d BIN[LOW] %d BIN{MID] %d BIN[HI] %d 
+4940,,[ sched_algo_dbg.c : 5240 ] 		====================== TAC STATS ======================= 
+4941,I,[ sched_algo_dbg.c : 5242 ] 		SAWF_DBG: sifs_disabled %u 
+4942,,[ sched_algo_dbg.c : 5243 ] ================================== STATS END =================================== 
+4943,iii,[ sched_algo_dbg.c : 5293 ] Average channel access latency for pdev %d, ac %d: %d 
+4944,ii,[ sched_algo_dbg.c : 5331 ] SAWF_DBG: sawf_sched_enable %d, ul_sawf_sched_en %d 
+4945,I,[ sched_algo_dbg.c : 5374 ] SAWF_DBG: qpeer is null, INCORRECT peer id %u 
+4946,I,[ sched_algo_dbg.c : 5379 ] SAWF_DBG: peer %u deleted 
+4947,IIIIIII,[ sched_algo_dbg.c : 5426 ] SAWF_DBG: peer %u ac %u tid %u SI %u Burst Size %u DB %u LAT_SET: %u 
+4948,I,[ sched_algo_dbg.c : 5428 ] SAWF_DBG: UL deterministic trigger not set as peer %u is not UL TRIG capable 
+4949,ii,[ sched_algo_dbg.c : 5653 ] DECOUPLE No of forced 2ss soundings: %d Force sounding failure : %d  
+4950,ii,[ sched_algo_dbg.c : 5654 ] DECOUPLE cbf_decouple_util: %d cbf_decouple_non_util %d 
+4951,,[ sched_algo_dbg.c : 5711 ] PREF LINK: Currently 20 bits in TID. Max value limited to 1,048,575us 
+4952,,[ sched_algo_dbg.c : 5716 ] PREF LINK: Currently 5 bits in TID. Max value limited to 31 
+4953,iiii,[ sched_algo_dbg.c : 5742 ]  PREFERRED_LINK_DBG_PRINT: mlo_sch_stats wal_pdev_pref_link_stats:num_sec_link_sched %d num_pref_link_timeout %d num_pref_link_sch_delay_ipc %d num_pref_link_timeout_ipc %d  
+4954,III,[ sched_algo_dbg.c : 5761 ] MUBRP for SUTxBF enable:%u force_en:%u new_threshold:%u  
+4955,iiiii,[ sched_algo_dbg.c : 5880 ] UL_MUMIMO_PUNCTURING_STATS: punc_mode: 0:%d 1:%d 2:%d 3:%d 4:%d
+ 
+4956,I,[ sched_algo_dbg.c : 5889 ] dbg: charter atf rtxop account constant = %u 
+4957,II,[ sched_algo_dbg.c : 5893 ] dbg: charter burst termination limit %u %u 
+4958,iii,[ sched_algo_dbg.c : 6030 ] unit test buf 1: %d, 2: %d, 3: %d 
+4959,II,[ sched_algo_dbg.c : 6039 ] Flush command existing peer addresses mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x 
+4960,,[ sched_algo_dbg.c : 6049 ] PEER flush policy is not correct 
+4961,IIIi,[ sched_algo_dbg.c : 6053 ] Flush command bss peer addresses mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x tidmap = 0x%x n_TWT = %d 
+4962,,[ sched_algo_dbg.c : 6304 ] SAWF_DBG: Cleared txop_hist 
+4963,ii,[ sched_algo_dbg.c : 6315 ] SAWF_DBG: g_sawf_bg_opt_enable = %d g_sawf_bg_txop_dur = %d  
+4964,i,[ sched_algo_dbg.c : 6343 ] SAWF_SBG_LOG :: g_sched_algo_cfg.param.en_delayed_ba_support = %d 
+4965,i,[ sched_algo_dbg.c : 6482 ] Multi AC QOS : multi_ac_qos_sched_enable %d 
+4966,i,[ sched_algo_dbg.c : 6635 ] pri_inactive_threshold_us = %d 
+4967,i,[ sched_algo_dbg.c : 6708 ] SAWF_DBG: g_sawf_disable_retain_sched_opt %d 
+4968,,[ sched_algo_dbg.c : 6720 ] SAWF_DBG: sched_opt_retain_bin_cnt set to 0 
+4969,IIII,[ sched_algo_dbg.c : 6853 ] latency_issue_debug FW_delay: %lu, RU alloc latency: %lu, Sched_delay: %lu, Datapath_delay: %lu  
+
+
+ 
+4970,IIIII,[ sched_algo_dbg.c : 6856 ] latency_issue_debug FW_delay: %lu, TQM_thread_not_empty_delay: %lu, tqm_not_empty_to_tid_reg_delay: %lu, Sched_delay: %lu, Datapath_delay: %lu  
+
+
+ 
+4971,i,[ sched_algo_dbg.c : 7340 ] SCHED_ALGO_DBG: g_sched_algo_cfg.opt.sched_error_dbg_cfg : %d 
+4972,I,[ sched_algo_dbg.c : 7353 ] SCHED_ALGO_DBG: en_scheduler_dbg_txq_mask: 0x%x 
+4973,iiiii,[ sched_algo_dbg.c : 7421 ] SCHED_DBG : sawf_cmn_sched_en %d, rt_atf_sch_en %d, rt_bwf_sch_en %d, rt_latency_sch_en %d, sched_scheme_cnt %d 
+4974,iiiii,[ sched_algo_dbg.c : 7424 ] SCHED_DBG : sawf_sched_en %d, ATF_ENABLED %d, BWF_ENABLED %d, Latency config %d, sched_scheme_cnt %d 
+4975,ii,[ sched_algo_dbg.c : 7506 ] SCHED_DBG: Num metrics %d, Qos weight btmap %d 
+4976,ii,[ sched_algo_dbg.c : 7508 ] SCHED_DBG: idx %d, wt_pri_order %d 
+4977,ii,[ sched_algo_dbg.c : 7511 ] SCHED_DBG: idx %d, wt_type_to_pri_idx %d 
+4978,II,[ sched_algo_dbg.c : 7723 ] SCHED_CNT - running_only_dl_sched = %u, running_only_ul_sched = %u 
+4979,II,[ sched_algo_dbg.c : 7725 ] SCHED_CNT - running_additional_dl_sched = %u, running_additional_ul_sched = %u 
+4980,,[ sched_algo_dbg.c : 7780 ] SCHED_DBG: wmi sent 
+4981,,[ sched_algo_dbg.c : 7840 ] SCHED_DBG: Invalid ac 
+4982,I,[ sched_algo_dbg.c : 7846 ] SCHED_DBG: qpeer is null, INCORRECT peer id %u 
+4983,I,[ sched_algo_dbg.c : 7851 ] SCHED_DBG: peer %u deleted 
+4984,IIIIIII,[ sched_algo_dbg.c : 7878 ] SCHED_DBG: peer %u ac %u tid %u SI %u Burst Size %u DB %u avg delay: %u 
+4985,I,[ sched_algo_dbg.c : 7880 ] SCHED_DBG: peer %u is not UL TRIG capable 
+4986,,[ sched_algo_dbg.c : 7902 ] SCHED_DBG: invalid peer 
+4987,,[ sched_algo_dbg.c : 7907 ] SCHED_DBG: found peer 
+4988,,[ sched_algo_dbg.c : 7913 ] SCHED_DBG: invalid tid 
+4989,IiI,[ sched_algo_dbg.c : 7933 ] SCHED_DBG: hc is :%u, comfigured delay bound is %d, new delay_bound is %u 
+4990,iiIii,[ sched_algo_dbg.c : 8641 ] SCHED_ALGO_DBG: Latency critical queue present: sw_peer_id %d tid_num %d  tqm_tid->msduq_mask_fields 0x%X pdev->num_active_tid_only_cfg_svc_inst %d IS_SET_SVC_CLASS_PRESENT_ON_TID(tid) %d  
+4991,i,[ sched_algo_dbg.c : 8746 ] SCHED_ALGO_DBG: g_sched_algo_cfg.opt.en_mlo_lowq_thresh_txtime_us = %d  
+4992,i,[ sched_algo_dbg.c : 8789 ] SCHED_ALGO_DBG: RTS RA feature enabled = %d
+ 
+4993,ii,[ sched_algo_dbg.c : 8790 ] SCHED_ALGO_DBG: RTS RA Data PPDU least exercised tx rate = %d Kbps obss load %d 
+ 
+4994,iiiii,[ sched_algo_dbg.c : 8791 ] SCHED_ALGO_DBG: RTS RA rate counters CCK_1MBPS = %d CCK_2MBPS = %d OFDM_6MBPS = %d OFDM_12MBPS %d OFDM_24MBPS %d
+ 
+4995,,[ sched_algo_dbg.c : 8928 ] Invalid usage 
+4996,,[ sched_algo_dbg.c : 8929 ] Usage:   wifitool athX setUnitTestCmd 0x48 4 1200 <First four octets of MAC address> <Last two octets of MAC address> <tag bitmap> 
+4997,,[ sched_algo_dbg.c : 8930 ] Example: wifitool athX setUnitTestCmd 0x48 4 1200 0x0003FBCD 0xE148 0x00000001 
+4998,III,[ sched_algo_dbg.c : 8934 ] args[1] 0x%x, args[2] 0x%x, args[3] 0x%x 
+4999,IIIIII,[ sched_algo_dbg.c : 8952 ] [SAWF_QOS_SAFE] Error! Could not find peer with given MAC %02x:%02x:%02x:%02x:%02x:%02x 
+5000,,[ sched_algo_dbg.c : 8980 ] Invalid usage 
+5001,,[ sched_algo_dbg.c : 8981 ] Usage:   wifitool athX setUnitTestCmd 0x48 4 1200 <First four octets of MAC address> <Last two octets of MAC address> 
+5002,IIIIII,[ sched_algo_dbg.c : 9001 ] [SAWF_QOS_SAFE] Error! Could not find peer with given MAC %02x:%02x:%02x:%02x:%02x:%02x 
+5003,I,[ sched_algo_dbg.c : 9009 ] qos_safe_profile = %x 
+5004,IiiIiIi,[ sched_algo_dbg.c : 9398 ] Tput Monitor tid_mask: 0x%x peer_id: %d, airtime: %d.%03d s, total Duration: %d.%03d s, Duration_percent: %d 
+5005,IiiIiIi,[ sched_algo_dbg.c : 9402 ] Tput Monitor tid_mask: 0x%x peer_id: %d, airtime: %d.%03d ms, total Duration: %d.%03d s, Duration_percent: %d 
+5006,IiiiIi,[ sched_algo_dbg.c : 9406 ] Tput Monitor tid_mask: 0x%x peer_id: %d, airtime: %d us, total Duration: %d.%03d s, Duration_percent: %d 
+5007,IiiI,[ sched_algo_dbg.c : 9420 ] Tput Monitor tid_mask: 0x%x peer_id: %d, Bandwidth: %d.%03d Gbits/sec 
+5008,IiiI,[ sched_algo_dbg.c : 9424 ] Tput Monitor tid_mask: 0x%x peer_id: %d, Bandwidth: %d.%03d Mbits/sec 
+5009,Iii,[ sched_algo_dbg.c : 9428 ] Tput Monitor tid_mask: 0x%x peer_id: %d, Bandwidth: %d Kbits/sec 
+5010,Iii,[ sched_algo_dbg.c : 9433 ] Tput Monitor tid_mask: 0x%x peer_id: %d, Bandwidth: %d bits/sec 
+5011,IiiI,[ sched_algo_dbg.c : 9447 ] Tput Monitor tid_mask: 0x%x peer_id: %d, MSDU Bandwidth: %d.%03d Gbits/sec 
+5012,IiiI,[ sched_algo_dbg.c : 9451 ] Tput Monitor tid_mask: 0x%x peer_id: %d, MSDU Bandwidth: %d.%03d Mbits/sec 
+5013,Iii,[ sched_algo_dbg.c : 9455 ] Tput Monitor tid_mask: 0x%x peer_id: %d, MSDU Bandwidth: %d Kbits/sec 
+5014,Iii,[ sched_algo_dbg.c : 9460 ] Tput Monitor tid_mask: 0x%x peer_id: %d, MSDU Bandwidth: %d bits/sec 
+5015,iiiiiiiii,[ sched_algo_dbg.c : 10665 ] AMSDU_DEBUG_CALC: rix=%d preamble=%d nss=%d mcs=%d gi=%d amsdu_64=%d amsdu_128=%d bw=%d rate_kbps=%d
+ 
+5016,iiiiiii,[ sched_algo_dbg.c : 10675 ] AMSDU_DEBUG_TBL: rix=%d preamble=%d nss=%d mcs=%d gi=%d bw=%d rate_kbps=%d
+ 
+5017,iiiii,[ sched_algo_dbg.c : 10883 ] GRP_SSID_DBG: g_dbg_atf_grp_ctxt.atf_grp_config[idx].group_id %d, g_dbg_atf_grp_ctxt.atf_grp_config[idx].group_units %d, g_dbg_atf_grp_ctxt.atf_grp_config[idx].flags  %d g_dbg_atf_grp_ctxt.atf_total_peer_cnt %d g_dbg_atf_grp_ctxt.atf_total_implicit_units %d 
+5018,,[ sched_algo_dbg.c : 10923 ] Charter Carrier NA in ATF DISABLE 
+5019,iiiiii,[ sched_algo_dbg.c : 11146 ] SCH_LATENCY : sched_latency = ,%d, %d, %d, %d, %d, %d 
+5020,iiiiii,[ sched_algo_dbg.c : 11150 ] SCH_LATENCY : rtxop_sched_latency = ,%d, %d, %d, %d, %d, %d 
+5021,iiiiii,[ sched_algo_dbg.c : 11154 ] SCH_LATENCY : tid_reg_latency = ,%d, %d, %d, %d, %d, %d 
+5022,ii,[ sched_algo_dbg.c : 11157 ] SCH_LATENCY : tid registered = %d, unregistered = %d  
+5023,IIiII,[ sched_algo_twt.c : 127 ] twt_dbg: twt_scheduler_timer1: tsf_now_msb=%u, lsb=%u, curr_slot_idx=%d, curr_slot_start msb=%u, lsb=%u 
+5024,iiII,[ sched_algo_twt.c : 134 ] twt_dbg: twt_scheduler_timer1: 5ghz=%d, next_slot_idx=%d, next_slot_start msb=%u, lsb=%u 
+5025,IIIi,[ sched_algo_twt.c : 160 ] tbr_dbg: twt_scheduler_timer:peer_id=%u, peer_end_tsf msb=%u, lsb=%u, twt_qid=%d 
+5026,Iiiiiii,[ sched_algo_twt.c : 272 ] twt_dbg: twt_scheduler_timer1:                         peer_id:%u i_twt_qid=%d is_sp0_valid_in_curr_slot:%d is_sp1_valid_in_curr_slot:%d is_twt_sp0:%d                         is_twt_sp1:%d is_i_twt_sp:%d 
+5027,IIII,[ sched_algo_twt.c : 279 ] twt_dbg: twt_scheduler_timer: peer_sp0_end_tsf msb=%u, lsb=%u, peer_sp1_end_tsf msb=%u, lsb=%u 
+5028,iii,[ sched_algo_twt.c : 286 ] twt_dbg: twt_scheduler_timer: sp0_r_twt:%d, sp1_r_twt:%d, is_r_twt_sp=%d 
+5029,Iiiiiii,[ sched_algo_twt.c : 428 ] twt_dbg: twt_scheduler_timer1:                         peer_id:%u i_twt_qid=%d is_sp0_valid_in_curr_slot:%d is_sp1_valid_in_curr_slot:%d is_twt_sp0:%d                         is_twt_sp1:%d is_i_twt_sp:%d 
+5030,IIII,[ sched_algo_twt.c : 435 ] twt_dbg: twt_scheduler_timer: peer_sp0_end_tsf msb=%u, lsb=%u, peer_sp1_end_tsf msb=%u, lsb=%u 
+5031,iii,[ sched_algo_twt.c : 442 ] twt_dbg: twt_scheduler_timer: sp0_r_twt:%d, sp1_r_twt:%d, is_r_twt_sp=%d 
+5032,Iii,[ sched_algo_twt.c : 655 ] twt_dbg: twt_construct_cl_super_cycle peer_id=%u dl_tidmask:%d ul_tidmask:%d 
+5033,iI,[ sched_algo_twt.c : 672 ] twt_dbg: twt_construct_cl_super_cycle next_tq->tid_num:%d, dl_tidmask:%x 
+5034,iI,[ sched_algo_twt.c : 697 ] twt_dbg: twt_construct_cl_super_cycle next_tq->tid_num:%d, ul_tidmask:%x 
+5035,IIIII,[ sched_algo_twt.c : 1073 ] twt_dbg: twt_update_start_end_time peer_id=%u, sp0_start_time=%u, sp0_end_time=%u, sp0_flags=0x%x, valid=%u 
+5036,IIII,[ sched_algo_twt.c : 1076 ] twt_dbg: twt_update_start_end_time peer_id=%u, sp1_start_time=%u, sp1_end_time=%u, sp1_flags=0x%x 
+5037,III,[ sched_algo_twt.c : 1079 ] twt_dbg: twt_update_start_end_time peer_id=%u, peer_twt_state sp0_start_time=%u, sp0_end_time=%u 
+5038,IIII,[ sched_algo_twt.c : 1083 ] twt_dbg: twt_update_start_end_time peer_id=%u, peer_twt_state sp1_start_time=%u, sp1_end_time=%u, last_updated_sp=%u 
+5039,IIIIIIII,[ sched_algo_twt.c : 1091 ] twt_dbg: protocol returning sp0_dl_tidmask:%x, sp0_ul_tidmask:%x sp1_dl_tidmask:%x, sp1_ul_tidmask:%x,                    peer_twt_state sp0_dl_tidmask:%x, sp0_ul_tidmask:%x sp1_dl_tidmask:%x, sp1_ul_tidmask:%x 
+5040,Iiiii,[ sched_algo_twt.c : 1125 ] twt_dbg: sched_algo_twt_sp_info_update peer_id=%u, is_announced_sp0=%d, is_ul_received_sp0=%d,                is_announced_sp1=%d, is_ul_received_sp1=%d 
+5041,I,[ sched_algo_twt.c : 1171 ] twt_dbg: sched_algo_twt_sp_info_update_triggered_super_cycle peer_id=%u 
+5042,II,[ sched_algo_twt.c : 1306 ] twt_dbg: twt_peer_register peer_id=%u, twt_peer_count=%u 
+5043,II,[ sched_algo_twt.c : 1310 ] twt_dbg: twt_peer_register g_dbg_disable_triggers_from_wmm_txq = %u; peer->is_wmm_txq_ul_trig_disabled = %u 
+5044,III,[ sched_algo_twt.c : 1360 ] twt_dbg: twt_peer_unregister peer_id=%u, twt_peer_count=%u, peer_twt_state=0x%x 
+5045,IIIIIII,[ sched_algo_twt.c : 1710 ] twt_dbg_eosp: check_eosp_eligibility:tid_num=%u, inactivity_time_us=%u, last_activity_ts=%u, frms_swq=%u, frms_hwq=%u, elapsed_time=%u, remaining_time=%u  
+5046,I,[ sched_algo_twt.c : 1714 ] is_eosp_eligible=%u
+ 
+5047,iii,[ sched_algo_twt.c : 1876 ] twt_dbg: Tried to schedule non prio tids for: txqid=%d, DL CL num_entries: %d UL CL num_entries: %d 
+5048,iii,[ sched_algo_twt.c : 1883 ] twt_dbg: Prio tids scheduled for: txqid=%d, DL CL num_entries: %d UL CL num_entries: %d 
+5049,,[ sched_algo_twt.c : 1199 ] Default TID NULL 
+5050,iiiii,[ esp_calculation.c : 312 ] PMLO_CCA_RAW: new_obss_rx_airtime:%d obss_rx_airtime:%d, sum:%d, average:%d, cnt:%d 
+5051,iiiiiiiii,[ esp_calculation.c : 315 ] PMLO_CCA_RAW: Buffer:%d:%d:%d:%d:%d:%d:%d:%d:%d 
+5052,iiiiii,[ esp_calculation.c : 317 ] PMLO_CCA_RAW: Buffer:%d:%d:%d:%d:%d:%d 
+5053,iiiii,[ esp_calculation.c : 391 ] PMLO_DEBUG_V5: AC[%d] traffic_condition = %d error_margin = %d ul_asymmetric_clients = %d dl_asymmetric_clients = %d 
+5054,iiiii,[ esp_calculation.c : 520 ] PMLO_DEBUG_V5: cycle_count:%d, cca_busy:%d, tx_usec:%d, pre_rx_usec:%d, my_rx_usec:%d  
+5055,iiiiii,[ esp_calculation.c : 570 ] PMLO_DEBUG_V5: free_channel: %d, my_rx_time: %d, my_tx_time: %d, obss_rx_airtime: %d, in_bss_airtime:%d, non_wifi_cu:%d 
+5056,ii,[ esp_calculation.c : 627 ] PMLO_DEBUG_V5r4: DL absolute average = %d moving average = %d 
+5057,ii,[ esp_calculation.c : 628 ] PMLO_DEBUG_V5r4: UL absolute average = %d moving average = %d 
+5058,ii,[ esp_calculation.c : 646 ] PMLO_DEBUG_V5r4: DL absolute average = %d moving average = %d 
+5059,ii,[ esp_calculation.c : 647 ] PMLO_DEBUG_V5r4: UL absolute average = %d moving average = %d 
+5060,iiii,[ esp_calculation.c : 676 ] PMLO_DEBUG_V5r4: UL ppdu_dur:%d, avg:%d, peer_id:%d moving_avg_ppdu_rx_duration: %d 
+5061,iiii,[ esp_calculation.c : 677 ] PMLO_DEBUG_V5r4: DL ppdu_dur:%d, avg:%d, peer_id:%d moving_avg_ppdu_tx_duration: %d 
+5062,ii,[ esp_calculation.c : 678 ] PMLO_DEBUG_V5r4: moving_rx_duration_per_peer: %d  moving_tx_duration_per_peer: %d 
+5063,iiii,[ esp_calculation.c : 698 ] PMLO_DEBUG_V5r4: UL ppdu_dur:%d, avg:%d, peer_id:%d moving_avg_ppdu_rx_duration: %d 
+5064,iiii,[ esp_calculation.c : 699 ] PMLO_DEBUG_V5r4: DL ppdu_dur:%d, avg:%d, peer_id:%d moving_avg_ppdu_tx_duration: %d 
+5065,iiiii,[ esp_calculation.c : 726 ] PMLO_DEBUG_V5r4: Imbalance Traffic case new: ac: %d n_active_dl_ac_sta:%d, n_effective_ul_ac:%d, load_asymmetry_ul:%d, load_asymmetry_dl:%d 
+5066,iiii,[ esp_calculation.c : 753 ] PMLO_DEBUG_V5r4:ac:%d e_busychannel_dl_ac_orig:%d, payload_ratio_dl:%d, my_txop_overhead:%d 
+5067,iiii,[ esp_calculation.c : 759 ] PMLO_DEBUG_V5r4:ac:%d e_busychannel_ul_ac_orig:%d, payload_ratio_ul:%d, my_rxop_overhead:%d 
+5068,iiii,[ esp_calculation.c : 785 ] PMLO_DEBUG_V5r4: CBR Traffic: ac:%d, new_free_channel:%d, b4 active_dl_ac_sta:%d, n_effective_ul_ac:%d 
+5069,iiiiii,[ esp_calculation.c : 834 ] PMLO_DEBUG_V5:  ac[%d]-> n_eff_ul:%d, overall_dur_ac_ul:%d, overall_non_ac_dur_ul:%d, num_associated_sta:%d, HWQ idle time_ms:%d 
+5070,iiiiii,[ esp_calculation.c : 836 ] PMLO_DEBUG_V5:  ac[%d]-> dl_airtime:%d, busy_channel_ul_ac:%d, e_busychannel_ul_ac:%d, busy_channel_dl_ac:%d, e_busychannel_dl_ac:%d 
+5071,iii,[ esp_calculation.c : 848 ] PMLO_DEBUG_V5: ST: estimated_air_time_per_ac:%d, dl_n_effective:%d, free_channel:%d 
+5072,iii,[ esp_calculation.c : 866 ] PMLO_DEBUG_V5: LT: estimated_air_time_per_ac:%d, free_channel:%d, pmlo_sampling_based_airtime:%d 
+5073,iiii,[ esp_calculation.c : 876 ] PMLO_DEBUG_V5: HT: estimated_air_time_per_ac:%d, dl_n_effective:%d, free_channel:%d, pmlo_sampling_based_airtime:%d 
+5074,i,[ esp_calculation.c : 888 ] PMLO_DEBUG_V5: CAL chan_latency = %d 
+5075,ii,[ esp_calculation.c : 907 ] PMLO_DEBUG_V5: CAL cal_sample_count = %d cal_sum = %d 
+5076,i,[ esp_calculation.c : 908 ] PMLO_DEBUG_V5: CAL chan latency after sliding = %d 
+5077,iii,[ esp_calculation.c : 947 ] PMLO_DEBUG_V5: CHAN_LAT_CALC1: estimated_air_time_per_ac:%d, idle_aa_per_ac:%d, obss_rx_airtime:%d 
+5078,iiiii,[ esp_calculation.c : 948 ] PMLO_DEBUG_V5: CHAN_LAT_CALC_2: estimated_air_time_per_ac:%d, g_wal_pmlo_chan_access_latency_override:%d free_channel:%d, pmlo_sampling_based_airtime:%d g_wal_pmlo_chan_access_latency_moving_avg_override:%d 
+5079,Ii,[ esp_calculation.c : 949 ] PMLO_DEBUG_V5: CHAN_LAT_CALC_3: chan_latency_us:%u chan_latency_based_aa:%d  
+5080,iii,[ esp_calculation.c : 982 ] PMLO_DEBUG_V5: CASE MT_1: estimated_air_time_per_ac:%d, total_inbss_portion:%d, n_active_ac_sta:%d 
+5081,iii,[ esp_calculation.c : 987 ] PMLO_DEBUG: CASE MT_2: estimated_air_time_per_ac:%d, free_channel:%d, pmlo_sampling_based_airtime:%d 
+5082,ii,[ esp_calculation.c : 995 ] PMLO_DEBUG_V5: n_active_dl_ac_sta AC %d : %d 
+5083,IIiiii,[ esp_calculation.c : 1045 ] PMLO_DEBUG_V5: pdev:%u, pmlo_dl_air_time_per_ac %x, AC0(BE) - %d, AC1(BK) - %d, AC2(VI) - %d, AC3(VO) - %d 
+5084,iiii,[ esp_calculation.c : 1050 ] PMLO_DEBUG_V5: avg_chan_lat_per_ac, AC0(BE) - %d, AC1(BK) - %d, AC2(VI) - %d, AC3(VO) - %d 
+5085,ii,[ esp_calculation.c : 1051 ] PMLO_DEBUG_V5: ul_inbss_airtime_non_ac %d, dl_inbss_airtime_non_ac %d 
+5086,iiii,[ esp_calculation.c : 1056 ] PMLO_DEBUG_V5: payload_ratio_dl_per_ac AC0(BE) - %d, AC1(BK) - %d, AC2(VI) - %d, AC3(VO) - %d 
+5087,iiii,[ esp_calculation.c : 1061 ] PMLO_DEBUG_V5: payload_ratio_ul_per_ac AC0(BE) - %d, AC1(BK) - %d, AC2(VI) - %d, AC3(VO) - %d 
+5088,iiii,[ esp_calculation.c : 1066 ] PMLO_DEBUG_V5: estimated_air_time_per_ac AC0(BE) - %d, AC1(BK) - %d, AC2(VI) - %d, AC3(VO) - %d 
+5089,iii,[ esp_calculation.c : 1334 ] PMLO_DEBUG pmlo_stats_timer_update_hdlr thread - %d, pdev_id %d, value %d 
+5090,iiiii,[ sched_algo_qos_result.c : 929 ] ofdma_user_cap: tx_mode: %d, num_users: %d, sta_count_having_short_payload: %d, ul_sta_count_having_low_mcs: %d, truncate_candidate_list: %d 
+5091,,[ sched_algo_qos_result.c : 1173 ] freq_bsrp_dbg - Overall RU Alloc failure - all users dropped 
+5092,ii,[ sched_algo_qos_result.c : 1200 ] freq_bsrp_dbg: check_bw : drop_users : pri_max_bw : %d sec_max_bw : %d 
+5093,ii,[ sched_algo_qos_result.c : 1213 ] freq_bsrp_dbg - DL SU -Max BW mismatch - all users dropped, tx_ppdu_max_bw = %d, bw = %d 
+5094,ii,[ sched_algo_qos_result.c : 1224 ] freq_bsrp_dbg - DL SU -RU Alloc failure - user dropped, sec mu_info->pat_mask = %d, pri punc_pattern.pat_mask = %d 
+5095,ii,[ sched_algo_qos_result.c : 1243 ] freq_bsrp_dbg - DL SU -Max BW mismatch - user dropped, pri_rate_sched->bw_info.max_bw = %d, sec_rate_sched->bw_info.max_bw = %d 
+5096,,[ sched_algo_qos_result.c : 1266 ] freq_bsrp_dbg - DL SU -RU Alloc failure - all users dropped 
+5097,iiIii,[ sched_algo_qos_result.c : 1301 ] freq_bsrp_dbg: ru_alloc : peer_id=%d, tid_num=%d, pat_mask=0x%x, ru_size_20=%d, ru_index_20=%d 
+5098,iiii,[ sched_algo_qos_result.c : 1309 ] freq_bsrp_dbg: ru_alloc : ru_size_40=%d, ru_index_40=%d, ru_size_80=%d, ru_index_80=%d 
+5099,ii,[ sched_algo_qos_result.c : 1347 ] freq_bsrp_dbg: check_bw : drop_users : pri_max_bw : %d sec_max_bw : %d 
+5100,ii,[ sched_algo_qos_result.c : 1360 ] freq_bsrp_dbg - Non-SU TX mode -Max BW mismatch - all users dropped, tx_ppdu_max_bw = %d, bw = %d 
+5101,ii,[ sched_algo_qos_result.c : 1370 ] freq_bsrp_dbg - DL SU -RU Alloc failure - user dropped, sec mu_info->pat_mask = %d, pri punc_pattern.pat_mask = %d 
+5102,,[ sched_algo_qos_result.c : 1392 ] freq_bsrp_dbg - DL SU -RU Alloc failure - all users dropped 
+5103,iiIiii,[ sched_algo_qos_result.c : 1439 ] freq_bsrp_dbg: ru_alloc : peer_id=%d, tid_num=%d, pat_mask=0x%x, max_bw : %d ru_size_20=%d, ru_index_20=%d 
+5104,iiii,[ sched_algo_qos_result.c : 1447 ] freq_bsrp_dbg: ru_alloc : ru_size_40=%d, ru_index_40=%d, ru_size_80=%d, ru_index_80=%d 
+5105,IiIii,[ sched_algo_qos_result.c : 2044 ] ul_dbg_passed_ru_alloc: peer=0x%x, tid_num=%d, pat_mask=0x%x, ru_size_20=%d, ru_index_20=%d 
+5106,iiii,[ sched_algo_qos_result.c : 2053 ] ul_dbg_passed_ru_alloc_2: ru_size_40=%d, ru_index_40=%d, ru_size_80=%d, ru_index_80=%d 
+5107,i,[ sched_algo_qos_result.c : 2303 ] ul_ppdu_count %d
+ 
+5108,IIIII,[ sched_algo_muedca.c : 194 ] MU_EDCA_DEBUG: ULMU- AIFS for BE = %u, CWMIN = %u, num_ax_sta: %u, num_legacy_sta: %u, num_non_ulmu_cap_sta: %u 
+5109,II,[ sched_algo_muedca.c : 211 ] MU_EDCA_DEBUG: ULMU- AIFS for VI = %u, CWMIN = %u 
+5110,IIIIII,[ sched_algo_muedca.c : 282 ] MU_EDCA_DEBUG: AIFS for BE = %u, CWMIN = %u, num_ax_sta: %u, num_legacy_sta: %u obss_interfernce_total %u avg channel acc lat %u 
+5111,II,[ sched_algo_muedca.c : 299 ] MU_EDCA_DEBUG: AIFS for VI = %u, CWMIN = %u 
+5112,iiiiiii,[ sched_algo_muedca.c : 382 ] MU_EDCA_DEBUG: tune_edca_parameters: trig_capable_user_count: %d, non_trig_capable_user_count: %d, obss_interfernce_total : %d, non_ulmu_trig_capable_user_count: %d, rx_loading_pct: %d, curr_state: %d, new_state: %d 
+5113,iiiiiiiii,[ sched_algo_muedca.c : 443 ] AP_EDCA_PARAM: dominating UL trig:%d, AC:%d --- old aifs: %d, old cwmin: %d, new cwmax:%d --- new aifs:%d, new cwmin:%d, new cwmax:%d, new muedca_timer:%d 
+5114,,[ sched_algo_muedca.c : 485 ] UL_MU_DISABLE_DBG - Disabling UL MU Triggers 
+5115,ii,[ sched_algo_muedca.c : 491 ] UL_MU_DISABLE_DBG - Disabling UL MU Triggers tcp user count:%d rx ppdu tcp:%d 
+5116,,[ sched_algo_muedca.c : 498 ] UL_MU_DISABLE_DBG - Re-enabling UL MU Triggers 
+5117,iiiiiiiiI,[ sched_algo_muedca.c : 542 ] MU_EDCA_DEBUG: compute_mu_edca_params: ac: %d, trig_capable_user_count: %d, non_trig_capable_user_count: %d, num_ulmu_non_cap_ax_sta: %d, rx_loading_pct: %d, num_mumimo_txop %d, ul_ppdu: %d, ul_tcp_ppdu: %d obss_interfernce_total %u 
+5118,IIiii,[ sched_algo_muedca.c : 567 ] MU_EDCA_DEBUG: MU-MIMO case MU-EDCA tuning - Trigger Status = %u for AC = %u ul_ppdu = %d ulmu_ppdu = %d unreliable_ulmu_cnt = %d 
+5119,,[ sched_algo_muedca.c : 602 ] MU_EDCA_DEBUG: MU-MIMO case MU-EDCA tuning based on RX and basic trigger pkts recieved  
+5120,II,[ sched_algo_muedca.c : 617 ] MU_EDCA_DEBUG: OFDMA case MU-EDCA tuning - Trigger Status = %u for AC = %u 
+5121,II,[ sched_algo_muedca.c : 640 ] MU_EDCA_DEBUG - disable_ul_ofdma_triggers_for_bidi_traffic = %u, ac = %u 
+5122,III,[ sched_algo_muedca.c : 650 ] MU_EDCA_DEBUG - unreliable_trig_user_count = % u, basic_trig_delay_user_count = %u, trig_capable_user_count = %u 
+5123,IIII,[ sched_algo_muedca.c : 676 ] DL_OFDMA_HISTORY_DBG - total_dl_ofdma_txop = %u, ac= %u, ulofdma_trig_count = %u, apply_aggressive_mu_edca_params_for_bidi_traffic = %u 
+5124,iiiiii,[ sched_algo_muedca.c : 786 ] MU_EDCA_PARAM: dominating UL trig:%d, AC:%d ---- aifsn:%d, ecwmin:%d, ecwmax:%d, edca_timer:%d 
+5125,IIII,[ sched_algo_muedca.c : 870 ] MU_EDCA_DEBUG: Sending WMI MESSAGE --- aifsn be = %u, bk = %u, vi = %u, vo = %u 
+5126,iiii,[ sched_algo_muedca.c : 902 ] MU_EDCA_DEBUG: ac: %d, aifs_n: %d, cw_min: %d, cw_max: %d 
+5127,II,[ sched_algo_muedca.c : 988 ] MU_EDCA_DEBUG: Current OFDMA Trigger Status = %u for AC = %u 
+5128,ii,[ sched_algo_tx_mode.c : 174 ] SCHED_ALGO_DBG: tx_mode_bucket=%d, element_count=%d:   
+5129,Ii,[ sched_algo_tx_mode.c : 183 ] SCHED_ALGO_DBG: peer 0x%lu.%d 
+5130,iiiiii,[ sched_algo_tx_mode.c : 431 ] MIXED_AC_DBG : evaluate_best_ac_mode_post_tids_processing                 Bypass latency compute = %d, Stop tracking stats = %d,                 n_tids_count (mixed ac) = %d, n_tids_count (same ac) = %d,                 tx time (mixed ac) = %d , tx time (same ac) = %d 
+ 
+5131,iiiiI,[ sched_algo_tx_mode.c : 721 ] TX_MODE_SEL : populate_candidate_from_tx_mode_list tx_mode=%d, bucket_idx=%d, list_type=%d, bucket_flags=%d, primary_user=%p 
+5132,ii,[ sched_algo_tx_mode.c : 759 ] TX_MODE_SEL : populate_candidate_from_tx_mode_list num_entries=%d, tx_mode=%d 
+5133,iii,[ sched_algo_tx_mode.c : 852 ] OFDMA_SCHED_DECISION: num_ul_ofdma_candidates: %d, lowq_users: %d, highq_low_mcs_users: %d 
+5134,iii,[ sched_algo_tx_mode.c : 1372 ] OFDMA_SCHED_DECISION: aid: %d, psd_boost_phy_rate_max: %d, phy_rate_estimate %d 
+5135,i,[ sched_algo_tx_mode.c : 1394 ] OFDMA_SCHED_DECISION: num_entries: %d 
+5136,iiiiI,[ sched_algo_tx_mode.c : 1435 ] OFDMA_SCHED_DECISION: aid: %d, avg_txtime_us: %d, avg_ul_qdepth_bytes: %d, txtime_us: %d, qdepth_bytes: %lu 
+5137,iii,[ sched_algo_tx_mode.c : 1452 ] OFDMA_SCHED_DECISION: num_entries: %d, lowq_users: %d, highq_low_mcs_users: %d 
+5138,iiiiiiii,[ sched_algo_tx_mode.c : 2820 ] TX_MODE_SEL: populate_tx_mode_buckets tx_mode_selection_type=%d, list_type=%d, primary_user=%d, input_tx_mode_bitmap=%d, txtime_us=%d, sched_eligible=%d, txmode_mask_in_tid=%d, populate_sec_bsr_bucket=%d 
+5139,iii,[ sched_algo_tx_mode.c : 2928 ] TX_MODE_SEL: populate_tx_mode_buckets tid_txmode_mask=%d, tid_eligibility_mask_low=%d, tid_eligibility_mask_high=%d 
+5140,i,[ sched_algo_tx_mode.c : 3184 ] ULOFDMA_MANUAL_TRIG txmode_mask = %d 
+5141,iIiiii,[ sched_algo_tx_mode.c : 3377 ] ul_dbg_populate_bsr_CTL: tid_num=%d, tidq=0x%x, sch_inp_lsb=%d,%d last_bsr_lsb=%d, trigger_timeout_ms=%d 
+5142,iii,[ sched_algo_tx_mode.c : 3817 ] TX_MODE_SEL_ULMIMO_DBG bucket_idx:%d udp ingress: %d tcp ingress :%d 
+5143,,[ sched_algo_tx_mode.c : 3828 ] TX_MODE_SEL_ULMIMO_DBG masking mimo at t1  
+5144,,[ sched_algo_tx_mode.c : 3838 ] TX_MODE_SEL_ULMIMO_DBG masking mimo at t2  
+5145,iiiiiiiIi,[ sched_algo_tx_mode.c : 4165 ] TX_MODE_SEL: run_latency_aware_txmode_selection selected_bucket_idx=%d, selected_bucket_txmode_mask=%d, element_count=%d, total_psdu_dur=%d, max_num_candidate_across_txmode_buckets=%d, min_su_psdu_dur=%d, max_su_psdu_dur=%d, primary_user=%p, simplified_txmode=%d 
+5146,iiiii,[ sched_algo_tx_mode.c : 4339 ] TX_MODE_SEL_ULMIMO_DBG Total_latency: %d No of triggers required in 1 txop :%d No of triggers required for entied psdu:%d  Total_triggers including spill over:%d Total_overhead:%d  
+5147,iiiiiiiii,[ sched_algo_tx_mode.c : 4363 ] TX_MODE_SEL tx_mode=%d, total_psdu_dur_per_txmode=%d, n_adjusted_users=%d, adjusted_sum_psdu_dur=%d, max_txop_dur=%d, over_head=%d, exact_num_txop_1000x=%d, ceiled_num_txop=%d, total_latency=%d
+ 
+5148,iiiiii,[ sched_algo_tx_mode.c : 4377 ] TX_MODE_SEL ac=%d, selected_tx_mode=%d, latency=%d, max_users=%d, element_count=%d, chan_access_lat=%d 
+ 
+5149,ii,[ sched_algo_tx_mode.c : 529 ] Candidate list: Num entries = %d, TX_MODE = %d 
+5150,iiiiii,[ sched_algo_tx_mode.c : 1308 ] OFDMA_SCHED_DECISION: aid: %d, cur_time_ms: %d, use_ul_su_phy_rate: %d, avg_ul_su_phy_rate: %d, rix: %d, phy_rate_kbps: %d 
+5151,iiii,[ sched_algo_tx_mode.c : 1311 ] OFDMA_SCHED_DECISION: aid: %d, cur_time_ms: %d, ul_su_update_time: %d, ul_ofdma_trig_time: %d 
+5152,iiii,[ sched_algo_tx_mode.c : 1355 ] OFDMA_SCHED_DECISION: aid: %d, psd_boost_ref_phy_rate: %d, ul_max_nss: %d, ul_max_bw: %d 
+5153,iiiiiiiii,[ sched_algo_tx_mode.c : 2488 ] TX_MODE_SEL: sched_algo_install_tidq_container tx_mode_selection_type=%d, list_type=%d, primary_user=%d, tid_num=%d, txmode_mask=%d, txtime_us=%d, bucket_index=%d, max_tidq_containers_per_bucket=%d, run_for_all_users=%d 
+5154,ii,[ sched_algo_tx_mode.c : 3934 ] TX_MODE_SEL: Disable MUMIMO txmode as min duration %d is less than %d 
+5155,Ii,[ sched_algo_sawf_utils.c : 632 ] SAWF_TPUT: g_ingress_total_bytes 0x%x curr_time_us %d  
+5156,IIIII,[ sched_algo_tbr.c : 227 ] tbr_dbg: tbr_construct_cl_super_cycle:peer_id=%u, START_TSF msb=%u, lsb=%u, peer_end_tsf msb=%u, lsb=%u 
+5157,I,[ sched_algo_tbr.c : 248 ] tbr_dbg: tbr_construct_cl_super_cycle not in time peer_id=%u 
+5158,,[ sched_algo_tbr.c : 48 ] WAL_MGMT_TID TID NULL 
+5159,,[ wlan_atf.c : 92 ] ATF_DBG : Invalid group command version 
+ 
+5160,iii,[ wlan_atf.c : 109 ] GRP_PRI_DBG: group_atf_percent: %d, group_id: %d  ssid_pri_atf_grp_id: %d  
+5161,II,[ wlan_atf.c : 171 ] ATF_DBG: ATF WAL PEER MAC: 0x%08x 0x%08x NOT FOUND! 
+ 
+5162,iii,[ wlan_atf.c : 304 ] GRP_SSID_DBG: peer id %d, ATF_PEER_PERCENT(qcache_peer) %d, atf_grp->group_id  %d 
+5163,,[ wlan_atf.c : 517 ] ATF_DBG:WMI_VDEV_ATF_REQUEST_CMDID is obsolete. Use WMI_PEER_ATF_REQUEST_CMDID instead 
+5164,ii,[ wlan_atf.c : 539 ] ATF_DBG:WMI Entry: %d ATF-UNITS: %d
+ 
+5165,ii,[ wlan_atf.c : 565 ] ATF_DBG : full_update: %d pending_cmds: %d 
+ 
+5166,,[ wlan_atf.c : 679 ] ATF_DBG : WMI_PEER_ATF_EXT_REQUEST_CMDID is not applicable for 512 peer mode 
+ 
+5167,II,[ wlan_atf.c : 711 ] ATF_DBG:ATF PEER MAC: 0x%08x 0x%08x 
+ 
+5168,,[ wlan_atf.c : 739 ] ATF_DBG:Invalid WMI command
+ 
+5169,iiiiii,[ wlan_latency_config.c : 41 ] LATENCY_CFG: peerid: %d tid_num: %d latency_tid_info: %d latency_info->service_interval: %d burst_size_diff: %d burst_size_sum: %d  
+5170,iiiiI,[ wlan_latency_config.c : 129 ] LATENCY_CFG: peer_id: %d, tid_num: %d, swap_state->service_interval: %d, swap_state->burst_size: %d lat_set: %u 
+5171,iii,[ wlan_latency_config.c : 134 ] LATENCY_CFG: peer_id: %d, tid_num: %d delay_bound: %d 
+5172,iiiiI,[ wlan_latency_config.c : 142 ] LATENCY_CFG: peer_id: %d, tid_num: %d, state->service_interval: %d, state->burst_size: %d lat_set: %u 
+5173,iii,[ wlan_latency_config.c : 153 ] LATENCY_CFG: peer_id: %d, tid_num: %d, delay_bound: %d 
+5174,iiI,[ wlan_latency_config.c : 198 ] LATENCY_CFG: peer_id: %d, tid_num: %d, min_tput: 0x%x resetting deterministic basic trigger params 
+5175,III,[ wlan_latency_config.c : 324 ] SAWF_DBG: Ignoring UL trigger set for peer %u ac %u tid %u 
+5176,ii,[ mu_gid_mgmt.c : 94 ] 11ac MU-MIMO GID MGMT: user successfully assigned completed: SW_PEER_ID: %d, mu_user_id: %d 
+5177,iii,[ mu_gid_mgmt.c : 112 ] 11ac MU-MIMO GID MGMT: Send GID MGMT failed. SW_PEER_ID: %d, mu_user_id: %d, status: %d 
+5178,iiIIIIII,[ mu_gid_mgmt.c : 158 ] 11ac MU-MIMO GID MGMT: Sending GID MGMT frame: SW_PEER_ID: %d, mu_user_id: %d, grp_status[0]: 0x%08x, grp_status[1]: 0x%08x, user_pos_map[0]: 0x%08x, user_pos_map[1]: 0x%08x, user_pos_map[2]: 0x%08x, user_pos_map[3]: 0x%08x 
+5179,ii,[ mu_gid_mgmt.c : 165 ] 11ac MU-MIMO GID MGMT: Send GID MGMT failed. SW_PEER_ID: %d, mu_user_id: %d 
+5180,,[ sched_algo_mu.c : 211 ] MBSSID_CTRL_FRM_DBG : Calling for ul mumimo trig frames 
+ 
+5181,iiiiiii,[ sched_algo_ul_mumimo.c : 644 ] UL_MUMIMO_PIH_DBG, Before PIH, AID:%d, nss:%d, mcs:%d, bw:%d, target_rssi:%d, uncapped_target_rssi:%d, uph:%d 
+ 
+5182,iiiii,[ sched_algo_ul_mumimo.c : 918 ] UL_MUMIMO_PIH_DBG, **UPH** Use UPH for weak user, weak_user_AID:%d, nss:%d, mcs:%d, excess_pwr:%d, uph:%d 
+ 
+5183,iiiiii,[ sched_algo_ul_mumimo.c : 951 ] UL_MUMIMO_PIH_DBG, **Power** Power dropped for strong user, strong_user_AID:%d, intf_adjust_pwr:%d, old_pwr:%d, new_pwr:%d, mcs:%d, remaining_excess_pwr:%d 
+ 
+5184,iii,[ sched_algo_ul_mumimo.c : 979 ] UL_MUMIMO_PIH_DBG, **MCS** mcs dropped for weak user, weak_user_AID:%d, old_mcs:%d, new_mcs:%d 
+ 
+5185,iiiii,[ sched_algo_ul_mumimo.c : 997 ] UL_MUMIMO_PIH_DBG, After PIH, AID:%d, target_rssi:%d, nss:%d, mcs:%d, adjust_mcs:%d 
+ 
+5186,IiIiii,[ sched_algo_ul_mumimo.c : 1905 ] UL_MUMIMO_DBG allocate1: peer=0x%x, tid_num=%d, tx_bw_mask=0x%x, ru_size_20=%d, ru_index_20=%d, stream_offset_20=%d 
+5187,iiiiii,[ sched_algo_ul_mumimo.c : 1916 ] UL_MUMIMO_DBG allocate2: ru_size_40=%d, ru_index_40=%d, ru_size_80=%d, ru_index_80=%d, stream_offset_40=%d, stream_offset_80=%d 
+5188,iiii,[ sched_algo_ulmu_grouping.c : 477 ] UL_MUMIMO_DBG: sched_algo_construct_ulmu_candidate_table. group size %d, max_intf_nss %d, tid_list_num_candidates: %d limit_1ss_rates:%d 
+5189,i,[ sched_algo_ulmu_grouping.c : 581 ] UL_MUMIMO_DBG: sched_algo_construct_ulmu_candidate_table. number of entries added %d 
+5190,i,[ sched_algo_ulmu_grouping.c : 1010 ] UL_MUMIMO_DBG: truncate UL MU-MIMO candidate list. num_entries %d 
+5191,i,[ sched_algo_ulmu_grouping.c : 1055 ] UL_MUMIMO_DBG: max_mu_grp_sz: %d 
+5192,iiii,[ sched_algo_ulmu_grouping.c : 1474 ] TXMODESEL_ULMIMO_DBG avg_ulmu_rate:%d avg_ulsu_rate:%d inverse_mu_phy_efficiency:%d avg num users:%d  
+5193,iiii,[ sched_algo_ul_mu_mimo_dbg.c : 74 ] ULMU_DENYLIST_STATS: ulmu_trig_mpdu_failed:%d, ulmu_trig_denylisted;%d, ulmu_consecutive_trig_failure:%d, ulmu_trig_bitmap_failure:%d  
+5194,III,[ sched_algo_ul_mu_mimo_dbg.c : 236 ] ULMU_PRINT: [Category: %u ] Total trigger %u:%u 
+5195,iiii,[ sched_algo_ul_mu_mimo_dbg.c : 256 ] ULMU_PRINT: ulmu_cts2self_seq_posted:%d,ulmu_traffic_classification_low :%d,ulmu_traffic_classification_med:%d, ulmu_traffic_classification_high:%d  
+5196,IIIIIII,[ txbf_mimo_subf_scheduler.c : 1629 ] CV_QUERY seq_type %u, peer_id %u, usr_idx %u, num_users %u, cv_query_status %u, cv_flags %u, txbf_flags %u. 
+5197,IIIII,[ txbf_mimo_cbf_handler.c : 281 ] cbf_mimo_ctrl SW Peer ID %u, Preamble %u, BUF_IDX %u, punc_bitmap:%x punc_bmap_w0:%x. 
+5198,IIIIIIII,[ txbf_mimo_cbf_handler.c : 293 ] cbf_mimo_ctrl NR %u, NC %u, FB %u, BW_FP %u, NG %u, CB %u, BUF_IDX %u, ASNR %u. 
+5199,IIII,[ txbf_mimo_cbf_handler.c : 307 ] cbf_mimo_ctrl NC index mismatch. SW_PEER_ID: %u, PEER_NC: %u, CV_NC: %u, Total Mismatch: %u. 
+5200,IIII,[ txbf_mimo_cbf_handler.c : 422 ] cbf_mimo_ctrl Incorrect CV push. SW_PEER_ID: %u, PEER_NC: %u, NUM_CV_STORED: %u, NC_REQUIRED: %u. 
+5201,i,[ hca_HwComponentBbBase_debug.cpp : 238 ] PHYDBG: HWS phyDbgGetCsrCapInfo recipe fail phyId: %d 
+5202,iii,[ hca_HwComponentBbBase_debug.cpp : 263 ] PHYDBG: TxGainCtrl recipe status %d, chainmsk %d, gainIdx %d 
+5203,ii,[ hca_HwComponentBbBase_debug.cpp : 899 ] PHYDBG: capturestop recipe Status %d phyId:%d 
+5204,i,[ hca_HwComponentBbBase_debug.cpp : 901 ] PHYDBG: capturestop recipe fail phyId:%d 
+5205,,[ hca_HwComponentBbBase_debug.cpp : 1289 ] adcCapture memory alloc failed 
+5206,IiIIIII,[ hca_HwComponentBbBase_debug.cpp : 1298 ] adcCapture buffer_size(%u) Started(%d) adc_buf vir(%p) phy(%p) durtaion(%u) trig(%u) frame(%x) 
+5207,,[ hca_HwComponentBbBase_debug.cpp : 1322 ] New_Phydbg_Capture: Invalid phyInput 
+5208,i,[ hca_HwComponentBbBase_debug.cpp : 1329 ] New_Phydbg_Capture: Clearing bank Bank Mask %d 
+5209,i,[ hca_HwComponentBbBase_debug.cpp : 1577 ] QDSS: eventmask: %d 
+5210,i,[ hca_HwComponentBbBase_debug_core.cpp : 68 ] PHYDBG: HWS phyDbgCapture recipe fail phyId %d 
+5211,i,[ hca_HwComponentBbBase_debug_core.cpp : 85 ] PHYDBG: HWS phyDbgCapture recipe fail phyId %d 
+5212,i,[ hca_HwComponentBbBase_debug_core.cpp : 101 ] PHYDBG: HWS phyDbgCapture recipe fail phyId %d 
+5213,iiiiiIiii,[ hca_HwComponentBbBase_dfs_phyerr_tlv.cpp : 187 ] DFS_DUMPS ts=%d fft_num=%d radar_check=%d total_gain=%d base_pwr=%d peak_sidx=%i relpwr=%d peak_mag=%d num_str_bins_ib=%d 
+5214,iiIiiiiii,[ hca_HwComponentBbBase_dfs_phyerr_tlv.cpp : 226 ] DFS_DUMPS ts=%d diff_ts=%d sidx=%i dur=%d chirp=%d det=%d radar_check=%d agc_event=%d rssi=%d  
+5215,iiii,[ hca_HwComponentBbBase_dfs_phyerr_tlv.cpp : 232 ] DFS_DUMPS delta_peak=%d delta_diff=%d total_gain=%d is_max_pw=%d  
+5216,I,[ hca_HwComponentBbBase_dfs_phyerr_tlv.cpp : 496 ] ic=%p, or curchan is null 
+5217,,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 170 ] dfs is NULL 
+5218,II,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 230 ] FFT_RAW %p 0x%x 
+5219,II,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 234 ] FFT_RAW %p 0x%x 
+5220,II,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 236 ] FFT_RAW %p 0x%x 
+5221,II,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 237 ] FFT_RAW %p 0x%x 
+5222,iii,[ hca_HwComponentBbBase_dfs_process_phyerr.cpp : 411 ] DFS_DUMP process_multiple_ring_element pHandle=%d ipc_ring_id=%d num_bufs=%d 
+5223,,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 487 ] dfs is NULL 
+5224,i,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 493 ] DFS_DUMPS radar event on non-DFS chan %d 
+5225,,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 562 ] event is NULL  
+5226,i,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 580 ] DFS_DUMPS Rejecting. Radar injected in non-DFS channel, freq offset=%d 
+5227,iIIII,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 746 ] PHYERR# = %d ts = %u  diff_ts = %u ppdu_rssi = %u dur = %u 
+5228,iiiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 750 ] is_hw_chirp = %d segid = %d sidx = %d peak_mag = %d delta_peak = %d  
+5229,iiiIi,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 754 ] delta_diff = %d agc_total_gain = %d agc_mb_gain = %d radar_subchan_mask = 0x%x pulse_height = %d 
+5230,iiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 758 ] triggering_agc_event = %d rs_pulse_rssi = %d pri80_inband_power = %d ext80_inband_power = %d 
+5231,IIIII,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 761 ] ts =%u re.re_dur=%u re.re_rssi =%u diff =%u pl->pl_lastelem.p_time=%lu 
+5232,Iiiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 817 ] ic_flags=0x%x, MHz separation=%d Peak Idx=%d,re_dur=%d,diff_ts=%d 
+5233,Iiiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 841 ] ic_flags=0x%x,MHz Separation=%d,Peak Index =%d,re_dur=%d,diff_ts=%d 
+5234,i,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 880 ] DFS_DUMPS Not a BIN5 pulse (dur=%d) 
+5235,ii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 917 ] DFS_DUMPS Rejecting pulses on rssi=%d, thresh=%d 
+5236,IiI,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 928 ] DFS_DUMPS Rejecting on pri deltaT=%lld this_ts =%d ft_minpri=%u 
+5237,iIIi,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 947 ] DFS_DUMPS filterID= %d:Rejecting on individual filter min PRI deltaT=%lld rf->rf_minpri=%u this_ts=%d 
+5238,iII,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 959 ] filterID= %d : Rejecting on individual filter max PRI deltaT=%lld rf->rf_minpri=%u 
+5239,iII,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 993 ] filterID= %d : Rejecting on individual filter max PRI deltaT=%lld rf->rf_minpri=%u 
+5240,iii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1053 ] DFS_DUMPS Found on channel minDur = %d, filterId = %d  seg_id = %d 
+5241,iiiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1126 ] DFS_DUMPS Radar Found with Filter Id = %d min dur=%d sidx=%d freq_offset=%d chan_width =%d 
+5242,iiiii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1128 ] DFS_DUMPS Radar Found Min dur =%d Max dur =%d Radar pulse threshold =%d Min pri =%d Max pri =%d 
+5243,ii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1135 ] CHANNEL_CLOSE radarevent dfs_test_mode=%d detection_mode=%d 
+5244,i,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1143 ] DFS_IN_FTM: Radar found on Primary detector freq %d 
+5245,i,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 1223 ] DFS_DEBUGS false_radar dfs->dfs_seq_num =%d 
+5246,III,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 312 ] DFS_DUMPS Rejecting Radar. Delta peak values are invalid : dl_delta_peak_match_count=%lu, dl_psidx_diff_match_count=%lu, rf_threshold=%lu 
+5247,Ii,[ hca_HwComponentBbBase_dfs_process_radarevent.cpp : 317 ] DFS_DUMPS Rejecting Radar. Duration diff %ld is > MAX_DIFF_DUR %d 
+5248,iiii,[ hca_HwComponentBbBase_pcss.cpp : 380 ] Pcss M3 Warm Reset Reason: %d, Reset Counter: %d isReset: %d warmResetPending: %d 
+5249,,[ hca_HwComponentBbBase_pcss.cpp : 461 ] PhyErrorCommand: Ucode hasn't consumed the events 
+5250,ii,[ hca_HwComponentBbBase_reset.cpp : 348 ] WarmReset MAC|PHYID=%d CF_ACTIVE=%d 
+5251,i,[ hca_HwComponentBbBase_reset.cpp : 354 ] SSR in progress on phyid:%d 
+5252,Ii,[ hca_HwComponentBbBase_reset.cpp : 372 ] WarmReset Cause = 0x%x|phyid = %d 
+5253,iii,[ hca_HwComponentBbIpq5424_ani.cpp : 60 ] STR_DET_WAR ERROR RATE %d < %d THR %d 
+5254,iii,[ hca_HwComponentBbIpq5424_ani.cpp : 94 ] STR_DET_WAR ERROR RATE %d > %d THR %d 
+5255,i,[ hca_HwComponentBbIpq5424_ani.cpp : 111 ] STR_DET_WAR ERROR RATE CONSECUTIVE LESS ERROR Reset Regs THR %d 
+5256,iIiIIIIII,[ hca_HwComponentBbIpq5424_ani.cpp : 232 ] ANI_EDCCA_PHYID%d MAX_ED_CCA=0x%x dynamicEdcca%d ED_A_VAL=0x%x ED_A_U_VAL=0x%x ED_B_VAL=0x%x ED_B_U_VAL=0x%x ED_C_VAL=0x%x ED_C_U_VAL=0x%x 
+5257,iiiii,[ hca_HwComponentBbIpq5424_debug.cpp : 66 ] PHYDBG: HWS PcssClkConfig recipe status: %d phyId: %d, clk_en: %d, phy_disable: %d, mac_tracer_disable: %d 
+5258,iii,[ hca_HwComponentBbIpq5424_debug.cpp : 84 ] PHYDBG: HWS GetCWRssiConfig recipe status: %d phyId: %d, rssi: %d 
+5259,ii,[ hca_HwComponentBbIpq5424_debug.cpp : 140 ] PHYDBG: HWS ReadRegs recipe status: %d phyId: %d 
+5260,I,[ hca_HwComponentBbIpq5424_debug.cpp : 276 ] REG DUMP: Started Selective PHY REGs store to buffer: 0x%08x 
+5261,i,[ hca_HwComponentBbIpq5424_debug.cpp : 292 ] length of the reg dump= %d 
+5262,III,[ hca_HwComponentBbIpq5424_debug.cpp : 387 ] phydbg : capture_event_mask:0x%x capture_destination:0x%x phydbg_mode:0x%x 
+5263,,[ hca_HwComponentBbIpq5424_debug.cpp : 405 ] Phydbg disabled. Skipping ADC capture 
+5264,ii,[ hca_HwComponentBbIpq5424_debug_core.cpp : 117 ] PHYDBG: HWS DumpAllRegisters recipe status: %d phyId: %d 
+5265,IIII,[ hca_HwComponentBbIpq5424_debug_core.cpp : 120 ] PHYDBG: CAPTURE_U 0x%lx , CAPTURE_L 0x%lx, PLAYBACK_0_L 0x%lx, PLAYBACK_0_U 0x%lx 
+5266,IIII,[ hca_HwComponentBbIpq5424_debug_core.cpp : 121 ] PHYDBG: PLAYBACK_1_L 0x%lx, TX_PRE_DESC_WR_1_L 0x%lx, ACTIVATION_CTRL_L 0x%lx, MODE_L 0x%lx 
+5267,III,[ hca_HwComponentBbIpq5424_debug_core.cpp : 122 ] PHYDBG: TRIGGER_0_L 0x%lx, TRIGGER_0_U 0x%lx, TRIGGER_1_L 0x%lx 
+5268,i,[ hca_HwComponentBbIpq5424_debug_core.cpp : 190 ] adc_capture_bitWidth %d 
+5269,i,[ hca_HwComponentBbIpq5424_dfs.cpp : 146 ] Sub band mask %d 
+5270,i,[ hca_HwComponentBbIpq5424_pcss.cpp : 55 ] PHY M3 Assert for PHY : %d 
+5271,IIII,[ hca_HwComponentBbIpq5424_pcss.cpp : 60 ] %c%c%c%c 
+5272,i,[ hca_HwComponentBbIpq5424_pcss.cpp : 73 ] PHY M3 Assert for PHY : %d 
+5273,IIII,[ hca_HwComponentBbIpq5424_pcss.cpp : 77 ] %c%c%c%c 
+5274,ii,[ hca_HwComponentBbIpq5424_pcss.cpp : 123 ] PCSS Version : Branch = %d, Build ID = %d  
+5275,,[ hca_HwComponentBbIpq5424_pcss.cpp : 167 ] Ipq5424_pcss::WriteBeaconRssiValueToVreg: Error Cannot Access Register in Sleep, return 
+5276,,[ hca_HwComponentBbIpq5424_preInit.cpp : 171 ] No BDF merge since one of the pointer is NULL or invalid length 
+5277,iiiiiiII,[ hca_HwComponentBbIpq5424_reset.cpp : 353 ] ResetPhyInputCommon: phyId %d bw %d mhz %d freq %d/%d dynPriChan %d txCM 0x%x rxCM 0x%x DFS En 
+5278,iiiIII,[ hca_HwComponentBbIpq5424_reset.cpp : 362 ] ResetPhyInputCommon: conc %d isSBS %d NF %d pwrMask 0x%x loadIniMask 0x%x BDF/Board_ID = 0x%x 
+5279,iIIIIIIII,[ hca_HwComponentBbIpq5424_reset.cpp : 399 ] ANI_DUMP_PHYID%d SAVE ANI DEFAULTS THR1A_DB=0x%x THR1B_DB=0x%x THR1C_DB=0x%x THR1D_DB=0x%x THR1A_EN=0x%x THR1B_EN=0x%x THR1C_EN=0x%x THR1D_EN=0x%x 
+5280,ii,[ hca_HwComponentBbIpq5424_reset.cpp : 682 ] M3_SSR:CheckIfPhyIsOff CF_active: %d readStatus: %d  
+5281,IIIIII,[ hca_HwComponentBbIpq5424_reset.cpp : 875 ] AVGCFO Print: delta_time %x, cur_cfo %x, old_cfo %x, new_cfo %x, %x, prgm to phy %x 
+5282,i,[ hca_HwComponentBbIpq5424_reset.cpp : 954 ] MMHostCmdForceRxGainTbl status rc = %d 
+5283,IIIIIII,[ hca_HwComponentBbIpq5424_rtt.cpp : 118 ] setswpeerIDAID:setVreg 0x%x,isImrEncrypted 0x%x,swPeerID 0x%x, aidRSID 0x%x, vregindex 0x%x, isAssoc 0x%x isLMRDelayedFeedback 0x%x  
+5284,i,[ hca_HwComponentBbIpq5424_spurMit.cpp : 108 ] SPUR_MIT: dynPriChn: %d 
+5285,iiii,[ hca_HwComponentBbIpq5424_spurMit.cpp : 177 ] SPUR_MIT: pri20Center: %d, sec20Center: %d spurDistFromPri20: %d spurDistFromSec20: %d 
+5286,iiii,[ hca_HwComponentBbIpq5424_spurMit.cpp : 188 ] SPUR_MIT: curSpurFreq1: %d, curSpurFreq2: %d curSpurFreq1Flag: %d, curSpurFreq2Flag: %d 
+5287,III,[ hca_HwComponentBbIpq5424_spurMit.cpp : 230 ] SPUR_MIT: numSpurs : %ld , 1stSpur : %ld , 2ndSpur : %ld 
+5288,,[ hca_HwComponentBbIpq5424_spurMit.cpp : 234 ] SPUR_MIT: receipe failure 
+5289,ii,[ phyrf_abi.c : 118 ] ABI_DUMP_PHYID%d ABI Enable status %d 
+5290,iii,[ phyrf_abi.c : 165 ] ABI STR_DET vlgt_max_gain %d vlgt_max_gain_ceil %d vlgt_max_gain_floor %d
+ 
+5291,iii,[ phyrf_abi.c : 166 ] ABI STR_DET lgt_max_gain %d lgt_max_gain_ceil %d lgt_max_gain_floor %d
+ 
+5292,iiiii,[ phyrf_abi.c : 322 ] ABI STR_DET 10MS ERROR RATE %d > %d convergence level %d LG MAX %d VLG MAX %d
+ 
+5293,iiiii,[ phyrf_abi.c : 340 ] ABI STR_DET 10MS ERROR RATE %d < %d level %d LG %d VLG %d
+ 
+5294,iiii,[ phyrf_abi.c : 383 ] ABI STR_DET ERROR RATE %d < %d LG %d VLG %d
+ 
+5295,ii,[ phyrf_abi.c : 432 ] ABI STR_DET reset to ceil value LG max %d VLG max %d 
+5296,iiiiiiii,[ phyrf_abi.c : 463 ] ABI STR_DET ERROR RATE %d > %d Set level %d analog_sat %d hold_mode %d hold_count %d LG MAX %d VLG MAX %d
+ 
+5297,ii,[ phyrf_abi.c : 503 ] ABI STR_DET reset to floor value LG max %d VLG max %d 
+5298,iiiiiii,[ phyrf_abi.c : 546 ] ABI STR_DET ERROR RATE CONSECUTIVE LESS ERROR Reset Regs prev %d level %d analog_sat %d hold_mode %d hold_count %d LG MAX %d VLG MAX %d 
+5299,iiii,[ phyrf_abi.c : 651 ] ANI-ABI-HIST phyId=%d, Last hist idx =%d, interval =%d ms, freq =%d 
+5300,,[ phyrf_abi.c : 653 ] ANI-ABI-HIST | Time delta ms | ABI level | analog_sat | hold_mode | LG_max_gain | VLG_max_gain | hold_count| Err rate| RO_RX_GAIN 
+5301,IIIIIIIII,[ phyrf_abi.c : 668 ] ANI-ABI-HIST |%15u|%11u|%12u|%11u|%13u|%14u|%11u|%9u|%11u 
+5302,iiiiii,[ phyrf_ani.c : 108 ] NFREAD%d PHYID=%d NFInDBr=%d NFInDBm=%d maxNumChain=%d maxNFInDBm=%d 
+5303,iii,[ phyrf_ani.c : 121 ] ANI_LOG: PHY Id %d ETSI Domain - maxNFInDBm=%d, DL_MAX value =%d 
+5304,iiii,[ phyrf_ani.c : 156 ] ANI_EDCCA_PHYID%d CHAIN%d NFBDF=%d NFRUNTIME=%d 
+5305,iiii,[ phyrf_ani.c : 207 ] eANI: rssi_comb_dBm %d nfbdf[0] %d nfbdf[1] %d maxnfbdf %d 
+5306,i,[ phyrf_ani.c : 230 ] eANI:dl_max_for_rssi %d 
+5307,iiii,[ phyrf_ani.c : 269 ] eANI: eAniMode %d updated_dl_max %d rssi_comb_dBm %d rssi_comb_dBm_NFComp %d 
+5308,i,[ phyrf_ani.c : 275 ] ANI_API_PHYID%d API: STR DET RECOVERY CONFIGURE 
+5309,iii,[ phyrf_ani.c : 315 ] vlgt_max_gain %d vlgt_max_gain_ceil %d vlgt_max_gain_floor %d
+ 
+5310,iiiiiii,[ phyrf_ani.c : 400 ] ANI DL max [%d]=%d, DL min [%d]=%d, error_threshold=%d, PollPeriod=%d, ListenPeriod=%d
+ 
+5311,iiii,[ phyrf_ani.c : 441 ] ANI_DUMP_PHYID%d DL_OFDM %d  DL_MIN %d DL_MAX %d 
+5312,I,[ phyrf_ani.c : 564 ] ANI_CHANNEL_CHANGE - resetCause=%x 
+5313,iii,[ phyrf_ani.c : 609 ] WBE_ANI phyId %d retflag %d Strong_detect_fail : %d 
+5314,iiiiiii,[ phyrf_ani.c : 799 ] WBE_ANI ofdmPhyErrCnt=%d, cckPhyErrCnt = %d, cck1PhyErrCnt = %d, cck2PhyErrCnt = %d, cck7PhyErrCnt = %d, lsigPhyErrCnt : %d sizing1 : %d  
+5315,iiiiiiii,[ phyrf_ani.c : 811 ] WBE_ANI retflag is %d, pAniParam->ofdmPhyErrCount=%d, cckPhyErrCount = %d, cck1PhyErrCount = %d, cck2PhyErrCount = %d, cck7PhyErrCount = %d, lsigPhyErrCount : %d,sizing1 : %d 
+5316,iiiiiii,[ phyrf_ani.c : 829 ] WBE_ANI cycleCnt=%d txFrameCnt=%d rxFrameCnt=%d cycleCounterKhz=%d prevcyclecounter_cycleCnt=%d prevcyclecounter_txFrameCnt=%d prevcyclecounter_rxFrameCnt=%d
+ 
+5317,iiii,[ phyrf_ani.c : 836 ] WBE_ANI cyclecount=%d txframecnt=%d rxframecnt=%d listen_time=%d 
+5318,ii,[ phyrf_ani.c : 881 ] eANI curEANIModeOrderIdx %d curEAniModeCnt %d 
+5319,i,[ phyrf_ani.c : 903 ] eANI Mode switch %d 
+5320,ii,[ phyrf_ani.c : 976 ] WBE_ANI phy_err_rate=%d mhz=%d 
+5321,iiiii,[ phyrf_ani.c : 988 ] ANI_LOG PHY%d POLL %dms LISTEN %dms: OFDM %d LSIG %d  
+5322,iiiiiiii,[ phyrf_ani.c : 991 ] ANI_LOG PHY%d CCK %d CCK1 %d CCK2 %d CCK7 %d SIZ1 %d M %d OFDM_DL -%d 
+5323,iiiiiiii,[ phyrf_ani.c : 995 ] ANI_LOG PHY%d CCK %d CCK1 %d CCK2 %d CCK7 %d SIZ1 %d M %d OFDM_DL %d 
+5324,iiii,[ phyrf_ani.c : 1149 ] ANI_DUMP_PHYID%d ANI Enable %d ABI Enable %d ANI Timer enable %d 
+5325,ii,[ phyrf_ani.c : 1196 ] ANI disabled! BDF value %d enable %d 
+5326,ii,[ phyrf_ani.c : 1220 ] ANI_DUMP_PHYID%d ANI Enable status %d 
+5327,i,[ phyrf_ani.c : 1252 ] ANI_EDCCA - State Change, cca_enable =%d 
+5328,iii,[ phyrf_ani.c : 1413 ] ANI_LOG PHYID%d STATIC_MODE prevMhz %d curMhz%d 
+5329,iii,[ phyrf_ani.c : 1422 ] ANI_LOG PHYID%d NORMAL_MODE prevMhz %d curMhz %d 
+5330,ii,[ phyrf_ani.c : 1475 ] ANI_DUMP_PHYID%d GET ANI STATE %d 
+5331,i,[ phyrf_ani.c : 1506 ] WBE_ANI Level= %d 
+5332,ii,[ phyrf_ani.c : 1602 ] ANI_DUMP_PHYID%d ERROR RATE < %d PERCENT 
+5333,iiii,[ phyrf_ani.c : 1615 ] ANI_DUMP_PHYID%d ERROR RATE > %d PERCENT INCREMENTING DESENSE LEVEL. dl_ofdm=%d dl_max=%d 
+5334,iii,[ phyrf_ani.c : 1648 ] ANI_DUMP_PHYID%d dl_ofdm=%d dl_min=%d 
+5335,ii,[ phyrf_ani.c : 1688 ] ANI_DUMP PHYID%d ramp_up_time %dms 
+5336,ii,[ phyrf_ani.c : 1708 ] ANI_DUMP PHYID%d ramp_down_time %dms 
+5337,iiii,[ phyrf_ani.c : 2026 ] ANI-VREG-ERR phyId=%d, Last hist idx =%d, interval =%d ms, freq =%d 
+5338,,[ phyrf_ani.c : 2032 ] ANI-VREG-ERR |rx_ofdma_timing_err | rx_cck_fail |mac_tx_abort | mac_rx_abort |phy_tx_abort | phy_rx_abort | phyrf_defer_abort| sizing1_evt | sizing2_evt 
+5339,IIIIIIIII,[ phyrf_ani.c : 2047 ] ANI-VREG-ERR |%20u|%13u|%13u|%14u|%13u|%14u|%18u|%13u|%13u 
+5340,,[ phyrf_ani.c : 2056 ] ANI-VREG-ERR |RX_PKT_CNT_11A |RX_PKT_CNT_11B |RX_PKT_CNT_11N |RX_PKT_CNT_11AC |RX_PKT_CNT_11AX |RX_PKT_CNT_GF 
+5341,IIIIII,[ phyrf_ani.c : 2068 ] ANI-VREG-ERR |%15u|%15u|%15u|%16u|%16u|%14u 
+5342,,[ phyrf_ani.c : 2077 ] ANI-VREG-ERR |RX_PKT_CRC_PASS_CNT_11A |RX_PKT_CRC_PASS_CNT_11B |RX_PKT_CRC_PASS_CNT_11N |RX_PKT_CRC_PASS_CNT_11AC |RX_PKT_CRC_PASS_CNT_11AX |RX_PKT_CRC_PASS_CNT_GF 
+5343,IIIIII,[ phyrf_ani.c : 2089 ] ANI-VREG-ERR |%24u|%24u|%24u|%25u|%25u|%23u 
+5344,,[ phyrf_ani.c : 2098 ] ANI-VREG-ERR |LSIG_ERROR | HTSIG_ERROR |VHTSIG_ERROR |HESIG_ERROR |RXTD_OTA |RXTD_FATAL |TXFD |TXTD |PHYRF 
+5345,IIIIIIIII,[ phyrf_ani.c : 2113 ] ANI-VREG-ERR |%11u|%13u|%13u|%12u|%9u|%11u|%5u|%5u|%5u 
+5346,,[ phyrf_ani.c : 2122 ] ANI-VREG-ERR |VOTING_FAIL |WEAK_DET_FAIL |STRONG_SIG_FAIL |CCK_FAIL |POWER_SURGE |BTCF_TIMING |BTCF_PACKET_DETECT |COARSE_TIMEOUT 
+5347,IIIIIIII,[ phyrf_ani.c : 2136 ] ANI-VREG-ERR |%12u|%14u|%16u|%9u|%12u|%12u|%19u|%14u 
+5348,I,[ phyrf_ani.c : 2145 ] ANI-VREG-ERR - Invalid Error TYPE = %x 
+5349,ii,[ phyrf_ani.c : 2175 ] OfdmLevel phyID=%d, aniEnabled=%d 
+5350,,[ phyrf_ani.c : 2183 ] CckLevel : CCK feature not yet enabled for Beryllium architecture  
+5351,ii,[ phyrf_ani.c : 2208 ] ANI_DUMP_PHYID%d AniEnableStatus=%d 
+5352,i,[ phyrf_ani.c : 2240 ] ANI_LOG SetWmiTimestamp- Invalid cmd_evt value =%d 
+5353,i,[ phyrf_ani.c : 2278 ] ANI_FTM: FTM ANI Flow is Not proper, Expected Value TRUE, ActualValue=%d  
+5354,ii,[ phyrf_ani.c : 2297 ] ANI_FTM: PollPeriod=%d, ListenPeriod=%d 
+5355,iii,[ phyrf_ani.c : 2324 ] ANI_FTM: g_ani_ftm_running=%d, ani_trigger[%d]=%d 
+5356,iiiiiiiii,[ phyrf_ani.c : 2367 ] ANI_FTM : listen_time=%d error_threshold=%d ofdmPhyErrCount=%d cckPhyErrCount=%d lsigPhyErrCount=%d ofdm_phy_err_rate=%d dl_ofdm=%d min=%d max=%d 
+5357,IIIi,[ phyrf_ann_powerboost.c : 194 ]  PowerBoost: send_cfg_flags 0x%x, mcs %u, ppdu_duration %u, XmitTrainingFrame status %d
+ 
+5358,iii,[ phyrf_ann_powerboost.c : 262 ] powerboost_stateHdlr : pbtFeature %d , g_ann_pbt_host_ready %d, memIndStatus %d 
+5359,iiiii,[ phyrf_ann_powerboost.c : 324 ] PaprdPerPacketTpcStats : paprd_tgt_pwr %d, paprd_meas_pwr %d, paprd_dac_gain %d, paprd_tx_gain_idx %d, paprd_clpc_err %d 
+5360,iiiiiii,[ phyrf_ann_powerboost.c : 464 ] StartTraining : reset %d, trainingDone %d, trainingPktBw %d, trainingPktMcs %d,isTrainingRequired %d, trainingStage %d, chainIdx %d 
+5361,ii,[ phyrf_ann_powerboost.c : 556 ] powerboost_TxCompletionHdlr : status %d, retry_training %d 
+5362,iiii,[ phyrf_ann_powerboost.c : 1158 ] powerboost_status_evt : training_stage %d, mcs %d, bandwidth %d, size %d 
+5363,i,[ phyrf_ann_powerboost.c : 1301 ] powerboost_stateHdlr : trainingState %d 
+5364,,[ phyrf_ann_powerboost.c : 1306 ] pbtFeature disabled 
+5365,iiii,[ phyrf_ann_powerboost.c : 684 ] evm_kpi_per_mcs %d, evm_error_margin %d, evm_slope %d, tx_pwr_per_chain %d 
+5366,iii,[ phyrf_ann_powerboost.c : 689 ] mask_error_margin %d, mask_slope %d, m_margin_off_per_mcs %d 
+5367,iiiiii,[ phyrf_ann_powerboost.c : 698 ] powerboost_first_stage_computation : estimated_power_evm %d, estimated_power_mask %d, estimated_tx_evm %d, estimated_tx_mask %d, PktBw %d, mcs %d 
+5368,iiiiiii,[ phyrf_ann_powerboost.c : 769 ] Second stage training : trainingPktBw %d, trainingPktMcs %d, estimated_power_evm %d, estimated_power_mask %d, estimated_tx_mask %d, estimated_tx_evm %d, boosted_power %d 
+5369,iiiiii,[ phyrf_ann_powerboost.c : 643 ] powerboost_ComputeFinalPBOffset : mcs_idx %d, phyrfAnnPbwGroupVal %d, tx_pwr_per_chain[%d] %d, boostPwr %d, iOffset %d 
+5370,iiIi,[ phyrf_bdf_v2.c : 1242 ] GetTpcMaxTxPwr: phyId %d txCM %d rcFlags 0x%x tpc_max_tx_power %d 
+5371,i,[ phyrf_bdf_v2.c : 2072 ] phyrf_bdf_SetBoardCalVersion: New CalVersion %d is programmed 
+5372,,[ phyrf_bdf_v2.c : 2075 ] phyrf_bdf_SetBoardCalVersion: SwCalVersion is zero, if MergeBDF() not executed due to NO-caldata in the board. 
+5373,iiiiiiii,[ phyrf_bdf_v2.c : 2527 ] phyrf_bdf_GetSignalLevel (combRssi = FALSE) - FlatIdx: [%d], iChain: [%d], ccaOrder: [%d], rssi_in_dbm: %d, rssi_in_db: %d, nfPerSubbandPerChain: %d, rssiSpurOffset: %d, rssiOffset: %d 
+5374,iiiii,[ phyrf_bdf_v2.c : 2562 ] phyrf_bdf_GetSignalLevel (combRssi = TRUE) - rssi_in_dbm: %d, rssi_in_db: %d, nfComb: %d, rssiSpurOffset: %d, rssiOffset: %d 
+5375,,[ phyrf_bdf_v2.c : 2857 ] DISPLAY_AOA_EVT: returned null 
+5376,ii,[ phyrf_bdf_v2.c : 3040 ] CustBoardSpecificFlags : flagBitNum %d flag_enabled %d 
+5377,I,[ phyrf_bdf_v2.c : 3662 ] Set_BDFVersion:WARNING: OTP fused: projectID: 0x%x 
+5378,i,[ phyrf_bdf_v2.c : 3663 ] Set_BDFVersion: status = %d
+ 
+5379,,[ phyrf_bdf_v2.c : 3678 ] Set_BDFVersion: Feature support unavailable 
+5380,ii,[ phyrf_bdf_v2.c : 3703 ] BDFVersion: SW major : %d , SW minor : %d 
+5381,I,[ phyrf_bdf_v2.c : 3709 ] BDFVersion: meta: %u 
+5382,I,[ phyrf_bdf_v2.c : 3723 ] BDFVersion: ProjectID: 0x%x 
+5383,,[ phyrf_bdf_v2.c : 3728 ] BDFVersion:OPERATION UNALLOWED  
+5384,,[ phyrf_bdf_v2.c : 3742 ] BDFVersion: Feature support unavailable 
+5385,iii,[ phyrf_bdf_v2.c : 3871 ] iwconfig_logs : phyrf_bdf_GetChainmaskMaxPwr : RateIndex=%d BW=%d Best Power Chainmask=%d 
+5386,ii,[ phyrf_bdf_v2.c : 4178 ] [LPI_CM_LIMIT]: phyrf_bdf_GetMaxPwrChainMask : ridx=%d chainmask=%d 
+5387,i,[ phyrf_bdf_v2.c : 4470 ] TPC_DUMP DumpTpcPerPacket : RATE_DUP_CCK, rtIdx=%d
+ 
+5388,i,[ phyrf_bdf_v2.c : 4475 ] TPC_DUMP DumpTpcPerPacket : RATE_DUP_OFDM, rtIdx=%d
+ 
+5389,i,[ phyrf_bdf_v2.c : 4480 ] TPC_DUMP DumpTpcPerPacket : RATE_EXT_CCK, rtIdx=%d
+ 
+5390,i,[ phyrf_bdf_v2.c : 4485 ] TPC_DUMP DumpTpcPerPacket : RATE_EXT_OFDM, rtIdx=%d
+ 
+5391,i,[ phyrf_bdf_v2.c : 4490 ] TPC_DUMP DumpTpcPerPacket : RATE_XR, rtIdx=%d
+ 
+5392,ii,[ phyrf_bdf_v2.c : 4497 ] TPC_DUMP DumpTpcPerPacket : RATE_RU_OTHER MCS%d, rtIdx=%d
+ 
+5393,ii,[ phyrf_bdf_v2.c : 4502 ] TPC_DUMP DumpTpcPerPacket : RATE_RU106 MCS%d, rtIdx=%d
+ 
+5394,ii,[ phyrf_bdf_v2.c : 4507 ] TPC_DUMP DumpTpcPerPacket : RATE_RU52 MCS%d, rtIdx=%d
+ 
+5395,ii,[ phyrf_bdf_v2.c : 4512 ] TPC_DUMP DumpTpcPerPacket : RATE_RU26 MCS%d, rtIdx=%d
+ 
+5396,iiii,[ phyrf_bdf_v2.c : 4521 ] TPC_DUMP DumpTpcPerPacket : WHAL_MOD_IEEE80211_T_CCK, Rate=%dMbps, NSS=%d, rtIdx=%d, RateIndex value in wal_rate.c=%d
+ 
+5397,iiii,[ phyrf_bdf_v2.c : 4527 ] TPC_DUMP DumpTpcPerPacket : WHAL_MOD_IEEE80211_T_OFDM, Rate=%dMbps, NSS=%d, rtIdx=%d, RateIndex value in wal_rate.c=%d
+ 
+5398,i,[ phyrf_bdf_v2.c : 4621 ] TPC_DUMP DumpTpcPerPacket : Invalid PHY premable ,rtIdx=%d
+ 
+5399,iiiii,[ phyrf_bdf_v2.c : 4627 ] TPC_DUMP DumpTpcPerPacket : %d, Rate=MCS%d, NSS=%d, rtIdx=%d, RateIndex value in wal_rate.c=%d
+ 
+5400,,[ phyrf_bdf_v2.c : 4839 ] TPC_DUMP DumpTpcPerPacket : Invalid PHY premable
+ 
+5401,iiiiiii,[ phyrf_bdf_v2.c : 5020 ] TPC_HM updated phyID %d cur_idx %d latest_glut_idx %d tx_pwr_perchain %d latest_tgt_pwr %d rateCode %d rtIdx %d  
+5402,iiiiiiii,[ phyrf_bdf_v2.c : 5033 ] TPC_HM_FILTER phyID %d latest_glut_idx %d tx_pwr_perchain %d latest_tgt_pwr %d rateCode %d rtIdx %d pwrdel %d tgtdel %d 
+5403,,[ phyrf_bdf_v2.c : 5049 ] TPC_HM: Abnormality in GLUT pickup Tx pwr increase case 
+5404,iii,[ phyrf_bdf_v2.c : 5053 ] TPC_HM: Abnormality latest_tgt_pwr[prev] %d latest_glut_idx[prev] %d latest_dac_gain[prev] %d 
+5405,iii,[ phyrf_bdf_v2.c : 5057 ] TPC_HM: Abnormality latest_tgt_pwr[cur] %d latest_glut_idx[cur] %d latest_dac_gain[cur] %d 
+5406,,[ phyrf_bdf_v2.c : 5065 ] TPC_HM: Abnormality in GLUT pickup Tx pwr decrease case 
+5407,iii,[ phyrf_bdf_v2.c : 5069 ] TPC_HM: Abnormality latest_tgt_pwr[prev] %d latest_glut_idx[prev] %d latest_dac_gain[prev] %d 
+5408,iii,[ phyrf_bdf_v2.c : 5073 ] TPC_HM: Abnormality latest_tgt_pwr[cur] %d latest_glut_idx[cur] %d latest_dac_gain[cur] %d 
+5409,i,[ phyrf_bdf_v2.c : 5134 ] SETTGTR2PTABLE return status %d
+ 
+5410,i,[ phyrf_bdf_v2.c : 5184 ] HC DEBUG GetHCMcsOffsetMap: HC CTL invalid phyID - %d 
+5411,iiiiii,[ phyrf_bdf_v2.c : 5608 ] DumpCalDoneMask: fullPointCalDoneMask5G=%d fullPointCalDoneMask2G=%d fullPointCalDoneMask6G=%d onePointCalDoneMask5G=%d onePointCalDoneMask2G=%d onePointCalDoneMask6G=%d 
+5412,iiiiii,[ phyrf_bdf_v2.c : 5617 ] DumpCalDoneMask: rxGainCalDoneMask5G=%d rxGainCalDoneMask2G=%d rxGainCalDoneMask6G=%d nfCalDoneMask5G=%d nfCalDoneMask2G=%d nfCalDoneMask6G=%d 
+5413,iiiii,[ phyrf_bdf_v2.c : 5625 ] DumpCalDoneMask: fullPointCalDoneMask=%d onePointCalDoneMask=%d rxGainCalDoneMask=%d  nfCalDoneMask=%d xtalCalDoneMask=%d 
+5414,ii,[ phyrf_bdf_v2.c : 5842 ] EnablePwrSaveReduction: Invalid Value =%d, (Max supported is MAX_TPC_POWER_REDUCTION_APPS=%d) 
+5415,iiiiiiii,[ phyrf_bdf_v2.c : 6164 ] iwconfig_logs : phyrf_bdf_GetRateTPCPerChain_Ext: tx_mode: %d rtIdx: %d rcFlags: %d tgtPwr: %d ctlPwr: %d regPwr: %d usrPwr: %d finalPwr: %d 
+5416,iiiii,[ phyrf_bdf_v2.c : 6313 ] ConfigTxPower TPSCALE phyId %d chan %d tpscale %d maxTxPower %d bHomeChan %d 
+5417,i,[ phyrf_bdf_v2.c : 6318 ] ConfigTxPower ANTENNA_GAIN ant_gain %d 
+5418,iiiiii,[ phyrf_bdf_v2.c : 6377 ] ConfigTxPower USER_POWER/CHANNEL_POWERLIMIT power %d, perChainPwr %d, flag %d, signedPwr %d, powerLimit2G %d powerLimit5G %d 
+5419,,[ phyrf_bdf_v2.c : 6382 ] ConfigTxPower Error: Invalid args 
+5420,ii,[ phyrf_bdf_v2.c : 6463 ]  TPC_ERR: Invalid PHY Mode=%d, Defaut Mode Chosen=%d 
+5421,i,[ phyrf_bdf_v2.c : 6799 ]  TPC_DUMP: TargetPowerTranslation - translation_flag :%d 
+5422,,[ phyrf_bdf_v2.c : 6892 ] TPC_DUMP: phyrf_bdf_TargetToDispTpcTranslation: Pointer is NULL 
+5423,Iii,[ phyrf_bdf_v2.c : 6896 ] TPC_DUMP: phyrf_bdf_TargetToDispTpcTranslation: Starting ratesArray:0x%x, wlanMode:%d, is_ext: %d  
+5424,ii,[ phyrf_bdf_v2.c : 7760 ] TPC_DUMP: FW Valid Bit:%d, HOST Valid Bit: %d 
+5425,ii,[ phyrf_bdf_v2.c : 7805 ] TPC_DUMP: HOST - Back off Not applied rtIdx=%d, mcs=%d 
+5426,iiiii,[ phyrf_bdf_v2.c : 7861 ] TPC_DUMP: phyrf_bdf_Update_TpcPwrReduction_backOff: band:%d, cck:%d, ofdm:%d, start_mcs:%d, end_mcs:%d 
+5427,ii,[ phyrf_bdf_v2.c : 7959 ] TPC_DUMP: phyrf_bdf_Populate_GetRateTPCPerChainHWAdjust_Cache: band:%d, locPhyIdx:%d 
+5428,i,[ phyrf_bdf_v2.c : 8087 ] TPC EIRP Per Chain Power(Quarter dBm) =%d 
+5429,iiiiii,[ phyrf_bdf_v2.c : 8093 ] TPC EIRP antennaGainFromBDF =%d , combinedChainGain =%d , EIRP power(Quarter dBm) =%d BW =%d , channel=%d numChains =%d 
+5430,Iiiii,[ phyrf_cal_sm_v3.c : 606 ] CALSM: %p,  callingContext=%d, dB size = %d, masterCalDbExist()=%d, isSBS=%d
+ 
+5431,iiii,[ phyrf_cal_sm_v3.c : 612 ] CALSM:  final 	calDBEnableSetting=%d, 	final CalTimeOutSetting = %d, 	final PersistentEnable = %d, ColdBootDfsCalEnable=%d
+ 
+5432,iIIiiiii,[ phyrf_cal_sm_v3.c : 678 ] current : PhyId=%d, rCM=%x, tCM=%x, TalIdx=%d, PwrMask=%d, RFmode=%d, band_center_freq1=%d puncture_bitmap = %d
+ 
+5433,iIIiiiii,[ phyrf_cal_sm_v3.c : 686 ] Previous: PhyId=%d, rCM=%x, tCM=%x, TalIdx=%d, PwrMask=%d, RFmode=%d, band_center_freq1=%d ,puncture_bitmap = %d
+ 
+5434,iiiiiiii,[ phyrf_cal_sm_v3.c : 747 ] PhyId=%d, cur callingContext = %d, doCalFlag = %d, doCalFlagCombIQ = %d, doCalFlagRxDCO = %d, doCalFlagPdc = %d, doCalFlagRxSpur = %d, doCalFlagPdet = %d 
+5435,iii,[ phyrf_cal_sm_v3.c : 750 ] preProfileExcludeScan = %d, txloCorrupted = %d, currentRFmode = %d
+ 
+5436,iiiii,[ phyrf_cal_sm_v3.c : 884 ]  %d	%d	%d	%d	%d 
+5437,iiii,[ phyrf_cal_sm_v3.c : 999 ] CAL SM: is_2GHz=%d, Phy mode=%d, IsTrue160Supported=%d, bwcode=%d
+ 
+5438,,[ phyrf_cal_v3.c : 251 ] GetNfPerChain failure. NULL point error 
+5439,iii,[ phyrf_cal_v3.c : 528 ] DetermineAltTblIdx: cur_tbl_idx:%d, cur_tbl_freq[0]:%d cur_tbl_freq[1]:%d  
+5440,iii,[ phyrf_cal_v3.c : 549 ] ReleaseAltTblIdx: cur_tbl_freq[%d]=%d, band_center_freq1=%d
+ 
+5441,iii,[ phyrf_cal_v3.c : 587 ] RunDPDCalibration : %d, phy %d phyrf %d 
+5442,,[ phyrf_cal_v3.c : 1186 ] Memory block not assigned for aoadata 
+5443,,[ phyrf_cal_v3.c : 1325 ] TEMPRECAL:: Phy not mapped to valid PhyId 
+5444,,[ phyrf_cal_uic_tracker.c : 246 ] UIC - Exit since no cal is pending to trigger 
+5445,i,[ phyrf_caldb_v3.c : 812 ] isDFS = %d
+ 
+5446,IIIII,[ phyrf_caldb_v3.c : 926 ] metaTable = %x, groupBimodal = %x, group_A_Ext = %x, group_B = %x, group_A = %x
+ 
+5447,i,[ phyrf_caldb_v3.c : 1081 ] ERROR: invalid band of %d
+ 
+5448,iiiiii,[ phyrf_caldb_v3.c : 1172 ] frequency=%d, bandw:%d calTypeIdx=%d,  *mapToCalGroupIdx=%d, *rfsub =%d, *sequentialSubBandIdx=%d
+ 
+5449,,[ phyrf_caldb_v3.c : 1240 ] error: phyId not matched to system supported number of PHYs.
+ 
+5450,II,[ phyrf_caldb_v3.c : 1634 ] groupA address = 0x%08x and valid = 0x%08x
+ 
+5451,,[ phyrf_caldb_v3.c : 1813 ] error: phyId not matched to system supported number of PHYs.
+ 
+5452,,[ phyrf_caldb_v3.c : 1894 ] error: phyId not matched to system supported number of PHYs. 
+5453,III,[ phyrf_caldb_v3.c : 1992 ] CC: rxiqStart: %p, txiqStart: %p, txloStart: %p
+ 
+5454,II,[ phyrf_caldb_v3.c : 2037 ] CC: rxiqGainMapStart: %p, rxiqDpdStart: %p
+ 
+5455,I,[ phyrf_caldb_v3.c : 2101 ] getTablePtrAdc:: calsmadc TableAdr *pStart : 0x%x 
+5456,I,[ phyrf_caldb_v3.c : 2106 ] getTablePtrAdc:: calsmadc adc_lut_data *pStart : 0x%x 
+5457,I,[ phyrf_caldb_v3.c : 2132 ] getTablePtrPadroop:: calsmpadroop TableAdr *pStart : 0x%x 
+5458,I,[ phyrf_caldb_v3.c : 2137 ] getTablePtrPadroop:: calsmpadroop padroop_lut_data *pStart : 0x%x 
+5459,iiiI,[ phyrf_caldb_v3.c : 2331 ] ValidateRxdcoCurChSwForFCS: phyId = %d, chainIdx = %d, *result = %d, RxdcoPinTestBitMask = 0x%x
+ 
+5460,iiiiii,[ phyrf_caldb_v3.c : 2940 ] CheckCombCalForFCS: tableIdx = %d, chainIdx = %d, chainIdxOffset = %d, chainIdx + chainIdxOffset = %d, testResult = %d, tempValidResult=%d
+ 
+5461,,[ phyrf_caldb_v3.c : 3056 ] error: phyId not matched to system supported number of PHYs.
+ 
+5462,,[ phyrf_caldb_v3.c : 3128 ] ERROR: CalDB checksum failure
+ 
+5463,iii,[ phyrf_caldb_v3.c : 3411 ] caldB_synopsis: Error MAX of calChTablEntry for reached calChTablEntry:%d chan:%d phymode:%d 
+5464,iiiiiiii,[ phyrf_caldb_v3.c : 3446 ] updating_caldB_synopsis: calChTablEntry=%d, [%d], 	phyID=%d, 	mHz=%d, 	f1=%d, 	temp=%d, 	phyMode=%d, 	fullResetTime(us)=%d
+ 
+5465,iII,[ phyrf_caldb_v3.c : 3461 ] updating_caldB_synopsis: RXDCO, 	chainIdx=%d, 	Addr=0x%08x, 	Valid=0x%08x
+ 
+5466,iiiiII,[ phyrf_caldb_v3.c : 3480 ] updating_caldB_synopsis: COMBIQ, 	sizeof(t_caldB_synopsis)=%d, 	calChTablEntry=%d, 	tableIdx=%d, 	chainIdx=%d, 	Addr=0x%08x, 	Valid=0x%08x
+ 
+5467,iII,[ phyrf_caldb_v3.c : 3498 ] updating_caldB_synopsis: DAC, 	chainIdx=%d, 	Addr=0x%08x, 	Valid=0x%08x
+ 
+5468,iII,[ phyrf_caldb_v3.c : 3514 ] updating_caldB_synopsis: ADC, 	chainIdx=%d, 	Addr=0x%08x, 	Valid=0x%08x
+ 
+5469,iII,[ phyrf_caldb_v3.c : 3530 ] updating_caldB_synopsis: PADROOP, 	chainIdx=%d, 	Addr=0x%08x, 	Valid=0x%08x
+ 
+5470,ii,[ phyrf_caldb_v3.c : 3541 ] updating_caldB_synopsis[%d], 	calTemperature=%d 
+5471,iiiiiiii,[ phyrf_caldb_v3.c : 3592 ] caldB_synopsis: [%d], phyID=%d, mHz=%d, f1=%d, temp=%d, phyMode=%d, tpc_glut_freq=%d fullResetTime(us)=%d 
+5472,IIII,[ phyrf_caldb_v3.c : 3627 ] caldB_synopsis: RXDCO Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5473,IIII,[ phyrf_caldb_v3.c : 3630 ] caldB_synopsis: RXDCO Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5474,IIII,[ phyrf_caldb_v3.c : 3638 ] caldB_synopsis: RXDCO Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5475,IIII,[ phyrf_caldb_v3.c : 3641 ] caldB_synopsis: RXDCO Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5476,II,[ phyrf_caldb_v3.c : 3646 ] caldB_synopsis: RXDCO Addr :0x%08x 0x%08x 
+5477,II,[ phyrf_caldb_v3.c : 3648 ] caldB_synopsis: RXDCO Valid:0x%08x 0x%08x 
+5478,ii,[ phyrf_caldb_v3.c : 3652 ] caldB_synopsis: RXDCO Time(us) : DoCal=%d CalSave =%d 
+5479,IIII,[ phyrf_caldb_v3.c : 3675 ] caldB_synopsis: COMIQ Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5480,IIII,[ phyrf_caldb_v3.c : 3678 ] caldB_synopsis: COMIQ Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5481,IIII,[ phyrf_caldb_v3.c : 3686 ] caldB_synopsis: COMIQ Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5482,IIII,[ phyrf_caldb_v3.c : 3689 ] caldB_synopsis: COMIQ Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5483,II,[ phyrf_caldb_v3.c : 3694 ] caldB_synopsis: COMIQ Addr :0x%08x 0x%08x 
+5484,II,[ phyrf_caldb_v3.c : 3696 ] caldB_synopsis: COMIQ Valid:0x%08x 0x%08x 
+5485,ii,[ phyrf_caldb_v3.c : 3701 ] caldB_synopsis: CombIQ Time(us) : DoCal=%d CalSave=%d 
+5486,IIII,[ phyrf_caldb_v3.c : 3724 ] caldB_synopsis: DAC Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5487,IIII,[ phyrf_caldb_v3.c : 3727 ] caldB_synopsis: DAC Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5488,IIII,[ phyrf_caldb_v3.c : 3735 ] caldB_synopsis: DAC Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5489,IIII,[ phyrf_caldb_v3.c : 3738 ] caldB_synopsis: DAC Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5490,II,[ phyrf_caldb_v3.c : 3743 ] caldB_synopsis: DAC Addr :0x%08x 0x%08x 
+5491,II,[ phyrf_caldb_v3.c : 3745 ] caldB_synopsis: dac Valid:0x%08x 0x%08x 
+5492,ii,[ phyrf_caldb_v3.c : 3748 ] caldB_synopsis: DAC Time(us) : DoCal=%d CalSave=%d 
+5493,IIII,[ phyrf_caldb_v3.c : 3771 ] caldB_synopsis: ADC Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5494,IIII,[ phyrf_caldb_v3.c : 3774 ] caldB_synopsis: ADC Valid:0x%08x 0x%08x;0x%08x, 0x%08x 
+5495,IIII,[ phyrf_caldb_v3.c : 3782 ] caldB_synopsis: ADC Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5496,IIII,[ phyrf_caldb_v3.c : 3785 ] caldB_synopsis: ADC Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5497,II,[ phyrf_caldb_v3.c : 3790 ] caldB_synopsis: ADC Addr :0x%08x 0x%08x 
+5498,II,[ phyrf_caldb_v3.c : 3792 ] caldB_synopsis: ADC Valid:0x%08x 0x%08x 
+5499,ii,[ phyrf_caldb_v3.c : 3795 ] caldB_synopsis: ADC Time(us) : DoCal=%d CalSave=%d 
+5500,IIII,[ phyrf_caldb_v3.c : 3819 ] caldB_synopsis: PADROOP Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5501,IIII,[ phyrf_caldb_v3.c : 3822 ] caldB_synopsis: PADROOP Valid:0x%08x 0x%08x;0x%08x, 0x%08x 
+5502,IIII,[ phyrf_caldb_v3.c : 3830 ] caldB_synopsis: PADROOP Addr :0x%08x 0x%08x,0x%08x, 0x%08x 
+5503,IIII,[ phyrf_caldb_v3.c : 3833 ] caldB_synopsis: PADROOP Valid:0x%08x 0x%08x,0x%08x, 0x%08x 
+5504,II,[ phyrf_caldb_v3.c : 3838 ] caldB_synopsis: PADROOP Addr :0x%08x 0x%08x 
+5505,II,[ phyrf_caldb_v3.c : 3840 ] caldB_synopsis: PADROOP Valid:0x%08x 0x%08x 
+5506,ii,[ phyrf_caldb_v3.c : 3843 ] caldB_synopsis: PADROOP Time(us) : DoCal=%d CalSave=%d 
+5507,i,[ phyrf_caldb_v3.c : 3847 ] caldB_synopsis: No of coldboot channels : %d 
+5508,iII,[ phyrf_caldb_v3.c : 3903 ] caldB_synopsis: phyId=%d calFileVersionID=0x%08x calFileRevisionID=0x%08x 
+5509,IIIIII,[ phyrf_caldb_v3.c : 3953 ] CALDB_DEBUG: Frequency table dump  Start Freq %u | End freq %u | Sequential Index %u | Master Index %u | TPC mapped freq %u | MAPPED_RFSUB_ENABlE_COL %u 
+5510,iiiii,[ phyrf_caldb_v3.c : 4155 ] GROUP_B:caldbFrequencyRanges[%d] freq: %d [MASTER_SUBBAND_REMAP_IDX]=%d, [RFSUB_ENABlE_COL]=%d, [MAPPED_RFSUB_ENABlE_COL]=%d 
+5511,iiiii,[ phyrf_caldb_v3.c : 4161 ] GROUP_A:caldbFrequencyRanges[%d] freq:%d [MASTER_SUBBAND_REMAP_IDX]=%d, [RFSUB_ENABlE_COL]=%d, [MAPPED_RFSUB_ENABlE_COL]=%d 
+5512,,[ phyrf_caldb_v3.c : 4189 ] calDbPtr is a Null pointer 
+5513,ii,[ phyrf_caldb_v3.c : 4212 ] CALDB :: tpcF1 %d 	chEntryIdx %d 
+5514,,[ phyrf_caldb_v3.c : 4234 ] calDbPtr is a Null pointer 
+5515,,[ phyrf_caldb_v3.c : 4270 ] calDbPtr is a Null pointer 
+5516,iiiii,[ phyrf_caldb_v3.c : 4276 ] CALDB :: latestTherm %d, caldB_synopsis[%d].calTemperature %d, tempThresholdInC %d, %d 
+5517,,[ phyrf_caldb_aging_v3.c : 123 ] REGEN_CALDB: Invalid Phy Handle 
+5518,,[ phyrf_caldb_aging_v3.c : 131 ] REGEN_CALDB: Invalid pdev Handle 
+5519,I,[ phyrf_caldb_aging_v3.c : 139 ] REGEN_CALDB: Skipping cal as freq %u is not supported 
+5520,,[ phyrf_caldb_aging_v3.c : 228 ] REGEN_CALDB: Software configuration to skip CalDb Regen 
+5521,,[ phyrf_caldb_aging_v3.c : 258 ] REGEN_CALDB: INVALID PHYID OR CALDB NOT CLEARED 
+5522,Ii,[ phyrf_caldb_aging_v3.c : 418 ] REGEN_CALDB: completed in %u uSec,g_regen_in_progress = %d 
+5523,Ii,[ phyrf_debug.c : 179 ] %s: failed to allocate response buffer. Buffer size should be %d 
+5524,Ii,[ phyrf_debug.c : 199 ] %s: failed to allocate response buffer. Buffer size should be %d 
+5525,i,[ phyrf_debug.c : 830 ] HALPHY DUMP: WIFITOOL issued with subcommand ID %d 
+5526,i,[ phyrf_debug.c : 841 ] Invalid or Unsupported halphy debug sub command: %d 
+5527,iii,[ phyrf_debug.c : 1273 ] CTL_ENGINE_Array_Gain_Cap[Ntx: %d][ Nss :%d] %d 
+5528,ii,[ phyrf_debug.c : 1477 ] VregDbgFeatureRxtdEvtLogOp bypass phyId %d enable %d 
+5529,iI,[ phyrf_debug.c : 1497 ] VregDbgFeatureRxtdEvtLogOp enabled phyId %d, enable_mask 0x%x 
+5530,,[ phyrf_debug_cmd.c : 293 ] Invalid no.of.arguments 
+5531,i,[ phyrf_debug_cmd.c : 300 ] Invalid PHY ID = %d 
+5532,i,[ phyrf_debug_cmd.c : 316 ] INVALID CMD: %d STUB API CALLED 
+5533,IIIii,[ phyrf_debug_cmd.c : 389 ] RegDumpId %u NFCAL_BDF_PER_CHAIN phyId %u Chain %u%d dBr %d dBm 
+5534,IIIii,[ phyrf_debug_cmd.c : 416 ] RegDumpId %u NFCAL_RUNTIME_PER_CHAIN phyId %u Chain %u%d dBr %d dBm 
+5535,III,[ phyrf_debug_cmd.c : 427 ] RegDumpId %u XTAL CAPIN=%u CAPOUT=%u 
+5536,IIi,[ phyrf_debug_cmd.c : 431 ] BdfDump XTAL CAPIN=%u CAPOUT=%u PPM=%d 
+5537,IIi,[ phyrf_debug_cmd.c : 434 ] BdfDump XTAL CAPIN=%u CAPOUT=%u PPM=-%d  
+5538,iii,[ phyrf_debug_cmd.c : 478 ] RxGainCalResult phyId:%d channel_idx:%d, _freq:%d 
+5539,iiiii,[ phyrf_debug_cmd.c : 484 ] RxGainCalResult phyId:%d channel_idx:%d, chain_idx:%d, DBr_value:%d, DBm_value:%d 
+5540,iI,[ phyrf_debug_cmd.c : 498 ] FTM_DEBUG: g_ftm_ctxt[%d] addr = %p 
+5541,iIIII,[ phyrf_debug_cmd.c : 501 ] FTM_DEBUG: g_ftm_ctxt[%d]: pdev = %p, vdev = %p, peer = %p, ftm_mode = 0x%x 
+5542,iIIII,[ phyrf_debug_cmd.c : 503 ] FTM_DEBUG: g_ftm_ctxt[%d]: send_mgmt = 0x%x, send_data = 0x%x, encap_cfg = %p, ctrl = %p 
+5543,,[ phyrf_debug_cmd.c : 507 ] FTM_DEBUG: encap_cfg pointer is NULL in g_ftm_ctxt !!  
+5544,iiiI,[ phyrf_debug_cmd.c : 512 ] FTM_DEBUG: g_ftm_ctxt[%d].encap_cfg: pkt_len = %d, pkt_type = %d, vdev = %p 
+5545,iIIIIII,[ phyrf_debug_cmd.c : 519 ] FTM_DEBUG: g_ftm_ctxt[%d].encap_cfg->sa_addr = 0x%02x:%02x:%02x:%02x:%02x:%02x 
+5546,iIIIIII,[ phyrf_debug_cmd.c : 527 ] FTM_DEBUG: g_ftm_ctxt[%d].encap_cfg->da_addr = 0x%02x:%02x:%02x:%02x:%02x:%02x 
+5547,iIIIIII,[ phyrf_debug_cmd.c : 535 ] FTM_DEBUG: g_ftm_ctxt[%d].encap_cfg->bss_addr = 0x%02x:%02x:%02x:%02x:%02x:%02x 
+5548,,[ phyrf_debug_cmd.c : 540 ] FTM_DEBUG: ctrl pointer is NULL in g_ftm_ctxt !! 
+5549,iii,[ phyrf_debug_cmd.c : 545 ] FTM_DEBUG: g_ftm_ctxt[%d].ctrl: num_pkts_to_send = %d, is_aggr_ok = %d 
+5550,iii,[ phyrf_debug_cmd.c : 549 ] FTM_DEBUG: g_dbg_overwrite_ppdu_dur_us = %d, g_dbg_gi_override = %d, g_dbg_he_ltf_override = %d 
+5551,iiii,[ phyrf_debug_cmd.c : 583 ] CALDB_DEBUG:   calDBEnableSetting=%d, CalTimeOutSetting = %d, PersistentEnable = %d, masterCalDbExist()=%d 
+5552,,[ phyrf_debug_cmd.c : 618 ] REGEN_CALDB: Re-generating cold boot calibration over debug - Command - wait for 60seconds ... 
+5553,,[ phyrf_debug_cmd.c : 634 ] REGEN_CALDB: wal_pdev is NULL. Skipping 
+5554,i,[ phyrf_debug_cmd.c : 668 ] CALDB_DEBUG: caldb_size = %d 
+5555,,[ phyrf_debug_cmd.c : 678 ] ERROR: CalDB checkSum Failure 
+5556,,[ phyrf_debug_cmd.c : 682 ] CalDB checkSum valid 
+5557,i,[ phyrf_debug_cmd.c : 695 ] CALDB: max_group_A_subband: %d 
+5558,I,[ phyrf_debug_cmd.c : 696 ] CALDB: supportedsubBandsIncalDB_A[0]: 0x%x 
+5559,I,[ phyrf_debug_cmd.c : 697 ] CALDB: supportedsubBandsIncalDB_A[1]: 0x%x 
+5560,I,[ phyrf_debug_cmd.c : 698 ] CALDB: supportedsubBandsIncalDB_A[2]: 0x%x 
+5561,I,[ phyrf_debug_cmd.c : 699 ] CALDB: supportedsubBandsIncalDB_A[3]: 0x%x 
+5562,I,[ phyrf_debug_cmd.c : 700 ] CALDB: supportedsubBandsIncalDB_A[4]: 0x%x 
+5563,i,[ phyrf_debug_cmd.c : 702 ] CALDB: max_group_B_subband: %d 
+5564,I,[ phyrf_debug_cmd.c : 703 ] CALDB: supportedsubBandsIncalDB_B[0]: 0x%x 
+5565,I,[ phyrf_debug_cmd.c : 704 ] CALDB: supportedsubBandsIncalDB_B[1]: 0x%x 
+5566,I,[ phyrf_debug_cmd.c : 705 ] CALDB: supportedsubBandsIncalDB_B[2]: 0x%x 
+5567,I,[ phyrf_debug_cmd.c : 706 ] CALDB: supportedsubBandsIncalDB_B[3]: 0x%x 
+5568,I,[ phyrf_debug_cmd.c : 707 ] CALDB: supportedsubBandsIncalDB_B[4]: 0x%x 
+5569,i,[ phyrf_debug_cmd.c : 822 ] DumpCurrChannelCalLuts Flag = %d 
+5570,i,[ phyrf_debug_cmd.c : 842 ] Invalid no.of.arguments %d 
+5571,i,[ phyrf_debug_cmd.c : 865 ] CTL_DISABLE DEBUG : Invalid no.of.arguments %d 
+5572,iiii,[ phyrf_debug_cmd.c : 869 ] CTL_DISABLE DEBUG : num_args %d cmd_id %d phy_id %d ctl_enable %d 
+5573,i,[ phyrf_debug_cmd.c : 881 ] CTL_DISABLE DEBUG Flag = %d 
+5574,,[ phyrf_debug_cmd.c : 899 ] CTL_DISABLE DEBUG: HC offset enable/disable command exit since the current state and input state are same 
+5575,ii,[ phyrf_debug_cmd.c : 904 ] CTL_DISABLE DEBUG: HC offset enable/disable command is executed. Current state: BDF HC_offset_ext_feature_enable field: %d, hcOffsetEnable Debug Input: %d 
+5576,i,[ phyrf_debug_cmd.c : 929 ] BDF DUMP: Invalid NV Section  %d 
+5577,i,[ phyrf_debug_cmd.c : 934 ] BDF DUMP: NV Section Size: %d 
+5578,ii,[ phyrf_debug_cmd.c : 945 ] BDF DUMP: sub-section size: %d sub-section id: 0x%d 
+5579,iI,[ phyrf_debug_cmd.c : 951 ] BDF DUMP: index: %d d: 0x%x 
+5580,iI,[ phyrf_debug_cmd.c : 960 ] BDF DUMP: index: %d d:0x%x 
+5581,,[ phyrf_debug_cmd.c : 1103 ] DO_NFCAL_ACTION Invalid Command 
+5582,II,[ phyrf_debug_cmd.c : 1114 ] DO_NFCAL_ACTION: Setting NFCAL home channel IterCount to %u for phyId = %u 
+5583,II,[ phyrf_debug_cmd.c : 1121 ] DO_NFCAL_ACTION: Setting NFCal type in home channel for phyId %u to 0x%x 
+5584,II,[ phyrf_debug_cmd.c : 1128 ] DO_NFCAL_ACTION: Setting NFCAL scan channel IterCount to %u for phyId = %u 
+5585,II,[ phyrf_debug_cmd.c : 1135 ] DO_NFCAL_ACTION: Setting NFCal type in scan channel for phyId %u to 0x%x 
+5586,II,[ phyrf_debug_cmd.c : 1148 ] DO_NFCAL_ACTION: WHAL_NFCAL_CONTINUOUS_STOP for phyId %u to 0x%x 
+5587,II,[ phyrf_debug_cmd.c : 1155 ] DO_NFCAL_ACTION: WHAL_NFCAL_CONTINUOUS_START for phyId %u to 0x%x 
+5588,II,[ phyrf_debug_cmd.c : 1163 ] DO_NFCAL_ACTION: WHAL_NFCAL_CONTINUOUS_ENABLE to be enabled before stop/start of continuous NF for phyId %u to 0x%x 
+5589,II,[ phyrf_debug_cmd.c : 1170 ] DO_NFCAL_ACTION: Dumping NFCal debug register for phyId %u to 0x%x 
+5590,II,[ phyrf_debug_cmd.c : 1177 ] DO_NFCAL_ACTION: Setting NFCal minccaFirpwrThrDb2 for phyId %u to 0x%x 
+5591,II,[ phyrf_debug_cmd.c : 1184 ] DO_NFCAL_ACTION: Setting NFCal minccaRelpwrThrDb2 for phyId %u to 0x%x 
+5592,II,[ phyrf_debug_cmd.c : 1191 ] DO_NFCAL_ACTION: Override NF read type for phyId %u to WHAL_NFCAL_MINCCA_20_MHZ_SUBBANDS_READ. Override Status %u 
+5593,II,[ phyrf_debug_cmd.c : 1198 ] DO_NFCAL_ACTION: Override NF read type for phyId %u to WHAL_NFCAL_MINCCAOUT_20_MHZ_SUBBANDS_READ. Override Status %u 
+5594,II,[ phyrf_debug_cmd.c : 1205 ] DO_NFCAL_ACTION: Override NF read type for phyId %u to WHAL_NFCAL_AVGCCAOUT_20_MHZ_SUBBANDS_READ. Override Status %u 
+5595,iiiiiii,[ phyrf_debug_cmd.c : 1251 ] ANI_LOG PHYID%d abi_enable %d abi_level %d hold_mode %d hold_count %d analog_sat %d adjust_lg_vlg_max_gain %d 
+5596,iiii,[ phyrf_debug_cmd.c : 1316 ] ANI_LOG PHYID%d sub_cmd %d, vlg_max_gain_or_backoff %d, lg_max_gain_or_backoff %d 
+5597,ii,[ phyrf_debug_cmd.c : 1336 ] ANI_LOG PHYID%d str_sig_err_thr %d 
+ 
+5598,i,[ phyrf_debug_cmd.c : 1348 ] ANI: Invalid PHY ID = %d
+ 
+5599,i,[ phyrf_debug_cmd.c : 1360 ] ANI_LOG_ERR - Value of ABI histogram=%d 
+5600,i,[ phyrf_debug_cmd.c : 1368 ] ANI_LOG_ERR - Value of 100ms ABI histogram=%d 
+5601,,[ phyrf_debug_cmd.c : 1372 ] ANI_LOG_ERR ABI HISTOGRAM VALUES 
+5602,,[ phyrf_debug_cmd.c : 1382 ] WIFITOOL: PHYID is not active 
+ 
+5603,iiii,[ phyrf_debug_cmd.c : 1441 ] ANI_LOG PHYID%d dl_min %d, dl_max %d, error_threshold %d 
+5604,ii,[ phyrf_debug_cmd.c : 1459 ] ANI_LOG PHYID%d ramp_down %d 
+5605,i,[ phyrf_debug_cmd.c : 1474 ] ANI_LOG_ERR - ANI histogram status %d 
+5606,,[ phyrf_debug_cmd.c : 1477 ] ANI_LOG_ERR VREG ERR COUNTER VALUES 
+5607,ii,[ phyrf_debug_cmd.c : 1524 ] ANI_LOG PHYID%d strong signal enable - %d 
+5608,,[ phyrf_debug_cmd.c : 1533 ] WIFITOOL: PHYID is not active 
+ 
+5609,ii,[ phyrf_debug_cmd.c : 1567 ] g_XtalCalPPM[%d]=%d 
+5610,ii,[ phyrf_debug_cmd.c : 1580 ] g_ThermalEnable[%d]=%d 
+5611,I,[ phyrf_debug_cmd.c : 1592 ] enable_ldocal_otp = %u 
+5612,I,[ phyrf_debug_cmd.c : 1610 ] ANI_LOG g_max_edcca=%x 
+5613,ii,[ phyrf_debug_cmd.c : 1631 ] ANI_LOG PHYID%d g_ani_cca %d 
+5614,iii,[ phyrf_debug_cmd.c : 1645 ] ANI_LOG PHYID%d ani_dl_min %d, ani_dl_max %d 
+5615,ii,[ phyrf_debug_cmd.c : 1661 ] ANI_LOG PHYID%d error_threshold %d 
+5616,ii,[ phyrf_debug_cmd.c : 1674 ] PAPRD: Phy ID %d | Enable for MM = %d 
+5617,iii,[ phyrf_debug_cmd.c : 1711 ] ForceRxGainTbl forceGainMode %d rxGainIdx %d rxGainTbl %d 
+5618,iIIi,[ phyrf_debug_cmd.c : 1725 ] ADDRVAL: indx = %d addr = 0x%X val = 0x%X en=%d 
+5619,iIIi,[ phyrf_debug_cmd.c : 1735 ] ADDRVAL: indx = %d addr = 0x%X val = 0x%X en=%d 
+5620,iIIi,[ phyrf_debug_cmd.c : 1741 ] ADDRVAL: indx = %d addr = 0x%X val = 0x%X en=%d 
+5621,iiii,[ phyrf_debug_cmd.c : 1767 ] PDL Version : %d.%d - RDL Version : %d.%d 
+5622,II,[ phyrf_debug_cmd.c : 1817 ] Unit Test ID %u : ChanGradeInfo returns A_STATUS : %u 
+5623,III,[ phyrf_debug_cmd.c : 1821 ] Unit Test ID %u : ChanGradeInfo returns A_STATUS : %u ( Success ), chanGradeInfoCount %u 
+5624,IIIi,[ phyrf_debug_cmd.c : 1830 ] %u. Freq %u, BW %u, ChanPerfMetric %d 
+5625,,[ phyrf_debug_cmd.c : 1845 ] GetSignalLevel : Invalid no.of.arguments 
+5626,IIIII,[ phyrf_debug_cmd.c : 1876 ] GetSignalLevel phyId %u, snrInput %u, chainMask %x, bandwidth %u, combRssi %u 
+5627,III,[ phyrf_debug_cmd.c : 1896 ] GetSignalLevel : SNR BW Segment Input %8x%8x for Chain %u 
+5628,I,[ phyrf_debug_cmd.c : 1905 ] GetSignalLevel : Returns %u (WHAL_EINVAL) 
+5629,Ii,[ phyrf_debug_cmd.c : 1913 ] GetSignalLevel : SNR=%u RSSI=%d 
+5630,iIIIiIIi,[ phyrf_debug_cmd.c : 1930 ] GetSignalLevel : SNR[%d][%u][%u]=%u RSSI[%d][%u][%u]=%d 
+5631,,[ phyrf_debug_cmd.c : 1970 ] phydbg_reconfigure : Invalid no.of.arguments 
+5632,ii,[ phyrf_debug_cmd.c : 1976 ] phydbg_reconfigure : PHYID = %d ,Event = %d 
+5633,i,[ phyrf_debug_cmd.c : 1998 ] DSS: WIFITOOL ISSUED TO ENABLE/DISABLE DSS %d 
+5634,ii,[ phyrf_debug_cmd.c : 2008 ] DSS: WIFITOOL ISSUED TO ENABLE/DISABLE DSS %d, phyId %d 
+5635,ii,[ phyrf_debug_cmd.c : 2010 ] DSS: SYNTH_CONTROL=%d FOR PHYID %d 
+5636,i,[ phyrf_debug_cmd.c : 2237 ] WIFITOOL: PHYID %d is not active 
+5637,ii,[ phyrf_debug_cmd.c : 2242 ] SetDssWarCFODeltaThreshold: cfo_threshold=%d FOR PHYID %d 
+5638,i,[ phyrf_debug_cmd.c : 2256 ] WIFITOOL: PHYID %d is not active 
+5639,ii,[ phyrf_debug_cmd.c : 2261 ] EnableDssWarCFO: enable=%d FOR PHYID %d 
+5640,i,[ phyrf_debug_cmd.c : 2279 ] WIFITOOL: PHYID %d is not active 
+5641,i,[ phyrf_debug_cmd.c : 2301 ] Setting PBS Mode to %d 
+5642,I,[ phyrf_debug_cmd.c : 2339 ] NFCAL_READ_TEST : phyId %u not available for test 
+5643,IIIIIi,[ phyrf_debug_cmd.c : 2358 ] NFCAL_READ_TEST : phyId %u, nfType 0x%x, bufferSize %u, validBuffer %u, bufferPointer 0x%x, returns %d 
+5644,IIIIII,[ phyrf_debug_cmd.c : 2366 ] CH%u_NFPERCHAIN_TYPE_0x%x 00:%04d, 01:%04d, 02:%04d, 03:%04d 
+5645,IIIIII,[ phyrf_debug_cmd.c : 2369 ] CH%u_NFPERCHAIN_TYPE_0x%x 04:%04d, 05:%04d, 06:%04d, 07:%04d 
+5646,IIIIII,[ phyrf_debug_cmd.c : 2372 ] CH%u_NFPERCHAIN_TYPE_0x%x 08:%04d, 09:%04d, 10:%04d, 11:%04d 
+5647,IIIIII,[ phyrf_debug_cmd.c : 2375 ] CH%u_NFPERCHAIN_TYPE_0x%x 12:%04d, 13:%04d, 14:%04d, 15:%04d 
+5648,IIIIII,[ phyrf_debug_cmd.c : 2386 ] CH%u_NFREGPERCHAIN_TYPE_0x%x 00:%04d, 01:%04d, 02:%04d, 03:%04d 
+5649,IIIIII,[ phyrf_debug_cmd.c : 2389 ] CH%u_NFREGPERCHAIN_TYPE_0x%x 04:%04d, 05:%04d, 06:%04d, 07:%04d 
+5650,IIIIII,[ phyrf_debug_cmd.c : 2392 ] CH%u_NFREGPERCHAIN_TYPE_0x%x 08:%04d, 09:%04d, 10:%04d, 11:%04d 
+5651,IIIIII,[ phyrf_debug_cmd.c : 2395 ] CH%u_NFREGPERCHAIN_TYPE_0x%x 12:%04d, 13:%04d, 14:%04d, 15:%04d 
+5652,ii,[ phyrf_debug_cmd.c : 2422 ] FORCED SYNTH: SYNTH_CONTROL=%d FOR PHYID %d 
+5653,,[ phyrf_debug_cmd.c : 2434 ] PAPRD: Invalid no.of.arguments 
+5654,ii,[ phyrf_debug_cmd.c : 2440 ] PAPRD: PHYID = %d ,Event = %d 
+5655,,[ phyrf_debug_cmd.c : 2583 ] adcCapture : Wrong arguments for Circular ADC Capture 
+5656,,[ phyrf_debug_cmd.c : 2584 ] adcCapture : Accepted args: <PhyID=0/1> <Start=1> <duration(us)=0-65000> <TrigEvent=0/1/2/3> <BufSize(Kb):192> <ChainMask> <BitWidth=10/12> <frame=1/2> <subtype=11/0> 
+5657,iI,[ phyrf_debug_cmd.c : 2620 ] PHYDBG Buf_size = %d Address_of_Buf = %x 
+5658,i,[ phyrf_debug_cmd.c : 2638 ] Setting PBS Mode to %d 
+5659,I,[ phyrf_debug_cmd.c : 2715 ] Set g_halphy_debug_mask =0x%x 
+5660,I,[ phyrf_debug_cmd.c : 2721 ] Set phyDebugMask =0x%x 
+5661,i,[ phyrf_debug_cmd.c : 2742 ] BT_CLOCK_ENABLE: %d 
+5662,iiII,[ phyrf_debug_cmd.c : 2797 ] CHAINMASKOVERRIDE %d - phy[%d]: txChMask 0x%x; rxChMask 0x%x 
+5663,,[ phyrf_debug_cmd.c : 2820 ] SPECTRAL_ENABLE: Invalid no.of.arguments 
+5664,,[ phyrf_debug_cmd.c : 2826 ] SPECTRAL_ENABLE: Invalid scanMode 
+5665,ii,[ phyrf_debug_cmd.c : 2853 ] GreenTx Enable[%d]=%d 
+5666,ii,[ phyrf_debug_cmd.c : 2870 ] ImpsBmpsControl: enable=%d, phyId=%d 
+5667,iii,[ phyrf_debug_cmd.c : 2884 ] ImpsBmpsControl: imps=%d, enable=%d, phyId=%d 
+5668,iiii,[ phyrf_debug_cmd.c : 2903 ] ImpsBmpsControl: imps=%d, w2s=%d, enable=%d, phyId=%d 
+5669,,[ phyrf_debug_cmd.c : 2921 ] DFS_ENABLE: Invalid no.of.arguments 
+5670,,[ phyrf_debug_cmd.c : 2956 ] IpcHandler_Enable: Invalid no.o.arguments 
+5671,ii,[ phyrf_debug_cmd.c : 2963 ] IpcHandler_Enable: enable=%d, phyId=%d 
+5672,,[ phyrf_debug_cmd.c : 2971 ] SetCcaThreshold: Invalid no.of.arguments 
+5673,,[ phyrf_debug_cmd.c : 3010 ] TpcPowerOverride: Invalid no.of.arguments 
+5674,,[ phyrf_debug_cmd.c : 3027 ] TpcPowerOverride: Invalid no.of.arguments 
+5675,ii,[ phyrf_debug_cmd.c : 3035 ] TpcPowerOverride: chain %d: power: %d 
+5676,,[ phyrf_debug_cmd.c : 3046 ] TPC CLPC SWITCH: Invalid no.of.arguments 
+5677,,[ phyrf_debug_cmd.c : 3053 ] TPC CLPC: TO BE IMPLEMENTED 
+5678,,[ phyrf_debug_cmd.c : 3080 ] MMHostCmdSetCalMask Invalid no.of.arguments 
+5679,I,[ phyrf_debug_cmd.c : 3089 ] Set g_halphy_debug_cal_mask =0x%x
+ 
+5680,,[ phyrf_debug_cmd.c : 3103 ] MMHostCmdDPDEDPDDisable Invalid no.of.arguments 
+5681,iI,[ phyrf_debug_cmd.c : 3112 ] Set g_halphy_dpd_disable[%d] =0x%x 
+5682,,[ phyrf_debug_cmd.c : 3128 ] Coldboot Calibration Feature Not Supported 
+5683,,[ phyrf_debug_cmd.c : 3132 ] Coldboot Calibration: Invalid no.of.arguments 
+5684,I,[ phyrf_debug_cmd.c : 3159 ] DUMP_TPC_REGS_ENABLE: Invalid pHandle for phyId%u 
+5685,I,[ phyrf_debug_cmd.c : 3164 ] DUMP_TPC_REGS_ENABLE: Invalid TPC structure for phyId%u 
+5686,i,[ phyrf_debug_cmd.c : 3169 ] DUMP_TPC_REGS_ENABLE: WIFITOOL ISSUED TO ENABLE TPC REG DUMP %d 
+5687,iiii,[ phyrf_debug_cmd.c : 3181 ] DUMP_TPC_REGS_ENABLE: WIFITOOL ISSUED TO ENABLE TPC REG DUMP TO SPECIFIC RATE INDEX %d phyid %d rtIdx min %d rtIdx max %d 
+5688,iii,[ phyrf_debug_cmd.c : 3190 ] DUMP_TPC_REGS_ENABLE: WIFITOOL ISSUED TO ENABLE PER PHY TPC LOGS  %d phyid %d pTpcStruct->regDumpEnable %d 
+5689,i,[ phyrf_debug_cmd.c : 3195 ] DUMP_TPC_REGS_ENABLE: wifitool : Invalid test arguments for cmd %d 
+5690,i,[ phyrf_debug_cmd.c : 3209 ] DUMP_TPC_GLUT_WAKEUP_SLEEP: WIFITOOL ISSUED TO ENABLE TPC GLUT DUMP %d
+ 
+5691,,[ phyrf_debug_cmd.c : 3213 ] DUMP_TPC_GLUT_WAKEUP_SLEEP: wifitool : Invalid no.of.arguments 
+5692,i,[ phyrf_debug_cmd.c : 3218 ] DUMP_TPC_GLUT_WAKEUP_SLEEP: WIFITOOL ISSUED TO DISABLE TPC GLUT DUMP %d
+ 
+5693,,[ phyrf_debug_cmd.c : 3229 ] GET BOARD CAL DETAILS : wifitool : Invalid no.of.arguments 
+5694,ii,[ phyrf_debug_cmd.c : 3233 ] GET BOARD CAL DETAILS : wifitool : SW version : %d.%d 
+5695,i,[ phyrf_debug_cmd.c : 3235 ] GET BOARD CAL DETAILS : wifitool : Meta version : %d 
+5696,I,[ phyrf_debug_cmd.c : 3238 ] GET BOARD CAL DETAILS : wifitool : ProjectID in OTP : 0x%x 
+5697,,[ phyrf_debug_cmd.c : 3257 ] DebugCmdPhyOnOffSeq : Invalid no.of.arguments 
+5698,I,[ phyrf_debug_cmd.c : 3266 ] DebugCmdPhyOnOffSeq : Invalid pResetStruct for phyId %u 
+5699,IIII,[ phyrf_debug_cmd.c : 3275 ] DebugCmdPhyOnOffSeq : Pretest Counter phyId %u, cfActiveLow_Fail_cnt %04u, cfActiveLow_Pass_cnt %04u, phyOffThroughVregCnt %04u 
+5700,I,[ phyrf_debug_cmd.c : 3286 ] DebugCmdPhyOnOffSeq : Validating vreg based phyOff for phyId %u 
+5701,I,[ phyrf_debug_cmd.c : 3290 ] DebugCmdPhyOnOffSeq : Validating tlv based phyOff followed by vreg based phyOff for phyId %u 
+5702,I,[ phyrf_debug_cmd.c : 3295 ] DebugCmdPhyOnOffSeq : Validating calling vreg based phyOff twice for phyId %u 
+5703,I,[ phyrf_debug_cmd.c : 3301 ] DebugCmdPhyOnOffSeq : Validating tlv based phyOff for phyId %u 
+5704,IIIIi,[ phyrf_debug_cmd.c : 3314 ] DebugCmdPhyOnOffSeq : Posttest Counter phyId %u, cfActiveLow_Fail_cnt %04u, cfActiveLow_Pass_cnt %04u, phyOffThroughVregCnt %04u , phyoff_status=%d 
+5705,,[ phyrf_debug_cmd.c : 3324 ] FUSE BOARD ID VALUE TO OTP : wifitool : Invalid no.of.arguments 
+5706,,[ phyrf_debug_cmd.c : 3330 ] FUSE BOARD ID VALUE TO OTP : wifitool :Completed  
+5707,,[ phyrf_debug_cmd.c : 3342 ] CWOFFSET : wifitool : Invalid no.of.arguments 
+5708,,[ phyrf_debug_cmd.c : 3359 ] MMHostCmdGenerateCWToneAtOffset: Invalid command 
+5709,,[ phyrf_debug_cmd.c : 3371 ] Invalid no.of.arguments 
+5710,,[ phyrf_debug_cmd.c : 3383 ] DebugFTMOverrides : Invalid no.of.arguments 
+5711,II,[ phyrf_debug_cmd.c : 3396 ] DebugFTMOverrides : Setting flagId FCSDISABLE for phyId %u to value %u 
+5712,II,[ phyrf_debug_cmd.c : 3402 ] DebugFTMOverrides : Setting flagId FTMMCCDISABLE for phyId %u to value %u 
+5713,II,[ phyrf_debug_cmd.c : 3407 ] DebugFTMOverrides : Invalid flagId %u for phyId %u 
+5714,i,[ phyrf_debug_cmd.c : 3430 ] phyrf_debug_MMHostCmdTPCDebug g_clpc_corr_thr %d  
+5715,ii,[ phyrf_debug_cmd.c : 3446 ] phyrf_debug_MMHostCmdTPCDebug pdadc_read %d meas_pwr %d 
+5716,ii,[ phyrf_debug_cmd.c : 3451 ] phyrf_debug_MMHostCmdTPCDebug PLUT[%d] = %d 
+5717,ii,[ phyrf_debug_cmd.c : 3459 ] TPC_HM TPC Stats(latest at TOP) cur_idx %d phyID %d 
+5718,,[ phyrf_debug_cmd.c : 3460 ] TPC_HM|idx|valid|    tstamp|tx_pwr_perchain|ltst_tgt_pwr|ltst_glut_idx|ltst_txgain_idx|ltst_dac_gain| 
+5719,IIIIIIII,[ phyrf_debug_cmd.c : 3472 ] TPC_HM|%3u|%5u|%10u|%15d|%12d|%13u|%15u|%13d| 
+5720,,[ phyrf_debug_cmd.c : 3483 ] TPC_HM|idx|valid| rc|rtIdx|aft_tgt_pwr|aft_ctl|latest_accum_clpc_err|latest_clpc_err|latest_meas_pwr_out| 
+5721,IIIIIIIII,[ phyrf_debug_cmd.c : 3496 ] TPC_HM|%3u|%5u|%3d|%5d|%11d|%7d|%21u|%15u|%19u| 
+5722,i,[ phyrf_debug_cmd.c : 3511 ] TPC_HM g_tpc_histogram_pwr_threshold %d 
+5723,,[ phyrf_debug_cmd.c : 3527 ] MMHostCmdTPCDebug Invalid commands 
+5724,i,[ phyrf_debug_cmd.c : 3538 ] ENABLE_CHAN_CHANGE_BREAKDOWN: WIFITOOL ISSUED TO ENABLE CHAN CHANGE BREAKDOWN %d
+ 
+5725,,[ phyrf_debug_cmd.c : 3542 ] ENABLE_CHAN_CHANGE_BREAKDOWN: wifitool : Invalid no.of.arguments 
+5726,i,[ phyrf_debug_cmd.c : 3547 ] ENABLE_CHAN_CHANGE_BREAKDOWN: WIFITOOL ISSUED TO DISABLE CHAN CHANGE BREAKDOWN %d
+ 
+5727,I,[ phyrf_debug_cmd.c : 3563 ] CAL_STATS: CAL PROFILE - COLD_BOOT_CAL (0x%x) 
+5728,I,[ phyrf_debug_cmd.c : 3566 ] CAL_STATS: CAL PROFILE - FULL_CHAN_SWITCH (0x%x) 
+5729,I,[ phyrf_debug_cmd.c : 3569 ] CAL_STATS: CAL PROFILE - SCAN_CHAN_SWITCH (0x%x) 
+5730,I,[ phyrf_debug_cmd.c : 3572 ] CAL_STATS: CAL PROFILE - DPD_SPLIT_CAL (0x%x) 
+5731,I,[ phyrf_debug_cmd.c : 3575 ] CAL_STATS: CAL PROFILE - TEMP_TRIGEER_CAL (0x%x) 
+5732,I,[ phyrf_debug_cmd.c : 3578 ] CAL_STATS: CAL PROFILE - POWER_SAVE_WAKE_UP (0x%x) 
+5733,I,[ phyrf_debug_cmd.c : 3581 ] CAL_STATS: CAL PROFILE - TIMER_TRIGGER_CAL (0x%x) 
+5734,I,[ phyrf_debug_cmd.c : 3584 ] CAL_STATS: CAL PROFILE - FTM_TRIGGER_CAL (0x%x) 
+5735,I,[ phyrf_debug_cmd.c : 3587 ] CAL_STATS: CAL PROFILE - POWER_DOWN_DTIM (0x%x) 
+5736,I,[ phyrf_debug_cmd.c : 3590 ] CAL_STATS: CAL PROFILE - NOISY_ENV_RXDO (0x%x) 
+5737,I,[ phyrf_debug_cmd.c : 3593 ] CAL_STATS: CAL PROFILE - UNKNOWN_PROFILE (0x%x) 
+5738,I,[ phyrf_debug_cmd.c : 3603 ] CAL_STATS: CAL TYPE - ADC (0x%x) 
+5739,I,[ phyrf_debug_cmd.c : 3606 ] CAL_STATS: CAL TYPE - DAC (0x%x) 
+5740,I,[ phyrf_debug_cmd.c : 3609 ] CAL_STATS: CAL TYPE - NOISE_FLOOR (0x%x) 
+5741,I,[ phyrf_debug_cmd.c : 3612 ] CAL_STATS: CAL TYPE - RXDCO (0x%x) 
+5742,I,[ phyrf_debug_cmd.c : 3615 ] CAL_STATS: CAL TYPE - COMB_TXLO_TXIQ_RXIQ (0x%x) 
+5743,I,[ phyrf_debug_cmd.c : 3618 ] CAL_STATS: CAL TYPE - DPD_MEMORYLESS (0x%x) 
+5744,I,[ phyrf_debug_cmd.c : 3621 ] CAL_STATS: CAL TYPE - DPD_MEMORY (0x%x) 
+5745,I,[ phyrf_debug_cmd.c : 3624 ] CAL_STATS: CAL TYPE - IBF (0x%x) 
+5746,I,[ phyrf_debug_cmd.c : 3627 ] CAL_STATS: CAL TYPE - PDET_AND_PAL (0x%x) 
+5747,I,[ phyrf_debug_cmd.c : 3630 ] CAL_STATS: CAL TYPE - RXDCO_DTIM (0x%x) 
+5748,I,[ phyrf_debug_cmd.c : 3633 ] CAL_STATS: CAL TYPE - RXDCO_IQ (0x%x) 
+5749,I,[ phyrf_debug_cmd.c : 3636 ] CAL_STATS: CAL TYPE - BWFILTER (0x%x) 
+5750,I,[ phyrf_debug_cmd.c : 3639 ] CAL_STATS: CAL TYPE - PADROOP (0x%x) 
+5751,I,[ phyrf_debug_cmd.c : 3642 ] CAL_STATS: CAL TYPE - PDADC (0x%x) 
+5752,I,[ phyrf_debug_cmd.c : 3646 ] CAL_STATS: CAL TYPE - RXSPUR (0x%x) 
+5753,I,[ phyrf_debug_cmd.c : 3650 ] CAL_STATS: CAL TYPE - INVALID_CAL_ID (0x%x) 
+5754,I,[ phyrf_debug_cmd.c : 3660 ] CAL_STATS: CAL TYPE - PERIODIC_NOISE_FLOOR (0x%x) 
+5755,I,[ phyrf_debug_cmd.c : 3663 ] CAL_STATS: CAL TYPE - PERIODIC_DPD_MEMORYLESS (0x%x) 
+5756,I,[ phyrf_debug_cmd.c : 3666 ] CAL_STATS: CAL TYPE - PERIODIC_INVALID_CAL (0x%x) 
+5757,iiii,[ phyrf_debug_cmd.c : 3689 ] MMHostCmdCalStats : num_args %d cmd_id %d phy_id %d sub_cmd_id %d 
+5758,,[ phyrf_debug_cmd.c : 3699 ] CAL_STATS : Reset calibration stats 
+5759,,[ phyrf_debug_cmd.c : 3705 ] CAL_STATS : Valid Cal profiles and cal types 
+5760,I,[ phyrf_debug_cmd.c : 3713 ] CAL_STATS : Number of cal types in this profile = %u 
+5761,,[ phyrf_debug_cmd.c : 3728 ] CAL_STATS : Calibration stats for valid Cal profiles and cal types 
+5762,,[ phyrf_debug_cmd.c : 3736 ] ************************************************ 
+5763,IIIII,[ phyrf_debug_cmd.c : 3750 ] CAL_STATS : cal_type = %u | cal_triggered_cnt = %u | cal_fail_cnt = %u | cal_fcs_cnt = %u | cal_fcs_fail_cnt = %u 
+5764,,[ phyrf_debug_cmd.c : 3754 ] ************************************************** 
+5765,,[ phyrf_debug_cmd.c : 3761 ] CAL_STATS : Calibration stats for valid Periodic Cal profiles and cal types 
+5766,I,[ phyrf_debug_cmd.c : 3765 ] CAL_STATS : PERIODIC CAL cal_profile = %u 
+5767,III,[ phyrf_debug_cmd.c : 3775 ] CAL_STATS : cal_type = %u | cal_triggered_cnt = %u | cal_fail_cnt = %u  
+5768,,[ phyrf_debug_cmd.c : 3796 ] GET_START_END_FREQ: wifitool : Invalid no.of.arguments 
+5769,iiii,[ phyrf_debug_cmd.c : 3800 ] GET_START_END_FREQ : wifitool : low_2ghz_chan = %d high_2ghz_chan=%d low_5ghz_chan=%d high_5ghz_chan=%d 
+5770,,[ phyrf_debug_cmd.c : 3862 ] PAPRD: Invalid no.of.arguments 
+5771,ii,[ phyrf_debug_cmd.c : 3867 ] PAPRD: PHYID = %d ,Event Val = %d 
+5772,,[ phyrf_debug_cmd.c : 3887 ] PaprdTimerOverride: Invalid no.of.arguments 
+5773,iii,[ phyrf_debug_cmd.c : 3908 ] PAPRD: Phy ID %d | PAPRDTIMEROVERRIDE %d | Duration ms = %d 
+5774,,[ phyrf_debug_cmd.c : 3928 ] SetOpModeOverride: Invalid no.of.arguments 
+5775,iii,[ phyrf_debug_cmd.c : 3941 ] SetOpModeOverride: phyId = %d, override_enable = %d, g_override_op_mode_val = %d 
+5776,,[ phyrf_debug_cmd.c : 3953 ] ANI: Invalid no.of.arguments 
+5777,iii,[ phyrf_debug_cmd.c : 3960 ] ANI: PHYID = %d , value of enable_10ms_ani_histogram[%d] = %d 
+5778,,[ phyrf_debug_cmd.c : 4012 ] PHYERRINJ: Invalid no.of.arguments 
+5779,iiii,[ phyrf_debug_cmd.c : 4017 ] PHYERRINJ: PHYID = %d ,  CsiCmd : %d , Injection Code: %d , Blocking Call : %d 
+5780,,[ phyrf_debug_cmd.c : 4036 ] CTL_DISABLE: Invalid no.of.arguments 
+5781,i,[ phyrf_debug_cmd.c : 4047 ] phyrf_debug_MMHostCmdForceTxPower: Enabling Forced Tx Power. Pwr = %d dBm 
+5782,,[ phyrf_debug_cmd.c : 4053 ] phyrf_debug_MMHostCmdForceTxPower: Disabling Forced Tx Power 
+5783,,[ phyrf_debug_cmd.c : 4094 ] REGDB wifitool debug cmd: Invalid no.of.arguments 
+5784,,[ phyrf_debug_cmd.c : 4109 ] REGDB : Regdb is selected and used for the regulatory database.  
+5785,ii,[ phyrf_debug_cmd.c : 4110 ] REGDB : regDbVersionMajor: %d  regDbVersionMinor: %d  
+5786,,[ phyrf_debug_cmd.c : 4113 ] REGDB : Neither BDF nor Regdb is selected. 
+5787,ii,[ phyrf_debug_cmd.c : 4119 ] REGDB : Regulatory Database Query : type : %d code : %d 
+5788,i,[ phyrf_debug_cmd.c : 4125 ] REGDB : Invoked Current Regulatory Database Query : phyId : %d 
+5789,,[ phyrf_debug_cmd.c : 4145 ] AFC: GraceTimeOverride: Invalid no.of.arguments  
+5790,,[ phyrf_debug_cmd.c : 4151 ] AFC: GraceTimeOverride: Invalid test arguments, grace count should be between 1 - 288 
+5791,,[ phyrf_debug_cmd.c : 4175 ] OverrideTemperature: Invalid no.of.arguments 
+5792,iii,[ phyrf_debug_cmd.c : 4195 ] OverrideTemperature: Phy ID %d | TEMPERATUREOVERRIDE %d | override temperature = %d 
+5793,,[ phyrf_debug_cmd.c : 4222 ] AFC Debug cmd: Invalid no.of.arguments 
+5794,,[ phyrf_debug_cmd.c : 4254 ] AFC Debug cmd: Invalid test arguments 
+5795,,[ phyrf_debug_cmd.c : 4318 ] AFC_CTL : CTL regenerattion logs 
+5796,,[ phyrf_debug_cmd.c : 4327 ] Invalid test argument 
+5797,,[ phyrf_debug_cmd.c : 4332 ] Invalid sub cmd ID 
+5798,,[ phyrf_debug_cmd.c : 4350 ] OverrideSwProfile: Invalid no.of.arguments 
+5799,,[ phyrf_debug_cmd.c : 4379 ] OverrideSwProfile: Invalid sub command; should be 0 or 1 
+5800,,[ phyrf_debug_cmd.c : 4384 ] OverrideSwProfile: Invalid SW profile 
+5801,,[ phyrf_debug_cmd.c : 4391 ] RxEVMDebugMask: Invalid no.of.arguments 
+5802,,[ phyrf_debug_cmd.c : 4404 ] RxEVM Enable: Invalid no.of.arguments 
+5803,i,[ phyrf_debug_cmd.c : 4482 ]  ERR BIOS Unit test %d 
+5804,iiiii,[ phyrf_debug_cmd.c : 4495 ] Unit test for Cust Tx Pwr args[1] = %d args[2] = %d args[3] = %d args[4] = %d args[5] = %d
+ 
+5805,,[ phyrf_debug_cmd.c : 4548 ] Invalid no.of.arguments 
+5806,,[ phyrf_debug_cmd.c : 4556 ] phyrf_debug_MMHostCmdSkipCaldbRestore: halphyDebugConfigStruct is NULL
+ 
+5807,iI,[ phyrf_debug_cmd.c : 4561 ] phyrf_debug_MMHostCmdSkipCaldbRestore: Skip caldb restore bmap for PHYID %d is %x
+ 
+5808,,[ phyrf_debug_cmd.c : 4580 ] Invalid no.of.arguments 
+5809,iiiiii,[ phyrf_debug_cmd.c : 4599 ] phyrf_debug_MMHostCmdHdsPrePostCrash: Command arguments, num_args:%d, phyId:%d, swProfile:%d, prePostProfile:%d, chanFreq:%d, bw:%d 
+5810,,[ phyrf_debug_cmd.c : 4720 ] ftmTsDebugHandler: Invalid no.of.arguments 
+5811,ii,[ phyrf_debug_cmd.c : 4752 ] PAPRD: PhyID %d | RECOVERYDISABLE %d 
+5812,IiI,[ phyrf_debug_cmd.c : 4756 ] PAPRD: Setting dpdTempThreshold and tempRecal to %u and %d for phyId %u 
+5813,ii,[ phyrf_debug_cmd.c : 4762 ] PAPRD: PhyID %d | Trigger dpd on GLUT change %d 
+5814,IIi,[ phyrf_debug_cmd.c : 4768 ] PAPRD: phyId %u Enable debugLog %u Debug mode %d 
+5815,,[ phyrf_debug_cmd.c : 4772 ] PAPRD : Invalid test argument 
+5816,i,[ phyrf_debug_cmd.c : 4805 ] RFAT control %d
+ 
+5817,,[ phyrf_debug_cmd.c : 4819 ] ForceRxGainMode: Invalid no.of.arguments 
+5818,i,[ phyrf_debug_cmd.c : 4825 ] ForceRxGainMode: gRxGainModeDebugMask %d 
+5819,,[ phyrf_debug_cmd.c : 4837 ] SetRxState: Invalid no.of.arguments 
+5820,i,[ phyrf_debug_cmd.c : 4843 ] SetRxState: Enable %d 
+5821,,[ phyrf_debug_cmd.c : 4855 ] SetRxDeaf: Invalid no.of.arguments 
+5822,i,[ phyrf_debug_cmd.c : 4861 ] SetRxDeaf: %d 
+5823,,[ phyrf_debug_cmd.c : 4874 ] PhyDbgMode: Invalid no.of.arguments 
+5824,i,[ phyrf_debug_cmd.c : 4898 ] PhyDbgMode: %d 
+5825,,[ phyrf_debug_cmd.c : 4908 ] SETTGTR2PTABLE : Invalid no.of arguments 
+5826,i,[ phyrf_debug_cmd.c : 4925 ] SETTGTR2PTABLE return status = %d
+ 
+5827,,[ phyrf_debug_cmd.c : 4949 ] GET_BDF_FEATURE_FLAGS: wifitool : Invalid no.of.arguments 
+5828,IIIIii,[ phyrf_debug_cmd.c : 4961 ] GET_BDF_FEATURE_FLAGS: wifitool : custBoardSpecificFlags [0:31]=0x%x [32:63]=0x%x [64:95]=0x%x [96:127]=0x%x CustFlag bit %d Enabled = %d 
+5829,i,[ phyrf_debug_cmd.c : 4974 ] WIFITOOL ISSUED TO ENABLE/DISABLE PER-PACKET CHAINMASK SUPPORT = %d
+ 
+5830,i,[ phyrf_debug_cmd.c : 4978 ] ENABLE/DISABLE PER-PACKET CHAINMASK SUPPORT: INVALID INPUT %d
+ 
+5831,,[ phyrf_debug_cmd.c : 5002 ] RTT: Invalid no.of.arguments 
+5832,,[ phyrf_debug_cmd.c : 5018 ] HDS_SEQ_EDITOR: Invalid no.of.arguments 
+5833,,[ phyrf_debug_cmd.c : 5029 ] HDS_SEQ_EDITOR: Invalid sub_cmd 
+5834,i,[ phyrf_debug_cmd.c : 5037 ] HDS_SEQ_EDITOR: Enabled state: %d 
+5835,,[ phyrf_debug_cmd.c : 5043 ] HDS_SEQ_EDITOR: feature is disabled, you can enable it with this cmd: wifitool ath0 setUnitTestCmd 67 3 121 0 1 
+5836,,[ phyrf_debug_cmd.c : 5057 ] HDS_SEQ_EDITOR: Invalid sub cmd - 0 sub cmd is to enable needs only 3 args 
+5837,,[ phyrf_debug_cmd.c : 5062 ] HDS_SEQ_EDITOR: Invalid sub cmd - requires setting ID arg 
+5838,ii,[ phyrf_debug_cmd.c : 5105 ] PHYDbgCmd: num_args %d phyId %d 
+5839,,[ phyrf_debug_cmd.c : 5124 ] RX_CHAIN_ONOFF DEBUG : invalid no.of.arguments 
+5840,iiiii,[ phyrf_debug_cmd.c : 5128 ] RX_CHAIN_ONOFF DEBUG : num_args %d cmd_id %d phy_id %d chain %d enable %d 
+5841,,[ phyrf_debug_cmd.c : 5155 ] RTT_11AZ: Updating global for delta thresholds 
+5842,,[ phyrf_debug_cmd.c : 5162 ] RTT_11AZ: Updating global for power scale 
+5843,,[ phyrf_debug_cmd.c : 5169 ] RTT_11AZ: Updating global for number_corrupted_che_limit 
+5844,,[ phyrf_debug_cmd.c : 5176 ] RTT_11AZ: invalid choice 
+5845,i,[ phyrf_debug_cmd.c : 5190 ] RTT_11AZ: invalid test arguments. input num_args is %d required args is 7 for updating global<0/1/2> and 3 - Program Vreg<3> 
+5846,ii,[ phyrf_debug_cmd.c : 5238 ] VERBOSE: %d %d 
+5847,,[ phyrf_debug_cmd.c : 5241 ] VERBOSE: Invalid no.of.arguments 
+5848,,[ phyrf_debug_cmd.c : 5247 ] VERBOSE: Invalid enable/disable value supplied 
+5849,,[ phyrf_debug_cmd.c : 5251 ] VERBOSE: Verbose configured 
+5850,,[ phyrf_debug_cmd.c : 5259 ] AGILE VERBOSE: Invalid no.of.arguments 
+5851,,[ phyrf_debug_cmd.c : 5265 ] AGILE VERBOSE: Invalid enable/disable value supplied 
+5852,,[ phyrf_debug_cmd.c : 5269 ] AGILE VERBOSE: Agile Verbose configured 
+5853,,[ phyrf_debug_cmd.c : 5282 ] DO_TEMP_RECAL_ACTION Invalid no.of.arguments 
+5854,i,[ phyrf_debug_cmd.c : 5294 ] DO_TEMP_RECAL_ACTION: tempReCalCnt %d 
+5855,II,[ phyrf_debug_cmd.c : 5303 ] DO_TEMP_RECAL_ACTION: Setting pResetStruct->tempReCalControl to %u for phyId = %u 
+5856,II,[ phyrf_debug_cmd.c : 5310 ] DO_TEMP_RECAL_ACTION: Setting pResetStruct->tempPeriodicReCalControl to %u for phyId %u 
+5857,i,[ phyrf_debug_cmd.c : 5344 ] Invalid subCmdId max subCmdId=%d 
+5858,,[ phyrf_debug_cmd.c : 5429 ] wifiradar requires 9 args 
+5859,i,[ phyrf_debug_cmd.c : 5444 ] wifiradar: INIT TX GAIN %d 
+5860,ii,[ phyrf_debug_cmd.c : 5447 ] wifiradar: Tx gain[%d] %d 
+5861,iii,[ phyrf_debug_cmd.c : 5457 ] wifiradar_dbg: rx gain %d txchain %d rxchain %d 
+5862,iIIIII,[ phyrf_debug_cmd.c : 5459 ] wifiradar_dbg: cal_done %d variance %u low variance %u LRrxgain %u high variance %u HRrxgain %u 
+5863,IIIi,[ phyrf_debug_cmd.c : 5477 ] wifiradar: cal_channel_list num %u, band_center_freq1 %u, channel bW %u, sm_ended %d 
+5864,ii,[ phyrf_debug_cmd.c : 5481 ] wifiradar: Tx gain[%d] %d 
+5865,Iii,[ phyrf_debug_cmd.c : 5490 ] wifiradar_dbg: rx gain[%D] %d, cal_done %d 
+5866,,[ phyrf_debug_cmd.c : 5502 ] wifiradar: requires 7 args 
+5867,,[ phyrf_debug_cmd.c : 5523 ] wifiradar: requires 3 args 
+5868,iiii,[ phyrf_debug_cmd.c : 5532 ] wifiradar_dbg: wr_cal_complete %d, wr_cal_failed, %d, wr_cal_valid %d, wr aborted %d 
+5869,II,[ phyrf_debug_cmd.c : 5534 ] wifiradar_dbg: Calibration completed in %u us with packet sucess count %u 
+5870,,[ phyrf_debug_cmd.c : 5551 ] wifiradar_dbg: Invalid Index 
+5871,iiiiI,[ phyrf_debug_cmd.c : 5587 ] UIC STATS[%d]: Seq Num: %d	 calPriorityIdx: %d	 calState: %d	 timestamp: %lu
+ 
+5872,i,[ phyrf_debug_cmd.c : 5812 ] num_args %d 
+5873,,[ phyrf_debug_cmd.c : 5885 ] wifitool SET TPC WMI simulation sent successfully 
+5874,IIi,[ phyrf_debug_cmd.c : 5898 ] Dump_AOA: Extrapol: Gain[%u] = %u:%dd 
+5875,IIi,[ phyrf_debug_cmd.c : 5923 ]  Dump_AOA: AoaGrpStopIdx[%u] = %u : %d 
+5876,II,[ phyrf_debug_cmd.c : 5964 ] Dump_AOA: Phase data for selected chan %u chainIdx %u 
+5877,,[ phyrf_debug_cmd.c : 5968 ]  Dump_AOA: No Data Available 
+5878,,[ phyrf_debug_cmd.c : 5978 ]  Dump_AOA: No Data Available 
+5879,,[ phyrf_debug_cmd.c : 5985 ]  Dump_AOA: Invalid case 
+5880,,[ phyrf_debug_cmd.c : 6059 ] EANI_DBG: Invalid no.of.arguments 
+5881,iIii,[ phyrf_debug_cmd.c : 6072 ] EANI_DBG Dump PHYID %d eAniFlag %x curEAniMode %d curEANIModeOrderIdx %d 
+5882,ii,[ phyrf_debug_cmd.c : 6074 ] EANI_DBG RSSI Read period %d ms, curPri20 RSSI in dBm %d 
+5883,iii,[ phyrf_debug_cmd.c : 6075 ] EANI_DBG Mode enum Default desense %d, Min desense %d, Max desense %d 
+5884,ii,[ phyrf_debug_cmd.c : 6078 ] EANI_DBG ModeDuration[%d] %d 
+5885,iiii,[ phyrf_debug_cmd.c : 6082 ] EANI_DBG RssiVal[%d] %d AniLevel[%d] %d 
+5886,ii,[ phyrf_debug_cmd.c : 6086 ] EANI_DBG ModeOrder[%d] %d 
+5887,,[ phyrf_debug_cmd.c : 6107 ] EANI_DBG: Invalid no.of.arguments 
+5888,,[ phyrf_debug_cmd.c : 6119 ] EANI_DBG: Invalid test arguments 
+5889,,[ phyrf_debug_cmd.c : 6130 ] EANI_DBG: Invalid test arguments 
+5890,,[ phyrf_debug_cmd.c : 6144 ] EANI_DBG: Invalid test arguments 
+5891,,[ phyrf_debug_cmd.c : 6157 ] EANI_DBG: Invalid test arguments 
+5892,i,[ phyrf_debug_cmd.c : 6161 ] EANI_DBG Invalid subCmdId %d 
+5893,,[ phyrf_debug_cmd.c : 6171 ] Invalid no.of.arguments 
+5894,iiii,[ phyrf_debug_cmd.c : 6179 ] totalDpdCalCount: %d chanChangeDpdCalCount: %d ThermalDpdCalCount: %d RecoveryDpdCalCount: %d
+ 
+5895,iiii,[ phyrf_debug_cmd.c : 6181 ] totalDpdFailCount: %d chanChangeDpdFailCount: %d ThermalDpFailCount: %d RecoveryDpdFailCount: %d
+ 
+5896,iiiiII,[ phyrf_debug_cmd.c : 6182 ] pbCalCount: %d pbFailCount: %d isDpdValid: %d isPowerBoostValid: %d lastDpdCalTimeMs: %lu lastPbCalTimeMs: %lu 
+5897,iii,[ phyrf_debug_cmd.c : 6186 ] powerBoostGain[%d][%d] = %d
+ 
+5898,,[ phyrf_debug_cmd.c : 6221 ] UpdateTgtPwrRatesArray: Invalid arguments 
+5899,,[ phyrf_debug_cmd.c : 6234 ] UpdateTgtPwrRatesArray: Input Validation Check Failed  
+5900,,[ phyrf_debug_cmd.c : 6286 ] MEM_DPD_THREAD: Invalid test arguments  
+5901,iI,[ phyrf_debug_cmd.c : 6296 ] MEM_DPD_THREAD: Dump TPC Globals: PHYID %d subCmdId %x 
+5902,i,[ phyrf_debug_cmd.c : 6297 ] MEM_DPD_THREAD: pTpcConfig->tpc_histogram_index:%d 
+5903,i,[ phyrf_debug_cmd.c : 6298 ] MEM_DPD_THREAD: Dump TPC Globals: tpc_compute_process_status %d 
+5904,i,[ phyrf_debug_cmd.c : 6299 ] MEM_DPD_THREAD: Dump TPC Globals: tpc_mem_dpd_thread_active  %d 
+5905,i,[ phyrf_debug_cmd.c : 6303 ] MEM_DPD_THREAD: Index: %d 
+5906,i,[ phyrf_debug_cmd.c : 6306 ] MEM_DPD_THREAD: Time Delta for MEM_DPD thread to start schedule :%d 
+5907,i,[ phyrf_debug_cmd.c : 6310 ] MEM_DPD_THREAD: Time Delta for PRE_TPC HDS Sequence in Mem DPD thread :%d 
+5908,i,[ phyrf_debug_cmd.c : 6314 ] MEM_DPD_THREAD: Total Time Taken in MEM_DPD thread :%d 
+5909,i,[ phyrf_debug_cmd.c : 6318 ] MEM_DPD_THREAD: Time wait in RT thread for the signal :%d 
+5910,i,[ phyrf_debug_cmd.c : 6321 ] MEM_DPD_THREAD: Dump TPC Globals: mem_dpd_thread_prio_execution %d  
+5911,iIi,[ phyrf_debug_cmd.c : 6335 ] MEM_DPD_THREAD: Dump TPC Globals: PHYID %d subCmdId %x MEM_DPDTHREADOVERRIDE : %d  
+5912,i,[ phyrf_debug_cmd.c : 6339 ] MEM_DPD_THREAD: Dump TPC Globals:Invalid subCmdId %d 
+5913,I,[ hca_HwComponentBb_reset.cpp : 26 ] Error: processCmd ID of %u, unknown state 
+5914,I,[ hca_HwComponentTrx_calDb.cpp : 23 ] Error: processCmd ID of %u, unknown state 
+5915,I,[ hca_HwComponentTrx_calSms.cpp : 24 ] Error: processCmd ID of %u, unknown state 
+5916,I,[ hca_HwComponentTrx_config.cpp : 24 ] Error: processCmd ID of %u, unknown state 
+5917,I,[ hca_HwComponentTrx_efuse.cpp : 21 ] Error: processCmd ID of %u, unknown state 
+5918,I,[ hca_HwComponentTrx_paprd.cpp : 25 ] Error: processCmd ID of %u, unknown state 
+5919,i,[ hca_config.cpp : 85 ] Invalid HW component type %d
+ 
+5920,i,[ phyrf_mc_paprd.c : 144 ] PAPRD:SM state %d 
+5921,iii,[ phyrf_mc_paprd.c : 331 ] PAPRD: Chain = %d, txgainIdx = %d, dacgain = %d 
+5922,iiii,[ phyrf_mc_paprd.c : 591 ] PAPRD: cur_channel %d, wal_channel %d, scan_channel %d, phyReset %d 
+5923,iiiii,[ phyrf_mc_paprd.c : 666 ]  PAPRD: readCurrentTemp : phyId %d, curr chan %d txchainmask %d currtime %d, degC %d 
+5924,i,[ phyrf_mc_paprd.c : 695 ] DPD is in progress on phyId %d 
+5925,iiii,[ phyrf_mc_paprd.c : 733 ] PAPRD: dpd_temp_timer phy %d Channel %d thermal channel %d tempTimerStatus %d 
+5926,iiiii,[ phyrf_mc_paprd.c : 741 ] PAPRD: Abort TempRecal phy %d Channel %d thermal channel %d bHomeChan %d tempTimerStatus %d 
+5927,iiiiiii,[ phyrf_mc_paprd.c : 769 ] PAPRD : dpd_temp_timer tempDiff %d currTemp %d temp %d dpdTemperatureDelta %d dpdTemperatureDeltaNeg %d thermalScaling %d thermalSlope %d 
+5928,iii,[ phyrf_mc_paprd.c : 790 ] PAPRD: TempRecal phy %d thermal channel %d tempTimerStatus %d 
+5929,iii,[ phyrf_mc_paprd.c : 879 ] PAPRD: temp_recal_timer started. tempRecalcount %d, phyId %d, calTemp %d 
+5930,ii,[ phyrf_mc_paprd.c : 891 ] PAPRD:Tx stats : hw_queued %d hw_reaped %d 
+5931,i,[ phyrf_mc_paprd.c : 892 ] PAPRD:Tx stats : tx_done %d 
+5932,iii,[ phyrf_mc_paprd.c : 894 ] PAPRD:Tx stats : tx_abort %d tx_abort_compl_err_status %d tx_abort_pdev_suspend %d 
+5933,iii,[ phyrf_mc_paprd.c : 896 ] PAPRD:Tx stats : tx_async_enqueue %d tx_async_dequeue %d tx_fail %d 
+5934,iiii,[ phyrf_mc_paprd.c : 915 ] PAPRD ApplyTempScaling: PhyId %d slope %d temp delta %d scaling %d 
+5935,ii,[ phyrf_mc_paprd.c : 931 ] PAPRD Signal from MEM_DPD thread has arrived out of context so Aborting curChan = %d workingChannel = %d
+ 
+5936,,[ phyrf_mc_paprd.c : 937 ] PAPRD MEM_DPD complete received on scan channel context, Will be retriggered when coming back to home
+ 
+5937,ii,[ phyrf_mc_paprd.c : 1102 ] PAPRD Calibration : Cancel Timer channel %d home chan %d 
+5938,i,[ phyrf_mc_paprd.c : 1127 ] PAPRD : Recovery DPD cal triggered dpd_recovery_count = %d
+ 
+5939,iii,[ phyrf_mc_paprd.c : 1224 ] PAPRD: Not triggered for bHomeChan %d Â channel %d workingChannel %d returning 
+5940,,[ phyrf_phy.c : 116 ] AID input is NULL 
+5941,,[ phyrf_phy.c : 123 ] Error while writing multi assoc ID 
+5942,,[ phyrf_phy.c : 125 ] Setting AID is not supported 
+5943,,[ phyrf_phy.c : 135 ] GetMultipleAssocID input is NULL 
+5944,,[ phyrf_phy.c : 142 ] Error while getting multi assoc ID 
+5945,,[ phyrf_phy.c : 144 ] Getting AID from VREG is not supported 
+5946,I,[ phyrf_boot_intf_api.c : 102 ] phyrf_boot_getcaldbsize_hdlr: %p  
+5947,i,[ phyrf_boot_intf_api.c : 104 ] phyrf_boot_getcaldbsize_hdlr: calDbsize: %d  
+5948,,[ phyrf_intf_async_hdlr.c : 14 ] Calling phyrf_reset_AfterPhyOn() API 
+5949,i,[ phyrf_wmi_cmd.c : 54 ] PowerBoost WMI_PDEV_SET_POWER_BOOST_MEMORY_IND_CMDID pdev id %d 
+5950,i,[ phyrf_wmi_cmd.c : 72 ] PowerBoost WMI_PDEV_POWER_BOOST_CMDID pdev id %d 
+5951,,[ phyrf_wmi_cmd.c : 88 ] PowerBoost Invalid WMI commmand 
+5952,i,[ phyrf_wmi_cmd.c : 172 ] ANI_WMI: WMI_PDEV_GET_HALPHY_CAL_STATUS_CMDID - pdev_id=%d 
+ 
+5953,ii,[ phyrf_wmi_event.c : 158 ] wlan_pdev_handle_get_channel_ani_cmd max_channel_limit %d, received_count %d 
+5954,i,[ phyrf_wmi_event.c : 170 ] wlan_pdev_handle_get_channel_ani_cmd memory allocation failed, %d 
+5955,ii,[ phyrf_wmi_event.c : 208 ] wlan_pdev_handle_get_channel_ani_cmd freq:%d, ani:%d 
+5956,i,[ phyrf_wmi_event.c : 215 ] wlan_pdev_handle_get_channel_ani_cmd unsupported freq:%d 
+5957,III,[ phyrf_wmi_event.c : 316 ] ANI_WMI: WMI_PDEV_GET_HALPHY_CAL_STATUS_EVENTID ev->pdev_id=%ld cal_bmap=%ld cal_status=%ld 
+5958,,[ phyrf_wmi_event.c : 335 ] ANI - Memory Allocation fail 
+5959,iii,[ phyrf_wmi_event.c : 360 ] ANI - OFDM_level=%d, pdev_id = %d, pdev_valid = %d 
+5960,,[ phyrf_wmi_event.c : 377 ] ANI - Memory Allocation fail 
+5961,iiiii,[ phyrf_reset.c : 466 ] DumpTpc-6: set trasmit chan power: %d, 2g limit: %d, 5g limit: %d, max tx: %d, homeChanFlag: %d 
+5962,iiiii,[ phyrf_reset.c : 509 ] DumpTpc-1: set trasmit chan power: %d, 2g limit: %d, 5g limit: %d, max tx: %d  limit: %d 
+5963,iiii,[ phyrf_reset.c : 579 ] DumpTpc-3: set trasmit chan power: %d, forced: %d, max tx: %d, homeChanFlag: %d 
+5964,iiiii,[ phyrf_reset.c : 679 ] SetHomeChannel: phyId %d bSet %d mhz %d freq1 %d i %d 
+5965,ii,[ phyrf_reset.c : 703 ] SetHomeChannel: ERROR: No more space for home channel... i = %d. Max_supported_home_channel=%d 
+5966,iiiii,[ phyrf_reset.c : 744 ] ReleaseHomeChannel: phyId %d mhz %d freq1 %d freq2 %d index %d 
+5967,iiiii,[ phyrf_reset.c : 788 ] DumpTpc-4: set trasmit chan power: %d, 2g limit: %d, 5g limit: %d, max tx: %d, homeChanFlag: %d 
+5968,iiiiii,[ phyrf_reset.c : 1039 ] End of UpdateHomeChanParms:[2_pri20 %d][2_center %d][1_pri20 %d][1_center %d] rss1 %d, rss2 %d  
+5969,I,[ phyrf_reset.c : 1355 ] Invalid Tx CM. Setting Valid CM %x0x 
+5970,I,[ phyrf_reset.c : 1363 ] Invalid Rx CM. Setting Valid CM %x0x 
+5971,ii,[ phyrf_reset.c : 1443 ] GetChainMasks : tx_chain_mask_sw %d rx_chain_mask_sw %d 
+ 
+5972,I,[ phyrf_reset.c : 1473 ] NSS_ChainMask: Invalid Chainmask Enum = 0x%lx 
+5973,iii,[ phyrf_reset.c : 1479 ] NSS_ChainMask : NSS=%d, tx_rx=%d ,numchains=%d
+ 
+5974,i,[ phyrf_reset.c : 1485 ] Invalid nss config. Updating to numchains supported %d 
+5975,iI,[ phyrf_reset.c : 1733 ] GetHwNf value = %d, isdBm = %u 
+5976,IIi,[ phyrf_reset.c : 2081 ] SetPbsMode: pbs_flag = 0x%x , pbs_mode = 0x%x, FOR PHYID %d 
+5977,II,[ phyrf_reset.c : 2343 ] PowerMode setting for phyId : 0x%x, value : 0x%x 
+5978,I,[ phyrf_reset.c : 2480 ] AR_DEBUG : Enabling ForceCal on phyId : 0x%x 
+5979,I,[ phyrf_reset.c : 2631 ] Enabling ForceCal on phyId : 0x%x 
+5980,i,[ phyrf_reset.c : 2657 ] Pre HDS first half : %d 
+5981,I,[ phyrf_reset.c : 2894 ] Translated chainmask 0x%x  
+5982,i,[ phyrf_reset.c : 2936 ] Invalid ChainIndex %d. Returning the input chainIndex without translating 
+5983,i,[ phyrf_reset.c : 2943 ] Invalid ChainIndex %d. Returning the input chainIndex without translating 
+5984,i,[ phyrf_reset.c : 2948 ] Translated ChainIndex %d 
+5985,i,[ phyrf_reset.c : 2977 ] IsChannelSwitchFCS: bHomeChanLocal=%d 
+5986,iiiii,[ phyrf_reset.c : 3023 ] IsChannelSwitchFCS: Home FCS failed, phyId=%d, doCalTPC=%d, doCalFlagRxDCO=%d, doCalFlagCombIQ=%d, reloadIni=%d 
+5987,iii,[ phyrf_reset.c : 3036 ] IsChannelSwitchFCS: Agile Scan FCS failed, phyId=%d, doScanCalFcsFlag=%d, reloadIni=%d
+ 
+5988,iii,[ phyrf_reset.c : 3045 ] IsChannelSwitchFCS: Scan FCS/Agile Scan FCS failed, phyId=%d, doScanCalFcsFlag=%d, reloadIni=%d
+ 
+5989,iii,[ phyrf_reset.c : 3052 ] IsChannelSwitchFCS: FCS Successful. phyId=%d, fcsEnableMask=%d, HomeChan=%d 
+5990,i,[ phyrf_reset.c : 3223 ] Invalid number of chains %d. Resetting PPET to all 0s 
+5991,iiIi,[ phyrf_reset.c : 3296 ] PPET  numNss_m1 %d, nss_2g %d, chainmask %x, numchains %d 
+5992,iiIi,[ phyrf_reset.c : 3313 ] PPET  numNss_m1 %d, nss_5g %d, chainmask %x, numchains %d 
+5993,iii,[ phyrf_reset.c : 3322 ] PPET updated = %d (1=YES,0=NO) phyId %d rf_mode %d 
+5994,iiiii,[ phyrf_reset.c : 3507 ] maxBandwidth %d phy_mode %d mhz = %d, fc1 = %d, fc2 = %d 
+5995,i,[ phyrf_reset.c : 3615 ] GetRssiDbmConversionParms : rssiTempOffset = %d
+ 
+5996,ii,[ phyrf_reset.c : 3658 ] GetRssiDbmConversionParms : RSSI Channel offset %d , current channel %d 
+5997,i,[ phyrf_reset.c : 3724 ] Get3HomeChannelSwitchTime %d 
+5998,iI,[ phyrf_reset.c : 3898 ] LP SW Stat(PHY ID %d) : 0x%x 
+5999,,[ phyrf_reset.c : 3905 ] CheckFreqNssChainMask: Error - pHandle is NULL 
+6000,IIIi,[ phyrf_reset.c : 3912 ] CheckFreqNssChainMask : freq=%u, cMask=0x%x, nss=%u, tx_rx=%d 
+6001,,[ phyrf_reset.c : 3916 ] Error - num chains < nss 
+6002,I,[ phyrf_reset.c : 4057 ] ModulesOnOff enable %u 
+6003,II,[ phyrf_reset.c : 4216 ] Received Invalid pHandle. Updating to valid pdev:0x%x and pHandle:0x%x 
+6004,i,[ phyrf_spectral.c : 307 ] SSCAN HDS ADT: HDS_ADT_IS_SPECTRAL_ENABLED_ID returned with STATUS:%d 
+ 
+6005,,[ phyrf_spectral.c : 320 ] SSCAN HDS ADT: Spectral scan is forceDisabled , skipping activation 
+6006,,[ phyrf_tpc.c : 398 ] DumpTpcRegisters:Error Cannot Access Register in Sleep and EMLSR mode, return 
+6007,iiiIii,[ phyrf_tpc.c : 795 ] ch %d, pwr %d, glutIdx %d txGainIdx %x, minDacGain %d  minTxPwr %d 
+6008,Ii,[ phyrf_tpc.c : 1110 ] wifiradar: tx_pwr_perchain %u, num gluts %d 
+6009,,[ phyrf_tpc.c : 1125 ] wifiradar: No operation 
+6010,,[ phyrf_tpc.c : 1133 ] wifiradar: error 
+6011,,[ phyrf_tpc.c : 1267 ] PRE_TPC: Out or Order Sequence for TPC calculation, RT thread to take care of PRE_TPC 
+6012,i,[ phyrf_tpc.c : 1275 ] PRE_TPC: PRE_TPC HDS Timings in Mem DPD Thread : Timings: %d 
+6013,ii,[ phyrf_tpc.c : 1311 ] PRE_TPC: Message posted to MEM_DPD thread - mem_dpd_thread_active_status: %d, tpc_rt_to_mem_dpd_thread_sched_time =%d 
+6014,iii,[ phyrf_tpc.c : 1369 ] PRE_TPC: Time Taken for Mem DPD thread to schedule: %d, max_time :%d, min_time :%d 
+6015,,[ phyrf_tpc.c : 1413 ] PRE_TPC: TPC_COMPUTATION_COMPLETED_IN_RT_THREAD 
+6016,,[ phyrf_tpc.c : 1434 ] PRE_TPC: TPC_COMPUTATION_COMPLETED_IN_RT_THREAD 
+6017,,[ phyrf_tpc.c : 1438 ] PRE_TPC: TPC_COMPUTATION_COMPLETED_IN_MEM_DPD_THREAD 
+6018,i,[ phyrf_tpc.c : 1462 ] PRE_TPC: Timings taken in RT thread for post TPC completion handlings : %d 
+6019,i,[ phyrf_tpc.c : 1483 ] PRE_TPC: Final Updated histogram index :%d 
+6020,ii,[ phyrf_bdf_tpc.c : 206 ] TPC_DBG: pdadc[%d] = %d 
+6021,iiii,[ phyrf_bdf_tpc.c : 209 ] TPC_ERR: PLUT is non-linear,last_pdadc[%d] = %d, current_pdadc[%d] = %d 
+6022,iiiii,[ phyrf_bdf_tpc.c : 354 ] TPC_ERR: ALUT: PDADC Measurement are Zero : calPerPointClpc[0]=%d calPerPointClpc[1]=%d calPerPointClpc[2]=%d calPerPointClpc[3]=%d calPerPointClpc[4]=%d 
+6023,i,[ phyrf_bdf_tpc.c : 541 ] TPC_DBG: ALUT update clpc_corr_thr_dBm:%d 
+6024,i,[ phyrf_bdf_tpc.c : 593 ] TPC_ERR:phyrf_tpc_device_GetGlutPierIndex- Zero TPC FreqPiers for the band %d
+ 
+6025,ii,[ phyrf_bdf_tpc.c : 620 ] TPC_DBG: phyrf_tpc_device_GetGlutPierIndex: match = %d idxToUse %d
+ 
+6026,iiiiii,[ phyrf_bdf_tpc.c : 725 ] TPC_DBG: channel:%d CalDBFreq:%d tpcF2:%d idxToUse:%d GLUTFreq:%d InterChainCal:%d 
+6027,i,[ phyrf_bdf_tpc.c : 747 ] TPC_ERR: GLUT_PROG_ERROR: pRawCalPerPointOlpcGtxExt was unexpectedly NULL, last 2 entries of GLUT NOT BEING PROGRAMMED maxGlutIdx = %d 
+6028,i,[ phyrf_bdf_tpc.c : 830 ] warning: Overflow condition hit, Capping to Max power: Actual meas_pwr=%d, 
+6029,i,[ phyrf_bdf_tpc.c : 847 ] warning: Overflow condition hit, Capping to Max power: next_meas_pwr=%d 
+6030,i,[ phyrf_bdf_tpc.c : 866 ] warning: Overflow condition hit, Capping to Max power: meas_pwr=%d 
+6031,i,[ phyrf_bdf_tpc.c : 881 ] warning: Overflow condition hit, Capping to Max power: next_meas_pwr=%d 
+6032,iiiiiiiii,[ phyrf_bdf_tpc.c : 889 ] TPC_DBG: glutIdx %d skipCheck %d, measPwr %d, nextMeasPwr %d chainIndex %d dacGain %d txGainIdx %d paCfg %d maxGlutIdx %d 
+ 
+6033,iii,[ phyrf_bdf_tpc.c : 904 ]  TPC_ERR: non-linearity glutIdx %d measPwr %d nextMeasPwr %d 
+6034,iiii,[ phyrf_bdf_tpc.c : 1051 ]  TPC_DBG: phyrf_tpc_device_ClpcPlutAlutUpdate tpcPowerOffset[%d] %d twoPtOffset[%d] %d 
+6035,,[ phyrf_bdf_tpc.c : 1078 ]  TPC_ERR: phyrf_tpc_device_ClpcPlutAlutUpdate returning for calPerPoint_clpcf_chan NULL 
+6036,,[ phyrf_bdf_tpc.c : 1114 ] TPC_ERR: phyrf_tpc_device_ClpcPlutAlutUpdate returning for clpcf_chanLo or clpcf_chanHi NULL 
+6037,i,[ phyrf_bdf_tpc.c : 1205 ] TPC_DBG: phyrf_tpc_device_GetClpcMode clpcmode=%d 
+6038,ii,[ phyrf_bdf_tpc.c : 1239 ] TPC_DBG: doCalTPC %d DO_CAL_TPC_MEM=%d 
+6039,iiiii,[ phyrf_bdf_tpc.c : 1277 ] TPC_DBG: phyrf_tpc_device_HdsGlutUpdate : calEnableFlag=%d, bHomeChan=%d, DO_CAL_TPC_MEM=%d, DO_CAL_TPC_REG=%d, DONT_CAL_SCAN_HOME_CHANGE=%d 
+6040,Iii,[ phyrf_bdf_tpc.c : 1355 ] TPC_DBG: pRawCalPerPointOlpc 0x%x, inputCALGLUTOffset=%d, onePointTpcOffset=%d 
+6041,II,[ phyrf_wifiradar.c : 88 ]  wifiradar: chain_comb_choice %u, idx_offset %u 
+6042,,[ phyrf_wifiradar.c : 236 ] wifiradar: error due to invalid max tx gain 
+6043,,[ phyrf_wifiradar.c : 369 ] wifiradar: passed null pointer 
+6044,,[ phyrf_wifiradar.c : 396 ] wifiradar: passed null pointer 
+6045,,[ phyrf_wifiradar.c : 414 ] wifiradar: passed null pointer 
+6046,,[ phyrf_wifiradar.c : 440 ] wifiradar: WifiRadarStartTimerhandler: pHandle NULL 
+6047,iii,[ phyrf_wifiradar.c : 459 ] wifiradar:  Timer Handler %d  current channel context is different from timer channel context [%d %d] 
+6048,i,[ phyrf_wifiradar.c : 464 ] wifiradar: Start Calibration : %d ms Timer expired  
+6049,,[ phyrf_wifiradar.c : 473 ] wifiradar: passed null pointer 
+6050,,[ phyrf_wifiradar.c : 483 ] wifiradar: disabled 
+6051,,[ phyrf_wifiradar.c : 501 ] wifiradar: passed null pointer 
+6052,,[ phyrf_wifiradar.c : 519 ] wifiradar: passed null pointer 
+6053,III,[ phyrf_wifiradar.c : 600 ] wifiradar_dbg: cal_adc_map_sel 0x%x, tlv_chain_mask 0x%x,rx_chain_pair 0x%x 
+6054,,[ phyrf_wifiradar.c : 618 ] wifiradar: invalid Tx chain Index 
+6055,I,[ phyrf_wifiradar.c : 664 ] wifiradar: DDR 0x%x 
+6056,,[ phyrf_wifiradar.c : 695 ] wifiradar: passed null pointer 
+6057,i,[ phyrf_wifiradar.c : 774 ] wifiradar: Exceeding %d channel count hence writing over oldest data 
+6058,,[ phyrf_wifiradar.c : 800 ] wifiradar: Not Enabled 
+6059,,[ phyrf_wifiradar.c : 805 ] wifiradar: Not Licensed 
+6060,,[ phyrf_wifiradar.c : 810 ] wifiradar: AP vap doesn't exist hence trigger failed 
+6061,,[ phyrf_wifiradar.c : 815 ] wifiradar: Trigerring cal for already done channel so Exit 
+6062,,[ phyrf_wifiradar.c : 821 ] wifiradar: Previous cal session hasn't ended 
+6063,iI,[ phyrf_wifiradar.c : 865 ] wifiradar_dbg: wr_cal_type %d, wr_cal_channel %u 
+6064,,[ phyrf_wifiradar.c : 881 ] wifiradar: passed null pointer 
+6065,,[ phyrf_wifiradar.c : 912 ] wifiradar: passed null pointer 
+6066,i,[ phyrf_wifiradar.c : 915 ] wifiradar_dbg: cal_type %d 
+6067,,[ phyrf_wifiradar.c : 930 ] wifiradar: passed null pointer 
+6068,,[ phyrf_wifiradar.c : 951 ] wifiradar: passed null pointer 
+6069,,[ phyrf_wifiradar.c : 1038 ] wifiradar: passed null pointer 
+6070,ii,[ phyrf_wifiradar.c : 1048 ] wifiradar: licensed %d enabled %d 
+6071,i,[ phyrf_wifiradar.c : 1107 ] wifiradar_dbg: cal_type %d 
+6072,,[ phyrf_wifiradar.c : 1171 ] wifiradar: passed null pointer 
+6073,i,[ phyrf_wifiradar.c : 1243 ] wifiradar_dbg: cal_type %d 
+6074,i,[ phyrf_wifiradar.c : 1265 ] wifiradar_dbg: cal_type %d 
+6075,I,[ phyrf_wifiradar.c : 1319 ]  wifiradar: tempRxChainMask 0x%x 
+6076,,[ phyrf_wifiradar.c : 1325 ] wifiradar: passed null pointer 
+6077,II,[ phyrf_wifiradar.c : 1386 ] wifiradar: cum var %u, mean var %u 
+6078,III,[ phyrf_wifiradar.c : 1411 ] wifiradar_tx:Tx chain %u, tx_gain_per_chain %u, max_tx_gain %u 
+6079,,[ phyrf_wifiradar.c : 1435 ] wifiradar: passed null pointer 
+6080,,[ phyrf_wifiradar.c : 1463 ] wifiradar: passed null pointer 
+6081,i,[ phyrf_wifiradar.c : 1469 ] wifiradar: transmitted_training_packets %d 
+6082,IiiiI,[ phyrf_wifiradar.c : 1511 ] wifiradar: tx chainmask 0x%x packet_bw %d n_rep %d skip_ltf_count %d dpd cm 0x%x 
+6083,,[ phyrf_wifiradar.c : 1521 ] wifiradar: passed null pointer 
+6084,,[ phyrf_wifiradar.c : 1541 ] wifiradar: passed null pointer 
+6085,iII,[ phyrf_wifiradar.c : 1553 ] wifiradar: RAW %d DWORD %p 0x%x 
+ 
+6086,III,[ phyrf_wifiradar.c : 1574 ] wifiradar: LVD %ld MVD %ld HVD %ld 
+ 
+6087,II,[ phyrf_wifiradar.c : 1638 ] wifiradar:case failed tx_chain%u,chainItr%u  
+ 
+6088,I,[ phyrf_wifiradar.c : 1688 ] wifiradar: Rx Chainmask 0x%x 
+6089,,[ phyrf_wifiradar.c : 1693 ] wifiradar: invalid chain index 
+6090,I,[ phyrf_wifiradar.c : 1771 ] wifiradar_recal: Rx Chainmask 0x%x 
+6091,,[ phyrf_wifiradar.c : 1776 ] wifiradar_recal: invalid chain index 
+6092,II,[ phyrf_wifiradar.c : 1796 ] wifiradar_recal: recal 0x%x for tx chain pair %u 
+6093,I,[ phyrf_wifiradar.c : 1818 ] wifiradar_recal: cal done mask 0x%u 
+6094,III,[ phyrf_wifiradar.c : 1835 ] wifiradar: mean_variance %u cum_variance %u target_variance %u 
+6095,,[ phyrf_wifiradar.c : 1876 ] wifiradar: invalid chain index 
+6096,II,[ phyrf_wifiradar.c : 1920 ] wifiradar: unable to converge for Tx gain, mean_variance %u, min_max_capture %u 
+6097,,[ phyrf_wifiradar.c : 1953 ] wifiradar: passed null pointer 
+6098,i,[ phyrf_wifiradar.c : 1960 ] wifiradar_dbg: cal_type %d 
+6099,,[ phyrf_wifiradar.c : 1975 ] wifiradar: invalid chain index 
+6100,II,[ phyrf_wifiradar.c : 1985 ] wifiradar lastChainPair %u, lastRxChainPair %u 
+6101,,[ phyrf_wifiradar.c : 2018 ] wifiradar: invalid chain index 
+6102,III,[ phyrf_wifiradar.c : 2030 ] wifiradar lastChainPair %u, lastRxChainPair %u recal_chainmask 0x%x 
+6103,i,[ phyrf_wifiradar.c : 2099 ] wifiradar: INITIAL_Tx_Gain %d 
+6104,,[ phyrf_wifiradar.c : 2174 ] wifiradar: passed null pointer 
+6105,,[ phyrf_wifiradar.c : 2190 ] wifiradar: passed null pointer 
+6106,I,[ phyrf_wifiradar.c : 2236 ] wifiradar_dbg: Calibration completed in %u us 
+6107,,[ phyrf_wifiradar.c : 2251 ] wifiradar: passed null pointer 
+6108,i,[ phyrf_wifiradar.c : 2254 ] wifiradar_dbg: %d
+ 
+6109,,[ phyrf_wifiradar.c : 2281 ] wifiradar_dbg: Exited the SM 
+6110,,[ wlan_swbmiss_offload.c : 256 ] wlan_swbmiss_vdev_free 
+6111,i,[ wlan_swbmiss_offload.c : 300 ] wlan_swbmiss_check_if_bmiss_enabled: vdev id=%d, bmiss timer isn't armed, restart it. 
+6112,,[ wlan_swbmiss_offload.c : 454 ] SWBMISS - final bmiss set bmiss flag 
+6113,iii,[ wlan_swbmiss_offload.c : 488 ] wlan_swbmiss_post_bcn_evt: evt=%d, is_qnull_success=%d, final_bmiss_cnt_in_wow=%d 
+6114,i,[ wlan_swbmiss_offload.c : 832 ] wlan_swbmiss_cons_bmiss_stats_set: timeout_interval_ms %d  
+6115,,[ wlan_swbmiss_offload.c : 910 ] vdevp is null from function  wlan_swbmiss_bmiss_tmr_fn 
+6116,iiiiiii,[ wlan_swbmiss_offload.c : 940 ] SWBMISS_TIMER_FN: vdev_id=%d, curr_bmiss_bcnt=%d, pre_bmiss_detected=%d, first_bmiss_detected=%d, final_bmiss_detected=%d, b_timeout=%d, cons_bmiss_count = %d  
+6117,i,[ wlan_swbmiss_offload.c : 973 ] SWBMISS DEBUG: cons_bmiss_cnt=%d 
+6118,i,[ wlan_swbmiss_offload.c : 1074 ] SWBMISS DEBUG: bmiss_type = %d 
+6119,iiiiiii,[ wlan_swbmiss_offload.c : 1609 ] wlan_swbmiss_set_bmiss_counts: firstBmiss=%d, finalBmiss=%d, total_bmiss_sec=%d, total_bmiss_sec_wow=%d, bi_ms=%d, bi_tu=%d, hw_bmiss_bcnt=%d 
+6120,iii,[ wlan_swbmiss_offload.c : 1632 ] wlan_swbmiss_wow_notify: notif=%d, ic_opmode=%d, final_bmiss_cnt_in_wow=%d 
+6121,ii,[ wlan_swbmiss_offload.c : 1697 ] wlan_swbmiss_unit_test %d %d 
+6122,i,[ wlan_swbmiss_offload.c : 1707 ] wlan_swbmiss_unit_test cons_bmiss_cnt=%d 
+6123,i,[ wlan_swbmiss_offload.c : 1716 ] wlan_swbmiss_unit_test assert_mode=%d 
+6124,iiiiiiiii,[ wlan_dev.c : 450 ] GreenAP Curr Chainmask: %d/%d, Phy_mode: %d, bw[20/40/80/160]: %d saved tx/rx chainmask: %d/%d, phymode: %d, freq1: %d, valid flag: %d 
+6125,i,[ wlan_dev.c : 509 ] GreenAP tx_ch_mask = %d
+ 
+6126,iiiiiiiii,[ wlan_dev.c : 537 ] GreenAP wlan_pdev_set_greenap_cmd enable:%d zero_cl:%d saved tx/rxchnmsk:%d/%d phymode:%d vldphy:%d vldtxch:%d vldrxch:%d vldclk:%d 
+6127,,[ wlan_dev.c : 847 ] GPIO_STATE_RES_EVENT BUF NULL 
+6128,,[ wlan_dev.c : 3184 ]  Sending teardown complete event after Umac reset 
+6129,,[ wlan_dev.c : 3197 ] Sending teardown complete event after Umac reset for WSI_REMAP pdev_id  
+6130,Ii,[ wlan_dev.c : 4134 ] Multi_VDEV_START  vdev_bitmap= 0x%x Error:%d
+ 
+6131,iIiiiII,[ wlan_dev.c : 4188 ] VDEV_SEQ_DBG WMI_PDEV_MULTIPLE_VDEV_RESTART_REQ for pdev_id %d flag 0x%x num_vdev %d num_dbw_chan:%d dbw_chan_info:%d puncture_bitmap:0x%x ts = %lu 
+6132,IIII,[ wlan_dev.c : 4196 ] PROG_DFS: mhz:%u cf1:%u cf2:%u info:%u 
+6133,I,[ wlan_dev.c : 4202 ] PROG_DFS:dbw_info punture_bit_map:0x%x 
+6134,I,[ wlan_dev.c : 4448 ] wlan_pdev_set_param: WMI_PDEV_PARAM_TX_CHAIN_MASK 0x%x not valid 
+6135,,[ wlan_dev.c : 5065 ] PDEV_PARAM_RX_FILTER not supported 
+6136,ii,[ wlan_dev.c : 6057 ] dispatch_wlan_set_multiple_pdev_vdev_cmd %d num_param %d 
+6137,Iii,[ wlan_dev.c : 6065 ] param_id 0x%x param_value %d vdev_id %d 
+6138,Iii,[ wlan_dev.c : 6077 ] param_id 0x%x param_value %d pdev_id %d 
+6139,i,[ wlan_dev.c : 6921 ] DISPLAY_AOA_EVT: wlan_wmi_send_pdev_enhanced_aoa_phasedelta_event() status=%d (0: success) 
+6140,ii,[ wlan_dev.c : 7202 ] wlan_dev_set_pcl not match pcl_cnt=%d,supp_chan_cnt=%d 
+6141,,[ wlan_dev.c : 7412 ] wlan_pdev_set_hw_mode_resp_event: WMI Event Alloc Failed!!! 
+6142,,[ wlan_dev.c : 7554 ] CTL_BLOB:: ctl blob load completed 
+6143,,[ wlan_dev.c : 7821 ] WMI_PDEV_UPDATE_PKT_ROUTING_CMDID SOC level command not valid
+ 
+6144,,[ wlan_dev.c : 8315 ] WMI_PDEV_SET_WMM_PARAMS_CMDID DEPRECATED - use VDEV level command instead 
+6145,,[ wlan_dev.c : 8561 ] wlan_pdev_resume_cmd: NOT expected to receive during wifi on 
+6146,i,[ wlan_dev.c : 8575 ] wlan_pdev_resume_cmd: NOT expected to receive during wifi on, mac id=%d 
+6147,,[ wlan_dev.c : 8708 ] WMI_REQUEST_LINK_STATS_CMDID, ftm mode 
+6148,iII,[ wlan_dev.c : 8827 ] WMI_LRO_CONFIG_CMDID 1 mac=%d en=%x flags=%x 
+6149,i,[ wlan_dev.c : 8914 ] CTL_WMI: WMI_PDEV_SET_CTL_TABLE_CMDID - pdev_id=%d 
+ 
+6150,i,[ wlan_dev.c : 8916 ] CTL_WMI: mac_id=%d 
+ 
+6151,Ii,[ wlan_dev.c : 9961 ] WMI_PDEV_RSSI_DBM_CONV alloc failure  EventId = 0x%x PendingEvents = %d 
+6152,Ii,[ wlan_dev.c : 10050 ] WMI_PDEV_RSSI_DBM_CONV alloc failure  EventId = 0x%x PendingEvents = %d 
+6153,Iiiiiiiii,[ wlan_dev.c : 10134 ] PROG_DFS: pdev:%p,pdev home   ch:%d phy_mode:%d cf1:%d cf2:%d,pdev cur   ch:%d phy_mode:%d cf1:%d cf2:%d 
+6154,iiii,[ wlan_dev.c : 10141 ] PROG_DFS: pdev halphy   ch:%d phy_mode:%d cf1:%d cf2:%d 
+6155,i,[ wlan_dev.c : 10207 ] unit_test: sleep for %d ms 
+6156,I,[ wlan_dev.c : 10216 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_ABG_MODE_TX_CHAIN_NUM, value = 0x%x 
+6157,iiiiiiiii,[ wlan_dev.c : 10239 ] STA_KICKOUT reason (pdev-id %d) 0:%d 1:%d 2:%d 3:%d 4:%d 5:%d 6:%d 7:%d 
+6158,iIIiiIIii,[ wlan_dev.c : 10250 ] STA_KICKOUT History (Current Peer Index %d) MAC_ADDR : 0x%x 0x%x VDEV_ID:%d Reason:%d  Next Peer MAC_ADDR : 0x%x 0x%x VDEV_ID:%d Reason:%d  
+6159,iIIii,[ wlan_dev.c : 10256 ] STA_KICKOUT History (Current Peer Index %d) MAC_ADDR : 0x%x 0x%x VDEV_ID:%d Reason:%d  
+6160,I,[ wlan_dev.c : 10266 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_TX_CHAIN_MASK, value=0x%x 
+6161,I,[ wlan_dev.c : 10275 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_RX_CHAIN_MASK, value=0x%x 
+6162,I,[ wlan_dev.c : 10285 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_TX_CHAIN_MASK_2G, value=0x%x 
+6163,I,[ wlan_dev.c : 10295 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_RX_CHAIN_MASK_2G, value=0x%x 
+6164,I,[ wlan_dev.c : 10305 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_TX_CHAIN_MASK_5G, value=0x%x 
+6165,I,[ wlan_dev.c : 10315 ] wlan_dev_unit_test: cmd = WMI_PDEV_PARAM_RX_CHAIN_MASK_5G, value=0x%x 
+6166,ii,[ wlan_dev.c : 10325 ] wlan_dev_unit_test: cca_busy_detector_config time_diff_threshold = %d us, cca_busy_percent_threshold = %d 
+6167,I,[ wlan_dev.c : 10381 ] wlan_dev_unit_test: obss_pd_th = %x 
+6168,I,[ wlan_dev.c : 10394 ] error on wlan_log_save_module_level: mod_id=%u 
+6169,IIII,[ wlan_dev.c : 10416 ] PDEV_configs atf_config 0x%x, tx_chain_mask 0x%x, rx_chain_mask 0x%x, num_peers 0x%x 
+6170,IIIIIII,[ wlan_dev.c : 10418 ] PDEV_configs cur_channel_mhz 0x%x home_channel_mhz 0x%x vdev_active_count 0x%x vow_config 0x%x rx_decap_count 0x%x max_nss 0x%x dynamic_bw 0x%x 
+6171,ii,[ wlan_dev.c : 10445 ] pdev_param: STATS_TX_XRETRY_EXT: pdev=%d arg=%d 
+6172,iiiiii,[ wlan_dev.c : 10471 ] Unit test cmd to send EML OMN en_dis=%d dialog_token %d link_bitmap %d param_update %d padding_delay %d transition_delay %d 
+6173,iII,[ wlan_dev.c : 10493 ] wlan_dev_unit_test: MESH Rx Filter mac_id  = %d macc_addr_32_0 = 0x%x mac_addr_47_32 = 0x%x 
+6174,II,[ wlan_dev.c : 10507 ] unit_Test srayapat set SRG Bitmap lsb:0x%x usb:0x%x 
+6175,II,[ wlan_dev.c : 10519 ] unit_Test srayapat set SRG partial bssid Bitmap lsb:0x%x usb:0x%x 
+6176,iiii,[ wlan_dev.c : 10532 ] PMLO_DEBUG in thread - %d, num_args : %d, pdev_id: %d, cal_time_ms %d 
+6177,II,[ wlan_dev.c : 10561 ] WMI_GPIO_STATE_RES_EVENTID: GPIO num = %x  GPIO state  = %x  
+6178,i,[ wlan_dev.c : 10585 ] BEACON_DIAG: g_dbg_defer_scan_war is %d 
+6179,i,[ wlan_dev.c : 10627 ] PROG_DFS: Unit test g_dbg_dbw: %d 
+6180,i,[ wlan_dev.c : 10639 ] PROG_DFS: Unit test mac_id:%d 
+6181,ii,[ wlan_dev.c : 10690 ] is_ipa=%d service_btmap_log = %d 
+6182,i,[ wlan_dev.c : 10703 ] GAP_TEST: GAP Enable is_zero_client:%d 
+6183,,[ wlan_dev.c : 10716 ] GAP_TEST: GAP Disable 
+6184,,[ wlan_dev.c : 10724 ] GAP_TEST: CLOCK Enable 
+6185,,[ wlan_dev.c : 10732 ] GAP_TEST: CLOCK Disable 
+6186,,[ wlan_dev.c : 11453 ] DISPLAY_TPC_STATS:  Alloc tpc_configs_reg_event_buf failed
+ 
+6187,,[ wlan_dev.c : 11477 ] DISPLAY_TPC_STATS:  Alloc tgt_pwrs_event_buf failed
+ 
+6188,,[ wlan_dev.c : 11506 ] DISPLAY_TPC_STATS:  Alloc tgt_pwrs_set2_event_buf failed
+ 
+6189,,[ wlan_dev.c : 11530 ] DISPLAY_TPC_STATS:  Alloc ctl_event_buf failed
+ 
+6190,,[ wlan_dev.c : 11546 ] DISPLAY_TPC_STATS:  Alloc tpc_stats_reset_event_buf failed
+ 
+6191,,[ wlan_dev.c : 11552 ] DISPLAY_TPC_STATS:  Allocation complete! 
+6192,,[ wlan_dev.c : 11595 ] DISPLAY_AOA_EVT:  Alloc aoa_gain_phase_data_evt_buf failed
+ 
+6193,,[ wlan_dev.c : 12051 ]  wlan_pdev_tsf_auto_report: no memory 
+6194,iiIIIIII,[ wlan_dev.c : 12084 ]  wlan_pdev_tsf_auto_report: vdev_id = %d, mac_id = %d, tsf_low = 0x%x(%u), qtimer_low=0x%x(%u),cur_delta_0x%x(%u) 
+6195,,[ wlan_dev.c : 12320 ] SETTGTR2PTABLE : evh is Failed to Allocate!
+ 
+6196,i,[ wlan_dev.c : 12427 ] wmi_edca_send_event: Failed to allocate event buffer of size %d 
+6197,,[ wlan_dev.c : 12494 ] AOA_EVT 1: Enhanced AOA WMI event 
+6198,,[ wlan_dev.c : 12498 ]  AOA_EVT : Skip the Event sending to host 
+6199,i,[ wlan_dev.c : 6236 ] REO_QREF: Host support : %d  
+6200,i,[ wlan_dev.c : 6239 ] BANG RADAR 320M: Host support : %d  
+6201,iiiI,[ wlan_dev.c : 7644 ] pdev_id = %d: DMA %d push config status %d event %p 
+6202,i,[ wlan_dev.c : 6732 ] WMI_PDEV_SUSPEND Event Alloc failed pdev_id = %d 
+6203,,[ wlan_dev.c : 7360 ] WMI_PDEV_SET_MAC_CONFIG_RESP_EVENT: WMI Event Alloc Failed!!! 
+6204,iIIiiI,[ wlan_peer.c : 646 ] RESOURCE_PEER_ALLOC duplicate PEER_TYPE_BSS vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x mac_id = %d/%d peer=0x%x 
+6205,iIIiiIi,[ wlan_peer.c : 657 ] RESOURCE_PEER_ALLOC duplicate PEER_TYPE_BSS vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x mac_id = %d/%d peer=0x%x peer_del_in_prog %d 
+6206,iIIIi,[ wlan_peer.c : 775 ] wal peer allocaton status = %d vdev_id_8/mac_id_8 = 0x%x mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x peer_type = %d 
+6207,iIIIi,[ wlan_peer.c : 798 ] wal peer allocaton status = %d vdev_id_8/mac_id_8 = 0x%x mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x peer_type = %d 
+6208,iIIii,[ wlan_peer.c : 995 ] VDEV EVT:RESOURCE_PEER_FREE vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x usage_count = %d del_resp=%d 
+6209,I,[ wlan_peer.c : 1247 ] wlan_set_peer_vht_txbf_cap vht_caps: %x 
+6210,IIiiIii,[ wlan_peer.c : 1619 ] peer_create for  mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x vdev  = %d p_cmd->peer_type =%d peer is = 0x%X
+ is_mlo_bridge_peer = %d status=%d 
+6211,iIIi,[ wlan_peer.c : 1695 ] peer delete command for vdev_id %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x status = %d 
+6212,iIIi,[ wlan_peer.c : 1786 ] peer delete command for vdev_id %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x status = %d 
+6213,i,[ wlan_peer.c : 1895 ] PEER_DELETE_DBG WAL_PEER_DEL_RESP_FAILURE status: %d 
+6214,,[ wlan_peer.c : 1950 ] PEER flush policy is not correct 
+6215,ii,[ wlan_peer.c : 1954 ] twt_flush_tidmap=%d n_TWT_SPs_to_expire = %d 
+ 
+6216,iI,[ wlan_peer.c : 2436 ] HE160NSS : 160_mcs_nss_set %d, 160_mcs_nss_map %x 
+6217,iI,[ wlan_peer.c : 3429 ] Peer_assoc:peer_eht_cap_phy[%d] = 0x%x 
+6218,iI,[ wlan_peer.c : 3432 ] Peer_assoc:peer_eht_cap_mac[%d] = 0x%x 
+6219,iII,[ wlan_peer.c : 3450 ] PEER_ASSOC :eht_mcs_nss_set.map[%d].(tx,rx)=(0x%x, 0x%x) 
+6220,Iiii,[ wlan_peer.c : 3496 ] Sending failure wlan_vdev_send_peer_assoc_conf_event hw_mld_link_id:%upartner_link_params index:%d chip_id: %d is_chip_participating: %d 
+6221,i,[ wlan_peer.c : 3510 ] PEER_ASSOC: Invalid mlo_params->mld_peer_id = %d
+ 
+6222,I,[ wlan_peer.c : 3518 ] PEER_ASSOC: Validation failed with status = 0x%x 
+6223,,[ wlan_peer.c : 3624 ] PEER_ASSOC mlo peer assoc to non mlo vdev 
+6224,,[ wlan_peer.c : 3668 ] ML_RECONFIG: self link marked for del. Block TIDs 
+6225,iiIIi,[ wlan_peer.c : 3785 ] PEER_ASSOC Overridding phymode. Orig phy %d, new phy %d. Orig flag 0x%x, new flag 0x%x. Error:%d 
+6226,IIiIIIiiI,[ wlan_peer.c : 3900 ] PEER_ASSOC cmd for mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x, num_peer_ht_rates=%d, ni_flags=0x%x phymode(8)|auth_mode(8)=0x%x nss=0x%x mpdudensity=%d a_mpdu_exp=%d vdev_id|peer_id|channel_mhz=0x%x 
+6227,,[ wlan_peer.c : 4398 ] ML_RECONIFG: PEER_ASSOC Block tids of newly added link 
+6228,,[ wlan_peer.c : 4405 ] VBSS wlan_vdev_dispatch_peer_assoc Block tids of VBSS Passive Peer  
+6229,II,[ wlan_peer.c : 4420 ] PEER_ASSOC peer = 0x%X status=0x%x 
+6230,ii,[ wlan_peer.c : 4492 ] smart antenna event len:%d is higher than buffer len:%d 
+6231,iIIIII,[ wlan_peer.c : 5106 ] wlan_vdev_dispatch_peer_change_bw: peerid=%d prev_ni_flags=%x new_ni_flags=%x new_bw=%x ht_caps=%x vht_caps=%x 
+6232,IIII,[ wlan_peer.c : 5629 ] wal_vdev non_data_rc:0x%x bcast_data_rc:0x%x mcast_data_rc:0x%x beacon_rc:0x%x 
+ 
+6233,I,[ wlan_peer.c : 5651 ] wal_peer: %x, wlan_peer_vdev_restart_done: tearing down tx_ba and rx_ba 
+6234,IIIIi,[ wlan_peer.c : 6112 ] MASK_CCK_RATES: wlan_peer=0x%x rc_node=0x%x legacy_rate=0x%x is_cck_rate_mask=0x%x msg_id=%d 
+6235,ii,[ wlan_peer.c : 6222 ] rate_udate peer %d msg id %d 
+6236,iiIIiiIII,[ wlan_peer.c : 6237 ] WLAN_PEER_ASSOC_REQ peer %d peer_assoc_evt %d, ni_flags 0x%x, valid_tx_chainmask 0x%x, peer_nss %d, phymode %d, ni_vht_mcs_set 0x%x, ni_legacy_rate_set 0x%x, TS %u 
+6237,iii,[ wlan_peer.c : 6298 ] WLAN_PEER_CHANGE_NSS peer %d  peer_nss %d ul_nss %d 
+6238,iIIiiII,[ wlan_peer.c : 6366 ] WLAN_PEER_CHANGE_CHAN_WIDTH peer %d ni_flags 0x%x, valid_tx_chainmask 0x%x, peer_nss %d, phymode %d, ni_vht_mcs_set 0x%x, ni_legacy_rate_set 0x%x, 
+6239,i,[ wlan_peer.c : 6464 ] WMI_PEER_UNMAP_RESPONSE_CMDID: %d 
+6240,ii,[ wlan_peer.c : 6471 ] peer_id[%d]: %d 
+6241,,[ wlan_peer.c : 6497 ] WMI_PEER_TX_PN_REQUEST :  Invalid Peer 
+6242,,[ wlan_peer.c : 6502 ] WMI_PEER_TX_PN_REQUEST :  Invalid wal_peer 
+6243,,[ wlan_peer.c : 6509 ] WMI_PEER_TX_PN_REQUEST :  Invalid dcache_Peer 
+6244,ii,[ wlan_peer.c : 6517 ] WMI_PEER_TX_PN_REQUEST : vdev_id = %d, key_type = %d   
+6245,,[ wlan_peer.c : 6551 ] WMI_PEER_TX_PN_REQUEST :  Invalid tx vap 
+6246,,[ wlan_peer.c : 6556 ] WMI_PEER_TX_PN_REQUEST :  Invalid non tx vap wal_peer 
+6247,iiiiiiii,[ wlan_peer.c : 6566 ] WMI_PEER_TX_PN_REQUEST : BIGTK cmd->key_ix %d vdev_id = %d, PN:%d:%d:%d:%d:%d:%d 
+6248,iiiiiiii,[ wlan_peer.c : 6583 ] WMI_PEER_TX_PN_REQUEST : GTK cmd->key_ix %d vdev_id = %d, PN:%d:%d:%d:%d:%d:%d 
+6249,,[ wlan_peer.c : 6618 ] RX_PN: WMI_PEER_RX_PN_REQUEST :  Invalid Peer 
+6250,,[ wlan_peer.c : 6623 ] WMI_PEER_RX_PN_REQUEST :  Invalid wal_peer 
+6251,ii,[ wlan_peer.c : 6631 ] WMI_PEER_RX_PN_REQUEST : vdev_id = %d, key_type = %d   
+6252,iiiiiii,[ wlan_peer.c : 6671 ] WMI_PEER_RX_PN_REQUEST : vdev_id = %d, PN:%d:%d:%d:%d:%d:%d 
+6253,iIIi,[ wlan_peer.c : 6696 ] PEER_TID_DEBUG: vdev_id:%d mac addr:0x%08x 0x%08x tid_num:%d  
+6254,iiiiiIiii,[ wlan_peer.c : 6707 ] PEER_TID_DEBUG: ack:%d aggr:%d rate:%d rcode:%d sw_retry:%d bitmap:0x%x rts_cts:%d ampdu:%d amsdu:%d  
+6255,III,[ wlan_peer.c : 6918 ] WMI_PEER_SCHED_MODE_DISABLE_CMDID: wlan_peer not found for peer with MAC: 0x%08x 0x%08x. disabled_sched_modes bitmap: 0x%08x 
+6256,III,[ wlan_peer.c : 6929 ] WMI_PEER_SCHED_MODE_DISABLE_CMDID: wal_peer not found for peer with MAC: 0x%08x 0x%08x. disabled_sched_modes_bitmap: 0x%08x 
+6257,i,[ wlan_peer.c : 6955 ] PEER_BULK_SET_CMDID received CMDID:%d 
+6258,,[ wlan_peer.c : 7223 ] Invalid sta_fixed_rate: Found CCK rate in 5G
+ 
+6259,,[ wlan_peer.c : 7240 ] Invalid sta_fixed_rate: Found CCK rate in 5G
+ 
+6260,IIIIiII,[ wlan_peer.c : 7305 ] OMI WMI from host rx_nss = 0x%lx, bw = 0x%lx, ulmu disable = 0x%lx, tx_nss = 0x%lx, er_su disable %d, ulmu_data_disable = 0x%lx bw_ext = 0x%x
+ 
+6261,IIIIIIII,[ wlan_peer.c : 7329 ] WMI_PEER_PARAM_DISABLE_AGGRESSIVE_TX:peer %x value %x mac_address %x:%x:%x:%x:%x:%x 
+6262,IIII,[ wlan_peer.c : 7383 ] WMI_PEER_FT_ROAMING_PEER_UPDATE:peer %x value %x mac_address 0:31=0x%x 32:47=0x%x 
+6263,iiiii,[ wlan_peer.c : 7652 ] SA_DEBUG received Start: %d train_pkts:%d PER_inp: %d PER: %d min_pkt: %d
+ 
+6264,,[ wlan_peer.c : 7750 ] PEER_CHAN_WIDTH null vdev 
+6265,IIi,[ wlan_peer.c : 7786 ] Invalid CHAN_WIDTH_SWITCH: mac_addr31to0 = 0x%x, mac_addr47to32 = 0x%x, phy_mode %d 
+6266,iIiiI,[ wlan_peer.c : 7798 ] Invalid CHAN_WIDTH_SWITCH:peer_id = %d  chan_width =0x%X, new_phy_mode= %d old_phy_mode = %d he_mcs_nss_160=0x%x 
+6267,iIiiI,[ wlan_peer.c : 7804 ] Invalid CHAN_WIDTH_SWITCH:peer_id = %d  chan_width =0x%X, new_phy_mode= %d old_phy_mode = %d he_mcs_nss_80_80=0x%x 
+6268,ii,[ wlan_peer.c : 8027 ] TXPEER_FILTER WMI_PEER_TX_FILTER_CMDID received, vdev_id:%d, action:%d
+ 
+6269,,[ wlan_peer.c : 8049 ] PEER_BULK_SET_CMDID null vdev 
+6270,i,[ wlan_peer.c : 8055 ] PEER_BULK_SET_CMDID received Num peers:%d 
+6271,i,[ wlan_peer.c : 8058 ] PEER_BULK_SET_CMDID  index:%d 
+6272,iiiIIi,[ wlan_peer.c : 8074 ] PEER_BULK_SET_CMDID invalid mac_id:%d peer_mac_id:%d ind:%d  mac_addr31to0 = 0x%x, mac_addr47to32 = 0x%x, param_id =%d 
+6273,iIIii,[ wlan_peer.c : 8081 ] PEER_BULK_SET_CMDID ind:%d  mac_addr31to0 = 0x%x, mac_addr47to32 = 0x%x, param_id =%d param_value = %d 
+6274,IIII,[ wlan_peer.c : 8427 ] wlan_peer_data_null_deauth_check skipping deauth frame for scan radio mac_addr1 %04x%08x mac_addr2 %04x%08x  
+6275,IIII,[ wlan_peer.c : 8511 ] NRP filter wh_addr_ra_0_31=%x wh_addr_ra_32_47=%x wh_addr_ta_0_31=%x wh_addr_ta_32_47=%x 
+6276,II,[ wlan_peer.c : 8538 ] Deauth frame is not sent because of different RT thread addr1 0x%x addr2 = 0x%x 
+6277,II,[ wlan_peer.c : 8882 ] WMI_VDEV_MULTIPLE_PEER_GROUP_CMDID: WMI_PEER_REMOVE_WDS_ENTRY_CMDID mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x 
+6278,iIIiii,[ wlan_peer.c : 561 ] RESOURCE_PEER_ALLOC error vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x usage_count = %d, peer_type = %d, delete_in_process:%d 
+6279,iIIiii,[ wlan_peer.c : 572 ] RESOURCE_PEER_ALLOC error return as peer delete is in progress vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x usage_count = %d, peer_type = %d, delete_in_process:%d 
+6280,,[ wlan_peer.c : 895 ] WMI_EVENT_ALLOC_FAILURE: WMI_PEER_DELETE_RESP_EVENTID buffer failure 
+6281,iiII,[ wlan_peer.c : 913 ] PEER_DELETE_DBG: VDEV EVT:WMI_PEER_DELETE_RESP_EVENTID send vdevId=%d time=%d peer_macaddr31to0 =0x%x peer_macaddr47to32 =0x%x 
+6282,iiIIi,[ wlan_peer.c : 1437 ] VDEV EVT:WMI_PEER_CREATE_RESP_EVENTID send vdevId=%d time=%d peer_macaddr31to0 =0x%x peer_macaddr47to32 =0x%x status = %d 
+6283,II,[ wlan_peer.c : 2320 ] OMI: wlan_peer_set_he_eht_omi_param:  disable mu :ulmu_disable: 0x%lx, ulmu_data_disable: 0x%lx, 
+ 
+6284,II,[ wlan_peer.c : 2327 ] OMI: wlan_peer_set_he_eht_omi_param:  enable mu :ulmu_disable: 0x%lx, ulmu_data_disable: 0x%lx, 
+ 
+6285,III,[ wlan_peer.c : 2353 ] Assoc OMI: NSS=0x%x BW=0x%x er_su_disable=0x%x 
+6286,iiiiii,[ wlan_peer.c : 5207 ] TXBF_UPDATE_PEER_PARAMS: he_su_bfer=%d, he_su_bfee=%d, suax_txbfer=%d, suax_txbfee=%d, peer_nss=%d, nc_idx=%d 
+6287,iiiiii,[ wlan_peer.c : 5232 ] TXBF_UPDATE_PEER_PARAMS_160M: he_su_bfer=%d, he_su_bfee=%d, suax_txbfer=%d, suax_txbfee=%d, peer_nss_160=%d, nc_idx_160=%d 
+6288,,[ wlan_peer.c : 2821 ] rc_node_update: ABORT 
+6289,,[ wlan_peer.c : 2931 ] wal_peer is NULL in wlan_peer_assoc_rate_internal 
+6290,I,[ wlan_peer.c : 4930 ] wlan_vdev_peer_change_bw_internal: new_bw = %x 
+6291,iii,[ wlan_peer.c : 4857 ] wlan_vdev_peer_change_phymode_internal: peerid=%d phymode=%d mhz=%d 
+6292,i,[ wlan_peer.c : 4668 ] RATE_DBG wlan_vdev_migrate_rate_reset peer_params NULL: peer_id %d 
+6293,i,[ sawf_mesh.c : 45 ] SAWF_DBG: Invalid hop count: %d 
+6294,i,[ sawf_mesh.c : 58 ] SAWF_DBG: Peer doesn't exist based on vdev id:%d 
+6295,i,[ sawf_mesh.c : 67 ] SAWF_DBG: Qpeer Cache not found based on peer id:%d 
+6296,ii,[ sawf_mesh.c : 99 ] SCHED_DBG: tid is:%d, peer is %d 
+6297,i,[ sawf_cfg.c : 287 ] sawf_dispatch_svc_class_cfg_cmd : status=%d (0: success) 
+6298,i,[ sawf_cfg.c : 306 ] invalid svc class ID %d 
+6299,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_RSSIWeight = %d 
+6300,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_CUWeight = %d 
+6301,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorValue1 = %d 
+6302,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorScore1 = %d 
+6303,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorValue2 = %d 
+6304,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorScore2 = %d 
+6305,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorValue3 = %d 
+6306,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorScore3 = %d 
+6307,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorValue4 = %d 
+6308,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorScore4 = %d 
+6309,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorValue5 = %d 
+6310,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_RSSIFactorScore5 = %d 
+6311,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorValue1 = %d 
+6312,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorScore1 = %d 
+6313,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorValue2 = %d 
+6314,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorScore2 = %d 
+6315,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorValue3 = %d 
+6316,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorScore3 = %d 
+6317,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorValue4 = %d 
+6318,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorScore4 = %d 
+6319,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorValue5 = %d 
+6320,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_RSSIFactorScore5 = %d 
+6321,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorValue1 = %d 
+6322,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorScore1 = %d 
+6323,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorValue2 = %d 
+6324,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorScore2 = %d 
+6325,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorValue3 = %d 
+6326,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorScore3 = %d 
+6327,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorValue4 = %d 
+6328,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_RSSIFactorScore4 = %d 
+6329,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_CUFactorValue1 = %d 
+6330,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_CUFactorScore1 = %d 
+6331,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_CUFactorValue2 = %d 
+6332,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band1_CUFactorScore2 = %d 
+6333,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_CUFactorValue1 = %d 
+6334,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_CUFactorScore1 = %d 
+6335,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_CUFactorValue2 = %d 
+6336,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band2_CUFactorScore2 = %d 
+6337,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_CUFactorValue1 = %d 
+6338,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_CUFactorScore1 = %d 
+6339,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_CUFactorValue2 = %d 
+6340,i,[ wlan_firmware_ini.c : 350 ] RoamAPScore_Band3_CUFactorScore2 = %d 
+6341,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_Trigger = %d 
+6342,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_Delta = %d 
+6343,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_FullScanPeriod = %d 
+6344,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_PartialScanPeriod = %d 
+6345,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_ActiveCH_DwellTime = %d 
+6346,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_PassiveCH_DwellTime = %d 
+6347,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_HomeTime = %d 
+6348,i,[ wlan_firmware_ini.c : 350 ] RoamNCHO_AwayTime = %d 
+6349,i,[ wlan_firmware_ini.c : 350 ] RoamWTC_ScanMode = %d 
+6350,i,[ wlan_firmware_ini.c : 350 ] RoamWTC_HandlingRSSIThreshold = %d 
+6351,i,[ wlan_firmware_ini.c : 350 ] RoamWTC_24GCandiRSSIThreshold = %d 
+6352,i,[ wlan_firmware_ini.c : 350 ] RoamWTC_5GCandiRSSIThreshold = %d 
+6353,i,[ wlan_firmware_ini.c : 350 ] RoamWTC_6GCandiRSSIThreshold = %d 
+6354,i,[ wlan_firmware_ini.c : 350 ] RoamBTCoex_ScoreWeight = %d 
+6355,i,[ wlan_firmware_ini.c : 350 ] RoamBTCoex_ETPWeight = %d 
+6356,i,[ wlan_firmware_ini.c : 350 ] RoamBTCoex_TargetMinRSSI = %d 
+6357,i,[ wlan_firmware_ini.c : 350 ] RoamBTCoex_Delta = %d 
+6358,i,[ wlan_firmware_ini.c : 350 ] RoamBTCoex_ThresholdTime = %d 
+6359,i,[ wlan_firmware_ini.c : 350 ] RoamCU_24DefaultCU = %d 
+6360,i,[ wlan_firmware_ini.c : 350 ] RoamCU_5DefaultCU = %d 
+6361,i,[ wlan_firmware_ini.c : 350 ] RoamCU_6DefaultCU = %d 
+6362,,[ wlan_mgmt_local_txrx.c : 238 ] SCAN_RADIO_SUPPORT_DBUG _wlan_mgmt_local_send cur_channel NULL 
+6363,ii,[ wlan_mgmt_local_txrx.c : 340 ] MGMT_TXRX_SENT_FROM_LOCAL: send failure:%d, flags:%d 
+6364,i,[ wlan_mgmt_local_txrx.c : 364 ] wlan_mgmt_txrx_omi_req_completion: set mu  as %d
+ 
+6365,IIIII,[ wlan_mgmt_local_txrx.c : 381 ] OMI: _wlan_mgmt_txrx_send_omi rx_nss: 0x%lx, bw: 0x%lx, ulmu_disable: 0x%lx, ulmu_data_disable: 0x%lx, tx_nss: 0x%lx
+ 
+6366,IIIII,[ wlan_mgmt_local_txrx.c : 396 ] OMI: _wlan_mgmt_txrx_send_omi_with_comp_args rx_nss: 0x%lx, bw: 0x%lx, ulmu_disable: 0x%lx, ulmu_data_disable: 0x%lx, tx_nss: 0x%lx
+ 
+6367,II,[ wlan_mgmt_local_txrx.c : 446 ] setUnitTestCmd 13 9 1 %x %x - couldn't find peer! 
+6368,IIIIiI,[ wlan_mgmt_local_txrx.c : 466 ] OMI: Unit test with rx_nss = 0x%lx, bw = 0x%lx, ulmu disable = 0x%lx, tx_nss = 0x%lx, er_su disable %d, ulmu_data_disable = 0x%lx
+ 
+6369,,[ wlan_mgmt_local_txrx.c : 470 ] Invalid input for OMI unit test.
+ 
+6370,,[ wlan_mgmt_local_txrx.c : 524 ] Invalid input for muedca unit test to set mu wmm params.
+ 
+6371,I,[ wlan_mgmt_local_txrx.c : 534 ] Unit test: mu edca enable = %lu
+ 
+6372,iiI,[ wlan_mgmt_local_txrx.c : 951 ] WIFI_RADAR_DBG vdev_id:%d, peer_id:%d, abf:%x 
+6373,iii,[ wlan_mgmt_local_txrx.c : 1121 ] UNIT_TEST_MONITOR_HOST_SCANS - g_probe_beacon_rx_count=%d frm_subtype=%d forward_to_host=%d 
+6374,iIIIIII,[ wlan_mgmt_local_txrx.c : 1147 ] FORWARD_TO_HOST: chan|vdevid=%d macid_type_subtype=0x%06x seq=%04d mac_addr=0x%04x%08x rssicomb_ch0_ch1=0x%06x fwdtohost_monmode_emasupp_complist=0x%08x 
+6375,IIII,[ wlan_mgmt_local_txrx.c : 1291 ] mac id mismatch:rx:%x vdev:%x, frame: %x, reason: %x 
+ 
+6376,III,[ wlan_mgmt_local_txrx.c : 1448 ] mac id mismatch:rx:%x vdev:%x, frame: %x
+ 
+6377,,[ wlan_mgmt_local_txrx.c : 1460 ] action match mld 
+6378,Ii,[ wlan_mgmt_local_txrx.c : 2008 ] _wlan_local_send_peer_change_omi: ht_ctrl=0x%x, omi_actrl_shift=%d 
+6379,iii,[ wlan_mgmt_txrx.c : 277 ] BA_LOG: ba_params_valid %d ba_win_size %d reo_win_size %d 
+6380,IIi,[ wlan_mgmt_txrx.c : 393 ] _wlan_mgmt_rx_frame_handler Droping frame from non associated Peer type=0x%x subtype=0x%x bNull=%d 
+6381,,[ wlan_mgmt_txrx.c : 459 ] SA_QUERY: Response frame received 
+6382,IIIIiiI,[ wlan_mgmt_txrx.c : 618 ] CONN_DBG_RX subtype=0x%02x mac_addr %04x%08x last_ok_bcn_seq(16)|seq_num(16)=0x%x chan|vdev=%d tx_status=%d timestamp=%lums 
+6383,i,[ wlan_mgmt_txrx.c : 648 ] fw_consumed event failed, seq num = %d 
+6384,II,[ wlan_mgmt_txrx.c : 728 ] ATH_BUF_FLAG_DROP abf = 0x%x %x 
+6385,IIIII,[ wlan_mgmt_txrx.c : 1276 ] MGMT_TX_WMI_FROM_HOST: dword0=0x%x dword1=0x%x, subtype:%x, ppdu_info:0x%x multiplier:0x%x 
+6386,I,[ wlan_mgmt_txrx.c : 1339 ] QOS_NULL_TX_WMI_FROM_HOST: Host is not expected to use this command other than QoS null, frame subtype = 0x%X  
+6387,iIiIi,[ wlan_mgmt_txrx.c : 1435 ] QOS_NULL_TX_WMI_FROM_HOST FAIL invalid input param vdev_id=%d, vdev_opmode=%x, desc_id=%d peer =0x%X  tx_status=%d 
+6388,IIIiIIIII,[ wlan_mgmt_txrx.c : 1734 ] MGMT_TX_WMI_FROM_HOST type|subtype=0x%04x mac_addr=0x%04x%08x chan|vdev=%d peer_type(8)|tid_num(8)|frame_len(16)=0x%x cmd_chan_freq(16)|desc_id(16)=0x%x ppdu_info=0x%x txvalid(8)|check_tag(4)|txflag_mode(4)|submode(16)=0x%x TS %u 
+6389,,[ wlan_mgmt_txrx.c : 1754 ] MLO_U.R wlan_mgmt_tx_send_wmi_cmd_handler: packets are discarding during umac reset window 
+6390,iii,[ wlan_mgmt_txrx.c : 1969 ] WMI TX comp send bundle, num:%d, desc id=%d comp=%d 
+6391,II,[ wlan_mgmt_txrx.c : 2000 ] MGMT_TX_WMI_FROM_HOST_COMP desc_id=0x%x tx_status=0x%x 
+6392,IIIII,[ wlan_mgmt_txrx.c : 2038 ] QOS_NULL_TX_WMI_FROM_HOST Send Evt: desc_id = 0x%x comp_type=0x%x,pdev_id =0x%X, ppdu_id=0x%X ack_rssi =0x%X 
+6393,IIii,[ wlan_mgmt_txrx.c : 2141 ] MGMT_TX_WMI_FROM_HOST_COMP desc_id=0x%x tx_status=0x%x ppdu_id:%d ack_rssi=%d 
+6394,i,[ wlan_mgmt_txrx.c : 2147 ] MGMT_TX_WMI_TXCOMP_SEND_EVT PKT NULL err_status=%d 
+6395,iIi,[ wlan_mgmt_txrx_int.c : 233 ] SCAN_RADIO_SUPPORT_DBUG/TPC_DBG WMI_SCAN_EVENT_FOREIGN_CHANNEL_ENTRY status: %d (0 : success) power_valid 0x%x pause_disable %d 
+6396,II,[ offload_mgr.c : 155 ] OFLD reg nondata name=0x%x, refcnt:0x%x 
+6397,IIIi,[ offload_mgr.c : 196 ] OFLD reg data name=0x%x, vdevid:0x%x, vdev_bitmap:0x%x max_len =%d 
+6398,II,[ offload_mgr.c : 230 ] OFLD reg wmi name=0x%x, refcnt:0x%x 
+6399,II,[ offload_mgr.c : 268 ] OFLD reg HTT name=0x%x, refcnt:0x%x 
+6400,ii,[ offload_mgr.c : 304 ] OFLD dereg nondata name=%d ref_cnt=%d 
+6401,iii,[ offload_mgr.c : 324 ] OFLD dereg data name=%d vdev id=%d,vdev mask=%d 
+6402,ii,[ offload_mgr.c : 345 ] OFLD dereg wmi name=%d ref_cnt=%d 
+6403,ii,[ offload_mgr.c : 366 ] OFLD dereg htt name=%d ref_cnt=%d 
+6404,Iiiii,[ offload_mgr.c : 630 ] OFLD data parse 11c_snap_hdr_t exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d,dsDir:%d 
+6405,Iiii,[ offload_mgr.c : 660 ] OFLD data parse ether_header exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6406,Iiii,[ offload_mgr.c : 677 ] OFLD data parse llc_snap_hdr_t exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6407,i,[ offload_mgr.c : 693 ] OFLD Unknown RX Decap mode %d 
+6408,Iiii,[ offload_mgr.c : 747 ] OFLD data parse IP_HDR exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6409,Iiii,[ offload_mgr.c : 762 ] OFLD data parse IP6_HDR exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6410,Iiii,[ offload_mgr.c : 794 ] OFLD data parse TCP_HDR exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6411,Iiii,[ offload_mgr.c : 807 ] OFLD data parse UDP_HDR exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6412,Iiii,[ offload_mgr.c : 819 ] OFLD data parse ICMPV6_HDR exceeds frame length pktbuf:%x,rx_mode:%d,buf_len:%d,offset:%d 
+6413,iiiiiI,[ offload_mgr.c : 997 ] OFLD enhanced data hdlr ofld id=%d status=%d, wow data state:%d vdev_id %d opmode %d pL2_attr->dsDir 0x%x 
+6414,i,[ offload_mgr.c : 1000 ] OFLD _offldmgr_enhanced_data_handler: OFFLOAD_STATUS_DROP error_code %d 
+6415,III,[ offload_mgr.c : 1351 ] OFLD offldmgr_non_data_handler: Received rx buf as null for peer = 0x%x  mac_id =0x%X rxbuf =0x%X 
+6416,III,[ offload_mgr.c : 1435 ] OFLD _ofld_non_data_hdlr: peer = 0x%x addr1 0x%x addr2 = 0x%x 
+6417,II,[ offload_mgr.c : 1538 ] _ofld_nondata_hdlr: status_h8/sub_sts_8/ofld_id_16:0x%x frmtyp = 0x%x 
+6418,IIII,[ offload_mgr.c : 1685 ] _ofld_nondata_hdlr: status = 0x%x pkt_rcv_cnt = 0x%x, drop_cnt 0x%x, fwdcnt 0x%x 
+6419,iii,[ offload_mgr.c : 1711 ] OFLD drop wmi evt, id=%d, len:%d status:%d 
+6420,ii,[ offload_mgr.c : 1859 ] OFLD wmi evt store evt_id=%d, evt_len=%d 
+6421,,[ offload_mgr.c : 1864 ] ofld wmi evt store failure - no memory 
+6422,ii,[ offload_mgr.c : 1890 ] OFLD wmi evt flush evt_id=%d, evt_len=%d 
+6423,,[ channel_mgr.c : 107 ] chan mgr pause complete timeout 
+6424,iIIiI,[ channel_mgr.c : 186 ] CHAN_MGR_VDEV_PAUSE: chan = %d link = 0x%x flg = 0x%x max_sw_time = %d curr_time = 0x%x 
+6425,iII,[ channel_mgr.c : 225 ] CHAN_MGR_VDEV_UNPAUSE:chan =%d link =0x%x curr_time = 0x%x 
+6426,iiIIIIi,[ channel_mgr.c : 468 ] CHAN_MGR_TRIGGER_CHANNEL_CHANGE: pri_ch = %d, chan_change_dur = %d,is_chm_valid = 0x%x tx_chm = 0x%x, rx_chm = 0x%x, selfgen_chm = 0x%x, pf_cnt = %d  
+6427,III,[ channel_mgr_sm.c : 129 ] RESMGR_CHMGR_SEND_CTS2SELF: cur_vc = 0x%x link = 0x%x status = 0x%x 
+6428,II,[ resmgr_wmi.c : 90 ] RESMGR_OCS_INVALID_QUOTA Different MAC: chan0 = 0x%x chan1 = 0x%x 
+6429,II,[ resmgr_wmi.c : 143 ] RESMGR_OCS_INVALID_LATENCY Different MAC: chan0 = 0x%x chan1 = 0x%x 
+6430,ii,[ resmgr.c : 94 ] resmgr_send_channel_quota_changed_event_to_host : max event size exceeded %d,max_limit %d 
+6431,i,[ resmgr.c : 100 ] resmgr_send_channel_quota_changed_event_to_host : memory allocation failed %d 
+6432,,[ resmgr.c : 179 ] resmgr_set_ch_param dyn_sch_ctx is null. 
+6433,II,[ resmgr.c : 399 ] RESMGR_REG_EVT_HDLR:  handler = 0x%x arg = 0x%x exists!!! 
+6434,II,[ resmgr.c : 407 ] RESMGR_REG_EVT_HDLR: handler = 0x%x arg = 0x%x no memory!!! 
+6435,II,[ resmgr.c : 417 ] RESMGR_REG_EVT_HDLR:  handler = 0x%x arg = 0x%x registered 
+6436,II,[ resmgr.c : 435 ] RESMGR_DEREG_EVT_HDLR:  handler = 0x%x arg = 0x%x not found!!! 
+6437,II,[ resmgr.c : 441 ] RESMGR_DEREG_EVT_HDLR:  handler = 0x%x arg = 0x%x deregistered 
+6438,ii,[ resmgr_ocm.c : 805 ] resmgr_ocm_update_ocs_min_cat_dur: ocs_ins = %d, min_cat_dur = %d 
+6439,i,[ resmgr_dyn_sch.c : 88 ] RESMGR_DYN_SCH_ACTIVE  is_active = %d 
+6440,iiii,[ resmgr_dyn_sch.c : 188 ] RESMGR_DYN_SCH_TOT_UTIL_PER  chan0_mhz = %d chan0_util_percentage = %d chan1_mhz = %d chan1_util_percentage = %d 
+6441,iiii,[ resmgr_dyn_sch.c : 265 ] RESMGR_DYN_SCH_HOME_CH_QUOTA  chan0_mhz = %d ch0_new_quota = %d chan1_mhz = %d ch1_new_quota = %d 
+6442,i,[ resmgr_ocs_init.c : 93 ] RESMGR_OCS_ALLOCRAM_SIZE  size_in_bytes = %d 
+6443,II,[ resmgr_ocs.c : 67 ] CHREQ_GRANT cur_time=0x%x chreq=0x%x 
+6444,IIIIiIII,[ resmgr_ocs.c : 492 ] CHREQ_UPDATE chreq=0x%x chan(2)|sec_chan(2)=0x%08x start_tsf=0x%x dur_usec=0x%x interval=%d req_id(1)|prio(1)|purge(1)|dtim_period(1)=0x%08x dtim_start_tsf=0x%x, end_tsf=0x%x 
+6445,ii,[ resmgr_ocs.c : 2668 ] RESMGR_OCS_WIN_CAT_DUR  duration = %d, chan_mhz = %d 
+6446,IIi,[ resmgr_ocs.c : 3412 ] RESMGR_OCS_CHREQ_TERMINATE: req_id = 0x%x cur_ch_req = 0x%x state = %d 
+6447,II,[ resmgr_ocs.c : 3681 ] MVDEV_START_TSF curr_time:0x%x curr_tsf:0x%x 
+6448,iIIIi,[ resmgr_ocs.c : 3920 ] OCS_INVOKED: ins=%d last_sch=0x%x entry=0x%x exit=0x%x next_sch=%d 
+6449,,[ resmgr_ocs.c : 4086 ] RESMGR_OCS_RESOURCES both ch_alloc->non_wlan_ch_allocator and ch_alloc->virtual_chan are NULL 
+6450,II,[ resmgr_ocs.c : 4259 ] channel request value = %p channel value = %p 
+6451,IIIiiIII,[ resmgr_ocs.c : 4574 ] CHREQ_UPDATE: chreq=0x%x chan(2)|sec_chan(2)=0x%08x start_tsf=0x%x dur_usec=%d interval=%d req_id(1)|prio(1)|dtim_period(2)=0x%08x dtim_start_tsf=0x%x end_tsf=0x%x  
+6452,III,[ resmgr_ocs.c : 4776 ] CHREQ_START: chreq=0x%x chan(2)|sec_chan(2)=0x%08x req_id(1)|prio(1)|freq2(2)=0x%08x 
+6453,IiiIiI,[ resmgr_ocs.c : 4781 ] CHREQ_START: start_tsf=0x%x dur_usec=%d interval=%d dtim_start_tsf=0x%x dtim_period=%d end_tsf=0x%x 
+6454,IiI,[ resmgr_ocs.c : 4828 ] CHREQ_STOP: chreq=0x%x chan=%d req_id(1)|state(1)|sec_chan(2)=0x%08x 
+6455,,[ virtual_channel.c : 213 ] RESMGR_VC_INIT_VIR_CHAN: virtual_chan is NULL 
+6456,iiiii,[ virtual_channel.c : 2125 ] RESMGR_VC_SET_HOME_CHAN: chan_mhz %d bset %d max_bw_limit_phy_mode %d max_phy_mode %d max_bandwidth %d 
+6457,IiiIiiII,[ virtual_channel_arbiter.c : 867 ] RESMGR_VC_ARBITRATE_CHAN_PARAM arbit_chan = 0x%x arbit_chan_mhz=%d arbit_chan_phy_mode=%d link_chan=0x%x link_chan_mhz=%d link_chan->phy_mode=%d link_chan->flags = 0x%x arbit_chan->flags = 0x%x 
+6458,iiiIiiI,[ virtual_channel_arbiter.c : 1214 ] RESMGR_VC_ARBITRATE_ATTRIBUTES  chan_mhz = %d phy_mode/vc_prog_latency = %d band_center_freq = %d virtual_chan_ctxt = 0x%x dbw_chan_mhz = %d dbw_chan_phy_mode = %d virtual_chan = 0x%x  
+6459,iiii,[ resmgr_concurrency_mgr.c : 285 ] resmgr_handle_vdev_concurrency: phyGTX:%d vdevid:%d FWGtxDisable:%d hostGtxDisable:%d 
+6460,iIII,[ resmgr_mlo_mgr.c : 88 ] MLO_MGR_DBG: mlo_set_force_link_active_callback notify_type = %d, force_active = 0x%x, force_inactive = 0x%x, cur_active = 0x%x 
+6461,,[ resmgr_mlo_mgr.c : 453 ] resmgr_mlomgr_wmi_mlo_ready_hdlr : MLO RECOVERY SUCCESS 
+6462,i,[ resmgr_mlo_mgr.c : 472 ] resmgr_mlomgr_wmi_mlo_tear_down_hdlr: UMAC RESET is getting trigger for pdev_id %d 
+6463,i,[ resmgr_mlo_mgr.c : 498 ]  send resmgr_mlomgr_send_teardown_complete_evt  pdev_id: %d 
+6464,iii,[ resmgr_mlo_mgr.c : 529 ] resmgr_mlomgr_wmi_mlo_tear_down_hdlr: reason_code received for powersave mode %d, erp_stanby_mode : %d, trigger_umac_reset : %d 
+6465,iii,[ resmgr_mlo_mgr.c : 544 ] resmgr_mlomgr_wmi_mlo_tear_down_hdlr: reason_code received for powersave mode %d, erp_stanby_mode : %d, trigger_umac_reset : %d 
+6466,,[ resmgr_mlo_mgr.c : 580 ]  WSI_REMAP resmgr_mlomgr_wmi_mlo_tear_down_hdlr wsi_remap already in progress 
+6467,i,[ resmgr_mlo_mgr.c : 626 ] resmgr_mlomgr_wmi_mlo_tear_down_hdlr: teardown recievd with trigger_umac_reset %d 
+6468,i,[ resmgr_mlo_mgr.c : 629 ] resmgr_mlomgr_wmi_mlo_tear_down_hdlr: teardown completion event is sent for pdev_id: %d 
+6469,iiii,[ resmgr_mlo_mgr.c : 666 ] T2LM_DBG_T2L: tid_num %d, dir %d, link_map_mask %d, def_map %d  
+6470,iiiIIi,[ resmgr_mlo_mgr.c : 818 ] T2LM_DBG:  bcast_tid_to_link_sync_ipc e_mac_id = %d sr_hw_link_id = %d hw_link_id = %d cur_tsf = %u map_swt_tme_tsf = %u
+ map_swt_time_cnt = %d 
+6471,iiI,[ resmgr_mlo_mgr.c : 863 ] T2LM_DBG: WMI_MLO_AP_VDEV_TID_TO_LINK_MAP_EVENTID status = %d  vdev_id = %d map_swt_time = %u 
+6472,IIi,[ resmgr_mlo_mgr.c : 881 ] T2LM_DBG: WMI/IPC  wlan_vdev = %p tid_to_link_ie_info = %p vdev id  = %d 
+6473,ii,[ resmgr_mlo_mgr.c : 892 ] T2LM_DBG: WMI/IPC command recevied vdev id  = %d num_tid_to_link_map = %d 
+6474,iiIIiII,[ resmgr_mlo_mgr.c : 932 ] T2LM_DBG: WMI/IPC indx=%d hw_link_id=%d map_switch_time=%u exp_duration=%u link_map_size=%d disabled_link_map:0x%x ieee_disabled_link_map:0x%x 
+6475,iI,[ resmgr_mlo_mgr.c : 936 ] T2LM_DBG: WMI/IPC indx = %d control field :0x%x 
+6476,iiiiii,[ resmgr_mlo_mgr.c : 1020 ] T2LM_DBG:  bcast_tid_to_link_sync_ipc send vdev_id = %d sr_hw_link_id = %d dest_hw_link_id = %d link_id = %d chip_id = %d local_link = %d
+ 
+6477,i,[ resmgr_mlo_mgr.c : 1041 ] T2LM_DBG: resmgr_mlomgr_wmi_mlo_ap_vdev_t2lm_hdlr num_tid_to_link_map_ie_info = %d 
+6478,IIIIII,[ resmgr_mlo_mgr.c : 1197 ] tlt_dbg_host: wmi_hldr: sw_peer_id=%u, num_links=%u, link_priority=%u:%u:%u, tlt_bitmap=0x%x 
+6479,,[ resmgr_mlo_mgr.c : 1238 ] DYN_LINK_REM : wlan_vdev/vdev_mlo_info NULL 
+6480,I,[ resmgr_mlo_mgr.c : 1245 ] DYN_LINK_REM : parsed_cmn_info has incorrect values, control_fields = %p 
+6481,,[ resmgr_mlo_mgr.c : 1255 ] DYN_LINK_REM : parsed_sta_profile has incorrect values 
+6482,,[ resmgr_mlo_mgr.c : 1307 ] PRI_UMAC_MIG : WMI_CMD : wlan_vdev/vdev_mlo_info NULL 
+6483,Iiiii,[ resmgr_mlo_mgr.c : 1363 ] mcast_link:link_map_mask:0x%x pri_link_id:%d mcast_link_id:%d new_mcast_link_id:%d cur_link_id:%d 
+6484,IIII,[ resmgr_mlo_mgr.c : 1558 ] MLO_MGR_DBG: mlomgr_wlan_ml_peer_alloc ml_bss = 0x%x ml_peer = 0x%x, mld_addr47_32 = 0x%04x, mld_addr31_0 = 0x%08x 
+6485,II,[ resmgr_mlo_mgr.c : 1582 ] MLO_MGR_DBG: mlomgr_wlan_ml_peer_free ml_peer = 0x%x, ml_bss = 0x%x 
+6486,III,[ resmgr_mlo_mgr.c : 1605 ] ML_RECONFIG: PEER_UPDT return peer:0x%x ml_peer:0x%x param:0x%x 
+6487,,[ resmgr_mlo_mgr.c : 1610 ] ML_RECONFIG: PEER_UPDT return num_links 0 
+6488,,[ resmgr_mlo_mgr.c : 1616 ] ML_RECONFIG: unexpected num link reduction 
+6489,iiiiI,[ resmgr_mlo_mgr.c : 1677 ] ML_RECONFIG: PEER_UPDT ml_peer_id:%d new peer_num:%d emlsr_supp cur:%d new:%d eml_link_bmap:0x%x 
+6490,III,[ resmgr_mlo_mgr.c : 1697 ] ML_RECONFIG: LINK_UPDT return peer:0x%x ml_peer:0x%x param:0x%x 
+6491,IIi,[ resmgr_mlo_mgr.c : 1708 ] ML_RECONFIG: LINK_UPDT return peer_info:0x%x wal_peer:0x%x ll_idx:%d 
+6492,iiii,[ resmgr_mlo_mgr.c : 1723 ] ML_RECONFIG: LINK_DEL for non existing link !! ml_peer_id:%d hw_link_id:%d LL_idx:%d mlo_en:%d  
+6493,iiiiii,[ resmgr_mlo_mgr.c : 1730 ] ML_RECONFIG: LINK_DEL ml_peer_id:%d chip_id:%d hw_link_id:%d LL_idx:%d num_peer:%d self_link_to_be_del:%d 
+6494,iiiii,[ resmgr_mlo_mgr.c : 1739 ] ML_RECONFIG: LINK_ADD for existing link !! ml_peer_id:%d cur_hw_link_id:%d cur_LL_idx:%d mlo_en:%d mlo_ini:%d 
+6495,iiiii,[ resmgr_mlo_mgr.c : 1783 ] ML_RECONFIG: LINK_ADD ml_peer_id:%d chip_id:%d hw_link_id:%d LL_idx:%d num_peer:%d 
+6496,IIIIII,[ resmgr_mlo_mgr.c : 1876 ] MLO_MGR_DBG: mlomgr_wlan_ml_peer_setup VDEV NULL ml_peer = 0x%x, peer = 0x%x, peer_info = 0x%x, wal_ml_peer = 0x%x, ml_peer_id = 0x%x, link_id|vdev_id|hw_link_id|peer_num = 0x%08x 
+6497,IIIIII,[ resmgr_mlo_mgr.c : 1933 ] MLO_MGR_DBG: mlomgr_wlan_ml_peer_setup ml_peer = 0x%x, peer = 0x%x, peer_info = 0x%x, wal_ml_peer = 0x%x, ml_peer_id = 0x%x, link_id|vdev_id|hw_link_id|peer_num = 0x%08x 
+6498,II,[ resmgr_mlo_mgr.c : 1966 ] MLO_MGR_DBG: mlomgr_wlan_ml_peer_teardown duplicate ml_peer = 0x%x, peer_info = 0x%x 
+6499,III,[ resmgr_mlo_mgr.c : 2129 ] MLO_MGR_DBG: resmgr_mlomgr_allow_new_active_bitmap_req DO NOT ALLOW new bitmap statelock:0x%x cur_bitmap:0x%x new_bitmap:0x%x 
+6500,II,[ resmgr_mlo_mgr.c : 2184 ] MLO_MGR_DBG: mlomgr_register_event_callback ml_bss = 0x%x, cb_fn = 0x%x 
+6501,II,[ resmgr_mlo_mgr.c : 2220 ] MLO_MGR_DBG: mlomgr_deregister_event_callback ml_bss = 0x%x, cb_fn = 0x%x 
+6502,i,[ resmgr_mlo_mgr.c : 2245 ] MLO_MGR_DBG: mlomgr_set_master_link link_id = %d 
+6503,,[ resmgr_mlo_mgr.c : 2365 ] MLO_MGR_DBG: mlomgr_find_ml_bss_by_ml_bssid not found 
+6504,iI,[ resmgr_mlo_mgr.c : 2398 ] MLO_MGR_DBG: resmgr_mlomgr_alloc_ml_link_id link_id = %d, avl_link_btmp = 0x%x 
+6505,iI,[ resmgr_mlo_mgr.c : 2406 ] MLO_MGR_DBG: resmgr_mlomgr_free_ml_link_id link_id = %d, avl_link_btmp = 0x%x 
+6506,Iii,[ resmgr_mlo_mgr.c : 2451 ] mlomgr_create_link old valid_link_bitmap=%x received hw_link_id=%d is_bridge_link = %d  
+6507,IIIII,[ resmgr_mlo_mgr.c : 2469 ] MLO_MGR_DBG: mlomgr_create_link ml link already exists ml_bss = 0x%x vdev_id|link_id|op_mode|assoc_link =0x%08x, valid_link_bitmap = 0x%x valid_bridge_link_bitmap = 0x%x ml_link = 0x%x  
+6508,IIIII,[ resmgr_mlo_mgr.c : 2528 ] MLO_MGR_DBG: mlomgr_create_link ml_bss = 0x%x vdev_id|link_id|op_mode|assoc_link = 0x%08x, valid_link_bitmap = 0x%x valid bridge_link_bitmap = 0x%x ml_link =0x%X  
+6509,IiIi,[ resmgr_mlo_mgr.c : 2624 ] MLO_MGR_DBG: mlomgr_delete_link ml_bss = 0x%x link_id = %d, valid_link_bitmap = 0x%x hw_link_id=%d 
+6510,III,[ resmgr_mlo_mgr.c : 2683 ] MLO_MGR_DBG: mlomgr_update_force_link ml_bss = 0x%x force_active = 0x%x, force_inactive = 0x%x 
+6511,IIIIII,[ resmgr_mlo_mgr.c : 2807 ] MLO_MGR_DBG: mlomgr_set_force_link_complete vdev_bitmaps force_active = 0x%x, force_inactive = 0x%xlinkid_bitmaps force_active = 0x%x, force_inactive = 0x%xlinkid_bitmaps cur_active = 0x%x, cur_inactive = 0x%x 
+6512,II,[ resmgr_mlo_mgr.c : 2872 ] MLO_MGR_DBG: mlomgr_get_vdevs_from_ml_bss ml_bss = 0x%x vdev_bitmp = 0x%x 
+6513,I,[ resmgr_mlo_mgr.c : 2889 ] MLO_MGR_DBG: mlomgr_alloc_vdev_mlo_info vdev_info = 0x%x 
+6514,I,[ resmgr_mlo_mgr.c : 2903 ] MLO_MGR_DBG: mlomgr_free_vdev_mlo_info vdev_info = 0x%x 
+6515,IiII,[ resmgr_mlo_mgr.c : 2977 ] MLO_MGR_DBG: mlomgr_ml_bss_alloc ml_bss = 0x%x opmode = %d, ml_bssid47_32 = 0x%04x, ml_bssid31_0 = 0x%08x 
+6516,I,[ resmgr_mlo_mgr.c : 3002 ] ml_link_free ml_link=0x%x 
+6517,I,[ resmgr_mlo_mgr.c : 3010 ] ml_bridge link_free ml_link=0x%x 
+6518,I,[ resmgr_mlo_mgr.c : 3038 ] MLO_MGR_DBG: mlomgr_ml_bss_free ml_bss = 0x%x 
+6519,iii,[ resmgr_mlo_mgr.c : 3301 ] MLO_MGR_DBG resmgr_mlomgr_rt_mlo_ipc_send msg_type %d dest_idx %d, src_idx %d 
+6520,III,[ resmgr_mlo_mgr.c : 3339 ] MLO_MGR_DBG: mlomgr_create_link : Link Mac is Zero mac hw_link_id = %x, vdev_id = %x, src_hw_link_id = %x 
+6521,iii,[ resmgr_mlo_mgr.c : 3353 ]  MLO_MGR_DBG vdev_start_ipc_handler is_link_local= %d is_bridge_link = %d link_params.hw_link_id = %d   
+6522,III,[ resmgr_mlo_mgr.c : 3372 ] MLO_MGR_DBG: mlomgr_create_link : ml link is not null. is_link_local = %x, hw_link_id = %x, src_hw_link_id = %x 
+6523,i,[ resmgr_mlo_mgr.c : 3453 ] wal_ml_peer_get_transition_delay_in_us invalid padding_delay, switching to default %d 
+6524,i,[ resmgr_mlo_mgr.c : 3493 ] wal_ml_peer_get_transition_delay_in_us invalid transiton_delay, switching to default %d 
+6525,iI,[ resmgr_mlo_mgr.c : 3516 ] MLO_MGR_DBG resmgr_mlomgr_peer_emlsr_mode_hdlr ml_peer_id %d ml_peer 0x%x 
+6526,i,[ resmgr_mlo_mgr.c : 3623 ] MLO_MGR_DBG resmgr_mlomgr_peer_mlo_peer_assoc_hdlr vdev_id = %d 
+6527,iiiiii,[ resmgr_mlo_mgr.c : 3675 ] MLO_MGR_DBG resmgr_mlomgr_peer_mlo_peer_assoc_ipc ml_peer_id %d setup_link_id %d, src_idx %d, peer_num %d, ml_idx %d, is_ml_rcfg_add %d 
+6528,iiiiIi,[ resmgr_mlo_mgr.c : 3714 ] MLO_MGR_DBG resmgr_mlomgr_peer_mlo_peer_delete_ipc_hdlr  ML_PEER_DELETE src_hw_link_id %d dest_hw_link_id %d link_idx_src %d ml_peer_id %d ml_peer 0x%x is_ml_rcfg_del %d 
+6529,iiiI,[ resmgr_mlo_mgr.c : 3742 ] ML_RECONFIG: peer delete IPC handler - ml_rcfg_del, ieee_link_id:%d hw_link_id:%d ll_id:%d wlan_peer:0x%x 
+6530,iiii,[ resmgr_mlo_mgr.c : 3800 ] src_hw_link_id=%d, dest_hw_link_id=%d,vdev_id=%d, hw_link_id=%d 
+6531,ii,[ resmgr_mlo_mgr.c : 3851 ] DYN_LINK_REM : resmgr_mlomgr_vdev_mlo_cu_sync_hdlr : status code = %d, elapsed TBTT Reset vdev-%d 
+6532,I,[ resmgr_mlo_mgr.c : 4029 ] MLO_MGR_DBG resmgr_mlomgr_peer_mlo_peer_assoc_ipc send ML_PEER_ASSOC  peer 0x%x 
+6533,Iiiiii,[ resmgr_mlo_mgr.c : 4117 ] MLO_MGR_DBG delete_ipc send ML_PEER_DELETE  peer 0x%x src_hw_link_id %d dest_hw_link_id %d ml_peer_id %d link_idx_src %d ml_rcfg_del %d 
+6534,iiiii,[ resmgr_mlo_mgr.c : 4173 ] resmgr_mlomgr_vdev_mlo_cu_sync_ipc : vdev-%d, HW_LINK_ID = %d, MLO_CSA = %d, MLO_QUIET = %d, DYN_LINK_REM = %d 
+6535,II,[ resmgr_mlo_mgr.c : 4246 ] MLO_MGR_DBG: resmgr_mlomgr_get_assoc_link ml_bss = 0x%x assoc_link = 0x%x 
+6536,I,[ resmgr_mlo_mgr.c : 4348 ] MLO_MGR_DBG: resmgr_mlo_mgr_acquire_bss_state_lock for linkbitmap:0x%x : links in steady state locked 
+6537,I,[ resmgr_mlo_mgr.c : 4371 ] MLO_MGR_DBG: resmgr_mlo_mgr_release_link_state_lock for link_bitmap = 0x%x 
+6538,ii,[ resmgr_mlo_mgr.c : 4397 ] MLO_MGR_DBG: resmgr_mlomgr_get_link_by_cur_state link_id = %d, state = %d 
+6539,i,[ resmgr_mlo_mgr.c : 4430 ] MLO_MGR_DBG: resmgr_mlo_mgr_t2lm_action_frame_hdlr vdev id %d 
+6540,Iiiiiii,[ resmgr_mlo_mgr.c : 4743 ] MLO_MGR_DBG resmgr_mlomgr_peer_mlo_eml_omn_ipc send ML_PEER_EMLSR_MODE  peer 0x%x src_hw_link_id %d dest_hw_link_id %d ml_peer_id %d emlsr_mode %d padding_delay %d transition_delay %d 
+6541,II,[ resmgr_mlo_mgr.c : 4762 ] resmgr_mlomgr_emlsr_mode_enable_disable wlan_vdev %p, peer 0x%x 
+6542,I,[ resmgr_mlo_mgr.c : 4843 ] resmgr_mlomgr_handle_emlsr_frame vdev NULL for peer 0x%x 
+6543,iI,[ resmgr_mlo_mgr.c : 4850 ] resmgr_mlomgr_handle_emlsr_frame vdev_id %d, peer 0x%x 
+6544,,[ resmgr_mlo_mgr.c : 4864 ] resmgr_mlomgr_handle_emlsr_fram invalid action_hdr 
+6545,i,[ resmgr_mlo_mgr.c : 4870 ] resmgr_mlomgr_handle_emlsr_fram invalid catahory_code %d 
+6546,i,[ resmgr_mlo_mgr.c : 4882 ] wlan_emlsr_action_frame_handler: omn_rx_frame->eml.link_bitmap=%d 
+6547,i,[ resmgr_mlo_mgr.c : 5362 ] DYN_LINK_REM : foreign link %d has become inactive 
+6548,ii,[ resmgr_mlo_mgr.c : 5375 ] DYN_LINK_REM : foreign link %d inactive status %d 
+6549,iiiiIii,[ resmgr_mlo_mgr.c : 5459 ] MLO_MGR_DBG resgmr_mlomgr_get_partner_link_count_down_estimate: (MLO_CSA | MLO_QUIET | DYN_LINK_REM) vdev_id-%d new_count = %d curr_bcn_intvl = %d partner_bcn_intvl = %d elem_id 0x%x max_tbtt_count %d elapsed_tbtt %d 
+6550,,[ resmgr_mlo_mgr.c : 5520 ] resmgr_mlomgr_acquire_vdev_stop_link_lock 
+6551,i,[ resmgr_mlo_mgr.c : 5677 ] MLO_MGR_DBG: resmgr_mlomgr_ieee_link_id_to_logical_link_id ieee_link_id %d not found 
+6552,i,[ resmgr_mlo_mgr.c : 5694 ] MLO_MGR_DBG: resmgr_mlomgr_logical_link_id_to_ieee_link_id link_id %d not valid 
+6553,i,[ resmgr_mlo_mgr.c : 5948 ] MLO_MGR_DBG: resmgr_mlo_mgr_request_link_state_change granted for moduleid %d 
+6554,Ii,[ resmgr_mlo_mgr.c : 5972 ] MLO_MGR_DBG: resmgr_mlo_mgr_link_state_change_done for link_bitmap = 0x%x, moduleid = %d 
+6555,iiiii,[ resmgr_mlo_mgr.c : 6015 ] VBSS wal_peer_vbss_get_peer_info emlsr mode : %d transition_delay_us : %d transition_timeout_us : %d padding_delay_us : %d link_bitmap : %d 
+6556,iiiii,[ resmgr_mlo_mgr.c : 6032 ] VBSS wal_peer_vbss_set_peer_info emlsr mode : %d transition_delay_us : %d transition_timeout_us : %d padding_delay_us : %d link_bitmap : %d 
+6557,iI,[ resmgr_mlo_mgr.c : 4585 ] MLO_MGR_DBG: resmgr_mlo_mgr_t2lm_beacon_reported defer swith timeout = %d, mst =0x%x 
+6558,iii,[ resmgr_mlo_mgr_sm.c : 600 ] MLO_MGR_LINK_SM_%d_EVENT: %d < %d 
+6559,iii,[ resmgr_mlo_mgr_sm.c : 622 ] MLO_MGR_LINK_SM_%d:  %d => %d 
+6560,iiiiii,[ wlan_scan_wmi.c : 265 ] SCAN_SCH_WMI_START_SCAN num_ssid from %d to %d, num_bssid from %d to %d, num_chan=%d ie_len=%d 
+6561,IIIIII,[ wlan_scan_wmi.c : 272 ] SCAN_SCH_WMI_START_SCAN bssid %02x:%02x:%02x:%02x:%02x:%02x 
+6562,iII,[ wlan_scan_wmi.c : 417 ] SCAN_START_COMMAND_FAILED err_ret_code=%d(1:vdev_is_free 2:scan_start_fail 3:nolCheckFailed), status=0x%x, vdev_id=0x%x 
+6563,I,[ wlan_scan_wmi.c : 442 ] SCAN_SCH_STOP_COMMAND_FAILED status=0x%x 
+6564,ii,[ wlan_scan_wmi.c : 479 ] SCAN_SET_CHANLIST_FAILED support_chan=%d, num_scan_chans=%d 
+6565,i,[ wlan_scan_wmi.c : 490 ] SCAN_SET_CHAN_LIST idx=%d 0Mhz channel 
+6566,iiiIIIii,[ wlan_scan_wmi.c : 598 ] SCAN_SET_CHAN_LIST idx=%d, mhz=%d, is_passive=%d, ch_info=0x%x, reg_info_1=0x%x, reg_info_2=0x%x, max_bd=%d, is_nan_disabled=%d 
+6567,iIIi,[ wlan_scan_sch.c : 87 ] SCAN_SCH_SUPPRESS_REQ req_mod_id=%d, sch_class=0x%x, id=0x%x, is_disable_scan=%d 
+6568,IIii,[ wlan_scan_sch.c : 230 ] SCAN_SCH_CANCEL scan_id=0x%x, requestor_id=0x%x, vdev_id=%d, req_type=%d 
+6569,IIiiii,[ wlan_scan_sch.c : 298 ] SCAN_SCH_CANCEL scan_id=0x%x, requestor_id=0x%x, vdev_id=%d, req_type=%d, is_already_cancelled=%d, is_match_found=%d 
+6570,III,[ wlan_scan_sch.c : 522 ] SCAN_SCH_SUSPEND bitmap_95_64=0x%x, bitmap_63_32=0x%x, bitmap_31_0=0x%x 
+6571,Iii,[ wlan_scan_sch.c : 542 ] SCAN_SCH_SUSPEND_NEXT_SCANsuspend_skip_module_bitmap=0x%x, suspend_all_count=%d, requestor=%d 
+6572,IIIIIII,[ wlan_scan_sch.c : 573 ] SCAN_SCH_SUPPRESS_MATCH scan_id=0x%x, requestor=0x%x, vdev_id=0x%x, suppress_vdev_id_bitmap=0x%x suppress_mod_bitmap[0:2] 0x%x 0x%x 0x%x 
+6573,Iii,[ wlan_scan_sch.c : 618 ] SCAN_SCH_SUSPENDEDsuspend_skip_module_bitmap=0x%x, suspend_all_count=%d, requestor=%d 
+6574,i,[ wlan_scan_sch.c : 645 ] SCAN_SCH_START_NEW_REQ_FAILED error_code=%d 
+6575,,[ wlan_scan_sch.c : 648 ] SCAN_DETERM_HIGH_PRI cur scan not completed 
+6576,iIIiII,[ wlan_scan_sch.c : 862 ] SCAN_SCH_CHECK_PARAMS_CH_INFO params->num_chan=%d, 2g(3)|5g_act(3)|5g_pas(3)=%09d, 6g_act(3)|6g_pas(3)=%06d, sbs_or_dbs_enable=%d, 5g_unii_L_act(3)|L_pas(3)=%06d, 5g_unii_H_act(3)|H_pas(3)=%06d 
+6577,IIIiiiii,[ wlan_scan_sch.c : 1094 ] SCAN_SCH_START scan_id = 0x%x requestor_id = 0x%x req_sub_id = 0x%x requested_priority = %d absolute_priority = %d actv_time_5g = %d actv_time_2g = %d pass_time = %d 
+6578,iIIIii,[ wlan_scan_sch.c : 1141 ] SCAN_SCH_START_FAIL err_code = %d(1:invalid scan_id or params, 2:misc, 3:vdev_invalid, 4:no_mem_new_req, 5:chunk_copy_fail, 6:param_pool_alloc_fail), scan_id=0x%x, requestor_id=0x%x, req_sub_id=0x%x, requested_priority=%d, ie_len=%d 
+6579,II,[ wlan_scan_sch.c : 1187 ] SCAN_SCH_ENGINE_STOP_DUE_TO_TIMEOUT  evt_scan_id=0x%x, evt_reason=0x%x 
+6580,i,[ wlan_scan_sch.c : 1253 ] SCAN_EVENT_COMPLETED really cancelled scan_id %d 
+6581,IIiiIIii,[ wlan_scan_sch.c : 1297 ] SCAN_INTERN_EVT evt_type=%x(1:start 2:compl 4:bss 8:frn_ch 10:deq 20:preempt 40:start_fail 80:restart 100:frn_ch_exit 200:susp 400:resume) scan_id=0x%x vdev_id=%d freq=%d req_sub_id=0x%x to_host(8b)|reason(8b)=0x%x abs_pri=%d dwell=%d 
+6582,IIi,[ wlan_scan_sch.c : 1339 ] SCAN_INTERN_EVT (PREEMPTED) scan_id=0x%x, preempted_by scan_id=0x%x, reason=%d 
+6583,IiiIi,[ wlan_scan_sch.c : 1414 ] SCAN_EVENT_SEND_FAILED scan_id=0x%x, vdev_id=%d, ch_freq=%d, req_sub_id=0x%x, reason=%d 
+6584,i,[ wlan_scan_sch.c : 1525 ] SCAN_SCH_NEXT_SCAN_FAILED error_code=%d 
+6585,I,[ wlan_scan_sch.c : 1595 ] SCAN_EVENT_SEND_FAILED 0x%x 
+6586,I,[ wlan_scan_sch.c : 1988 ] SCAN_SCH_CSA_FAILED status=0x%x 
+6587,IIIi,[ wlan_scan_sch.c : 2230 ] SCAN_SCH_SUSPEND requestor_id=0x%x, suspend_skip_module_bitmap[curr:new]=0x%x:0x%x, suspend_all_count=%d 
+6588,IIIi,[ wlan_scan_sch.c : 2273 ] SCAN_SCH_RESUME requestor_id=0x%x, suspend_skip_module_bitmap[cur:new]=0x%x:0x%x, suspend_all_count=%d 
+6589,iiiII,[ wlan_scan_eng.c : 92 ] AUTO_CHAN_EVT_HDNLR CURR_CHAN_STATS_ERROR error_code=%d (1:scan_handle NULL, 2:chan_freq 0), scan_id=%d, evt_mac_id=%d, type=0x%x, freq=0x%x 
+6590,i,[ wlan_scan_eng.c : 246 ] SCAN_CLEAR_CHAN_STATS due to PDEV:%d wal reset 
+6591,iI,[ wlan_scan_eng.c : 387 ] SCAN_ENG_MAX_SCAN_TIMEOUT scanhandle_id=%d, scan_id=0x%x 
+6592,IIIIIiii,[ wlan_scan_eng.c : 450 ] SCAN_ENG_START scan_id=0x%x, eng_id(3)|req_type(3)=%06d, num_chans_[req(3)|granted_2g(3)|granted_5g(3)]=%09d, num_[ssid(3)|bssid(3)]=%06d, flags=0x%x, vdev_freq=%d, cur_ch_idx_2g|5g = %d %d 
+6593,iiiiii,[ wlan_scan_eng.c : 462 ] SCAN_ENG_PARAM_1 dwell_time_active = %d dwell_time_active_2g = %d msec dwell_time_passive = %d msec min_rest_time = %d msec max_rest_time = %d msec max_scan_time = %d msec 
+6594,iiiiiii,[ wlan_scan_eng.c : 473 ] SCAN_ENG_PARAM_2 idle_time = %d msec repeat_probe_time = %d msec probe_spacing_time = %d msec probe_delay = %d msec burst_duration = %d msec max_num_probes(2g|5g) = %d cancel_probe_req_defer = %d 
+6595,iiiiiiii,[ wlan_scan_eng.c : 1009 ] SCAN_ENG_CALC_CHAN num_2g=%d, num_5g=%d, num_5g_active=%d (num_5g_low_act_ch=%d), num_5g_passive=%d, double_passive_chan_scan=%d, num_6g_ch=%d, num_extra_6g_ch=%d 
+6596,IIII,[ wlan_scan_eng.c : 1037 ] SCAN_ENG_SPOOFED_MAC_ADDR full_mac_addr=%08x%04x, partial_mac_addr=%08x%04x 
+6597,IIIi,[ wlan_scan_eng.c : 1154 ] SCAN_ENG_START_IN_PROGRESS=1, scan_id=0x%x, requestor=0x%x, req_sub_id=0x%x, priority=%d -> return EBUSY 
+6598,I,[ wlan_scan_eng.c : 1239 ] SCAN_SM_START_COMMAND_FAILED cur_sch_scan_req=NULL, handle=0x%x 
+6599,iIIiii,[ wlan_scan_eng.c : 1284 ] SCAN_ENG_CANCEL scanhandler_id=%d, scan_id=0x%x, requestor=0x%x, stop_mode=%d, scan_in_progress=%d, cancel_in_progress=%d 
+6600,iIii,[ wlan_scan_eng.c : 1429 ] SCAN_BCN_RECVD mhz=%d at %08x is_scan_in_progress=%d (0 ignored) send_probe_req_on_DFS_ch=%d (1 ignored) 
+6601,III,[ wlan_scan_eng.c : 1645 ] SCAN_ENG stop found target bssid %02x:%02x:%02x 
+6602,i,[ wlan_scan_eng.c : 1669 ] SCAN_ENG stop failed with reason[%d] 
+6603,iii,[ wlan_scan_sm.c : 114 ] SCAN_SM_DISPATCH_%d %d < %d 
+6604,iii,[ wlan_scan_sm.c : 129 ] SCAN_SM_TRANS_%d %d => %d 
+6605,ii,[ wlan_scan_sm.c : 361 ] SCAN_SM_BSSCH_ENTRY BT_COEX id = %d min_rest_time = %d 
+6606,i,[ wlan_scan_sm.c : 1152 ] SCAN_SM_REQ_NEXT_CHAN !error! not implemented scan policy: %d 
+6607,iiii,[ wlan_scan_sm.c : 1860 ] SCAN_SM_LEGACY_MAC_CHANGE id = %d, last_legacy_macid = %d req_mac_id = %d, index = %d 
+6608,iii,[ wlan_scan_sm.c : 1942 ] SCAN_SM_FOREIGN_CH actual_probe_delay = %d, scan_sch_handle->cancel_probe_req_defer = %d, params.cancel_probe_req_defer = %d 
+6609,Ii,[ wlan_scan_sm.c : 2153 ] wlan_scan_sm_state_foreign_chan_exit chan.ext_flags 0x%x Freq %dMhz 
+6610,Ii,[ wlan_scan_sm.c : 2168 ] wlan_scan_sm_state_foreign_chan_exit chan.ext_flags 0x%x Freq %dMhz 
+6611,iii,[ wlan_scan_sm.c : 2823 ] SCAN_SM_PROBE_REQ_FRAME_GEN_FAILED scanhandler_id = %d 5g_freq = %d 2g_freq = %d 
+6612,i,[ wlan_scan_sm.c : 2945 ] SCAN_SM_PROBE_REQ_FRAME_GEN_FAILED scanhandler_id = %d 
+6613,,[ wlan_scan_sm.c : 3112 ] TPC_DBG not to send probe request if a power is invalid 
+6614,iii,[ wlan_scan_sm.c : 3214 ] SCAN_SM_MLO_PROBE_REQ_FRAME_GEN_FAILED scanhandler_id = %d 5g_freq = %d 2g_freq = %d 
+6615,i,[ wlan_scan_sm.c : 3470 ] UNIT_TEST_MONITOR_HOST_SCANS - Bad case g_scan_monitor_instance=%d 
+6616,ii,[ wlan_scan_sm.c : 3474 ] UNIT_TEST_MONITOR_HOST_SCANS - Bad case, STA: Asserting freq:%d rx_cnt=%d 
+6617,i,[ wlan_scan_sm.c : 3486 ] UNIT_TEST_MONITOR_HOST_SCANS - Good case g_scan_monitor_instance=%d 
+6618,ii,[ wlan_scan_sm.c : 3490 ] UNIT_TEST_MONITOR_HOST_SCANS - Good case, STA: Asserting freq:%d rx_cnt=%d 
+6619,iii,[ wlan_scan_sm.c : 3517 ] UNIT_TEST_MONITOR_HOST_SCANS - ch_idx=%d, mode=%d g_bad_case_hit=%d 
+6620,,[ wlan_scan_sm.c : 3519 ] UNIT_TEST_MONITOR_HOST_SCANS - return as already case got executed in this instance 
+6621,iii,[ wlan_scan_sm.c : 3529 ] UNIT_TEST_MONITOR_HOST_SCANS - 2Ghz scan channel:%d rx_cnt=%d req=%d 
+6622,iii,[ wlan_scan_sm.c : 3539 ] UNIT_TEST_MONITOR_HOST_SCANS - 5Ghz scan channel:%d rx_cnt=%d req=%d 
+6623,i,[ wlan_scan_sm.c : 3567 ] SCAN_SM_FOREIGN_CHAN_EVENT !error! not implemented scan policy: %d 
+6624,Iiii,[ wlan_scan_sm.c : 3796 ] SCAN_SM_OCS_TIMEOUT scan_id 0x%x, requestor = %d, curr_index = %d, curr_policy = %d 
+6625,iii,[ wlan_scan_sm.c : 90 ] wlan_scan_update_chan_info of channel freq %d to wideband phymode %d having centre freq1: %d 
+6626,iI,[ wlan_scan_sm.c : 94 ] wlan_scan_update_chan_info Enabling Premium scan for higher MCS  %d  chan_ext_flags 0x%x 
+6627,Iiiii,[ wlan_scan_mgr.c : 98 ] SCAN_MGR_STATE_CHANGE scan_id=0x%x, num_ssid=%d, num_bssid=%d, num_chan=%d, new_scan_state=%d (0:completed 1:legacy 2:sync_DBS 3:async_DBS 4:agile 5:agile_DFS_2g 6:agile_DFS_5g) 
+6628,IIiiiiIii,[ wlan_scan_mgr.c : 263 ] SCAN_MGR_EVENT_PREEMPTED scan_id=0x%x, cur_chan_index=0x%x, 2g_next_idx=%d, 2g_curr=%d, 5g_next_idx=%d, 5g_curr=%d reason=0x%x, cur_scan_policy=%d, drop_event=%d 
+6629,IIIii,[ wlan_scan_mgr.c : 270 ] SCAN_MGR_EVENT_SUSPENDED scan_id=0x%x, cur_chan_index=0x%x, reason=0x%x, cur_scan_policy=%d, drop_event=%d 
+6630,iI,[ wlan_scan_mgr.c : 297 ] SCAN_MGR_EVENT_FAIL: Invalid input - scan_handler_id=%d, current_scan_sch_req=0x%x 
+6631,iIiiii,[ wlan_scan_mgr.c : 359 ] SCAN_MGR_EVENT_COMPLETED eng_id=%d, scan_id=0x%x, num_ssid=%d, num_bssid=%d, num_chan=%d, is_drop=%d 
+6632,IIII,[ wlan_scan_mgr.c : 401 ] SCAN_POLICY_EVENT current_allowed_policy=0x%x, new_allowed_policy=0x%x, current_scan_req=0x%x, suppress_mode_bitmap=0x%x 
+6633,iiii,[ wlan_scan_mgr.c : 430 ] SCAN_MGR_PDEV_SUSPEND_RESUME_CHANGE_EVT pdev_id=%d, requestor=%d, reason=%d, state=%d 
+6634,Iii,[ wlan_scan_mgr.c : 668 ] SCAN_MGR_SCAN_START_NON_DBS scan_id=0x%x, cur_scan_policy=%d, scan_for_cca_measure=%d 
+6635,IIii,[ wlan_scan_mgr.c : 705 ] SCAN_MGR_CANCEL scan_id=0x%x, requstor=0x%x, stop_mode=%d, scan_eng_start_pending=%d 
+6636,II,[ wlan_scan_mgr.c : 799 ] SCAN_MGR_CANCEL comp_pending=0x%x cancel_pending=0x%x 
+6637,i,[ wlan_scan_mgr.c : 859 ] SCAN_SCH_NEXT_SCAN_FAILED after setting new channel lists, error_code=%d 
+6638,,[ wlan_scan_mgr.c : 1101 ] SCAN_MGR_CH_MODE_CHANGE scan cancelled 
+6639,iiiii,[ wlan_scan_mgr.c : 1167 ] SCAN_MGR_CHECK_PARAMS_CHANNELS params->num_chan=%d, params->chan_list[0]=%d, has_2g_chan=%d, has_5g_chan_active=%d, has_5g_chan_passive=%d 
+6640,iiiii,[ wlan_scan_mgr.c : 1215 ] SCAN_MGR_SCAN_POLICY_RECOMPUTE invalid chan index has_2g_chan=%d passive_5g=%d has_5g_chan_active=%d passive_6g=%d has_6g_ch_active=%d 
+6641,IiI,[ wlan_scan_mgr.c : 1345 ] SCAN_MGR_SCAN_POLICY_RECOMPUTE_START suppress mode bitmap=0x%x, is_scan_start=%d, ch_list_mode(2)|suspend(2)|preempted(2)=%06d 
+6642,iiiiiII,[ wlan_scan_mgr.c : 1391 ] SCAN_MGR_SCAN_POLICY_RECOMPUTE_END chan_index=%d, policy_sel=%d, new_scan_policy=%d, cur_scan_policy=%d, scan_policy_max=%d, suppress_vdev_id_bitmap=0x%x, caller_id=0x%x 
+6643,I,[ wlan_dcs.c : 254 ] WMI_EVENT_ALLOC_FAILURE EventId = 0x%x 
+6644,I,[ wlan_dcs.c : 310 ] WMI_EVENT_ALLOC_FAILURE EventId = 0x%x 
+6645,i,[ wlan_scan_unit_test.c : 69 ] SCAN_NUM_SUPP_CHAN_LIST %d 
+6646,ii,[ wlan_scan_unit_test.c : 544 ] ZERO_SCAN_UNIT_TEST enable=%d channel_freq=%d 
+6647,iii,[ wlan_scan_unit_test.c : 569 ] UNIT_TEST_MONITOR_HOST_SCANS monitor_mode:%d, max_iter:%d, ch_freq:%d 
+6648,iiiiiii,[ wlan_scan_unit_test.c : 583 ] UNIT_TEST_WIDE_BAND_SCAN freq1:%d, freq2:%d, freq3:%d bw1: %d, bw2: %d, bw3: %d, wifi-ver: %d 
+6649,i,[ wlan_scan_unit_test.c : 640 ] UNIT_TEST_PAUSE_HOME_CHAN_BIT home_chan_pause:%d 
+6650,,[ wlan_stats.c : 854 ] Event not getting allocated evh = NULL 
+6651,iiiiii,[ wlan_stats.c : 1088 ] wlan_stats_processor: vdev=%d ac=%d good=%d xretry=%d xretry_orig=%d (bumped up=%d) 
+6652,i,[ wlan_stats.c : 1099 ] wlan_stats_processor: inactive vdev_id:%d 
+6653,i,[ wlan_stats.c : 1104 ] wlan_stats_processor: active vdev_id:%d, set rssi -50 
+6654,iii,[ wlan_stats.c : 1190 ] wlan_stats_processor: peer_stats->peer_tx_rate = %d rx_rate = %d rssi = %d 
+6655,,[ wlan_stats.c : 1440 ] wlan_stats_processor: Ran out of buffers; Aborting Report generation;               Sending Report to Host  
+6656,,[ wlan_stats.c : 1779 ] PS_STA_AVG_CHANNEL_CONGESTION(ERROR0):total_awake_period == 0 
+6657,II,[ wlan_stats.c : 1798 ] PS_STA_AVG_CHANNEL_CONGESTION(ERROR1):diff_all(%u) < diff_tx(%u) 
+6658,I,[ wlan_stats.c : 1816 ] PS_STA_AVG_CHANNEL_CONGESTION(ERROR2): chan_activity(%u) > 100 
+6659,,[ wlan_stats.c : 2068 ] radio_link_stats_process no buffer 
+6660,ii,[ wlan_stats.c : 2093 ] radio_link_stats_process cur_pwr_state:%d next_pwr_state:%d 
+6661,,[ wlan_stats.c : 2124 ] _wlan_iface_link_stats_process: vdev is NULL 
+6662,iii,[ wlan_stats.c : 2253 ] total_num_peers:%d num_peer_stats_events:%d num_peer_in_event: %d 
+6663,,[ wlan_stats.c : 2818 ] BIGDATA ERR: mem alloc failed  
+6664,iiiiiiii,[ wlan_wmi_ctrl_path_stats.c : 2895 ] NEW_LOG GroupTX = %d GroupRX = %d TX_OK = %d ack_fail = %d TX_fail = %d FCS_err = %d RTS_OK = %d RTS_Fail = %d 
+6665,,[ wlan_halphy_stats.c : 78 ] WMI_HCP_TPC_STATS: wmi_tpc_stats_event_complete 
+6666,,[ wlan_halphy_stats.c : 105 ] DISPLAY_TPC_STATS: WMI tpc stats evt, allocation failed! 
+6667,iI,[ wlan_rssi_monitor.c : 620 ] RSSI_MONITOR_HW_EVENT: vdevid=%d, event_type=%x 
+6668,iii,[ wlan_thermal_unit_test.c : 500 ] wlan_thermal_unit_test num_args = %d args[0]=%d vdev_id = %d 
+6669,i,[ wlan_thermal_unit_test.c : 339 ] TT_DBG num_args invalid exp:3 obs: %d  
+6670,ii,[ wlan_thermal_unit_test.c : 347 ] TT_DBG tt_temp_enabled: %d temp: %d 
+6671,i,[ wlan_thermal_unit_test.c : 324 ] TT_DBG num_args invalid exp:2 obs: %d  
+6672,,[ wlan_thermal_unit_test.c : 356 ] TT_DBG_STATS Invalid Pdev 
+6673,I,[ wlan_vdev.c : 470 ] allow during connecting, subtype:%x 
+6674,iiI,[ wlan_vdev.c : 529 ] set_restore_mac_addr status = %d, freq = %d, evh = 0x%x 
+6675,Ii,[ wlan_vdev.c : 553 ] resmgr link already exist: 0x%X vdev_id = %d 
+6676,iiiI,[ wlan_vdev.c : 937 ] VDEV_SEQ_DBG VDEV_CREATE_CMD Duplicate mld_macaddr existing_vdev_id %d incoming_vdev_id %d duplicate_mld_macaddr_cnt %d mac_addr 0x%x 
+6677,iiiI,[ wlan_vdev.c : 958 ] VDEV_SEQ_DBG VDEV_CREATE_CMD Duplicate link_macaddr existing_vdev_id %d incoming_vdev_id %d  duplicate_link_macaddr_cnt %d mac_addr 0x%x 
+6678,iiIIiI,[ wlan_vdev.c : 1001 ] VDEV_SEQ_DBG VDEV_CREATE_CMD vdev_id %d pdev_id %d opmode 0x%x sub_opmode 0x%x vdevid_trans %d flag 0x%x 
+6679,iii,[ wlan_vdev.c : 1296 ] VDEV EVT:RT thread handle vdev_stop_down_del msg cmd = %d, vdev_id = %d, vdev_mode = %d 
+6680,ii,[ wlan_vdev.c : 1446 ] VDEV EVT:RT thread handle vdev_stop_down_del cmd:%d, vdev_id:%d 
+6681,i,[ wlan_vdev.c : 1488 ] wlan_beacon_tx: vdev id = %d vdev delete return becasue bcn ctxt is not free yet 
+6682,iiIIi,[ wlan_vdev.c : 1527 ] VDEV EVT peer not cleared idx=%d vdev_id = %d mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x usage_count = %d 
+6683,iiii,[ wlan_vdev.c : 1564 ] VDEV_SEQ_DBG WMI_VDEV_DELETE_RESP_EVENTID vdev_id %d pdev_id %d vdev_type %d vdev_subtype: %d 
+6684,iiiiI,[ wlan_vdev.c : 1847 ] VDEV_SEQ_DBG VDEV_DELETE_CMD vdev_id %d pdev_id %d opmode %d sub_opmode %d vdev 0x%x 
+6685,iii,[ wlan_vdev.c : 1855 ] VDEV_SEQ_DBG VDEV_DELETE_CMD is received without VDEV_STOP/VDEV_DOWN_CMD vdev_id %d pdev_id %d opmode %d  
+6686,II,[ wlan_vdev.c : 2231 ] wlan_vdev_migrate vdev_id[31-16]/from_mac[15-8]/to_mac[7-0] 0x%x, is_up[24]/is_active[16]/mode[15-8]/submode[7-0] 0x%x 
+6687,iiii,[ wlan_vdev.c : 2582 ] GreenAP Home Chan restored :%d Mhz:%d Cent_Freq1:%d phymode:%d 
+6688,iIIiiIiII,[ wlan_vdev.c : 2779 ] VDEV_SEQ_DBG VDEV_START_CMD/AWGN_INT_DBG for vdev_id %d opmode 0x%x subopmode 0x%x phy_mode %d freq %dMHz flag 0x%x restart_resp %d wmi_flags = 0x%x cur_time = %u 
+6689,Iii,[ wlan_vdev.c : 2816 ] VDEV_START_BEGIN: vdev_id[31-24]/mode[23-16]/mode[15-8]/ori_mac_id[7-0] = 0x%x restart :%d is suspended_vdev(%d) 
+6690,I,[ wlan_vdev.c : 3108 ] VDEV START: RXPCU_R0_RFF_RX_FILTER: 0x%08x, UCAST bit unset 
+6691,IiiiiiII,[ wlan_vdev.c : 3308 ] VDEV_START: vdev_id[31-24]/mode[23-16]/mode[15-8]/mac_id[7-0] = 0x%x chan_mhz = %d  phy_mode=%d band_center_freq1=%d band_center_freq2=%d ldpc_rx_enabled=%d chan_flags :0x%x link_param_flags: 0x%x 
+6692,iii,[ wlan_vdev.c : 3356 ] VDEV START vdev_id : %d is_mlo_enabled : %d is_primary_vdev : %d 
+6693,iiiiii,[ wlan_vdev.c : 3623 ] GreenAP VDEV_STOP vdev:%d pdev:%d; ACT_AP_CNT_MAC %d; ACT_VDEV_CNT_TOT %d; gap_en_wmi %d; gap_fw_int_dis %d 
+6694,ii,[ wlan_vdev.c : 3626 ] GreenAP disabled in vdev stop vdev:%d pdev:%d 
+6695,iiI,[ wlan_vdev.c : 4115 ] VDEV_MGR_VDEV_UP/AWGN_INT_DBG id=%d, mode=%d cur_time = %u 
+6696,iII,[ wlan_vdev.c : 4425 ] KA: wlan_vdev_up() -> start timer vdev_id = %d keepalive_interval = 0x%x keepalive_method = 0x%x 
+6697,i,[ wlan_vdev.c : 4471 ] wlan_vdev_sr_disable_internal_trigger value:%d 
+6698,ii,[ wlan_vdev.c : 4550 ] wlan_vdev_down: pickup new ul resp, pdev id:%d vdev id:%d 
+6699,,[ wlan_vdev.c : 5389 ] wlan_vdev_bw_change_smps_compl_cb invalid VDEV 
+6700,iiiiiiiii,[ wlan_vdev.c : 5469 ] wlan_vdev_start_bw_change: vdev_id=%d, assoc_phy_mode=%d, ap_operate_bw=%d, cur_phy_mode=%d, new_phy_mode=%d, old_bw=%d, new_bw=%d, leaky_ap_detect_req_pend=%d, leaky_ap_detect_enabled=%d 
+6701,,[ wlan_vdev.c : 5514 ] wlan_vdev_bw_change_mlo_evt_handler invalid VDEV 
+6702,i,[ wlan_vdev.c : 5530 ] wlan_vdev_bw_change_mlo_evt_handler: unregister on mlomgr fail, %d 
+6703,i,[ wlan_vdev.c : 5576 ] wlan_vdev_change_bw_with_notify: status: %d (0: success) 
+6704,III,[ wlan_vdev.c : 7131 ] VDEV free error, peer addr:0x%x, mac:0x%x 0x%x 
+6705,iii,[ wlan_vdev.c : 7165 ] WAL Peer event vdevp %d is_free %d, is_vdev_stopping %d 
+6706,iii,[ wlan_vdev.c : 7173 ] WAL Peer event Vdev ID = %d HW Q depth= %d, SW Q depth = %d 
+6707,IIII,[ wlan_vdev.c : 7319 ] VDEV_STOP_ABORT_TX try_to_abort 0x%x abort_fails 0x%x abort_succeeds 0x%x after_abort 0x%x 
+6708,ii,[ wlan_vdev.c : 7425 ] WMI_CMD_PARAMS VdevId/AC/Arg1 = %d Cmd/Med-Time/Action/Arg2 = %d 
+6709,,[ wlan_vdev.c : 7475 ] WMI_EVENT_ALLOC_FAILURE: VDEV_REJECT_VDEV_START_REQ_RESP_EVENTID buffer failure 
+6710,iii,[ wlan_vdev.c : 7495 ] VDEV_SEQ_DBG VDEV_START/RESTART_RESP failed for vdev_id %d status %d is_restart %d 
+6711,Ii,[ wlan_vdev.c : 7615 ] VDEV_START_PARAMS: vdev_id= 0x%x status %d (0: success)  
+6712,Ii,[ wlan_vdev.c : 7926 ] VDEV_START_REJECT vdev_id: 0x%x Status: %d  
+6713,ii,[ wlan_vdev.c : 8013 ] WMI_VDEV_SET_WMM_PARAMS_CMDID : VDEV ID = %d status=%d (0: success) 
+6714,iI,[ wlan_vdev.c : 8304 ] security: DELAY key install peer_id:%d qpeer_flags:0x%x 
+6715,iI,[ wlan_vdev.c : 8414 ] WAL_DBGID_SET_M4_SENT_MANUALLY  VDEV ID = %d, peer = 0x%x 
+6716,iIIi,[ wlan_vdev.c : 8468 ] VDEV_INSTALL_KEY vdev_id %d mac_addr %04x:%08x ret_value %d 
+6717,ii,[ wlan_vdev.c : 8585 ] wlan_vdev_tsf_tstamp_action: vdev_id = %d, vdev_ifUp = %d 
+6718,IIIIIii,[ wlan_vdev.c : 8725 ] WLAN_DISPATCH_VDEV_UP vdev_flags:0x%x vdev_bssid:%x_%x trans_bssid:%x_%x profile_idx:%d profile_num:%d 
+6719,,[ wlan_vdev.c : 8759 ] WLAN_DISPATCH_VDEV_UP detect non_tx 
+6720,,[ wlan_vdev.c : 8762 ] WLAN_DISPATCH_VDEV_UP detect tx 
+6721,,[ wlan_vdev.c : 8771 ] WLAN_DISPATCH_VDEV_UP !!!host sends wrong MBSSID param!!! 
+6722,iiIi,[ wlan_vdev.c : 8791 ] VDEV_SEQ_DBG VDEV_UP_CMD vdev_id %d pdev_id %d vdev_flag 0x%x, vdev_up_cnt %d 
+6723,iii,[ wlan_vdev.c : 8854 ] VDEV_SEQ_DBG VDEV_DOWN_CMD vdev_id %d pdev_id %d vdev_down_cnt %d 
+6724,,[ wlan_vdev.c : 8900 ] BIGDATA ERR: vdev NULL or FREE 
+6725,i,[ wlan_vdev.c : 9047 ] WMI_VDEV_GET_KEEPALIVE_CMDID: vdev_id = %d event alloc failed 
+6726,i,[ wlan_vdev.c : 9248 ] WMI_VDEV_GET_ARP_STAT_CMDID: vdev_id = %d event alloc failed 
+6727,iii,[ wlan_vdev.c : 10218 ] LIMIT_OFFCHAN_ERROR client_id=%d vdev_id=%d status=%d 
+6728,iiiiiii,[ wlan_vdev.c : 10254 ] WMI_OEM_DATA_CMD_SET_AC_CONFIG: Old values: AC:%d, AMPDU:%d, AMSDU:%d, RETRY_LIMIT:%d, PPDU_DUR:%d, TTL:%d, vdev_id:%d  
+6729,i,[ wlan_vdev.c : 10260 ] WMI_OEM_DATA_CMD_SET_AC_CONFIG: read TLV failed vdev_id:%d 
+6730,i,[ wlan_vdev.c : 10281 ] warning: Invalid AC TLV in WMI_OEM_DATA_TLV_TYPE_AGGR_TYPE vdev_id:%d 
+6731,iii,[ wlan_vdev.c : 10315 ] wlan_oem_vdev_set_custom_ac_limit_cmd TX AMSDU AGGR SZ: ac:%d, num_frames:%d, vdev_id:%d  
+6732,i,[ wlan_vdev.c : 10325 ] warning: Invalid AGGR type TLV in WMI_OEM_DATA_TLV_TYPE_TX_AGGR_SIZE CMD vdev_id:%d 
+6733,i,[ wlan_vdev.c : 10346 ] warning: Invalid AC TLV in WMI_OEM_DATA_TLV_TYPE_TX_AGG_RETRY_LIMIT CMD vdev_id:%d 
+6734,IIiii,[ wlan_vdev.c : 10363 ] wlan_oem_vdev_set_custom_ac_limit_cmd SU PPDU Duration: ctl_region :%x cca_region:0%x  ac:%d, duration:%d, vdev_id:%d   
+6735,i,[ wlan_vdev.c : 10373 ] warning: No Accetegory TLV in wlan_oem_vdev_set_custom_ac_limit_cmd vdev_id:%d 
+6736,iii,[ wlan_vdev.c : 10380 ] wlan_oem_vdev_set_custom_ac_limit_cmd TX MSDU TTL: ac:%d, TTL:%d, vdev_id:%d  
+6737,i,[ wlan_vdev.c : 10397 ] warning: No Accetegory TLV in wlan_oem_vdev_set_custom_ac_limit_cmd vdev_id:%d 
+6738,i,[ wlan_vdev.c : 10401 ] wlan_oem_vdev_set_custom_ac_limit_cmd warning: wrong TLV type vdev_id:%d 
+6739,iiiiiii,[ wlan_vdev.c : 10414 ] WMI_OEM_DATA_CMD_SET_AC_CONFIG: New values: AC:%d, AMPDU:%d, AMSDU:%d, RETRY_LIMIT:%d, PPDU_DUR:%d, TTL:%d, vdev_id:%d  
+6740,iiiii,[ wlan_vdev.c : 10467 ] Error: vdev id %d, aggregation type %d, ac %d, max num frames %d, enable_bitmap %d 
+ 
+6741,iiiii,[ wlan_vdev.c : 10727 ] wlan_vdev_handle_wfa_config_cmd override_rsnxe=%d, ignore_csa=%d, deauth_on_saquery_timeout=%d override_oci_chan frame_types=%d, override_oci_chan=%d 
+6742,iii,[ wlan_vdev.c : 10758 ] iwconfig_logs:: SET_TPC fixed params: psd_power=%d, eirp_power=%d, powermode =%d 
+6743,iii,[ wlan_vdev.c : 10772 ] iwconfig_logs:: AFC_CTL - SET_TPC psd_num_pwr_levels = %d, eirp_num_pwr_levels = %d, ch_power_info.both_psd_and_eirp_support %d 
+6744,iiii,[ wlan_vdev.c : 10777 ] iwconfig_logs:: AFC_CTL - SET_TPC ch_power_info.psd_cfreq[%d] = %d, ch_power_info.psd_tx_power[%d] = %d 
+6745,iiii,[ wlan_vdev.c : 10783 ] iwconfig_logs:: AFC_CTL - SET_TPC ch_power_info.eirp_cfreq[%d] = %d, ch_power_info.eirp_tx_power[%d] = %d 
+6746,ii,[ wlan_vdev.c : 10792 ] iwconfig_logs:: SET_TPC: ch_power_info.both_psd_and_eirp_support %d, ch_power_info.num_pwr_levels %d 
+6747,iiii,[ wlan_vdev.c : 10803 ] iwconfig_logs:: SET_TPC ch_power_info.chan_cfreq[%d] = %d, ch_power_info.tx_power[%d] = %d 
+6748,iii,[ wlan_vdev.c : 10845 ] iwconfig_logs:: SET_TPC complianced pwrmode power_type_6ghz = %d is_6g_cbp %d power_valid %d 
+6749,iiii,[ wlan_vdev.c : 10857 ]  iwconfig_logs:: vdev_handle_tpc_power_cmd : psd_num_pwr_level %d , eirp_num_pwr_levels %d, num_pwr_levels %d, status=%d (0: success) 
+6750,i,[ wlan_vdev.c : 11041 ] WMI_VDEV_SET_ULOFDMA_MANUAL_SU_TRIG_CMDID : status=%d (0: success) 
+6751,,[ wlan_vdev.c : 11091 ] WMI_VDEV_SET_ULOFDMA_MANUAL_MU_TRIG_CMDID - Failed to allocate TID 
+6752,i,[ wlan_vdev.c : 11122 ] WMI_VDEV_SET_ULOFDMA_MANUAL_MU_TRIG_CMDID status=%d (0: success) 
+6753,iIIi,[ wlan_vdev.c : 11418 ] WMI_MLO_VDEV_GET_LINK_INFO_CMDID: failed, status:%d vdev:0x%p ml_vdev_bitmap:0x%x tmp_vdev_id:%d 
+6754,,[ wlan_vdev.c : 11438 ] WMI_MLO_VDEV_GET_LINK_INFO_CMDID: event alloc failed 
+6755,i,[ wlan_vdev.c : 11832 ] WMI_VDEV_MULTIPLE_PEER_GROUP_CMDID  Invalid pmac pdevid:%d 
+6756,i,[ wlan_vdev.c : 11841 ] WMI_VDEV_MULTIPLE_PEER_GROUP_CMDID  Invalid vdevid:%d 
+6757,iI,[ wlan_vdev.c : 12120 ] wlan_vdev_unit_test: vdev_id = %d, cmd = WMI_VDEV_PARAM_ABG_MODE_TX_CHAIN_NUM, value = 0x%x 
+6758,iI,[ wlan_vdev.c : 12129 ] wlan_vdev_unit_test: vdev_id = %d, set_ctrl_path_sw_event_bitmap: value = 0x%x 
+6759,iI,[ wlan_vdev.c : 12140 ] wlan_vdev_unit_test: vdev_id = %d, vdev threshold = %u 
+6760,ii,[ wlan_vdev.c : 12152 ] wlan_vdev_unit_test: vdev_id = %d, sr prohibit = %d 
+6761,iiI,[ wlan_vdev.c : 12156 ] wlan_vdev_unit_test: vdev_id = %d, sr prohibit = %d, tid_mask = 0x%x 
+6762,iII,[ wlan_vdev.c : 12264 ] wlan_vdev_set_max_pause_delay_us vdev_id=%d curr_pause_delay=0x%x max_pause_delay_us = 0x%x 
+6763,iI,[ wlan_vdev.c : 12373 ] VDEV_UPDATE_MAC_ADDR_CMD Event sent for vdev_id = %d status=0x%x 
+6764,iIIII,[ wlan_vdev.c : 12409 ] VDEV_UPDATE_MAC_ADDR_CMD Received for vdev_id = %d vdev mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x, mld mac_addr31to0 = 0x%x mac_addr47to32 = 0x%x 
+6765,I,[ wlan_vdev.c : 12428 ] VDEV_UPDATE_MAC_ADDR_CMD mac_addr_in_use_bitmap=0x%x 
+6766,iI,[ wlan_vdev.c : 12546 ] VDEV_UPDATE_MAC_ADDR_CMD internal fail vdev_id=%d mac_addr_in_use_bitmap=0x%x 
+6767,IIi,[ wlan_vdev.c : 12591 ] wlan_vdev_set_ltf_keyseed_handler peer_mac %02x:%02x status %d  
+6768,,[ wlan_vdev.c : 12656 ] VBSS wal_peer_vbss_get_peer_info Invalid Peer 
+6769,,[ wlan_vdev.c : 12671 ] VBSS wal_peer_vbss_get_peer_info Set Peer State to Passive 
+6770,iii,[ wlan_vdev.c : 12726 ] VBSS wal_peer_vbss_get_peer_info omi : %d eht omi : %d pm : %d 
+6771,IIIIIIi,[ wlan_vdev.c : 12761 ] VBSS wlan_vdev_dispatch_vbss_config_cmd GET PEER Context peer mac MAC Address : %x:%x:%x:%x:%x:%x sw_peer_id : %d 
+6772,,[ wlan_vdev.c : 12767 ] VBSS wlan_vdev_dispatch_vbss_config_cmd GET PEER Context Initiate TWT teardown 
+6773,,[ wlan_vdev.c : 12770 ] VBSS wlan_vdev_dispatch_vbss_config_cmd GET PEER Context No TWT Session 
+6774,IIIIIIi,[ wlan_vdev.c : 12777 ] VBSS wlan_vdev_dispatch_vbss_config_cmd SET PEER Context peer mac MAC Address : %x:%x:%x:%x:%x:%x sw_peer_id : %d 
+6775,ii,[ wlan_vdev.c : 12800 ] VBSS SET PEER Context Tx SSN tid_num:%d ssn:%d  
+6776,iii,[ wlan_vdev.c : 12810 ] VBSS SET PEER Context DYN INFO omi:%d eht_omi:%d pm:%d 
+6777,IIIIIIi,[ wlan_vdev.c : 12825 ] VBSS  wlan_vdev_dispatch_vbss_config_cmd RX SUSPEND PEER MAC Address : %x:%x:%x:%x:%x:%x sw_peer_id : %d 
+6778,i,[ wlan_vdev.c : 8037 ] security: wlan_peer_ptk_handler INSTALLING after eapol tx comp peer_id:%d 
+6779,ii,[ wlan_vdev.c : 8041 ] security: WAL_DBGID_TX_EAPOL_PKT: NOT INSTALLING KEY !!! resp_event:%d peer_id:%d 
+6780,,[ wlan_vdev.c : 8049 ] wlan_peer_ptk_handler keymgmt_ctxt is NULL 
+6781,,[ wlan_vdev.c : 8069 ] wlan_peer_ptk_handler keymgmt_ctxt is NULL 
+6782,i,[ wlan_vdev_misc.c : 254 ] STA_KICKOUT: Reason=%d 
+6783,i,[ wlan_vdev_misc.c : 1202 ] vdev %d ignore the packet! 
+6784,IIIIi,[ wlan_vdev_misc.c : 1353 ] OMI: Error peernss = 0x%lx OMI nss = 0x%lx bssBw= %1x OMI Bw= %1x peerMaxBw = %d
+ 
+6785,i,[ wlan_vdev_misc.c : 1641 ] wlan_vdev_reconfig: wlan_vdev vdev_id = %d is not up 
+6786,i,[ wlan_vdev_misc.c : 1715 ] wlan_vdev_find_vdev_or_panic wlan pdev is NULL: vdev_id=%d 
+6787,ii,[ wlan_vdev_misc.c : 2225 ] wlan_vdev_fill_vdev_mac_entry: vdev_id=%d, pdev_id=%d 
+6788,i,[ wlan_vdev_misc.c : 2575 ] FD_TMPL_CMD: failed status : %d (0 : success) 
+6789,iiiiiiII,[ wlan_vdev_misc.c : 2667 ] FILS_DEBUG vdev_id %d FILS_TX_FAIL comp_status %d p_tx_comp_desc's status %d                   tx_tries %d flush_reason %d seq_num %d (comp_time_ms - enq_time_ms) %u ms fils tx time %u us 
+6790,iIiIII,[ wlan_vdev_misc.c : 2672 ] FILS_DEBUG vdev_id %d (comp_time_ms - enq_time_ms) is %u ms > than fils_period %d                   ms cur_tsf_time  %u us next_tftt_abs %u us calc_fils_period %u us 
+6791,iIIIi,[ wlan_vdev_misc.c : 2770 ] FILS_DEBUG vdev_id %d  FILS_ENQUEUE_FAIL cur_time %u ms last_enq_time %u ms last_completion_time %u ms reason_code %d 
+6792,IIIIII,[ wlan_vdev_misc.c : 644 ] VENDOR SPECIFIC IE :%u, %u, %02x, %02x, %02x, %02x 
+6793,IIIII,[ wlan_vdev_misc.c : 728 ] set_ignore_check_for_OUI :: VENDOR SPECIFIC IE :%u, %u, %02x, %02x, %02x 
+6794,,[ wlan_vdev_misc.c : 615 ] 2xLTF not supported 
+6795,iiii,[ wlan_vdev_keepalive.c : 232 ] VDEV_MGR_AP_KEEPALIVE STAKO batch size (%d) reached, usr_cfg_batch_sz:%d, mac_id:%d, saved peer_id:%d 
+6796,iiiiiii,[ wlan_vdev_keepalive.c : 354 ] VDEV_MGR_AP_KEEPALIVE_IDLE vdev_id:%d assoc_id:%d is_primary %d hw_link_id %d self link inactivity ts %d Partner link inactivity ts %d partner_sta_last_txrx_activity_time_us %d 
+6797,iiiIIIii,[ wlan_vdev_keepalive.c : 395 ] VDEV_MGR_AP_KEEPALIVE timer reset vdev_id:%d, assoc_id:%d, peer->inactivity_generation:%d, sta_last_inactivity:0x%x, peer_now:0x%x peer_last_gen:0x%x stako_sent:%d, stako_time:%d 
+6798,iiiiiii,[ wlan_vdev_keepalive.c : 417 ] VDEV_MGR_AP_KEEPALIVE vdev_id %d assoc_id %d inact_gen %d n_buffered_mpdu %d min_idle_inactive_time_secs %d max_idle_inactive_time_secs %d max_unresponsive_time_secs %d 
+6799,iiii,[ wlan_vdev_keepalive.c : 448 ] VDEV_MGR_AP_KEEPALIVE retry inact STAKO: vdevid:%d, aid:%d, last_stako_sent:%d, cur_inact:%d 
+6800,iiiiiiiii,[ wlan_vdev_keepalive.c : 492 ] VDEV_MGR_AP_KEEPALIVE: vdev_id:%d assoc_id:%d is_mlo:%d is_primary:%d hw_link_id:%d curr_link_in_ps:%d qdepth:%d allow_stako_evt:%d null_frame_queued_after_ml_rcfg:%d 
+6801,iiiIIIIi,[ wlan_vdev_keepalive.c : 514 ] VDEV_MGR_AP_KEEPALIVE KICKOUT: vdevid:%d, aid:%d, inact:%d, last_txrx_activity:0x%x, curr_time:0x%x, data_act:0x%x, mgmt_ctrl_act:0x%x, IdleOption:%d 
+6802,iiii,[ wlan_vdev_keepalive.c : 518 ] VDEV_MGR_AP_KEEPALIVE KICKOUT evt FAILURE: vdevid:%d, aid:%d, status:%d, inact:%d 
+6803,iiii,[ wlan_vdev_keepalive.c : 524 ] VDEV_MGR_AP_KEEPALIVE KICKOUT waiting for peer delete: vdevid:%d, aid:%d, STAKO time:%d, inact:%d 
+6804,iIIIIii,[ wlan_vdev_keepalive.c : 732 ] KA: VDEV_MGR_AP_KEEPALIVE_INACTIVE  vdev_id = %d cur_txrx_ref_time = 0x%x last_txrx_time = 0x%xlast_tx_time = 0x%x last_rx_time = 0x%xinactive_time_ms = %d keepalive_interval_ms = %d 
+6805,iii,[ wlan_vdev_keepalive.c : 815 ] swbmiss_evt: vdev_id = %d evt->evt_type = %d vdevp->ifOutOfSync = %d 
+6806,iIIIIi,[ wlan_vdev_schedule.c : 1086 ] VDEV_MGR_AP_TBTT_CONFIG: vdev_id = %d, chan_mhz = 0x%x, tbtt_link_type = 0x%x, ni_intval = 0x%x, ap_tbtt_offset = 0x%x, is_bt_enable:%d 
+6807,iIIIIi,[ wlan_vdev_schedule.c : 1213 ] VDEV_MGR_AP_TBTT_CONFIG: vdev_id = %d, chan_mhz = 0x%x, tbtt_link_type = 0x%x, ni_intval = 0x%x, ap_tbtt_offset = 0x%x, is_bt_enable:%d 
+6808,Ii,[ wlan_vdev_schedule.c : 1436 ] SCAN_RADIO_SUPPORT_DBUG scan_radio_lpri_req setup lp_ch_req created = %p channel = %d
+ 
+6809,iIiiiiiI,[ wlan_vdev_schedule.c : 1504 ] CHAN_SWITCH_METRICS vdev_id = %d End-to-End FW 1)Channel Switch Time = %uus 2)Page Fault Count = %d pdev_id %d opmode = %d,resp_type %d status %d cur_time = %u 
+6810,ii,[ wlan_vdev_schedule.c : 1529 ] WMI_EVENT_ALLOC_FAILURE: vdev_id = %d, opmode = %d, evt_id = WMI_PDEV_MULTIPLE_VDEV_RESTART_RESP_EVENTID 
+6811,iIiiii,[ wlan_vdev_schedule.c : 1565 ] CHAN_SWITCH_METRICS vdev_id = %d End-to-End FW 1)Channel Switch Time = %uus 2)Page Fault Count = %d pdev_id = %d status %d id_map:%d  
+6812,ii,[ wlan_vdev_schedule.c : 1632 ] WLAN_VDEV_DPD_CAL_DONE vdev_id:%d ch:%d 
+6813,iiI,[ wlan_vdev_schedule.c : 1876 ] VDEV_MGR_VDEV_START_OCS_CRIT_REQ_END: vdev_id = %d is_vdev_up = %d ch_req_flag = 0x%x 
+6814,i,[ wlan_vdev_schedule.c : 1969 ] Calling vdev start again for vdev_id %d as it failed to receive channel grant in MVRR 
+6815,ii,[ wlan_vdev_schedule.c : 2063 ] WLAN_VDEV_CH_REQ_UPDATE_STATUS: %d vdev_id:%d 
+6816,iI,[ wlan_vdev_schedule.c : 2343 ] VDEV_MGR_LOWPOWER_HP_CHREQ_ENABLED: vdev_id = %d, chan_mhz  = 0x%x 
+6817,iIII,[ wlan_vdev_schedule.c : 2420 ] VDEV_MGR_HP_START_TIME: vdev_id = %d, chan_mhz  = 0x%x, start_tsf = 0x%x, sta offset:0x%x 
+6818,iIIi,[ wlan_vdev_schedule.c : 2598 ] VDEV_MGR SWBA  protection critical channel request: vdev_id = %d, chan_mhz = 0x%x, start_tsf = 0x%x, duration = %d 
+6819,iIIi,[ wlan_vdev_schedule.c : 2663 ] VDEV_MGR AP Connection protection critical channel request: vdev_id = %d, chan_mhz = 0x%x, start_tsf = 0x%x, duration = %d 
+6820,iII,[ wlan_vdev_schedule.c : 2780 ] wlan_vdev_sta_concurrency_event_handler: vdev_id = %d, next_state  = 0x%x, cur_state = 0x%x 
+6821,iIII,[ wlan_vdev_schedule.c : 660 ] Corr_sta_tbtt_drift: vdev_id = %d, chan_mhz = 0x%x, start_tsf = 0x%x 0x%x 
+6822,iIIIIi,[ wlan_vdev_schedule.c : 580 ] VDEV_MGR_AP_TBTT_CONFIG: vdev_id =%d, chan_mhz = 0x%x, tbtt_link_type = 0x%x, ni_intval = 0x%x, tbtt_offset = 0x%x, is_bt_enabled:%d 
+6823,,[ wlan_vdev_schedule.c : 1318 ] vdev_bmiss_crit_ch_req_cb: ch_req completed without receiving beacon 
+6824,iiiii,[ wlan_vdev_pause.c : 229 ] VDEV_MGR_VDEV_PAUSE_COMP: vdev_id = %d pause_status = LEAKY AP DETECTED data_null_tx_delay = %d actual_leak_window = %d pause_delay_us = %d consec_detect_leaky_ap_cnt = %d 
+6825,iiiii,[ wlan_vdev_pause.c : 296 ] VDEV_MGR_VDEV_PAUSE_COMP: vdev_id = %d pause_status = FAILURE data_null_tx_delay = %d avg_data_null_tx_delay = %d actual_leak_window = %d avg_rx_leak_window = %d 
+6826,iI,[ wlan_vdev_pause.c : 478 ] VDEV Unpause Failure: VDEV ID = %d pause_bitmap = 0x%x in Unpause complete 
+6827,,[ wlan_vdev_pause.c : 559 ] VDEV_PAUSE_FAIL ifPaused set with pause_bitmap = 0 in _wlan_vdev_pause 
+6828,IIiiI,[ wlan_vdev_pause.c : 629 ] VDEV_MGR_VDEV_PAUSE: enable_null_leaky_ap_pause=0x%x no_null_to_ap_bitmap=0x%x leakyAp_cts2s_enable=%d pause_delay_us=%d req from mod_id = %x 
+6829,iiiIii,[ wlan_vdev_pause.c : 729 ] VDEV_PAUSE_DBG wlan_vdev_pause for vdev_id %d pdev_id %d ts %dms module_id 0x%x pause_bitmap %d status %d 
+6830,I,[ wlan_vdev_pause.c : 801 ] VDEV_UNPAUSE_FAIL: ifPaused not set with pause_bitmap = 0x%x in _wlan_vdev_unpause 
+6831,iiiIii,[ wlan_vdev_pause.c : 895 ] VDEV_PAUSE_DBG wlan_vdev_unpause for vdev_id %d pdev_id %d ts %dms module_id 0x%x pause_bitmap %d status %d 
+6832,Iii,[ wlan_vdev_pause.c : 1217 ] enable_null_leaky_ap_pause=0x%x vdev_id = %d pause_delay_us = %d 
+6833,Ii,[ wlan_vdev_pause.c : 1230 ] no_null_to_ap_bitmap=0x%x en=%d 
+6834,IIIIIIII,[ wlan_vdev_unit_test.c : 150 ] PRINT_XDUMP_DIAG buff   0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 
+6835,IIIIIII,[ wlan_vdev_unit_test.c : 153 ] PRINT_XDUMP_DIAG buff   0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 
+6836,iIiIi,[ wlan_vdev_unit_test.c : 189 ] PRINT_XDUMP_DIAG vdev_id:%d vdev:%p print_type:%d bcn_ptr:%p len:%d 
+6837,iIiIi,[ wlan_vdev_unit_test.c : 204 ] PRINT_XDUMP_DIAG vdev_id:%d vdev:%p print_type:%d bcn_ptr:%p len:%d 
+6838,,[ wlan_vdev_unit_test.c : 218 ] wlan_vdev_config_test: vdev is NULL 
+6839,iiiii,[ wlan_vdev_unit_test.c : 232 ] wlan_vdev_config_test: vdev_id = %d, test_cmd = %d, args[1] = %d, args[2] = %d, num_args = %d  
+6840,iii,[ wlan_vdev_unit_test.c : 267 ] wlan_vdev_unit_test: vdev_id = %d, custom_aggr_size_cmd, subfram %d ac = %d 
+6841,iiii,[ wlan_vdev_unit_test.c : 289 ] wlan_vdev_unit_test: vdev_id = %d, custom_sw_retry_th_cmd, ac %d sw_retry_type = %d sw_retry_th = %d 
+6842,,[ wlan_vdev_unit_test.c : 318 ] wlan_vdev_unit_test: disable QoS per peer per tid configuration 
+6843,I,[ wlan_vdev_unit_test.c : 327 ] wlan_vdev_unit_test: g_wmi_cmd_enable_pf_log = 0x%x 
+6844,III,[ wlan_vdev_unit_test.c : 341 ] wlan_vdev_unit_test: mlo_set_active_link_bitmap ml_bss = 0x%x, active_bitmap = 0x%x, anchor_link_id = 0x%x 
+6845,i,[ wlan_vdev_unit_test.c : 365 ] wlan_vdev_unit_test: config min_req_dur = %d 
+6846,i,[ wlan_vdev_unit_test.c : 376 ] wlan_vdev_unit_test: config channel_change_time = %d 
+6847,ii,[ wlan_vdev_unit_test.c : 388 ] wlan_vdev_unit_test: vdev_id = %d config channel quota = %d 
+6848,i,[ wlan_vdev_unit_test.c : 414 ] enable mcc ll mode = %d 
+6849,iii,[ wlan_vdev_unit_test.c : 454 ] wlan_vdev_unit_test: update vdev bandwidth setting: vdev_id=%d ieee_link_id=%d leakyap_detect=%d 
+6850,iiii,[ wlan_vdev_unit_test.c : 463 ] wlan_vdev_unit_test: update vdev bandwidth per link ieee_link_id=%d mlo_link_id=%d, vdev_id=%d vdev_status=%d 
+6851,i,[ wlan_vdev_unit_test.c : 508 ]  UNIT_TEST: Vdev_id - %d ml_bss is NULL 
+6852,i,[ wlan_vdev_unit_test.c : 512 ]  UNIT_TEST: Vdev_id - %d vdev_mlo_info is NULL 
+6853,IIIIIII,[ wlan_vdev_unit_test.c : 541 ]  UNIT_TEST: vdev_id | vdev_flags - %x, ni_bssid - %02x:%02x:%02x:%02x:%02x:%02x  
+6854,IIIIIII,[ wlan_vdev_unit_test.c : 543 ]  UNIT_TEST: ml_bss - %x ml_bssid - %02x:%02x:%02x:%02x:%02x:%02x  
+6855,iii,[ wlan_vdev_unit_test.c : 548 ]  UNIT_TEST: link_vdev_id - %d hw_link_id - %d mlo_ieee_link_inactive - %d  
+6856,IIIIII,[ wlan_vdev_unit_test.c : 550 ]  UNIT_TEST: link_macaddr - %02x:%02x:%02x:%02x:%02x:%02x  
+6857,,[ wlan_vdev_unit_test.c : 553 ] UNIT_TEST: -------------------------------------------------- 
+6858,IIIIIIi,[ wlan_vdev_det_sched.c : 67 ] WMI_VDEV_SCHED_MODE_PROBE_REQ_CMDID: time: %u, vdev_id: %u, cookie: %u, mode_to_probe: 0x%08x, on_duration_ms: %u, off_duration_ms: %u status=%d (0: success) 
+6859,IIIII,[ wlan_vdev_det_sched.c : 83 ] WMI_VDEV_SCHED_MODE_PROBE_RESP_EVENTID: time: %u, vdev_id: %u, cookie: %u, tput_mbps_on: %u, tput_mbps_off: %u 
+6860,Ii,[ wlan_vdev_mlo.c : 115 ] mlo_vdev_start vdev_id|opmode|is_mlo|is_assoc = 0x%08x, emlsr %d 
+6861,,[ wlan_vdev_mlo.c : 228 ] mlo_vdev_start : dyn_link_add 
+6862,,[ wlan_vdev_mlo.c : 250 ] wlan_vdev_mlo_handle_peer_assoc_partner_links: bss_id is 0 
+6863,,[ wlan_vdev_mlo.c : 256 ] wlan_vdev_mlo_handle_peer_assoc_partner_links already initilized or ml_bss is null 
+6864,iiii,[ wlan_vdev_mlo.c : 301 ] peer_assoc_partner_links from host: vdevid %d link_id:%d, mhz:%d, ieee_link_id:%d 
+6865,,[ wlan_vdev_mlo.c : 317 ] wlan_vdev_mlo_populate_partner_links_from_vdev, ml_bss is null or link_props already initilized 
+6866,iiii,[ wlan_vdev_mlo.c : 344 ] wlan_vdev_mlo_populate_partner_links_from_vdev vdevid %d, link_id:%d, mhz:%d, ieee_link_id:%d 
+6867,,[ wlan_vdev_mlo.c : 376 ] ML_RECONFIG peer_assoc wlan_ml_peer NULL 
+6868,iiiiiiiI,[ wlan_vdev_mlo.c : 385 ] ML_RECONFIG: handle_peer_assoc vdev_id:%d ml_peer_id:%d num_partner_link:%d LL_idx:%d LL_idx_val:%d peer_ll_id:%d emlsr_supp:%d ml_peer_ptr:0x%x 
+6869,,[ wlan_vdev_mlo.c : 410 ] ML_RECONFIG peer assoc to indicate self link to be deleted 
+6870,i,[ wlan_vdev_mlo.c : 420 ] ML_RECONFIG: tmp_partner_link is NULL, i:%d 
+6871,iiiiiii,[ wlan_vdev_mlo.c : 429 ] ML_RECONFIG: partner_link_params[%d] ll_id:%d ll_valid:%d hw_link_id:%d link_add:%d link_del:%d ml_en:%d 
+6872,ii,[ wlan_vdev_mlo.c : 435 ] ML_RECONFIG: skipping as LL idx invalid, idx:%d val:%d 
+6873,i,[ wlan_vdev_mlo.c : 442 ] ML_RECONFIG: skipping self link idx %d in partner link params 
+6874,,[ wlan_vdev_mlo.c : 480 ] ML_RECONFIG: received wmi for existing link with no reconfig op 
+6875,III,[ wlan_vdev_mlo.c : 531 ] mlo_peer_assoc vdev_id|opmode|is_mlo|is_assoc = 0x%08x, emlsr|ieee_link_id 0x%08x, emlsr_trans_TO 0x%x 
+6876,iiiiI,[ wlan_vdev_mlo.c : 599 ] wlan_vdev_mlo_handle_peer_assoc wmi link params is_assoc %d is_primary %d num_partner_link %d ml_rcfg_new_link_add %d wlan_ml_peer 0x%x 
+6877,IIIi,[ wlan_vdev_mlo.c : 757 ] mlo_vdev_stop vdev_id|opmode = 0x%08x, ml_bss = 0x%x, ml_link = 0x%x, emlsr = %d 
+6878,i,[ wlan_vdev_mlo.c : 1045 ] mlo_vdev_suspend_pause_cb vdev_id = %d 
+6879,I,[ wlan_vdev_mlo.c : 1141 ] mlo_vdev_suspend_home_chan vdev_id|is_suspended = 0x%08x 
+6880,i,[ wlan_vdev_mlo.c : 1186 ] mlo_vdev_pause_home_chan vdev_id = %d 
+6881,i,[ wlan_vdev_mlo.c : 1209 ] wlan_vdev_mlo_first_beacon_recv vdev id: %d 
+6882,IIi,[ wlan_vdev_mlo.c : 1353 ] mlo_vdev_resume_home_chan vdev_id(8)|is_suspend(8) = 0x%04x, crit_ch_req= 0x%x, prefer_mac_id = %d 
+6883,i,[ wlan_vdev_mlo.c : 1685 ] MLO_CSA : csa_partner_notify_pending max_tbtt = %d 
+6884,i,[ wlan_vdev_mlo.c : 1697 ] MLO_QUIET : quiet_partner_notify_pending max_tbtt = %d 
+6885,I,[ wlan_vdev_mlo.c : 2170 ] get_ieee_link_id_bitmap vdev_id_bitmap 0x%x 
+6886,I,[ wlan_vdev_mlo.c : 2182 ] get_ieee_link_id_bitmap ieee_linkid_map 0x%x 
+6887,IIIIi,[ wlan_vdev_mlo.c : 1013 ] CHANGE_BW: peer 0x%x rc_node %x ni_flags 0x%x ni_flags_ext 0x%x new_bw %d 
+6888,Ii,[ wlan_vdev_mlo.c : 1230 ] ignoring mlo_vdev_resume_cb after vdev delete req= 0x%x event = %d 
+6889,II,[ wlan_vdev_mlo.c : 1239 ] mlo_vdev_resume_cb vdev_id(8)|event(8)|is_suspend(8) = 0x%06x, req= 0x%x 
+6890,i,[ wlan_coex_main.c : 232 ] WLAN_COEX_VDEV_EVENT: Preventing the invocation of coex apis when coex is not enabled : wlan_vdev_mgr_notif->type = %d 
+6891,IiIIi,[ wlan_coex_ocs.c : 383 ] WLAN_OCS_REQ: Error(0x%x), status(%d) ocs_req_state(0x%x) bt_req(0x%x) priority(%d) 
+6892,III,[ wlan_coex_ocs.c : 428 ] WLAN_OCS_REQ: OCS Start: COEX_OCS_START_ERROR (0x%x), ocs_cal_req_state(0x%x) bt_cal_req(0x%x) 
+6893,IIIi,[ wlan_coex_ocs.c : 529 ] WLAN_OCS_REQ: OCS Start: COEX_OCS_START_ERROR (0x%x), ocs_req_state(0x%x) bt_req(0x%x) priority(%d) 
+6894,IIi,[ wlan_coex_ocs.c : 594 ] WLAN_COEX_BTREQ: One Shot  0x%x 0x%x priority(%d) 
+6895,IiIIi,[ wlan_coex_ocs.c : 852 ] WLAN_OCS_UPDATE: Error(0x%x) status(%d) ocs_req_state(0x%x) bt_req(0x%x) priority(%d) 
+6896,i,[ wlan_coex_test.c : 206 ] WAL_COEX_FORCED_ALGO: forced_algo(%d) 
+6897,ii,[ wlan_coex_test.c : 269 ] PTA set cont info delay pta_num : %d, time:%d 
+6898,ii,[ wlan_coex_test.c : 273 ] PTA set cont nack pta_num:%d, time:%d 
+6899,,[ wlan_coex_test.c : 276 ] COEX_SET_PTA_TIMERS_INTERVALS: invalid argument 
+6900,i,[ wlan_coex_test.c : 293 ] PTA Cont info delay time %d 
+6901,i,[ wlan_coex_test.c : 297 ] PTA Cont info nack time  %d 
+6902,,[ wlan_coex_test.c : 300 ] COEX_GET_PTA_TIMERS_INTERVALS: invalid argument 
+6903,i,[ wlan_coex_test.c : 332 ] Automation Code %d 
+6904,ii,[ wlan_coex_test.c : 389 ] COEX_UNIT_TEST_COMMANDS: Enable coex = %d dis_bttx_concurrency = %d 
+6905,iiiiiI,[ wlan_coex_test.c : 403 ] COEX_UNIT_TEST_COMMANDS: Configure PTA parameters pta_num = %d pta_mode = %d first_slot_time = %d bt_prio_time = %d pta_algo=%d pta_prio=%x 
+6906,iii,[ wlan_coex_test.c : 434 ] COEX_UNIT_TEST_COMMANDS: Configure duty cycle period = %d wlan_dur = %d bt_dur = %d 
+6907,iii,[ wlan_coex_test.c : 447 ] COEX_UNIT_TEST_COMMANDS: Configure WLAN packet priority bitmap = %d wlan_dur_wght = %d bt_dur_wght = %d 
+6908,i,[ wlan_coex_test.c : 469 ] COEX_UNIT_TEST_COMMANDS: Invalid Values -- Command = %d 
+6909,,[ wlan_coex_test.c : 470 ] COEX_UNIT_TEST_COMMANDS: 1:COEX_ENABLE 2:COEX_CONFIG_PTA 3:COEX_CONFIG_FORCED_ALGO 4:COEX_CONFIG_DUTY_CYCLE 5:COEX_CONFIG_WLAN_PKT_PRIORITY  
+6910,,[ wlan_coex_test.c : 471 ] COEX_UNIT_TEST_COMMANDS: Inputs parameters expected range 
+6911,,[ wlan_coex_test.c : 472 ] COEX_UNIT_TEST_COMMANDS: COEX_ENABLE - 2 inputs ---> 0/1 0/1 
+6912,,[ wlan_coex_test.c : 473 ] COEX_UNIT_TEST_COMMANDS: COEX_CONFIG_PTA - 6 inputs ---> 0/1 0-3 0-255 0-255 1/2 0-FFFFFFFF 
+6913,,[ wlan_coex_test.c : 474 ] COEX_UNIT_TEST_COMMANDS: COEX_CONFIG_FORCED_ALGO - 1 input ---> 1/2 
+6914,,[ wlan_coex_test.c : 475 ] COEX_UNIT_TEST_COMMANDS: COEX_CONFIG_DUTY_CYCLE - 2 inputs ---> input2 <= input1 
+6915,,[ wlan_coex_test.c : 476 ] COEX_UNIT_TEST_COMMANDS: COEX_CONFIG_WLAN_PKT_PRIORITY - 4 inputs ---> 0-63 0 0-255 0-255 
+6916,II,[ wlan_coex_cts2s.c : 249 ] WLAN_COEX_CTS2S_TIMEOUT: Now : %u, WbPrepare: %u 
+6917,,[ wlan_coex_cts2s.c : 310 ] COEX_CTS2S_SEND: cts send fail 
+6918,I,[ wlan_coex_cts2s.c : 356 ] COEX_GENERIC_ERROR: COEX_ERROR_UNKNOWN_NULLPTR Status(%u) 
+6919,,[ wlan_coex_wmi.c : 202 ] COEX_CONFIG_CMD: Either Invalid 2G vdev ID or 2G Mac is not Enabled 
+6920,i,[ wlan_coex_wmi.c : 286 ] COEX_REPORT_BT_INFO_TO_HOST: coex_profile_evt(%d) 
+6921,IIII,[ wlan_coex_ps_handler.c : 97 ] WLAN_COEX_SLEEP: status(%u) enable(%u) mac(%u) reason(%u) 
+6922,iI,[ wlan_coex_ps_handler.c : 552 ] COEX_GENERIC_ERROR: Set TDM Guard Period to %d, Error (0x%x) 
+6923,iIIII,[ wlan_coex_utils.c : 305 ] WLAN_COEX_VDEV_PAUSE: status(%d) max_time(%u) pause(%u) softAp(%u) opmode(%u) 
+6924,I,[ wlan_coex_utils.c : 466 ] WLAN_COEX_SET_SWBMISS: wlan_vdev_t is NULL, enable: %u 
+6925,iI,[ wlan_coex_utils.c : 505 ] WLAN_COEX_MCS_RATE: status(%d) min_mcs(%u) 
+6926,iI,[ wlan_coex_utils.c : 518 ] WLAN_COEX_MCS_RATE: status(%d) max_mcs(%u) 
+6927,IIII,[ wlan_coex_utils.c : 550 ] WLAN_COEX_PER: bw_idx(%u) nss(%u) rate_max(%u) PER(%u) 
+6928,iI,[ wlan_coex_utils.c : 563 ] WLAN_COEX_SMPS_BW: new_bw(%d), status(%u) 
+6929,I,[ wlan_coex_utils.c : 763 ] COEX_BTC_ROAM_INIT: Invalid timeout: (%u) 
+6930,ii,[ wlan_coex_utils.c : 1219 ] WLAN_COEX_SLEEP: Received WOW Entered/Exit event from OffloadMgr %d,                                                        coex_struct_ptr->is_wow_entered = %d 
+6931,i,[ wlan_coex_utils.c : 1492 ] COEX_VDEV_AUTH_MODE: coex_vdev_get_auth_mode: isEnterprise(%d) 
+6932,iiiII,[ wlan_pmf_offload.c : 170 ] 11w PMF: Update BiGTK vdevId=%d, keyIdx=%d, KeyLen=%d, vdev=0x%x, pmf_vdev_ctxt=0x%x 
+6933,,[ wlan_pmf_offload.c : 192 ] igtk: Same key reinstalled 
+6934,i,[ wlan_pmf_offload.c : 240 ] 11W PMF: Beacon add MMIE No BIGTK installed key length: %d 
+6935,i,[ wlan_pmf_offload.c : 259 ] 11W PMF: Beacon add MMIE can not handle frame size: %d 
+6936,iiiII,[ wlan_pmf_offload.c : 555 ] 11w PMF: Update iGTK vdevId=%d, keyIdx=%d, KeyLen=%d, vdev=0x%x, pmf_vdev_ctxt=0x%x 
+6937,,[ wlan_pmf_offload.c : 575 ] igtk: Same key reinstalled 
+6938,iiiiI,[ wlan_pmf_offload.c : 624 ] 11w PMF: can not handle frame size: %d, key_cipher: %d, mmie_len: %d, vdev_id: %d, fc0: 0x%x 
+6939,,[ wlan_pmf_offload.c : 643 ] 11w PMF: IE is not Mgmt MIC IE or Invalid length 
+6940,iI,[ wlan_pmf_offload.c : 667 ] 11w PMF: BC/MC/Beacon MGMT IPN check Failed vdev_id %d, fc0 0x%x 
+6941,iI,[ wlan_pmf_offload.c : 731 ] 11w PMF: BC/MC/Beacon CMAC MGMT frame MMIE MIC check Failed vdev_id %d, fc0 0x%x 
+6942,iI,[ wlan_pmf_offload.c : 804 ] 11w PMF: BC/MC/Beacon GMAC MGMT frame MMIE MIC check Failed vdev_id %d, fc0 0x%x 
+6943,iiiii,[ wlan_pmf_offload.c : 938 ] 11w PMF: KEY ID MISMATCH MMIE is_bcn = %d, key_id = %d, bigtk_key_id = %d, igtk_key_id = %d, vdev_id %d 
+6944,IIIIIIiii,[ wlan_pmf_offload.c : 957 ] 11w PMF: MIC_VALIDATION FAIL fc[0] = 0x%x bip_protocol = 0x%x  wh->i_addr2 = %08x%04x  wh->i_addr1 = %08x%04x mic_validate_status = %d mmiw_drop_cnt = %d vdev_id %d 
+6945,,[ wlan_pmf_offload.c : 964 ] 11w PMF: trigger STA_KICKOUT for beacon only 
+6946,i,[ wlan_pmf_offload.c : 1160 ] 11w PMF mgmt hdlr Beacon Protection not enabled vdev_id %d 
+6947,iI,[ wlan_pmf_offload.c : 1165 ] 11w PMF mgmt hdlr pmf not enabled vdev_id %d fc[0] 0x%x 
+6948,,[ wlan_pmf_offload.c : 1222 ] 11w PMF BIP check failed  
+6949,I,[ wlan_pmf_offload.c : 1237 ] 11w PMF decrypt error, rx status 0x%x 
+6950,iii,[ wlan_pmf_offload_init.c : 123 ] 11W PMF Offload CMD hdlr: WMI_PMF_OFFLOAD_SET_SA_QUERY_CMDID vdevId=%d, interval=%d, retry_count=%d 
+6951,II,[ wlan_framegen.c : 668 ] frmgen action_ba : pAddr2[4:5]: %x %x 
+6952,,[ wlan_framegen.c : 1681 ] wlan_frmgen_get_action_tmr: ERR: null vdev 
+6953,I,[ wlan_framegen.c : 1690 ] wlan_frmgen_get_action_tmr: ERR: wal_peer:%p 
+6954,ii,[ wlan_framegen.c : 1708 ] wlan_frmgen_get_action_tmr: ERR: is_secure_measurement:%d, iv_len:%d 
+6955,IIIIII,[ wlan_framegen.c : 1814 ] wlan_frmgen_get_action_tmr: addr1:%8x|%4x, addr2:%8x|%4x abf:%p fc_1:0x%x 
+6956,iiiiIIi,[ wlan_framegen.c : 1819 ] wlan_frmgen_get_action_tmr: is_sec_ranging:%d iv_len:%d, ivmic_len:%d, seq_num:%d, fc_0:0x%x, fc_1:0x%x, frm_len:%d 
+6957,I,[ wlan_framegen.c : 2375 ] WLAN_FRMGEN_GET_ACTION_SMPS incorrect sm_power_control:0x%x 
+6958,IIiiii,[ wlan_framegen.c : 4087 ] wlan_frmgen_get_eml_omn_setup_v2: emlsr_control: 0x%x, emlsr_param_update: 0x%x, eml_omn_len: %d padding_delay %d transition_delay %d u8 %d 
+6959,iii,[ wlan_frameparse.c : 576 ] FRMPARSE_WARN ie->ie_len %d (exp %d) remaining_len %d. ignore this IE 
+6960,II,[ wlan_frameparse.c : 803 ] eht_ppe_threshold ppet: 0x%x, ie_len:0x%x 
+6961,i,[ wlan_frameparse.c : 1759 ] MLME_FRMPARSE_VENDOR_VHT unknown type %d 
+6962,ii,[ wlan_frameparse.c : 1769 ] MLME_FRMPARSE_WARN_VENDOR_VHT remaining_len %d (exp %d) ignore this IE 
+6963,I,[ wlan_frameparse.c : 1782 ] MLME_FRMPARSE_WARN_VENDOR_VHT ERROR vht_caps. status %x
+ 
+6964,I,[ wlan_frameparse.c : 1796 ] MLME_FRMPARSE_WARN_VENDOR_VHT ERROR vht_oper. status %x
+ 
+6965,iI,[ wlan_key_mgmt.c : 56 ] KEYMGMT_ADD_PEER_ENTRY DELAY in key clear install sw q is flushed peer_id:%d peer flag %02x 
+6966,iIi,[ wlan_key_mgmt.c : 63 ] security: wal_peer_set_key for key clear failed peer id %d peer flag %02x status %d 
+6967,iI,[ wlan_key_mgmt.c : 86 ] KEYMGMT_ADD_PEER_ENTRY DELAY in key clear install AP's bss peer unblock called peer_id:%d  peer flag %02x 
+6968,iiiIiiii,[ wlan_key_mgmt.c : 107 ] KEYMGMT_ADD_PEER_ENTRY  key_cipher:%d key_len:%d is_mcast:%d flags=0x%x key_txmic_len:%d key_rxmic_len:%d keyid=%d pairwise=%d 
+6969,iii,[ wlan_key_mgmt.c : 259 ] wal_peer_set_key type=%d, keyid=%d,pairwise=%d failed 
+ 
+6970,i,[ wlan_key_mgmt.c : 291 ] KEYMGMT_ADD_PEER_ENTRY : status=%d (0: success) 
+6971,i,[ wlan_key_mgmt.c : 435 ] KEYMGMT_ADD_GROUP_KEY WEP ERROR : status=%d (0: success) 
+6972,iIIiI,[ wlan_key_mgmt.c : 696 ] KEYMGMT_ADD_KEYSEED_ENTRY id=%d peer_mac 0x%x:0x%x seed_len=%d keyseed=%p 
+6973,I,[ wlan_key_mgmt.c : 705 ] KEYMGMT_ADD_KEYSEED_ENTRY : 0x%x  
+6974,,[ wlan_key_mgmt.c : 720 ] KEYMGMT_ADD_KEYSEED_ENTRY_NO_MEM 
+6975,ii,[ wlan_key_mgmt.c : 482 ] KEYMGMT_ADD_KEY_ENTRY_NO_MEM id=%d key_idx=%d 
+6976,,[ wlan_beacon.c : 211 ] beacon_init POOL ALLOC FAILURE 
+6977,II,[ wlan_beacon.c : 598 ] tsf_beacon: 0x%08x%08x 
+6978,II,[ wlan_beacon.c : 796 ] wlan_beacon_handle_quiet: ml_vdev_bitmap =%0x ml_vdevId=%0x 
+6979,,[ wlan_beacon.c : 2401 ] arbiter_clinet POOL ALLOC FAILURE 
+6980,,[ wlan_beacon.c : 2414 ] arbiter_clinet POOL ALLOC FAILURE 
+6981,ii,[ wlan_mbssid.c : 537 ] WLAN_MBSSID_GET_MAX_INDICATOR mismatch cur = %d previous = %d 
+6982,ii,[ wlan_mbssid.c : 542 ] WLAN_MBSSID_GET_MAX_INDICATOR Big max_bssid_ind = %d (max = %d) 
+6983,ii,[ wlan_mbssid.c : 854 ] WLAN_MBSSID_GET_MAX_INDICATOR mismatch cur = %d previous = %d 
+6984,ii,[ wlan_mbssid.c : 859 ] WLAN_MBSSID_GET_MAX_INDICATOR Big max_bssid_ind = %d (max = %d) 
+6985,ii,[ wlan_mbssid.c : 1009 ] DYN_LINK_REM wlan_mbssid_get_est_ie_len_multi_link_ie: vdev_id-%d reconfig_tbtt_count %d 
+6986,ii,[ wlan_mbssid.c : 1702 ] WLAN_MBSSID_GET_MAX_INDICATOR Big max_bssid_ind = %d (max = %d) 
+6987,i,[ wlan_mbssid.c : 1738 ] WLAN_MBSSID_GET_IE %d 
+6988,,[ wlan_mbssid.c : 1288 ] tx_vdev is null 
+6989,i,[ wlan_multilink.c : 409 ] wlan_ml_defrag_sub_element %d 
+6990,iI,[ wlan_multilink.c : 883 ] T2LM_DBG: post processing link_id:%d state_change_bitmap:0x%x 
+6991,i,[ wlan_multilink.c : 911 ] T2LM_DBG: TIDs pasused link_id:%d 
+6992,i,[ wlan_multilink.c : 915 ] T2LM_DBG: TIDs unpaused link_id:%d 
+6993,i,[ wlan_multilink.c : 939 ] T2LM_DBG: TIDs unpaused link_id:%d 
+6994,I,[ wlan_multilink.c : 968 ] T2LM_DBG: wlan_bcast_t2lm_process_mst  vdev = 0x%p  
+6995,iiI,[ wlan_multilink.c : 1014 ] T2LM_DBG: wlan_bcast_t2lm_process_mst MST updated. link_id:%d indx:%d MST:%u 
+6996,,[ wlan_multilink.c : 1044 ] RNR link stats 1 
+6997,ii,[ wlan_multilink.c : 1051 ] T2LM_DBG: wlan_bcast_t2lm_process_mst MST expired.link_id=0x%d stop_beacn:%d 
+6998,,[ wlan_multilink.c : 1135 ] T2LM_DBG: wlan_get_bcast_tid_to_link_map_exp_dur_exp BCAST_T2LM_STATE_ED_EXPIRED 
+6999,,[ wlan_multilink.c : 1149 ] T2LM_DBG: wlan_get_bcast_tid_to_link_map_exp_dur_exp bcast T2LM index 0 updated 
+7000,,[ wlan_multilink.c : 1430 ] BEACON_DIAG: buffer copy len mismatch 
+7001,iiiii,[ wlan_multilink.c : 1515 ] MLO_CSA : wlan_bmle_ap_append_per_sta_profile_ie : vdev-%d csa_tbtt_count : %d csa_ie_present = %d hw_link_id = %d ieee_link_id : %d  
+7002,i,[ wlan_multilink.c : 1720 ] DYN_LINK_REM : parse_cmn_info : Invalid ML-IE %d 
+7003,i,[ wlan_multilink.c : 1731 ] DYN_LINK_REM : parse_cmn_info : cmn_info_len %d 
+7004,II,[ wlan_multilink.c : 1740 ] DYN_LINK_REM : parse_cmn_info : ml_mac_addr %x, %x 
+7005,i,[ wlan_multilink.c : 1775 ] DYN_LINK_REM : parse_sta_profile : sta_info_len %d 
+7006,II,[ wlan_multilink.c : 1784 ] DYN_LINK_REM : parse_sta_profile : link_mac_addr %x, %x 
+7007,,[ wlan_multilink.c : 1789 ] DYN_LINK_REM : parse_sta_profile : In-correct Link MAC Addr 
+7008,i,[ wlan_multilink.c : 1796 ] DYN_LINK_REM : parse_sta_profile : del_timer : %d 
+7009,i,[ wlan_multilink.c : 1897 ] DYN_LINK_REM : partner Re-Config IE Append : del_timer =  %d 
+7010,iIIiI,[ wlan_multilink.c : 1916 ] DYN_LINK_REM : Re-Config IE Append : del_timer|link_mac_31_0 |link_mac_47_32|prof_len|link_id_info -> %d, %x, %x, %d, %x 
+7011,ii,[ wlan_phyerr_internal.c : 138 ] phyerr event err: buf_len:%d>%d 
+7012,,[ wlan_phyerr_internal.c : 225 ] phyerr event: alloc event failure 
+7013,i,[ wlan_dfs_phyerr_offload.c : 142 ] PHYERR offload cac timeout vdevId=%d 
+7014,ii,[ wlan_dfs_phyerr_offload.c : 291 ] PHYERR offload mac_id=%d enabled=%d 
+7015,ii,[ wlan_dfs_phyerr_offload.c : 314 ] PHYERR offload cac check, isDFSAP=%d phyerr_offloaded=%d 
+7016,iiiiiiiii,[ wlan_dfs_phyerr_offload.c : 413 ] DFS_DUMPS PHYERR offload RADAR_DETECTION_EVENT pdev_id %d wmi_pdevid %d det_mode %d, chan_freq %dMHz chan_width %dMHz freq_offset %d det_id %d seg_id %d ts %d 
+7017,i,[ wlan_dfs_phyerr_offload.c : 465 ] PHYERR offload enable pdev_id=%d 
+7018,,[ wlan_dfs_phyerr_offload.c : 502 ] PHYERR unexpected offload disable command for HKv2! 
+7019,ii,[ wlan_dfs_phyerr_unit_test.c : 64 ] wlan_dfs_phyerr_offload_unit_test input: set radar mac_id=%d cmd=%d 
+7020,I,[ wlan_txbf_unit_test.c : 78 ] WLAN_TXBF_CONFIG param = 0x%x 
+7021,II,[ unit_test.c : 332 ] UNIT_TEST_GEN  0x%x 0x%x 
+7022,,[ wlan_beacon_tx_offload.c : 244 ] QUIET IE AP_swba: BCN_CTXT Null 
+7023,I,[ wlan_beacon_tx_offload.c : 257 ] QUIET IE AP_swba: SWBA  Enable/Disable value = %x 
+7024,iiiiii,[ wlan_beacon_tx_offload.c : 324 ] OPTDBG: vdevid:%d,  vdev chan_idx:%d, vdev opclass:%d, cca_regdomain:%d,rnr opclass: %d, rnr_chidx:%d 
+7025,ii,[ wlan_beacon_tx_offload.c : 1117 ] BEACON_DIAG: GreenAP enabling in beacon done vdev:%d pdev:%d 
+7026,iiIIIiii,[ wlan_beacon_tx_offload.c : 1205 ] BEACON_DIAG: TX_OK chan|vdev:%d seq_num:%d TBTT:%luus compl_TS:%luus delay_from_TBTT:%luus bcn_delta:%d.%dms consec_bcn_fail:%d 
+7027,iiIIiiiii,[ wlan_beacon_tx_offload.c : 1222 ] BEACON_DIAG: TX_FAIL chan|vdev:%d seq_num:%d TBTT:%luus compl_TS:%luus last_tx_ok_seq_num:%d cons_fail:%d err_st:%d tx_attm:%d flush_rc:%d 
+7028,Iii,[ wlan_beacon_tx_offload.c : 1299 ] BEACON_DIAG: BEACON_ENQUEUE_FAILED vdev_id = %x g_sap_bcn_fail = %d , Timestamp = %d ms  
+7029,IIIIiiI,[ wlan_beacon_tx_offload.c : 1436 ] BEACON TX ignored, vdev id:%x, mac_id:%x, bcn_tx_paused:%x, pdev_id:%x, swba_delay:%d consec_beacon_skip:%d, on_chan = %x 
+7030,IIIiii,[ wlan_beacon_tx_offload.c : 1598 ] BEACON TX bcn_ctxt->do_not_send_bcn_h8/bcn_ctxt->csa_in_progress_8/send_evt_to_host_16 : 0x%x ,update_switch_count:%x, bcn_ctxt->current_csa_count:%x, bcn_ctxt->csa_event_bitmap:%d pmac->csa_cur_sw_count:%d do_not_send_bcn:%d 
+7031,ii,[ wlan_beacon_tx_offload.c : 1681 ] BEACON_DIAG: send csa event - num_vdev_to_host=%d, csa_cur_sw_count=%d 
+7032,ii,[ wlan_beacon_tx_offload.c : 1745 ] BEACON_DIAG: send csa event - num_vdev_to_host=%d, csa_cur_sw_count=%d 
+7033,I,[ wlan_beacon_tx_offload.c : 1904 ] HE_RTS_THRESHOLD_DBG: enter: he_op_ie rts_thresh: %lu 
+7034,iiii,[ wlan_beacon_tx_offload.c : 1937 ] HE_RTS_THRESHOLD_DBG: middle: he_rts_load_enable_threshold: %d, load_metric: %d, active_user_count: %d, rx_load_pct: %d 
+7035,I,[ wlan_beacon_tx_offload.c : 1953 ] HE_RTS_THRESHOLD_DBG: exit: he_op_ie rts_thresh: %lu 
+7036,ii,[ wlan_beacon_tx_offload.c : 1970 ] MU_EDCA_DEBUG: id: %d, update_cnt: %d 
+7037,iiiii,[ wlan_beacon_tx_offload.c : 1975 ] MU_EDCA_DEBUG: id: %d, BK: cwmin: %d, cwmax: %d, aifsn: %d, edca_timer: %d 
+7038,iiiii,[ wlan_beacon_tx_offload.c : 1980 ] MU_EDCA_DEBUG: id: %d, BE: cwmin: %d, cwmax: %d, aifsn: %d, edca_timer: %d 
+7039,iiiii,[ wlan_beacon_tx_offload.c : 1985 ] MU_EDCA_DEBUG: id: %d, VI: cwmin: %d, cwmax: %d, aifsn: %d, edca_timer: %d 
+7040,iiiii,[ wlan_beacon_tx_offload.c : 1990 ] MU_EDCA_DEBUG: id: %d, VO: cwmin: %d, cwmax: %d, aifsn: %d, edca_timer: %d 
+7041,ii,[ wlan_beacon_tx_offload.c : 2586 ] PROBE_RESP_TX: Err sending probe response not on home channel vdev home channel = %d, mac cahnnel = %d 
+7042,,[ wlan_beacon_tx_offload.c : 2815 ] PROBE_RESP_TX: send probe resp 
+7043,iiii,[ wlan_beacon_tx_offload.c : 3357 ] MCST : csa_inprogress = %d, chan %d(=0xFFFF if vdev->bss is not valid), vdev-id %d, Timestamp = %d ms 
+7044,i,[ wlan_beacon_tx_offload.c : 3431 ] BEACON_DIAG :MLO_CSA curr_link CSA Count = %d  
+7045,ii,[ wlan_beacon_tx_offload.c : 3450 ] MCST : %d vdev-id : %d 
+7046,,[ wlan_beacon_tx_offload_wmi.c : 96 ] bcn_ctxt POOL ALLOC FAILURE 
+7047,iiiii,[ wlan_beacon_tx_offload_wmi.c : 294 ] BEACON_DIAG: bcn_tmpl_invalid pdev_id:%d vdev_id:%d bcn_len:%d tmpl_idx:%d inv_bcn_tmpl_cnt:%d 
+7048,iii,[ wlan_beacon_tx_offload_wmi.c : 365 ] MCST : curr chan %d(=0xFFFF if vdev->bss is not valid), vdev-id %d, %d 
+7049,iii,[ wlan_beacon_tx_offload_wmi.c : 373 ] MCST : new chan %d(=0xFFFF if vdev->bss is not valid), vdev-id %d, %d 
+7050,ii,[ wlan_beacon_tx_offload_wmi.c : 570 ] tmplt_idx %d >= profile_period %d 
+7051,I,[ wlan_beacon_tx_offload_wmi.c : 638 ] mesh VAP channel switch countdown timer in microseconds=%u 
+7052,,[ wlan_beacon_tx_offload_wmi.c : 709 ] CSA_SWITCH_COUNT_STATUS_EVENT for mesh VAP is initiated 
+7053,IIII,[ wlan_beacon_tx_offload_wmi.c : 764 ] Ganesh: PRB_TMPL_CMDID_ML_INFO : cat1 lo %x, cat1 hi %x, cat2 lo %x, cat2 hi %x 
+7054,iI,[ wlan_beacon_tx_offload_wmi.c : 796 ] WOW_PROBE_RESP_TX: PRB TMPL CMDID, probe_resp_len=%d flags=%x 
+7055,ii,[ wlan_beacon_tx_offload_wmi.c : 822 ] Beacon template length is %d and is greater than max size %d 
+7056,IIIII,[ wlan_beacon_tx_offload_wmi.c : 873 ] QUIET IE AP: vdev_id= %x period = %x duration = %x off = %x flag = %x 
+7057,ii,[ wlan_beacon_tx_offload_wmi.c : 894 ] Probe response template length is %d and is greater than max size %d 
+7058,,[ wlan_beacon_tx_offload_wmi.c : 902 ] vdev is NULL 
+7059,,[ wlan_beacon_tx_offload_wmi.c : 960 ] VBSS WMI_BEACON_CTRL_TX_DISABLE Tx Connection block  
+7060,I,[ wlan_beacon_tx_offload_wmi.c : 974 ] QUIET IE AP_swba: TIM  Disable value = %x 
+7061,I,[ wlan_beacon_tx_offload_wmi.c : 984 ] QUIET IE AP_swba: TIM  Enable value = %x 
+7062,i,[ wlan_beacon_tx_offload_wmi.c : 1155 ] DYN_LINK_REM : wmi event : tbtt_count = %d 
+7063,I,[ wlan_beacon_tx_offload_wmi.c : 1504 ] QUIET IE AP: num_args= %x failed 
+7064,IIIII,[ wlan_beacon_tx_offload_wmi.c : 1516 ] QUIET IE AP: vdev_id= %x period = %x duration = %x off = %x flag = %x 
+7065,,[ wlan_beacon_tx_offload_wmi.c : 1610 ] 11w Bcn prot test : CSA IE not added by host 
+7066,Iii,[ wlan_beacon_tx_offload_wmi.c : 176 ] BEACON_DIAG: bcn_tmpl_invalid param bcn_buf:0x%x bcn_len:%d max_bcn_len:%d 
+7067,iiIii,[ wlan_beacon_tx_offload_wmi.c : 208 ] BEACON_DIAG: bcn_tmpl tagged_param_idx:%d tag_num:%d(0x%x) tag_len:%d rem_buf_len:%d 
+7068,iiIiiii,[ wlan_beacon_tx_offload_wmi.c : 221 ] BEACON_DIAG: bcn_tmpl_invalid sanity failed, num_bcn_ie:%d tag_num:%d(0x%x) (wrong)tag_len:%d (expected)tag_len:%d CSA_IE:%d, EXT_CSA_IE:%d 
+7069,IIi,[ csa_offload_main.c : 128 ]  csa vdev_start notif,csa ch freq:0x%x,                      prev csa ch freq:0x%x vdev id %d 
+7070,ii,[ csa_offload_main.c : 147 ] csa vdev notif csa_dev_ctx->csa_ctrl.csa_proc_state %d 					   notif->type  %d 
+7071,i,[ obss_offload_api.c : 58 ] bss color: register on mlomgr fail, %d 
+7072,i,[ obss_offload_api_init.c : 142 ] bss color: SCAN_SCH_START_ALLOC_FAIL, %d 
+7073,III,[ bss_color_offload_int.c : 83 ] bss color tbtt calibration: curr_tsf=%x next_tbtt=%x bi_us=%x 
+7074,ii,[ bss_color_offload_int.c : 209 ] bss color: event report fails in wow, vdev id:%d, evt_type:%d  
+7075,iiII,[ bss_color_offload_int.c : 234 ] bss color: event report,vdev id:%d, evt_type:%d, color bitmap:32to63 0x%x 0to31 0x%x 
+7076,i,[ bss_color_offload_int.c : 245 ] bss color: stop color collision detection vdev_id=%d 
+7077,i,[ bss_color_offload_int.c : 258 ] bss color: reject restart color collision detection as vdev_id=%d is suspend 
+7078,i,[ bss_color_offload_int.c : 280 ] bss color: restart color collision detection vdev_id=%d 
+7079,i,[ bss_color_offload_int.c : 333 ] 11d: STOP_COMMAND_FAILED, %d 
+7080,i,[ bss_color_offload_int.c : 358 ] bss color: bss clr chg timeout hdlr vdev_id=%d 
+7081,i,[ bss_color_offload_int.c : 379 ] bss color offload: not support: vdev id:%d 
+7082,ii,[ bss_color_offload_int.c : 410 ] bss color offload: vdev id:%d, enable=%d 
+7083,i,[ bss_color_offload_int.c : 428 ] bss color offload: not support: vdev id:%d 
+7084,iiiii,[ bss_color_offload_int.c : 494 ] bss color offload : collision det cmd: vdev id:%d, evt_type=%d vdev cfg: det_per=%d scan_per=%d expiry_per=%d 
+7085,iii,[ bss_color_offload_int_handlers.c : 187 ] bss color: check color collision detection vdev_id=%d vdev_mode=%d col_detect=%d 
+7086,,[ bss_color_offload_int_handlers.c : 256 ] BSS COLOR: SCAN_START_COMMAND_FAILED, vdev bss NULL 
+7087,i,[ bss_color_offload_int_handlers.c : 303 ] BSS COLOR: SCAN_START_COMMAND_FAILED, %d 
+7088,i,[ bss_color_offload_int_handlers.c : 415 ] bss color: obss clr colli det timeout hdlr vdev_id=%d 
+7089,i,[ bss_color_offload_unit_test.c : 94 ] bss_color ofld unit test fails: bss_color vdev not exist id:%d 
+7090,iiii,[ bss_color_offload_unit_test.c : 105 ] bss color ofld unit test: args %d %d %d %d 
+7091,i,[ obss_offload_priv.c : 64 ] bss color: len wrong:%d 
+7092,ii,[ obss_offload_priv.c : 73 ] bss color: wrong type:%d, sub:%d 
+7093,iii,[ wlan_quiet_ie_ap.c : 114 ] QUIET IE AP: timer cb-next evt:%d, cac:%d, paused:%d 
+7094,II,[ wlan_quiet_ie_ap.c : 244 ] QUIET IE AP: not appending quiet IE. time_to_quite_period_start = 0x%x, time_to_bcn_tx = 0x%x 
+7095,i,[ wlan_quiet_ie_ap.c : 339 ] QUIET IE AP: start quiet IE: input duration out of range, duration_us = %d 
+7096,III,[ wlan_quiet_ie_ap.c : 397 ] QUIET IE AP: quiet IE Start time=0x%x Curr_time=0x%x timeout=0x%x 
+7097,IiiiiI,[ wlan_quiet_ie_sta.c : 245 ] QUIET IE STA, time-usec:0x%x, vdevId=%d, evt:%d,all_tids_tx_blocked:%d, supend_alwd:%d, period:0x%x 
+7098,,[ wlan_quiet_ie_sta.c : 605 ] QUIET IE STA: test cfg, vdev is NULL 
+7099,IiiiiIi,[ wlan_quiet_ie_sta.c : 685 ] QUIET IE STA: PS SM callback , time-usec:0x%x, vdevId=%d, next_evt:%d, all_tids_tx_blocked:%d, supend_alwd:%d, period:0x%x, sleep = %d 
+7100,IIIII,[ wlan_quiet_ie_sta.c : 729 ] QUIET IE STA:time_diff_us = 0x%x,current_quite_ie =0x%x,sum =0x%x, ref_time = 0x%x, curr_ts=0x%x 
+7101,Ii,[ wlan_quiet_ie_sta.c : 777 ] QUIET IE STA: wake recved in ON period timer:0x%x, nxt_evnt:%d 
+7102,Ii,[ wlan_quiet_ie_sta.c : 795 ] QUIET IE STA: wake recved in OFF period timer:0x%x, nxt_evnt:%d 
+7103,iii,[ offload_unit_test.c : 85 ] Offload unit test input: vdevid:%d, group=%d, type=%d 
+7104,iiii,[ wlan_powersave_emlsr_protocol.c : 51 ] wlan_elmsr_send_elmsr_omn_frame: eml_control_field size:%d  mode:%d link_map:%d, vdev:%d 
+7105,iii,[ wlan_powersave_emlsr_protocol.c : 111 ] wlan_emlsr_action_frame_handler: cat=%d, act=%d, len=%d 
+7106,i,[ wlan_powersave_ap.c : 70 ] wlan_ps_ap_send_message: status=%d (0: success)  
+7107,i,[ wlan_powersave_ap.c : 86 ] AP_PS_DBGID_CAB_FINISH vdev_id = %d 
+7108,iiiIi,[ wlan_powersave_ap.c : 135 ] AP_PS_DBGID_DELIVER_CAB vdev_id = %d Tid = %d NumMPDU = %d Flags = 0x%x RetryOther = %d 
+7109,i,[ wlan_powersave_ap.c : 228 ] AP_PS_DBGID_START_CAB vdev_id = %d 
+7110,i,[ wlan_powersave_ap.c : 837 ] AP_PS_DBGID_VDEV_CREATION_FAILURE AP PS:vdev_id = %d vdev alloc failed 
+7111,i,[ wlan_powersave_sta.c : 714 ] STA PS vdev_id = %d, No buffers available for null frames 
+7112,ii,[ wlan_powersave_sta.c : 750 ] PS_STA_INACTIVITY_INFO ITO picked = %d us, current ITO = %d,  
+7113,Ii,[ wlan_powersave_sta.c : 1053 ] wlan_ps_sta_bmps_request: bmps_cli_bitmap:0x%x ps-mode:%d
+ 
+7114,,[ wlan_powersave_sta.c : 1251 ] sta_handle POOL ALLOC FAILURE 
+7115,iIIi,[ wlan_powersave_sta.c : 2147 ] PS_STA_TIM_DATA_PENDING vdev:%d, flag:%x flag2:%x status %d (0: success) 
+7116,iI,[ wlan_powersave_sta.c : 2489 ] STA PS: wlan_ps_sta_health_monitor_timeout: vdev_id=%d sta_flags=0x%X 
+7117,IIiiiI,[ wlan_powersave_sta.c : 2875 ] wlan_ps_sta_sched_pm_pause_unpause_ext vdev = 0x%x, module_id = 0x%x , pause = %d sched_enabled = %d, sched_paused = %d , pause_cli_bitmap = 0x%x  
+7118,i,[ wlan_powersave_sta.c : 2890 ] wlan_ps_sta_sched_pm_pause_unpause_ext :: status: %d (0: success) 
+7119,IiiiI,[ wlan_powersave_sta.c : 3049 ] wlan_ps_sta_sched_pm_pause_unpause mod_id = 0x%x , pause = %d , sched_enabled = %d, sched_paused = %d , pause_cli_bitmap = 0x%x  
+7120,iiIII,[ wlan_powersave_sta.c : 3104 ] wlan_ps_sta_scan_evt_handler[SCAN_STARTED]: vdev=%d, scan_vdev=%d, sched_flags=0x%x , sta_handl_flags = 0x%x pause_bitmap = 0x%x  
+7121,iiIII,[ wlan_powersave_sta.c : 3116 ] wlan_ps_sta_scan_evt_handler[SCAN_COMPLETED]: vdev=%d, scan_vdev=%d, sched_flags=0x%x , sta_handl_flags = 0x%x pause_bitmap = 0x%x  
+7122,iiiiiii,[ wlan_powersave_sta.c : 3366 ] min_sleep_dur = %d , SP = %d, SI = %d min_tol_SI = %d , max_tol_SI = %d min_tol_SP = %d, max_tol_SP = %d  
+7123,ii,[ wlan_powersave_sta.c : 3661 ] wlan_ps_sta_sched_pm_send_comp_status_vdev: max event size exceeded %d, max_limit %d 
+7124,i,[ wlan_powersave_sta.c : 3672 ] wlan_ps_sta_sched_pm_send_comp_status_vdev: memory allocation failed, %d 
+7125,iii,[ wlan_powersave_sta.c : 3679 ] wlan_ps_sta_sched_pm_send_comp_status_vdev: cmd = %d, tlv_var = %d, status = %d  
+7126,iii,[ wlan_powersave_sta.c : 3795 ] wlan_ps_sta_sched_pm_send_comp_status: cmd = %d, tlv_var = %d, status = %d ,  
+7127,ii,[ wlan_powersave_sta_sm.c : 626 ] wlan_ps_sta_data_activity_pending: vdev_id=%d, inactive_time_us=%d 
+7128,ii,[ wlan_powersave_sta_sm.c : 1211 ] wlan_ps_sta_state_pause_event: vdev id = %d, pause_stat_rx_frms_leaked = %d 
+7129,i,[ wlan_powersave_sta_sm.c : 1676 ] WLAN_PS_STA_F3_USER_DEF_SPEC_WAKE  =%d 
+7130,,[ wlan_powersave_sta_sm.c : 2658 ] total_spec_pspoll_count reaches MAX: reset it 
+7131,ii,[ wlan_smps_sm.c : 185 ] SMPS_STATE_STATIC_EVENT: chain: %d, dropped ev:%d 
+7132,,[ wlan_powersave_sta_wmi.c : 275 ] wlan_ps_wmi_vdev_pause_handler: Failed to get the wlan vdev 
+7133,ii,[ wlan_powersave_sta_wmi.c : 281 ] wlan_ps_wmi_vdev_pause_handler: pause_type=%d, pause_dur_ms=%d 
+7134,iiI,[ wlan_twt.c : 200 ] wlan_twt_wmi_enable: pdev_id=%d, sta_cong_timer_ms=%d, pdev-flags=0x%x 
+7135,ii,[ wlan_twt.c : 239 ] wlan_twt_wmi_enable_complete_event: pdev_id=%d, status=%d 
+7136,iIi,[ wlan_twt.c : 317 ] wlan_twt_wmi_disable: pdev_id=%d, flags=0x%x, reason_code = %d  
+7137,iii,[ wlan_twt.c : 382 ] wlan_twt_wmi_vdev_config: pdev_id=%d, vdev_id=%d, twt_support=0x%d 
+7138,ii,[ wlan_twt.c : 407 ] wlan_twt_wmi_disable_complete_event: pdev_id=%d, status=%d 
+7139,ii,[ wlan_twt.c : 461 ] wlan_twt_wmi_add_dialog: vdev_id=%d, id=%d 
+7140,iii,[ wlan_twt.c : 553 ] wlan_twt_wmi_add_dialog_complete_event: vdev=%d, id=%d, status=%d 
+7141,iii,[ wlan_twt.c : 626 ] wlan_twt_wmi_del_dialog: vdev_id=%d, id=%d, b_twt_persistence=%d 
+7142,iii,[ wlan_twt.c : 650 ] wlan_twt_wmi_del_dialog_complete_event: vdev=%d, id=%d, status=%d 
+7143,ii,[ wlan_twt.c : 687 ] wlan_twt_wmi_pause_dialog: vdev_id=%d, id=%d 
+7144,iii,[ wlan_twt.c : 708 ] wlan_twt_wmi_pause_dialog_complete_event: vdev=%d, id=%d, status=%d,  
+7145,iii,[ wlan_twt.c : 745 ] wlan_twt_wmi_resume_dialog: vdev_id=%d, id=%d, next_twt_size=%d 
+7146,iii,[ wlan_twt.c : 772 ] wlan_twt_wmi_resume_dialog_complete_event: vdev=%d, id=%d, status=%d  
+7147,iiii,[ wlan_twt.c : 811 ] wlan_twt_wmi_nudge_dialog: vdev_id=%d, id=%d, suspend_duration_ms=%d, next_twt_size=%d 
+7148,iiiI,[ wlan_twt.c : 839 ] wlan_twt_wmi_nudge_dialog_complete_event: vdev=%d, id=%d, status=%d, next_twt=0x%x 
+7149,ii,[ wlan_twt.c : 890 ] wlan_twt_wmi_btwt_invite_sta: vdev_id=%d, id=%d 
+7150,IIIi,[ wlan_twt.c : 918 ] wlan_twt_wmi_btwt_invite_sta: lsb_mac=%x:%x:%x status: %d (0: success) 
+7151,iii,[ wlan_twt.c : 933 ] wlan_twt_wmi_btwt_invite_sta_complete_event: vdev=%d, id=%d, status=%d 
+7152,ii,[ wlan_twt.c : 977 ] wmi_twt_btwt_remove_sta: vdev_id=%d, id=%d 
+7153,IIIi,[ wlan_twt.c : 1005 ] wlan_twt_wmi_btwt_remove_sta: lsb_mac=%x:%x:%x status: %d (0: success) 
+7154,iii,[ wlan_twt.c : 1020 ] wlan_twt_wmi_btwt_remove_sta_complete_event: vdev=%d, id=%d, status=%d 
+7155,iii,[ wlan_twt_protocol.c : 222 ] wlan_twt_action_frame_handler: cat=%d, act=%d, len=%d 
+7156,III,[ wlan_twt_ap.c : 315 ] AP TWT: Cant find peer lsb_mac=%x:%x:%x 
+7157,i,[ wlan_twt_ap.c : 594 ] AP TWT: Vdev id = %d not TWT enabled 
+7158,i,[ wlan_twt_ap.c : 812 ] AP TWT: peer id = %d not TWT enabled 
+7159,i,[ wlan_twt_ap.c : 1104 ] AP TWT: Vdev id = %d not TWT enabled 
+7160,i,[ wlan_twt_ap.c : 1058 ] AP TWT: Vdev id = %d not TWT enabled 
+7161,iiiii,[ wlan_powersave_sta_unit_test.c : 150 ] wlan_powersave_sta_unit_test vdev_id = %d, args[0] = %d, args[1] = %d, args[2] = %d, args[3] = %d 
+7162,i,[ wlan_twt_unit_test.c : 80 ] AP TWT: Vdev id = %d not TWT enabled 
+7163,,[ wlan_twt_unit_test.c : 109 ] wlan_ap_twt_set_twt_cap: null peer 
+7164,iii,[ wlan_twt_unit_test.c : 621 ] HWSCH_LUT: peer_id:%d, pmfilter:%d, twtfilter:%d 
+7165,iiiiiiii,[ wlan_twt_unit_test.c : 691 ] wlan_twt_unit_test: vdev_id=%d, num_args=%d, type=%d, args:%d-%d-%d-%d-%d 
+7166,i,[ wlan_twt_unit_test.c : 694 ] vdev == NULL: %d 
+7167,i,[ wlan_twt_unit_test.c : 695 ] !vdev->ifUp, %d 
+7168,i,[ wlan_twt_unit_test.c : 717 ] wlan_twt_unit_test: peer id %d not found, for WLAN_TWT_TEST_TYPE_CAP 
+7169,i,[ wlan_twt_unit_test.c : 722 ] wlan_twt_unit_test: wrong num_args==%d, for WLAN_TWT_TEST_TYPE_CAP 
+7170,i,[ wlan_twt_unit_test.c : 738 ] wlan_twt_unit_test: wrong num_args==%d, for WLAN_TWT_TEST_TYPE_EN 
+7171,i,[ wlan_twt_unit_test.c : 779 ] wlan_twt_unit_test: wrong num_args==%d, for WLAN_TWT_TEST_TYPE_ADD 
+7172,III,[ wlan_twt_unit_test.c : 485 ] AP TWT: Cant find peer: lsb_mac=%x:%x:%x 
+7173,III,[ wlan_twt_unit_test.c : 491 ] wlan_twt_unit_test_join_btwt: WMI_PEER_TYPE_SELF: lsb_mac=%x:%x:%x 
+7174,III,[ wlan_twt_unit_test.c : 516 ] AP TWT: Cant find peer: lsb_mac=%x:%x:%x 
+7175,III,[ wlan_twt_unit_test.c : 522 ] wlan_twt_unit_test_join_btwt: WMI_PEER_TYPE_SELF: lsb_mac=%x:%x:%x 
+7176,i,[ wlan_rtt.c : 493 ] wmi_channel_width_to_rtt_cap_bw: ERR: unknown WMI BW: %d, fallback to WMI_RTT_CAP_160M 
+7177,iIIII,[ wlan_rtt.c : 690 ] wlan_rtt_register_mac_addr: mac_addr_registered:%d self_mac_addr:%08x%04x vdev->ic_myaddr:%08x%04x 
+7178,,[ wlan_rtt.c : 706 ] RTT wlan_rtt_register_mac_addr failed 
+7179,iIi,[ wlan_rtt.c : 1096 ] wlan_rtt_band_change_req_init_cb: event: %d init_ctxt: 0x%08x rtt_2g: %d 
+7180,IiIi,[ wlan_rtt.c : 1242 ] wlan_rtt_buffer_init() p_pdev_rtt_ctxt:0x%p mac_is:%d init_ctxt:0x%p, ctxt->index:%d 
+7181,iiiiii,[ wlan_rtt.c : 1448 ] cancel_measurement_req: vdev_type: %d, req_id: %d, curr_state:%d, free_curr_init: %d, is_cancelled: %d frame_type_handler_called %d 
+7182,Iii,[ wlan_rtt.c : 1566 ] wlan_rtt_vdev_notify_handler() vdev = 0x%08x vdev_id = %d notification type = %d 
+7183,iIII,[ wlan_rtt.c : 2245 ] wlan_rtt_terminate_repetitive_ss_request: red_id:%d init_ctxt_usage_flags:0x%x dest_mac :%x %x 
+7184,,[ wlan_rtt.c : 2524 ] All requests done nothing to schedule 
+7185,iiii,[ wlan_rtt.c : 2540 ] wlan_rtt_process_report_buffer: report_buffer_error:%d, initialized:%d, report_type:%d, request_id_complete:%d 
+7186,i,[ wlan_rtt.c : 2553 ] wlan_rtt_process_report_buffer: wlan_rtt_is_request_id_complete:%d 
+7187,,[ wlan_rtt.c : 2569 ] wlan_rtt_process_report_buffer: invoke wal_report_type2_buffer_update_loop_info 
+7188,,[ wlan_rtt.c : 2574 ] wlan_rtt_process_report_buffer: invoke wal_report_type2_buffer_done 
+7189,,[ wlan_rtt.c : 2583 ] wlan_rtt_process_report_buffer: Else part 
+7190,,[ wlan_rtt.c : 3415 ] wlan_rtt_exit_clean 
+7191,iii,[ wlan_rtt.c : 3498 ] wlan_rtt_resp_exit_clean() state: %d tmr_subtype:%d, meas_cnt:%d 
+7192,Ii,[ wlan_rtt.c : 3503 ] wlan_rtt_resp_exit_clean() resp_ctxt %p ftm_state %d 
+7193,I,[ wlan_rtt.c : 3566 ] wlan_rtt_resp_exit_clean resp context vdev = 0x%08x 
+7194,II,[ wlan_rtt.c : 3589 ] Unregistered wlan_rtt_vdev_notify_handler() for resp context vdev = 0x%08x status = 0x%x 
+7195,iiiI,[ wlan_rtt.c : 3648 ] wlan_rtt_pm_arb_req(): mac_id: %d state: %d client: %d client_bitmap: 0x%x 
+7196,,[ wlan_rtt.c : 3739 ] RTT_CALL_FLOW: WLAN_RTT_BEACON_RX 
+7197,ii,[ wlan_rtt.c : 3850 ] wlan_rtt_dfs_chan_init_handler rtt_ctxt->chnl_switch_ctxt.cb_fn %d rtt_ctxt->chnl_switch_ctxt.owner%d  
+7198,iIII,[ wlan_rtt.c : 3877 ] RTT_CHANNEL_DFS_SWITCH_HDL  ev = %d sw_ctxt->arg = 0x%08x sw_ctxt->cb_fn 0x%08x, ts_ms = %u 
+7199,i,[ wlan_rtt.c : 4122 ] wlan_rtt_init_handler: 11az request not ready!! curr_state %d 
+7200,i,[ wlan_rtt.c : 4129 ] wlan_rtt_init_handler: 11az request not ready!! curr_state %d 
+7201,IIiIIiII,[ wlan_rtt.c : 4165 ] wlan_rtt_init_handler: Starting initiator with mac_addr = %08x%04x  init_idx = %d init_ctxt_usage_flags = 0x%x pmac: %p mac_id: %d vdev: %p rate_info: 0x%x 
+7202,,[ wlan_rtt.c : 4170 ] RTT request on a different vdev than the one set during channel change 
+7203,IIIII,[ wlan_rtt.c : 4678 ] rtt_set_config_param_req_hdl: reqId:%u, type:%u, value_31_to_0:0x%x, value_63_to_32:0x%x, bit_len:%u 
+7204,iiii,[ wlan_rtt.c : 4963 ] RTT_UNIT_TEST_CMD 1  num_args = %d arg0(CMD) = %d vdev_id = %d mac_id = %d 
+7205,,[ wlan_rtt.c : 5033 ] MAC address not configured 
+7206,,[ wlan_rtt.c : 5044 ] Channel not configured 
+7207,iiiiiiii,[ wlan_rtt.c : 5126 ] RTT_UNIT_TEST_CMD numFrms=%d ChnlFrmt=%d frmType=%d reportType=%d burstDr= %d asap_mode= %d, burst_exp:%d, force_leg_ack:%d 
+7208,iiiiiIIIi,[ wlan_rtt.c : 5151 ] RTT_11AZ_UNIT_TEST_CMD TMR_subtype=%d format_bw(ChnlFrmt)=%d numFrms(num_meas)=%d reportType=%d sec_mode= %d min_time_bw_meas:%u max_time_bw_meas:%u i2r_fdbk_policy:%u, tb_ranging_priority:%d 
+7209,iii,[ wlan_rtt.c : 5156 ] RTT_11AZ_UNIT_TEST_CMD tb_ranging_period:%d tb_ranging_duration:%d, tb_max_session_expiry:%d 
+7210,IIIIIII,[ wlan_rtt.c : 5449 ] RTT_11AZ_FORCE_PEER_CREATE_INSTALL_KEY peer mac addressmac_addr[0] = %x, mac_addr[1] = %x, mac_addr[2] = %x, mac_addr[3] = %x, mac_addr[4] = %x, mac_addr[5] = %x, peer = %p 
+7211,IIII,[ wlan_rtt.c : 5547 ] UT_ISTA_AW: count:%u, D2:%08x D1:%08x D0:%08x 
+7212,,[ wlan_rtt.c : 5661 ] WLAN_RTT_FORCE_LTF_KEY 
+7213,,[ wlan_rtt.c : 5685 ] WLAN_RTT_FORCE_LTF_IV 
+7214,iii,[ wlan_rtt.c : 5794 ] wlan_oem_rtt_measreq_hdl: client %d running. cannot new req from client: %d. So Dropping req_id: %d 
+7215,i,[ wlan_rtt.c : 5820 ] wlan_oem_rtt_measreq_hdl: Request with id %d won't be served because of an error 
+7216,i,[ wlan_rtt.c : 5831 ] wlan_oem_rtt_measreq_hdl: asm_req  status %d would be served from call back due to NACK 
+7217,iii,[ wlan_rtt.c : 6405 ] wlan_rtt_check_iftmr_ie: ERR: IE len (%d), len(%d), subelemId:%d 
+7218,i,[ wlan_rtt.c : 6413 ] wlan_rtt_check_iftmr_ie: ERR: ranging param ie_len (%d) does not match subelem payload 
+7219,i,[ wlan_rtt.c : 6425 ] wlan_rtt_check_iftmr_ie: ERR: 11mc and 11az both IEs present together, sub_elemId:%d 
+7220,ii,[ wlan_rtt.c : 6434 ] wlan_rtt_check_iftmr_ie: received invalid FTMR frame ie_len %d len %d 
+7221,i,[ wlan_rtt.c : 6485 ] VENDOR IE sub_type = %d 
+7222,II,[ wlan_rtt.c : 6502 ] wlan_rtt_get_ie: received invalid frame, ie_len=%u, len=%u 
+7223,,[ wlan_rtt.c : 7080 ] RTT_RESP_CTXT_EXIST 
+7224,,[ wlan_rtt.c : 7111 ] RTT_RESP_REQ_ACCEPT 
+7225,,[ wlan_rtt.c : 7121 ] RTT_RESP_BUSY 
+7226,III,[ wlan_rtt.c : 7267 ] VENDOR IE :tx chain = 0x%x, rx chain = 0x%x, chain_iter = 0x%x 
+7227,i,[ wlan_rtt.c : 8316 ] wlan_rtt_enable: pm_arb_req create instance failed for index:%d 
+7228,iIiiiIi,[ wlan_rtt.c : 8736 ] wlan_rtt_send_measurement_report_hdl: client_id: %d curr_init_ctxt: 0x%08x token_id:%d frag_idx:%d more_frag: %d buf:0x%08x buf_len:%d 
+7229,iiiI,[ wlan_rtt.c : 8826 ] wlan_rtt_resp_chan_switch_hdl()  ev_id = %d ftm_state:%d is_ftmr_pending:%d, ts_ms = %u 
+7230,iI,[ wlan_rtt.c : 9055 ] RTT_CHANNEL_SWITCH_GRANT  ev_id = %d p_pdev_rtt_ctxt = %p  
+7231,iIIIiiI,[ wlan_rtt.c : 9067 ] RTT_CHANNEL_SWITCH_GRANT  ev_id = %d p_pdev_rtt_ctxt = 0x%x p_owner = 0x%x p_rtt_ctxt = 0x%x, index:%d, req_id:%d, ts_ms = %u 
+7232,,[ wlan_rtt.c : 9071 ] RTT_CHANNEL_SWITCH_GRANT  NULL values, return  
+7233,I,[ wlan_rtt.c : 9328 ] WHAL_CHANNEL_RTT_HIGHER_BW - chan ext_flags:0x%x 
+7234,iiiiIIi,[ wlan_rtt.c : 9351 ] RTT_CHANNEL_SWITCH_REQ  module_id %d duration = %d channel = %d priority = %d, fn:%p, start_tsf:0x%x, flags:%d 
+7235,iiiIIiI,[ wlan_rtt.c : 9355 ] RTT_CHANNEL_SWITCH_REQ  strict_start:%d, strict_end:%d, dtim_period:%d, dtim_start_tsf:0x%x, end_time_us:0x%x, interval:%d ts_ms:%u 
+7236,iiiIIii,[ wlan_rtt.c : 9466 ] wlan_rtt_local_send()status: %d pmac_mac_id: %d vdev_mac_id: %d selfgen_chm: 0x%x abf: 0x%08x peer_type: %d vdev_id: %d 
+7237,,[ wlan_rtt.c : 11111 ] rtt_tmr_rx_hdl() vdev not found 
+7238,,[ wlan_rtt.c : 11117 ] rtt_tmr_rx_hdl() wal_vdev not found 
+7239,,[ wlan_rtt.c : 11135 ] rtt_tmr_rx_hdl() rtt_resp not supported 
+7240,,[ wlan_rtt.c : 11182 ] RTT_ERROR_REPORT :RTT_GET_INVALID_TMR_STOP 
+7241,,[ wlan_rtt.c : 11202 ] RTT_ERROR_REPORT :RTT_GET_INVALID_TMR_STOP 
+7242,iIII,[ wlan_rtt.c : 12003 ] nan_ranging_terminate_completion_handler: req_id: %d init_ctxt: 0x%08x wait_status: %x nan_active %x 
+7243,i,[ wlan_rtt.c : 12038 ] nan_ranging_terminate_completion_handler for req_id: %d is not processed !!! 
+7244,iIiii,[ wlan_rtt.c : 12165 ] wlan_rtt_ranging_negotiation_status_notif_handler: ReqId %d init_ctxt 0x%08x wait_status_notif %d frame_type_hdlr %d event_handled %d 
+7245,,[ wlan_rtt.c : 12268 ] Event buffer allocation for send_responder_cfg_info response failed 
+7246,iii,[ wlan_rtt.c : 12575 ] wlan_rtt_sta_resp_chan_switch: channel.mhz: %d band_center_freq1: %d phy_mode: %d 
+7247,,[ wlan_rtt.c : 12613 ] wlan_internal_disable_responder 
+7248,II,[ wlan_rtt.c : 12690 ] wlan_rtt_get_clear_stats ranging_dur: %x resp_dur: %x  
+7249,iI,[ wlan_rtt.c : 12727 ] wlan_rtt_cancel_all_rtt_operation attached to vdev_id: %d p_pdev_rtt_ctxt: 0x%08x 
+7250,iIIi,[ wlan_rtt.c : 12848 ] wlan_rtt_terminate_all_ftm_resp_context() idx: %d resp_ctxt = 0x%08x vdev = 0x%08x ftm_state = %d 
+7251,IiI,[ wlan_rtt.c : 12919 ] wlan_rtt_nan_burst_start_notif_handler init_ctxt %p burst_start %d curr_time 0x%x 
+7252,iii,[ wlan_rtt.c : 13119 ] wlan_rtt_get_ranging_params_ie: cat:%d, act:%d fixed header len:%d 
+7253,iii,[ wlan_rtt.c : 13256 ] wlan_rtt_action_frame_rx_handler: ia_category:%d, ia_action:%d, rxbuf->totalLen:%d 
+7254,,[ wlan_rtt.c : 13273 ] wlan_rtt_action_frame_rx_handler: Ranging param IE not found 
+7255,iiiiiI,[ wlan_rtt.c : 13298 ] wlan_rtt_action_frame_rx_handler: is_secure_frm:%d, iv_len:%d, is_11mc:%d, is_11az:%d, num_tlvs:%d, tlv_head:%p 
+7256,,[ wlan_rtt.c : 13303 ] wlan_rtt_action_frame_rx_handler: ERR: invalid frame type 
+7257,iiii,[ wlan_rtt.c : 13396 ] wlan_rtt_resp_chain_iter: CHAIN_IDX_ITER_EN : tx_ch_max:%d, resp_tmp_iter: %d,resp_tx_chain_idx:%d,resp_iter:%d 
+7258,i,[ wlan_rtt.c : 13421 ] wlan_rtt_resp_chain_iter: CHAIN_IDX_FIXED : %d 
+7259,,[ wlan_rtt.c : 13427 ] wlan_rtt_resp_chain_iter: CHAIN_IDX_ITER_DISABLE  
+7260,IIII,[ wlan_rtt.c : 331 ] wlan_rtt_page_log_reentrancy: %c%c caller 0x%08x entry_count %4d 
+7261,iIIi,[ wlan_rtt.c : 1330 ] wlan_rtt_terminate_all_ftm_resp_context() idx: %d resp_ctxt = 0x%08x vdev = 0x%08x ftm_state = %d 
+7262,I,[ wlan_rtt.c : 2105 ] wlan_rtt_free_init_ctxt() usage flags = 0x%x  
+7263,Iii,[ wlan_rtt.c : 4305 ] wlan_rtt_init_handler_pt2: curr_init_ctxt:%p, frame_type:%d, tmr_subtype:%d 
+7264,IIIi,[ wlan_rtt.c : 9531 ] wlan_rtt_send_null_frame: abf: 0x%08x channel: %x pmac = 0x%08x spoofed_seqno = %d 
+7265,Ii,[ wlan_rtt.c : 9549 ] RTT NULL frame Tx failed: abf: 0x%08x ret: %d 
+7266,iiii,[ wlan_rtt.c : 10443 ] RTT Null frame Tx status: %d tx_fail_count: %d num_meas: %d terminate: %d 
+7267,iii,[ wlan_rtt.c : 10462 ] Null frame ack handler: tx_fail_count: %d, num_meas:%d, Tx fail thresold:%d 
+7268,iIii,[ wlan_rtt.c : 8685 ] wlan_rtt_measurement_report: client_id: %d curr_init_ctxt:0x%08x size: %d freq: %d 
+7269,,[ wlan_rtt.c : 10352 ] wlan_rtt_tmr_handler 
+7270,Iiii,[ wlan_rtt.c : 10293 ] wlan_rtt_tmr_post_ch_switch_handler: init_ctxt:%p, req_id:%d, frame_type:%d, tmr_subtype:%d 
+7271,,[ wlan_rtt.c : 10305 ] wlan_rtt_tmr_post_ch_switch_handler: call wal_rtt_ctxt_init 
+7272,,[ wlan_rtt.c : 799 ] Event buffer allocation for cancel measurement response failed 
+7273,iiii,[ wlan_rtt.c : 3388 ] RTT_MEAS_REQ_HEAD  req_id = %d num_chan = %d sps = %d client: %d 
+7274,iiiiiiiI,[ wlan_rtt.c : 3254 ] RTT_MEAS_REQ_HEAD ch_mhz = %d, center_freq1 = %d ch_mode = %d sta_num:%d, max_reg_power: %d antenna_max: %d, max_tx_power: %d, ch_flags: 0x%04x 
+7275,II,[ wlan_rtt.c : 3185 ] CHAIN IDX INFO init=0x%x,resp=0x%x 
+7276,iIIIIIIII,[ wlan_rtt.c : 3194 ] RTT_MEAS_REQ_BODY:1 idx = %d dest_mac_0to31 = 0x%x dest_mac_32to47 = 0x%x sppof_bssid_0to31 = 0x%x spoof_bssid_32to47 = 0x%x control_flag = 0x%x meas_inf = 0x%x meas_params1 = 0x%x meas_params2 = 0x%x 
+7277,iiii,[ wlan_rtt.c : 3202 ] RTT_MEAS_REQ_BODY:2 MinTBMeas:%d, MaxTBMeas:%d, tb_period:%d, tb_duration:%d 
+7278,,[ wlan_rtt.c : 2853 ] TBR request dropped due to license check 
+7279,,[ wlan_rtt.c : 3083 ] discarding the request in case of AP initiatorif peer is not created or key is not installed 
+7280,iiiiii,[ wlan_rtt.c : 3116 ] wlan_rtt_process_wmi_measreq_peer_info:init iter = %d,tx = %d,rx = %d, resp iter = %d,tx = %d,rx =%d 
+7281,II,[ wlan_rtt.c : 8117 ] Init PTSF fired resp_tsf_h = 0x%x resp_tsf_l = 0x%x 
+7282,IIiiiii,[ wlan_rtt.c : 7985 ] wlan_rtt_ftm_init_burst_periodic_timeout: dest_mac:%x%x is_multiburst(%d) is_repetitive_ss(%d) current_burst:%d total_bursts:%d curr_state: %d 
+7283,iII,[ wlan_rtt.c : 8027 ] wlan_rtt_ftm_init_burst_periodic_timeout channel req not granted, skip burst %d for dest_mac:%x%x!!  
+7284,iII,[ wlan_rtt.c : 8085 ] wlan_rtt_ftm_init_burst_periodic_timeout: ERR: Some other request is in progress; skip current burst %d for dest_mac:%x%x 
+7285,,[ wlan_rtt.c : 3683 ] RTT_CALL_FLOW: WLAN_RTT_DFS_TIMEOUT_HANDLER 
+7286,iiIIII,[ wlan_rtt.c : 667 ] wlan_rtt_init_set_self_sta_address vdev_type %d random %d self_sta_macaddr:%08x%04x vdev_myaddr:%08x%04x 
+7287,i,[ wlan_rtt.c : 4726 ] _wlan_wmi_oem_req: Non TLV format msg received; tlv_head: %d 
+7288,iiii,[ wlan_rtt.c : 4743 ] wlan_wmi_oem_req: INFO: OEM Req received with sub_type:%d, req_id:%d client: %d, pdev_id: %d 
+7289,iiiiii,[ wlan_rtt.c : 4388 ] wlan_rtt_cap_msg_req_hdl: client_id: %d Req:%d Reqid:%d Major:%d Minor:%d Revision:%d 
+7290,,[ wlan_rtt.c : 4403 ] Event buffer allocation for wlan_rtt_cap_msg_req response failed 
+7291,,[ wlan_rtt.c : 4479 ] capability_req_hdl:Capability event sent to host 
+7292,iiiiiiii,[ wlan_rtt.c : 6118 ] wlan_rtt_burst_instance_done: num_burst_done:%d total_bursts:%d curr_state:%d burst_duration:%d, index:%d ftm1_done:%d num_meas:%d ftm_per_burst:%d 
+7293,,[ wlan_rtt.c : 6227 ] Wait for NAN module to finish sending NAN ranging termination frame 
+7294,,[ wlan_rtt.c : 6243 ] CHAIN_IDX_ZEROED 
+7295,iiI,[ wlan_rtt.c : 7880 ] wlan_rtt_resp_ftm1_timeout: ftm_state: %d asap: %d resp_ctxt: 0x%08x 
+7296,iii,[ wlan_rtt.c : 7953 ] wlan_rtt_ftm_resp_burst_timeout: ftm_state: %d num_burst_exp: %d no_burst_count: %d 
+7297,ii,[ wlan_rtt.c : 11942 ] wlan_rtt_resp_house_keeping: channel_mhz: %d nearest_sched_resp_tsf_ctxt_index: %d 
+7298,iiiii,[ wlan_rtt.c : 8252 ] wlan_rtt_resp_chan_switch (req_higher_bw): chan.dump: mhz: %d band_center_freq1: %dband_center_freq2: %d max_reg_power:%d max_tx_power:%d 
+7299,IIiII,[ wlan_rtt.c : 8258 ] wlan_rtt_resp_chan_switch (req_higher_bw): phy_mode: %u flags:0x%X antenna_max:%dpuncture_bitmap:0x%X ext_flags:0x%X 
+7300,I,[ wlan_rtt.c : 6640 ] wlan_rtt_get_band_center_freq: Invalid band/bandwidth combination - chan.mhz: %u, bw: VHT40 
+7301,I,[ wlan_rtt.c : 6649 ] wlan_rtt_get_band_center_freq: Invalid band/bandwidth combination - chan.mhz: %u, bw: VHT80 
+7302,I,[ wlan_rtt.c : 6658 ] wlan_rtt_get_band_center_freq: Invalid band/bandwidth combination - chan.mhz: %u, bw: VHT160 
+7303,Ii,[ wlan_rtt.c : 6666 ] wlan_rtt_get_band_center_freq: chan.mhz: %u, chan.center_freq: %d 
+7304,I,[ wlan_rtt.c : 8177 ] wlan_rtt_ftm_delta_timeout() Ignore ctxt freed %p 
+7305,II,[ wlan_rtt.c : 2463 ] wlan_rtt_init_scheduler => curr_init:0x%x init_ctxt_usage_flags:0x%x 
+7306,i,[ wlan_rtt.c : 2398 ] wlan_rtt_init_scheduler: Skipping initiator with index %d as it may creep into next multiburst start time 
+7307,iiii,[ wlan_rtt.c : 2415 ] wlan_rtt_init_scheduler => index:%d curr_index:%d schedule_timeout:%d next_mb_slot_index: %d 
+7308,iiiI,[ wlan_rtt.c : 8547 ] RTT_ERROR_WMI_EVENT: ERROR: client_id: %d req_id:%d reason:%d init_ctxt: 0x%08x 
+7309,,[ wlan_rtt.c : 8590 ] Event buffer allocation for send_rtt_error_report failed 
+7310,IIIi,[ wlan_rtt.c : 8807 ] Channel Granted(Responder): Responder operating freq = 0x%x pmac = 0x%08x Granted on freq: 0x%x phymode: %d 
+7311,ii,[ wlan_rtt.c : 8919 ] pm arbibtration mac id(%d) not same as channel granted pmac mac id(%d) 
+7312,iii,[ wlan_rtt.c : 8930 ] vdev mac id(%d) not same as pmac mac id(%d): change PM lock & set mac address: %d 
+7313,iiiiI,[ wlan_rtt.c : 8953 ] Channel Granted(Initiator): RTT requested freq: %d phymode: %d Grant came on freq: %d phymode: %d chan_flags: 0x%04x 
+7314,iIIi,[ wlan_rtt.c : 9013 ] Downgraded the BW: New bw: %d chnl_format: %u rate_info: %u, tmr_subtype:%d 
+7315,II,[ wlan_rtt.c : 9846 ] Sending RTT Trigger frame resp_tsf_h = 0x%x resp_tsf_l = 0x%x 
+7316,,[ wlan_rtt.c : 9878 ] RTT_ERROR_REPORT :ALLOCATE_FRAME_BUFFER_ERROR 
+7317,IIi,[ wlan_rtt.c : 9907 ] wlan_rtt_send_tmr_frame: channel: %x pmac = 0x%08x spoofed_seqno = %d 
+7318,,[ wlan_rtt.c : 9949 ] RTT_TIMER_STOP 
+7319,iiI,[ wlan_rtt.c : 10514 ] RTT TMR frame Tx status: %d curr_state: %d ftmr_tx_ts: %u 
+7320,IIIII,[ wlan_rtt.c : 6532 ] RTT_FTM_PARAM_INFO  arg1 = 0x%x arg2 = 0x%x arg3 = 0x%x arg4 = 0x%x arg5 = 0x%x 
+7321,I,[ wlan_rtt.c : 9679 ] RTT_CALL_FLOW: WLAN_RTT_SET_VENDOR_IE_HT_VHT_ACK ts = %u 
+7322,III,[ wlan_rtt.c : 9705 ] RTT_CALL_FLOW: WLAN_RTT_SET_VENDOR_IE_FOR_CHAIN_INFO resp tx_chain = 0x%x,rx_chain = 0x%x,iter 0x%x 
+7323,ii,[ wlan_rtt.c : 7696 ] wlan_rtt_resp_init:current session is active: session_index: %d slot: %d 
+7324,ii,[ wlan_rtt.c : 7711 ] wlan_rtt_resp_init: Received a frame which we are not in slot send FTM stop frame. session_index: %d slot: %d 
+7325,,[ wlan_rtt.c : 7725 ] wlan_rtt_resp_init NAN channel req not active !! 
+7326,,[ wlan_rtt.c : 7748 ] Duplicate FTM frame received, drop!! 
+7327,iiii,[ wlan_rtt.c : 6825 ] wlan_rtt_resp_init_rate: req_higher_bw: %d orig.tx_bw: %d chan.bw: %d PTSF no pref:%d 
+7328,iiiiiiii,[ wlan_rtt.c : 6855 ] wlan_rtt_resp_init_rate: vdev_id: %d phy_mode: %d mhz: %d ftm_chnl_format: %d param_ie_valid: %d tx_bw: %d tx_preamble: %d mcs: %d 
+7329,II,[ wlan_rtt.c : 6858 ] wlan_rtt_resp_init_rate: rate_info:%u ftm_param:0x%x 
+7330,IIIII,[ wlan_rtt.c : 11844 ] Received FTMR resp_tsf_h = 0x%x resp_tsf_l = 0x%x curslot_slot_idx: 0x%x cur_diff: 0x%x resp_ref_tsf: 0x%x 
+7331,III,[ wlan_rtt.c : 11861 ] wlan_rtt_is_burst_in_slot: diff_tesf: %u next_burst_tsf: %u cur_tsf: %u 
+7332,iii,[ wlan_rtt.c : 7556 ] wlan_rtt_resp_init_body: session_active: %d init_new_session: %d ftm_state: %d 
+7333,iii,[ wlan_rtt.c : 7560 ] wlan_rtt_resp_init_body: asap: %d ftm_state: %d session_active: %d 
+7334,iiI,[ wlan_rtt.c : 7596 ] wlan_rtt_resp_init_body:ftm_state: %d asap: %d resp_ctxt: 0x%08x 
+7335,IiII,[ wlan_rtt.c : 7336 ] Registered wlan_rtt_vdev_notify_handler() for resp context vdev: 0x%08x vdev_type: %d pmac: 0x%08x status: 0x%x 
+7336,I,[ wlan_rtt.c : 7361 ] wlan_rtt_resp_init_new_session(req_higher_bw): resp_ftm_sync_ptsf: 0x%x 
+7337,ii,[ wlan_rtt.c : 7506 ] wlan_rtt_resp_init_new_session: slot: %d param_info.status: %d 
+7338,iiI,[ wlan_rtt.c : 7515 ] END_FTM_INVALID_REQUEST: ftm_state: %d asap: %d resp_ctxt: 0x%08x 
+7339,IIIIIIII,[ wlan_rtt.c : 11787 ] wlan_rtt_resp_get_free_slot 0x%x 0x%x 0x%x 0x%x 0x%x 0x%x dest_mac:%08x%02x 
+7340,IIIIII,[ wlan_rtt.c : 6970 ] wlan_rtt_populate_resp_ftm_param: next_sched_tsf: %u resp_ref_tsf: %u partial_tsf: %u diff_tsf: %u current_resp_tsf64: 0x%08x%08x 
+7341,IIIIII,[ wlan_rtt.c : 6999 ] wlan_rtt_populate_resp_ftm_param: next_sched_tsf: %u diff_tsf: %u nearest_tsf: %u resp_partial_tsf: %u next_burst_tsf: 0x%08x%08x 
+7342,,[ wlan_rtt.c : 10013 ] wlan_rtt_send_tm_frame: vdev is seen as NULL in resp_ctxt 
+7343,,[ wlan_rtt.c : 10148 ] RTT_ERROR_REPORT :ALLOCATE_FRAME_BUFFER_ERROR 
+7344,IiIIiiiiI,[ wlan_rtt.c : 10157 ] wlan_rtt_send_tm_frame: abf: 0x%08x freq: %d pmac = 0x%08x resp_ctxt: 0x%08x tkn = %d follow_tkn = %d tx_bw = %d resp_ctxt ftm state = %d chan_flags = 0x%04x 
+7345,i,[ wlan_rtt.c : 10883 ] RTT TM frame Tx status: %d 
+7346,iii,[ wlan_rtt.c : 10765 ] wlan_rtt_tm_ack_handle_completion: ftm_state: %d num_burst_exp: %d no_burst_count: %d 
+7347,IiIII,[ wlan_rtt.c : 10797 ] wlan_rtt_tm_ack_handle_completion: init_ftmr_rx_ts: %10u completion_status: %d ftm_tx_ts: %10u init_ftmr_offset: %6u delta_ftm_act: %6u 
+7348,i,[ wlan_rtt.c : 10830 ] RTT_TWOSIDED_RESP_CNT  number = %d 
+7349,iii,[ wlan_rtt.c : 10850 ] wlan_rtt_tm_ack_success: ftm_state: %d num_burst_exp: %d no_burst_count: %d 
+7350,iii,[ wlan_rtt.c : 10855 ] wlan_rtt_tm_ack_success:Don't continue burst: ftm_state: %d num_burst_exp: %d no_burst_count: %d  
+7351,iii,[ wlan_rtt.c : 1278 ] wlan_rtt_terminate_resp_context() state: %d busrt_exp: %d burst_count: %d 
+7352,,[ wlan_rtt.c : 11519 ] RTT_ERROR_REPORT :RTT_GET_TM_NOTWAIT_TM 
+7353,,[ wlan_rtt.c : 11537 ] RTT_ERROR_REPORT :RTT_GET_TM_NOTWAIT_TM 
+7354,IIiIIII,[ wlan_rtt.c : 11625 ] wlan_rtt_tm_rx_hdl: status: 0x%x RTT_TWOSIDED_RESP_CNT  number = %2d recv_state: %d init_ftmr_tx_ts: %10u ftm_rx_ts: %10u init_ftmr_offset: %6u delta_ftm_act: %6u 
+7355,iIIiIII,[ wlan_rtt.c : 11245 ] state = %d tsf_sync_info = 0x%x resp_tsf = 0x%x Diff: %d ftm_req_start_time = 0x%x ftm_req_complete_time = 0x%x current_tsf = 0x%x 
+7356,II,[ wlan_rtt.c : 11256 ] RTT TM FTM curr_tsf_delta = 0x%x new_tsf_delta = 0x%x 
+7357,,[ wlan_rtt.c : 11444 ] RTT_ERROR_REPORT :TM_TOKEN_MISMATCH 
+7358,,[ wlan_rtt.c : 11447 ] RTT_ERROR_REPORT :TM_CFR_CAPTURE_ERROR 
+7359,,[ wlan_rtt.c : 11449 ] RTT_ERROR_REPORT :TM_SEQUENCE_RESTART 
+7360,IIIII,[ wlan_rtt.c : 11801 ] wlan_rtt_resp_free_existing_slot 0x%x 0x%x 0x%x dest_mac:%08x%02x 
+7361,iiiI,[ wlan_rtt.c : 2774 ] wlan_rtt_init_update_channel: chan-phymode err: tmr_subtype:%d while preamble :%d, phy_mode: %d, mhz:%u 
+7362,iii,[ wlan_rtt.c : 2786 ] WHAL_CHANNEL_RTT_HIGHER_BW - initiator req_higher_bw set:%d chan_bw-%d init_ctxt->tx_bw-%d 
+7363,ii,[ wlan_rtt.c : 2790 ] WHAL_CHANNEL_RTT_HIGHER_BW - initiator req_higher_bw reset: chan_bw-%d init_ctxt->tx_bw - %d 
+7364,iiiI,[ wlan_rtt.c : 2804 ] wlan_rtt_init_update_channel ERR: tmr_subtype:%d while preamble :%d, phy_mode: %d, mhz:%u 
+7365,iiiIiii,[ wlan_rtt.c : 2824 ] wlan_rtt_init_update_channel mhz=%d bw=%d preamble=%d rate_info=0x%x chnl_format=%d tmr_subtype:%d, error_code=%d 
+7366,Iii,[ wlan_rtt.c : 12933 ] wlan_rtt_nan_init_scheduler: init_ctxt_usage_flag 0x%x num_nan_req %d discovery_termination_pending %d 
+7367,iIIII,[ wlan_rtt_11az_api.c : 103 ] wlan_rtt_11az_validate_pn: status:%d, new_pn:0x%x%08x, old_pn:0x%x%08x 
+7368,iIiiii,[ wlan_rtt_11az_api.c : 129 ] wlan_rtt_11az_check_security_config: is_protected: %d, wal_peer:%p, URNM_MFPR:%d, mfpc:%d, mfpr:%d, is_decrypterr:%d 
+7369,,[ wlan_rtt_11az_api.c : 147 ] wlan_rtt_11az_check_security_config: ERR: null wlan_peer or wlan_vdev 
+7370,iIIii,[ wlan_rtt_11az_api.c : 156 ] wlan_rtt_11az_check_security_config: assoc_id:%d, wlan_peer:%p, bss_peer:%p, is_authmode_wpa3_plus:%d, ut_cfg_wpa3:%d 
+7371,,[ wlan_rtt_11az_api.c : 244 ] sec_ltf_key_seed_len is 0 
+7372,IiIIIiIII,[ wlan_rtt_11az_api.c : 287 ] wlan_rtt_11az_get_ista_rsta_tlf_keys: wlan_peer:%p, aid:%d, sec_tlf_cnt:0x%x%x, sac:0x%x ista_rsta_ltf_key_len = %d ista_rsta_ltf_key_buff[0] = %x ista_rsta_ltf_key_buff[1] = %x ltf_key_seed_len = %lu 
+7373,iI,[ wlan_rtt_11az_api.c : 290 ] ista_rsta_ltf_key_buff[%d]:0x%x 
+7374,,[ wlan_rtt_11az_api.c : 325 ] wlan_rtt_11az_rx_handler: NULL peer received, deriving peer 
+7375,III,[ wlan_rtt_11az_api.c : 331 ] wlan_rtt_11az_rx_handler: i_addr2:%08x%04x derived peer:%p 
+7376,,[ wlan_rtt_11az_api.c : 340 ] wlan_rtt_11az_rx_handler: Err: vdev for un-associated case is NULL 
+7377,,[ wlan_rtt_11az_api.c : 363 ] wlan_rtt_11az_rx_handler: received secured frame while peer is NULL 
+7378,iiii,[ wlan_rtt_11az_api.c : 409 ] wlan_rtt_11az_rx_handler: action category:%d, rtt_frame_type:%d is_wep:%d, iv_len:%d 
+7379,ii,[ wlan_rtt_11az_api.c : 419 ] wlan_rtt_11az_rx_handler: ERR: incompatible request: is_wep:%d, is_protected_ftm: %d 
+7380,,[ wlan_rtt_11az_api.c : 427 ] wlan_rtt_11az_rx_handler: Err: security config validation failed 
+7381,IIIIII,[ wlan_rtt_11az_api.c : 543 ] log_ranging_param: status:%u, value:%u, i2r_lmr_feedback:%u, ranging_priority:%u, r2i_toa_type:%u, i2r_toa_type:%u 
+7382,IIIIIII,[ wlan_rtt_11az_api.c : 553 ] log_ranging_param: format_and_bw:%u, imdt_r2i_feedback:%u, imdt_i2r_feedback:%u, max_i2r_repetition:%u, max_r2i_repetition:%u, max_r2i_sts_le_80mhz:%u, max_r2i_sts_gr_80mhz:%u  
+7383,IIIII,[ wlan_rtt_11az_api.c : 561 ] log_ranging_param: max_r2i_ltf_total:%u, max_i2r_ltf_total:%u, max_i2r_sts_le_80mhz:%u, max_i2r_sts_gr_80mhz:%u, bss_color:%u 
+7384,IIIIII,[ wlan_rtt_11az_api.c : 574 ] log_ntb_subElem: sub_elem_id:%u, sub_elem_len:%u, min_time_betwn_meas:%u, max_time_betwn_meas:%u, r2i_tx_power:%u, i2r_tx_power:%u 
+7385,IIIIIIIII,[ wlan_rtt_11az_api.c : 590 ] log_tb_subElem: sub_elem_id:%u, sub_elem_len:%u, aid_rsid:%u, device_class:%u, full_bw_ul_mumimo:%u, tf_mac_pad_dur:%u max_session_exp:%u, passive_tb_ranging:%u, reserved:%u 
+7386,IIIII,[ wlan_rtt_11az_api.c : 599 ] rSTA_avail_win_Elem: elem_id:%u, elem_len:%u, elem_id_extn:%u, count:%u, avail_win_bcat_fmt:%u 
+7387,IIIII,[ wlan_rtt_11az_api.c : 614 ] rSTA_avail_win_Inf: partial_tsf:%u, duration:%u, reserved:%u, periodicity:%u, passive_tb_range_params:0x%x 
+7388,IIII,[ wlan_rtt_11az_api.c : 622 ] iSTA_avail_win_Elem: elem_id:%u, elem_len:%u, elem_id_extn:%u, count:%u,  
+7389,iI,[ wlan_rtt_11az_api.c : 626 ] iSTA_avail_win_Elem: bmap[%d]:0x%02x 
+7390,IIiIII,[ wlan_rtt_11az_api.c : 642 ] log_sec_ltf_subElem: sec_ltf_elem_id:%u, elem_len:%u,  secure_ltf_req:%d, r2i_tx_window:%u, i2r_tx_window:%u, rsvd:%u 
+7391,,[ wlan_rtt_11az_api.c : 651 ] log_sec_ltf_IE:  NULL sec_ltf_ie 
+7392,IIiIIII,[ wlan_rtt_11az_api.c : 663 ] log_sec_ltf_IE: sec_ltf_elem_id:%u, elem_len:%u, elem_id_extn:%d, secure_ltf_counter:%u, validation_sac:0x%x, measurement_sac:0x%x, mgmt_result_ltf_offset:%u 
+7393,IIIIIII,[ wlan_rtt_11az_api.c : 684 ] LMR: category:%x, action:0x%x, a1:%08x%04x, a2:%08x%04x, dia_token:0x%x 
+7394,IIIIII,[ wlan_rtt_11az_api.c : 692 ] LMR: TOD:0x%04x%08x, TOA:0x%04x%08x, TODerr:0x%x, TOAerr:0x%x 
+7395,IIII,[ wlan_rtt_11az_api.c : 696 ] LMR: cfo_paramater:0x%x, r2i_ndp_tx_power:0x%x, r2i_ndp_target_rssi:0x%x, lmr_invalid_meas:%u 
+7396,iI,[ wlan_rtt_11az_api.c : 714 ] NDPA_STAINFO_%d: 0x%08x 
+7397,iIIIIiII,[ wlan_rtt_11az_api.c : 742 ] LOG_NDPA: is_Ranging:%d, ra:%08x%04x, ta:%08x%04x, dia_token:%d buff_len:%u, sta_info_cnt:%u 
+7398,iIIII,[ wlan_rtt_11az_api.c : 765 ] wlan_rtt_11az_log_ranging_trigger subtype:%d, ts_ms:%u trig_cmn_info:0x%08x%08x, ranging_cmn_info:%x 
+7399,IIIII,[ wlan_rtt_11az_api.c : 776 ] wlan_rtt_11az_log_ranging_trigger SECURE_SOUNDING: aid_rsid:%u, i2r_repetition:%u, ss_allocation:0x%x, pwr:%u, sac:0x%x 
+7400,iiiii,[ wlan_rtt_11az_api.c : 891 ] wlan_rtt_get_11az_ftm_chnl_code: returned chnl_format_bw: %d, preamble:%d, bw:%d, phy_mode:%d, is_err:%d  
+7401,iiiii,[ wlan_rtt_11az_api.c : 934 ] wlan_rtt_11az_set_security_config: rtt_rsnxe_URNM_MFPR:%d rtt_rsnxe_URNM_MFPR_X20:%drtt_rsn_cap_MFPC:%d rtt_rsn_cap_MFPR:%d rtt_rsta_extcap_i2r_lmr_fb:%d 
+7402,III,[ wlan_rtt_11az_api.c : 964 ] wlan_rtt_11az_find_sub_elem_in_ranging_parameters_elem: ERR: invalid sub_elem_len=%u for ptr=%p, end_ptr=%p 
+7403,II,[ wlan_rtt_11az_api.c : 985 ] wlan_rtt_11az_init_timer: ERR: Invalid timer:%p or handler:%p 
+7404,I,[ wlan_rtt_11az_api.c : 998 ] wlan_rtt_11az_start_timer: ERR: Invalid timer:%p 
+7405,I,[ wlan_rtt_11az_api.c : 1010 ] wlan_rtt_11az_start_timer: ERR: Invalid timer:%p 
+7406,I,[ wlan_rtt_11az_api.c : 1022 ] wlan_rtt_11az_start_timer: ERR: Invalid timer:%p 
+7407,,[ wlan_rtt_11az_api.c : 1051 ] rtt_11az_process_ntb_sequence_completion: NULL arg 
+7408,iiiiII,[ wlan_rtt_11az_api.c : 1061 ] wlan_rtt_11az_process_sequence_status: ind_type: %d, sw_peer_id:%d, ftype:%d, sch_cmd_status:%d, peer_mac:%08x%04x 
+7409,,[ wlan_rtt_11az_api.c : 1082 ] NTB sequence failed, programme NULL sac (0) for next ranging 
+7410,,[ wlan_rtt_11az_api.c : 1102 ] rtt_11az_process_ntb_sequence_completion: SEQ SUCCESS, wait for LMR 
+7411,I,[ wlan_rtt_11az_api.c : 1187 ] RTT: 11az: Unknown control frame subtype:0x%x received 
+7412,II,[ wlan_rtt_11az_api.c : 1248 ] rtt_11az_alloc_vreg_index: allocated vreg_index:%u, used_vreg_index_bmap:0x%x 
+7413,Ii,[ wlan_rtt_11az_api.c : 1260 ] wlan_rtt_11az_vreg_index: vreg_index:%u rtt_ctx_id:%d 
+7414,,[ wlan_rtt_11az_api.c : 1449 ] wlan_rtt_11az_check_ranging_param_sub_ie_len: ERR: TB subelem has invalid format 
+7415,Ii,[ wlan_rtt_11az_ista.c : 52 ] wlan_rtt_11az_free_init_ctxt() usage flags = 0x%x, index:%d 
+7416,II,[ wlan_rtt_11az_ista.c : 101 ] wlan_rtt_11az_free_init_ctxt() deleted temp ranging peer: %p, bss_peer:%p 
+7417,Ii,[ wlan_rtt_11az_ista.c : 139 ] 11az_ranging_instance_done: init_context is freed, init_ctxt:%p, index:%d 
+7418,,[ wlan_rtt_11az_ista.c : 152 ] 11az_ranging_instance_done: NTB sequence still in progress !! Wait 
+7419,ii,[ wlan_rtt_11az_ista.c : 173 ] 11az_ranging_instance_done: ERR: legacy ranging type:%d, subtype:%d, Check.. 
+7420,iiiIIi,[ wlan_rtt_11az_ista.c : 183 ] wlan_rtt_11az_ranging_instance_done: curr_state:%d index:%d num_meas:%d, dest_mac:%08x%04x, report_buffer_initialized:%d 
+7421,,[ wlan_rtt_11az_ista.c : 226 ] wlan_rtt_11az_ranging_instance_done: invoke wal_report_type2_buffer_update_loop_info 
+7422,,[ wlan_rtt_11az_ista.c : 256 ] wlan_rtt_11az_ranging_instance_done: invoke wal_rtt_ctxt_clean 
+7423,IIiii,[ wlan_rtt_11az_ista.c : 279 ] peer addr:%08x%04x not found on vdevid:%d with opmode:%d, sub_opmode:%d 
+7424,Iiii,[ wlan_rtt_11az_ista.c : 287 ] pdev level search: peer: %p found on vdev_id:%d with opmode:%d, sub_opmode:%d 
+7425,ii,[ wlan_rtt_11az_ista.c : 307 ] wlan_rtt_update_11az_init_contex: ERR: tb_period:%d > max supported:%d 
+7426,I,[ wlan_rtt_11az_ista.c : 418 ] wlan_rtt_update_11az_init_contex: allocated peer for rSTA: 0x%p 
+7427,,[ wlan_rtt_11az_ista.c : 422 ] wlan_rtt_update_11az_init_contex: Failed to create peer for rSTA 
+7428,iI,[ wlan_rtt_11az_ista.c : 436 ] wlan_rtt_update_11az_init_contex: peer_type %d ni_flags 0x%x 
+7429,,[ wlan_rtt_11az_ista.c : 509 ] wlan_rtt_11az_tmr_post_ch_switch_handler: ERR: null curr_init 
+7430,,[ wlan_rtt_11az_ista.c : 731 ] wlan_rtt_11az_wait_for_lmr_timeout_hdlr: LMR is not received 
+7431,IIIi,[ wlan_rtt_11az_ista.c : 754 ] wlan_rtt_11az_ftmr_ack_hdl: INFO: frame_ctxt(init_ctxt):%p, tx_comp_desc:%p, abf:%p, completion_status:%d 
+7432,iiIII,[ wlan_rtt_11az_ista.c : 772 ] RTT 11AZ TMR frame Tx cmpln_status:%d, curr_state:%d, ftmr_tx_ts:%u, peer_handle:%p, abf:%p 
+7433,I,[ wlan_rtt_11az_ista.c : 823 ] wlan_rtt_11az_find_ranging_param_ie_in_ftmr: ERR: wal_peer:%p 
+7434,Iii,[ wlan_rtt_11az_ista.c : 889 ] wlan_rtt_send_11az_ftmr: init_ctxt:%p, tmr_subtype:%d, tmr_type:%d 
+7435,iiiii,[ wlan_rtt_11az_ista.c : 944 ] rtt_11az_send_frmr: tb_sub_elem.aw.ista_awe.elem_len:%d, ista_aw_elem_size:%d tb_sub_elem.sub_elem_len:%d, ranging_param_ie.elem_len:%d, tb_ntb_sub_elem_len:%d 
+7436,,[ wlan_rtt_11az_ista.c : 1020 ] wlan_rtt_send_11az_ftmr: get_action_tmr failed 
+7437,iIiI,[ wlan_rtt_11az_ista.c : 1050 ] wlan_rtt_send_11az_ftmr: channel: %d pmac = 0x%08x spoofed_seqno = %d, abf->ranging_params_ie:%p 
+7438,iIII,[ wlan_rtt_11az_ista.c : 1091 ] Sending 11az FTMR frame: trigger:%d, resp_tsf_h:0x%x, resp_tsf_l:0x%x, ftmr_tx_start_time_l:0x%x 
+7439,III,[ wlan_rtt_11az_ista.c : 1180 ] check_and_update_ranging_params: INFO: iSTA i2r_lmr_feedback_policy:%u, rSTA i2r_lmr_feedback_policy:%u, CFG_i2r_lmr_policy:%u 
+7440,II,[ wlan_rtt_11az_ista.c : 1207 ] check_and_update_ranging_params: ERR: init_ctxt->secure_ltf_req:%u, sec_ltf_sub_elem:%p 
+7441,II,[ wlan_rtt_11az_ista.c : 1219 ] check_and_update_ranging_params: ERR: init_ctxt->secure_ltf_req:%u, ie->sec_ltf_sub_elem:%u 
+7442,II,[ wlan_rtt_11az_ista.c : 1230 ] check_and_update_ranging_params: ERR: ie->secure_ltf_req:%u, sec_ltf_ie:%p 
+7443,iii,[ wlan_rtt_11az_ista.c : 1260 ] check_and_update_ranging_params: WARN:  format bw over-writteniSTA requested: %d, rSTA suggested: %d, using new bw:%d 
+7444,iiii,[ wlan_rtt_11az_ista.c : 1272 ] check_and_update_ranging_params: WARN: requested: imdt_r2i_feedback: %d, imdt_i2r_feedback: %d rSTA suggested: imdt_r2i_feedback: %d, imdt_i2r_feedback: %d, ACCEPTING AP ASK... 
+7445,III,[ wlan_rtt_11az_ista.c : 1320 ] check_and_update_ranging_params: avail window len ERR: rsta_elem_len:%u, is_bcast_fmt:%u, cnt:%u 
+7446,III,[ wlan_rtt_11az_ista.c : 1341 ] check_and_update_ranging_params: rSTA awail window parse ERR: elem_id:%u, elem_id_extn:%u, len:%u 
+7447,ii,[ wlan_rtt_11az_ista.c : 1395 ] wlan_rtt_11az_parse_ftm: ERR: ntb/tb subelem not present: ie_len:%d, min_ranging_param_len: %d 
+7448,III,[ wlan_rtt_11az_ista.c : 1418 ] wlan_rtt_11az_parse_ftm: subelem NTB:%p, TB:%p, SECLTF:%p 
+7449,,[ wlan_rtt_11az_ista.c : 1445 ] wlan_rtt_11az_parse_ftm: ERR: Mandatory ranging param IE missing 
+7450,Ii,[ wlan_rtt_11az_ista.c : 1462 ] max_time_bw_meas_timeout_handler: INFO: arg:%p, IS_TB_REQUEST:%d 
+7451,I,[ wlan_rtt_11az_ista.c : 1508 ] 11az_measurement_start_timer_handler: INFO: arg:%p 
+7452,iiiIIII,[ wlan_rtt_11az_ista.c : 1532 ] 11az_measurement_start_timer_handler: ranging triggered status:%d  init_index:%d, tmr_subtype:%d, peer:%p, peer_mac:%04x%08x, dia_tkn:%u 
+7453,I,[ wlan_rtt_11az_ista.c : 1550 ] wlan_rtt_11az_start_ranging: timeout_ms:%u 
+7454,I,[ wlan_rtt_11az_ista.c : 1637 ] 11az_measurement_report_params: ERROR: NULL pdev_rtt_ctxt/pmac: pdev_rtt_ctxt:%p 
+7455,IIIiiii,[ wlan_rtt_11az_ista.c : 1655 ] 11az_measurement_report_params: rtt_11az_param_1:0x%08x, rtt_11az_param_2:0x%08x, rtt_11az_param_3:0x%08x, num_loc_civ_ie:%d, tx_bw:%d, tx_nsts:%d, tx_nrep:%d 
+7456,IIIIIIII,[ wlan_rtt_11az_ista.c : 1698 ] 11az_update_peer_ranging_info:1: i2r_lmr_en:%u, max_bw:%u, tx_sts_le_80:%u, tx_sts_gt_80:%u, tx_nrep:%u, rx_sts_le_80:%u, rx_sts_gt_80:%u, rx_nrep:%u 
+7457,iIIIii,[ wlan_rtt_11az_ista.c : 1705 ] 11az_update_peer_ranging_info:2: sw_peer_id:%d, ltf_offset:%u, target_ndp_rssi_valid:%u, target_ndp_rssi:%u, is_phy_sec:%d, bss_color:%d  
+7458,IIIii,[ wlan_rtt_11az_ista.c : 1762 ] 11az_update_peer_security_info:1: vreg_index:%u, secure_lmr:%u, aid_rsid:%u, is_assoc:%d  imdt_i2r_fb = %d 
+7459,II,[ wlan_rtt_11az_ista.c : 1797 ] 11az_update_peer_ranging_info:SAC mismatch terminating the session sac 0x%x, 11az.validation_sac 0x%x  
+7460,Ii,[ wlan_rtt_11az_ista.c : 1944 ] wlan_rtt_11az_rate_node_update: ni_flags 0x%x, rate_node_bw %d  
+7461,iIIiIII,[ wlan_rtt_11az_ista.c : 1993 ] rtt_11az_tb_handshake_completion state:%d, tsf_sync_info:0x%x, resp_tsf:0x%x, respTsf_TsfSyncInf_diff:%d, ftm_req_start_time:0x%x, ftm_req_complete_time:0x%x, current_tsf:0x%x 
+7462,II,[ wlan_rtt_11az_ista.c : 2012 ] rtt_11az_tb_handshake_completion: curr_tsf_delta:0x%x, new_tsf_delta:0x%x 
+7463,IIIIII,[ wlan_rtt_11az_ista.c : 2051 ] rtt_11az_tb_handshake_completion: resp current_tsf:%u, aw_ptsf:%u, aw_periodicity:%u, dur_from_now_us:%u chan_park_time_us:%u, time to first TF Poll(ms):%u 
+7464,,[ wlan_rtt_11az_ista.c : 2109 ] wlan_rtt_11az_recv_ftmr: ERR: null wlan_peer 
+7465,,[ wlan_rtt_11az_ista.c : 2115 ] wlan_rtt_11az_recv_ftmr: ERR: curr init context is null 
+7466,ii,[ wlan_rtt_11az_ista.c : 2135 ] wlan_rtt_11az_recv_ftmr: ERROR: rxbuf->totalLen:%d, min_frm_len(wh+tm):%d 
+7467,,[ wlan_rtt_11az_ista.c : 2153 ] wlan_rtt_11az_recv_ftm: TM frame not directed to me. Don't process 
+7468,Ii,[ wlan_rtt_11az_ista.c : 2262 ] wlan_rtt_11az_recv_ftm: ******* 11az %cTB negotiation completed successfuly state:%d ******* 
+7469,i,[ wlan_rtt_11az_ista.c : 2270 ] wlan_rtt_11az_recv_ftm: WARN received FTM frame in state: %d 
+7470,i,[ wlan_rtt_11az_ista.c : 2304 ] wlan_rtt_11az_send_meas_report: report_buffer_initialized:%d 
+7471,iI,[ wlan_rtt_11az_ista.c : 2330 ] wlan_rtt_11az_process_ntb_sequence_completion: status:%d, init_ctxt:%p 
+7472,,[ wlan_rtt_11az_ista.c : 2334 ] wlan_rtt_11az_process_ntb_sequence_completion: ERROR: NULL init_ctxt 
+7473,ii,[ wlan_rtt_11az_ista.c : 2342 ] wlan_rtt_11az_process_ntb_sequence_completion: index:%d, meas_cnt:%d 
+7474,iiIIII,[ wlan_rtt_11az_ista.c : 2424 ] wlan_rtt_11az_recv_lmr: rxbuf->totalLen:%d, min_frm_len:%d, wlan_peer:%p, curr_init:%p, init_ctxt:%p, resp_ctxt:%p 
+7475,,[ wlan_rtt_11az_ista.c : 2431 ] wlan_rtt_11az_recv_lmr returning as session is terminated 
+7476,,[ wlan_rtt_11az_ista.c : 2523 ] wlan_rtt_11az_recv_lmr: ERROR: sec_ltf_IE received in non PHY sec mode 
+7477,i,[ wlan_rtt_11az_ista.c : 2616 ] wlan_rtt_11az_pasn_resource_timer_handler curr_state = %d 
+7478,ii,[ wlan_rtt_11az_ista.c : 2672 ] RTT_11AZ_ISTA_REQ_PEER_SEC_PARAMS : num_sta = %d vdev_id = %d 
+7479,,[ wlan_rtt_11az_ista.c : 2688 ] RTT_11AZ_ISTA_REQ_PEER_SEC_PARAMS event alloc failed !! 
+7480,IIIII,[ wlan_rtt_11az_ista.c : 2728 ] RTT_11AZ_ISTA_REQ_PEER_SEC_PARAMS : dest_mac_addr=%08x%04x self_mac_addr=%08x%04x control_flag=0x%x 
+7481,IIiii,[ wlan_rtt_11az_ista.c : 2775 ] wlan_rtt_11az_ista_peer_create dest_mac 0x%x:0x%x curr_state %d chan_mac %d peer_mac %d 
+7482,IIIi,[ wlan_rtt_11az_ista.c : 2835 ] wlan_rtt_11az_ista_peer_update dest_mac 0x%x:0x%x ni_flags 0x%x curr_state %d 
+7483,IIIii,[ wlan_rtt_11az_ista.c : 2879 ] wlan_rtt_11az_ista_peer_set_ltf_keyseed dest_mac 0x%x:0x%x ni_flags 0x%x curr_state %d keyseed_present %d 
+7484,IIii,[ wlan_rtt_11az_ista.c : 2905 ] wlan_rtt_11az_ista_set_peer_authorized dest_mac 0x%x:0x%x curr_state %d authorized %d 
+7485,iii,[ wlan_rtt_11az_ista.c : 2951 ] wlan_rtt_11az_init_scheduler => index:%d curr_index:%d curr_state:%d 
+7486,i,[ wlan_rtt_11az_ista.c : 2992 ] wlan_rtt_11az_process_tsf_sync_info: received frm sub_type:%d 
+7487,iII,[ wlan_rtt_11az_ista.c : 3033 ] wlan_rtt_11az_register_for_bcn_prb_fils: index:%d, frm_src:%08x%04x 
+7488,iII,[ wlan_rtt_11az_ista.c : 3065 ] wlan_rtt_11az_unregister_for_bcn_prb_fils: index:%d, frm_src:%08x%04x 
+7489,,[ wlan_rtt_11az_ista.c : 3090 ] rtt_11az_negotiate_tb_ranging: ERROR: NULL init ctxt 
+7490,IIII,[ wlan_rtt_11az_ista.c : 3098 ] wlan_rtt_11az_negotiate_tb_ranging: ista_tsf:0x%x%08x, rsta_tsf:0x%x%08x 
+7491,iIII,[ wlan_rtt_11az_ista.c : 3142 ] wlan_rtt_11az_probe_req_completion_hdl: ERR: completion_status:%d, frame_ctxt:%p, tx_comp_desc:%p, abf:%p 
+7492,iIiiI,[ wlan_rtt_11az_ista.c : 3148 ] RTT 11AZ PROBE frame Tx cmpln_status:%d, init_ctxt:%p, init_idx:%d, curr_state:%d, peer_handle:%p 
+7493,iI,[ wlan_rtt_11az_ista.c : 3192 ] wlan_rtt_11az_send_probe_request: ret_value:%d, abf:%p 
+7494,II,[ wlan_rtt_11az_ista.c : 3205 ] is_assoc_mode: ERR: wlan_peer:%p, wlan_vdev:%p 
+7495,III,[ wlan_rtt_11az_ista.c : 3278 ] wlan_rtt_11az_ista_get_aligned_aw: curr_ista_tsf:0x%08x, curr_rsta_tsf:0x%08x, aw_start_tsf:0x%08x 
+7496,I,[ wlan_rtt_11az_ista.c : 3286 ] wlan_rtt_11az_ista_get_aligned_aw: Setting BIT at offset:%u 
+7497,I,[ wlan_rtt_11az_ista.c : 3318 ] rtt_11az_find_assoc_mode_ista_aw: no STA vdev present on mac_id:%u 
+7498,IIiII,[ wlan_rtt_11az_ista.c : 3324 ] rtt_11az_find_assoc_mode_ista_aw: vdev:%p, vdev_id:%u, mac_id:%d, assoc_id:%u, vdev->bss:%p 
+7499,IIIIIIII,[ wlan_rtt_11az_ista.c : 3352 ] rtt_11az_find_assoc_mode_ista_aw: sta_tsf:0x%x%08x, tbtt:0x%x%08x, time_to_aw_start:0x%x%08x, aw_start_tsf:0x%x%08x 
+7500,iiiIII,[ wlan_rtt_11az_ista.c : 3459 ] get_ista_availability_window: avail_bmap_len:%d, avail_bmap_end:%d isPaddingERR:%d, aw_bmap:%08x:%08x:%08x 
+7501,iiiiIII,[ wlan_rtt_11az_ista.c : 3475 ] get_ista_availability_window: id:%d, len:%d, extn_id:%d, count:%d, aw_bmap:%08x:%08x:%08x 
+7502,iiiIII,[ wlan_rtt_11az_ista.c : 3528 ] rtt_11az_process_chan_grant_completion: index:%d, req_id:%d, curr_state:%d ctxt:%p, peer_mac:%08x%04x 
+7503,IIII,[ wlan_rtt_11az_ista.c : 3590 ] rtt_11az_process_chan_grant_completion: tb_meas_duration expired. ftmr_tx_complete_time:%u, current_tsf:%u, tb_meas_duration:%u, diff:%u 
+7504,iiii,[ wlan_rtt_11az_ista.c : 3630 ] prepare_tb_ranging_session: index:%d, req_id:%d, state:%d, is_assoc_mode:%d 
+7505,IIi,[ wlan_rtt_11az_ista.c : 3754 ] 11az_process_ranging_ndpa_rx_ista: init_ctxt:%p, wal_peer:%p, init_subtype:%d 
+7506,iiIi,[ wlan_rtt_11az_ista.c : 3793 ] wlan_11az_ista_ptk_done peer %d encr_en %d init_ctxt 0x%x state %d 
+7507,IIi,[ wlan_rtt_11az_rsta.c : 73 ] 11az_unsecure_ranging_peer_alloc: peer mac: %08x%04x, status:%d 
+7508,IIi,[ wlan_rtt_11az_rsta.c : 87 ] 11az_unsecure_ranging_peer_free: peer mac: %08x%04x, status:%d 
+7509,Iiii,[ wlan_rtt_11az_rsta.c : 111 ] rtt_11az_resp_exit_clean: peer:%p, state:%d, tmr_subtype:%d, ftm_stop_aggregated:%d 
+7510,i,[ wlan_rtt_11az_rsta.c : 185 ] wlan_rtt_11az_reply_failure: status:%d 
+7511,I,[ wlan_rtt_11az_rsta.c : 253 ] wlan_rtt_11az_max_time_bw_meas_timeout_handler: INFO: arg:%p 
+7512,IIIIIIII,[ wlan_rtt_11az_rsta.c : 356 ] 11az_update_rsta_peer_ranging_info:1: i2r_lmr_en:%u, max_bw:%u, tx_sts_le_80:%u, tx_sts_gt_80:%u, tx_nrep:%u, rx_sts_le_80:%u, rx_sts_gt_80:%u, rx_nrep:%u 
+7513,iIIIII,[ wlan_rtt_11az_rsta.c : 363 ] 11az_update_rsta_peer_ranging_info:2: sw_peer_id:%d, ltf_offset:%u, target_ndp_rssi_valid:%u, target_ndp_rssi:%u, sec_mode:%u, bss_color:%u 
+7514,IIIii,[ wlan_rtt_11az_rsta.c : 451 ] 11az_update_peer_ranging_info:3: vreg_index:%u, secure_lmr:%u, aid_rsid:%u, is_assoc:%d imdt_r2i_fb = %d 
+7515,IIIII,[ wlan_rtt_11az_rsta.c : 529 ] rtt_11az_resp_init_format_bw: ERR: req bw:%u, utcfg:%u, is_sec:%uURNM_MFPR:%u, URNM_MFPR_X20:%u 
+7516,i,[ wlan_rtt_11az_rsta.c : 542 ] wlan_rtt_11az_resp_init_format_bw: ERR: 11az requested but current operating phymode is non HE %d 
+7517,iiiiiii,[ wlan_rtt_11az_rsta.c : 568 ] wlan_rtt_11az_resp_init_format_bw: requested_format_bw:%d, requested_bw:%d, requested_pream:%d, curr_phy_mode:%d, current_bw:%d, final_bw:%d, final_rtt_bw:%d 
+7518,iiiiii,[ wlan_rtt_11az_rsta.c : 585 ] wlan_rtt_11az_resp_init_format_bw: curr_phy_mode:%d freq:%drequested: format_bw:%d, bw:%d, derived: format_bw:%d, final_bw_rtt:%d 
+7519,IiI,[ wlan_rtt_11az_rsta.c : 611 ] wlan_rtt_11az_resp_init_new_session: Register wlan_rtt_vdev_notify_handler() for resp context vdev: 0x%08x vdev_type: %d pmac: 0x%08x 
+7520,iiI,[ wlan_rtt_11az_rsta.c : 819 ] wlan_rtt_resp_init_11az_new_session: 11AZ HAND-SHAKE-ERR:  status: %d, ftm_state: %d resp_ctxt: 0x%08x 
+7521,II,[ wlan_rtt_11az_rsta.c : 957 ] TBR:get_aw_bmap_for_stage: tbtt_tu:%u, time_of_next_aw_start_tu:%u 
+7522,II,[ wlan_rtt_11az_rsta.c : 961 ] TBR:get_aw_bmap_for_stage: tbtt_tu:%u, time_of_next_aw_start_tu:%u 
+7523,iII,[ wlan_rtt_11az_rsta.c : 968 ] TBR:get_aw_bmap_for_stage: stage:%d, bcn_offset_from_aw_start_tu:%u, bcn_pos_in_aw_10tu_unit:%u 
+7524,iI,[ wlan_rtt_11az_rsta.c : 1020 ] TBR: after applying policy, avail_bmap[%d]:0x%x 
+7525,iii,[ wlan_rtt_11az_rsta.c : 1120 ] TBR: wlan_rtt_11az_process_tb_availability_window: Invalid iSTA AW: id:%d, id_ext:%d, len:%d 
+7526,Iiiii,[ wlan_rtt_11az_rsta.c : 1135 ] TBR: wlan_rtt_11az_process_tb_availability_window: ista_awe:%p, ista_awe->elem_len:%d, ista_aw_bmap_bytes:%d, bi_tu:%d, i_cnt:%d 
+7527,iI,[ wlan_rtt_11az_rsta.c : 1139 ] TBR: ista_awe->avail_bmap[%d]== 0x%x 
+7528,,[ wlan_rtt_11az_rsta.c : 1145 ] TBR: no bits set in iSTA AW 
+7529,iIII,[ wlan_rtt_11az_rsta.c : 1160 ] TBR: after pad reset, ista_awe->avail_bmap[%d]== 0x%x, pad_mask:0x%x, total_set_bits_in_ista_aw:%u 
+7530,I,[ wlan_rtt_11az_rsta.c : 1170 ] process_tb_availability_window: resp_ctxt:%p ERR: alloc RSID failed 
+7531,Iiiiii,[ wlan_rtt_11az_rsta.c : 1208 ] TBR: bss_peer:%p, device_class:%d, full_bw_ul_mumimo:%d, tf_mac_pad_dur:%d, max_session_exp:%d, max_trig_frm_mac_pad_duration:%d 
+7532,IIIIIIII,[ wlan_rtt_11az_rsta.c : 1213 ] TBR: tsf:0x%x%08x, tsf_tu::0x%x%08x, tbtt:0x%x%08x, tbtt_tu:0x%x%08x 
+7533,III,[ wlan_rtt_11az_rsta.c : 1218 ] TBR: i_periodicity:%u, time_already_passed_in_curr_aw:%u, time_of_next_aw_start_tu:%u 
+7534,I,[ wlan_rtt_11az_rsta.c : 1229 ] TBR: time_of_next_aw_start_tu += i_periodicity, NEW time_of_next_aw_start_tu:%u 
+7535,I,[ wlan_rtt_11az_rsta.c : 1243 ] TBR: RSTA derived offset:%u 
+7536,IIIII,[ wlan_rtt_11az_rsta.c : 1296 ] TBR: rawif->partial_tsf:%u, duration:%u, periodicity:%u, resp_tb_param->aid_rsid:%u, time to first TF Poll(ms): %u 
+7537,,[ wlan_rtt_11az_rsta.c : 1529 ] rtt_11az_populate_resp_ftm_param: ERR: LTF Keyseed not installed yet 
+7538,,[ wlan_rtt_11az_rsta.c : 1542 ] rtt_11az_populate_resp_ftm_param: ERR: PhySec with 1 rep not allowed 
+7539,ii,[ wlan_rtt_11az_rsta.c : 1600 ] wlan_rtt_11az_resp_init_body: session_active: %d ftm_state: %d 
+7540,,[ wlan_rtt_11az_rsta.c : 1666 ] wlan_rtt_11az_resp_init: ERR!! Keys not installed 
+7541,,[ wlan_rtt_11az_rsta.c : 1701 ] wlan_rtt_11az_resp_init: ERR: NULL ranging_parameters_ie 
+7542,IIi,[ wlan_rtt_11az_rsta.c : 1766 ] wlan_rtt_11az_tm_ack_hdl: peer_handle:%p, abf:%p, completion_status:%d 
+7543,IIi,[ wlan_rtt_11az_rsta.c : 1817 ] RESP: Populate Resp secure ltf Params LMR val_sac:0x%x, meas_sac:0x%x, secure_ltf_counter %d 
+7544,iiii,[ wlan_rtt_11az_rsta.c : 1972 ] wlan_rtt_11az_rx_handler: tb_sub_elem->sub_elem_id:%d, sub_elem_len:%d, ranging_param_ie.elem_len:%d, tb_sub_elem.sub_elem_len:%d 
+7545,IIiIII,[ wlan_rtt_11az_rsta.c : 1981 ] log_sec_ltf_subElem: sec_ltf_elem_id:%u, elem_len:%u,  secure_ltf_req:%d, r2i_tx_window:%u, i2r_tx_window:%u, rsvd:%u 
+7546,,[ wlan_rtt_11az_rsta.c : 1989 ] wlan_rtt_11az_rx_handler: secure LTF required, Add sec ltf ie 
+7547,,[ wlan_rtt_11az_rsta.c : 2046 ] RTT_ERROR_REPORT :ALLOCATE_FRAME_BUFFER_ERROR 
+7548,iIIiiiiI,[ wlan_rtt_11az_rsta.c : 2060 ] wlan_rtt_11az_send_ftm_frame: FTM buffer alloc failed freq: %d, pmac = 0x%08x resp_ctxt: 0x%08x tkn = %d follow_tkn = %d tx_bw = %d resp_ctxt ftm state = %d chan_flags = 0x%04x 
+7549,IiIIiiiIIi,[ wlan_rtt_11az_rsta.c : 2073 ] wlan_rtt_11az_send_ftm_frame: abf: 0x%08x freq: %d pmac = 0x%08x resp_ctxt: 0x%08x tkn = %d follow_tkn = %d tx_bw = %d resp_ctxt ftm state(2)|no_secure_ltf_sub_elem_in_iftm(2) = 0x%x chan_flags = 0x%04x, no_secure_ltf_sub_elem_in_iftm:%d 
+7550,,[ wlan_rtt_11az_rsta.c : 2098 ] we must have peer created for 11az 
+7551,iIiIIiiI,[ wlan_rtt_11az_rsta.c : 2117 ] wlan_rtt_11az_send_ftm_frame: FTM tx failed with stauts :%d, abf: 0x%08x freq: %d pmac = 0x%08x resp_ctxt: 0x%08x tx_bw = %d resp_ctxt ftm state = %d chan_flags = 0x%04x 
+7552,,[ wlan_rtt_11az_rsta.c : 2151 ] wlan_rtt_11az_recv_ftmr: ERR: NULL ranging_parameters_ie 
+7553,,[ wlan_rtt_11az_rsta.c : 2166 ] TBR ftmr dropped due to license check 
+7554,iii,[ wlan_rtt_11az_rsta.c : 2239 ] wlan_rtt_11az_recv_ftmr: ERROR: rxbuf->totalLen:%d, min_frm_len(wh + tmr):%d, iv_len %d 
+7555,IIIIi,[ wlan_rtt_11az_rsta.c : 2280 ] wlan_rtt_11az_recv_ftmr: A1:%08x%04x, A2:%08x%04x, trigger:%d 
+7556,Iiiii,[ wlan_rtt_11az_rsta.c : 2285 ] wlan_rtt_11az_recv_ftmr: seq_ctrl:0x%x, retry:%d, rx_buf_len:%d, iv_len:%d, ie_len:%d 
+7557,,[ wlan_rtt_11az_rsta.c : 2289 ] wlan_rtt_11az_recv_ftmr: Err: Invalid length 
+7558,,[ wlan_rtt_11az_rsta.c : 2296 ] wlan_rtt_11az_recv_ftmr() vdev not found 
+7559,,[ wlan_rtt_11az_rsta.c : 2304 ] wlan_rtt_11az_recv_ftmr() wal_vdev not found 
+7560,,[ wlan_rtt_11az_rsta.c : 2316 ] wlan_rtt_11az_recv_ftmr() Invalid frame 
+7561,,[ wlan_rtt_11az_rsta.c : 2323 ] wlan_rtt_11az_recv_ftmr() Responder role not supported 
+7562,,[ wlan_rtt_11az_rsta.c : 2333 ] wlan_rtt_11az_recv_ftmr() unable to allocate responder context 
+7563,,[ wlan_rtt_11az_rsta.c : 2404 ] RTT_ERROR_REPORT :RTT_GET_INVALID_TMR_STOP 
+7564,Ii,[ wlan_rtt_11az_rsta.c : 2457 ] rtt_11az_rsta_process_new_ranging: ERR: resp_ctxt:%p, terminate:%d 
+7565,i,[ wlan_rtt_11az_rsta.c : 2509 ] wlan_rtt_11az_rsta_process_new_ranging: ERR: Invalid tmr_subtype:%d 
+7566,II,[ wlan_rtt_11az_rsta.c : 2565 ] wlan_rtt_11az_rsta_peer_create: responder context not found for PASN peer dest_mac: %08x%04x 
+7567,IIi,[ wlan_rtt_11az_rsta.c : 2572 ] wlan_rtt_11az_rsta_peer_create dest_mac 0x%x:0x%x ftm_state %d 
+7568,IIi,[ wlan_rtt_11az_rsta.c : 2635 ] wlan_rtt_11az_rsta_peer_update dest_mac 0x%x:0x%x ftm_state %d 
+7569,IIi,[ wlan_rtt_11az_rsta.c : 2670 ] wlan_rtt_11az_rsta_peer_set_ltf_keyseed dest_mac 0x%x:0x%x ftm_state %d  
+7570,i,[ wlan_rtt_11az_rsta.c : 2737 ] wlan_rtt_11az_rsta_pasn_resource_timer_handler ftm_state = %d 
+7571,Iii,[ wlan_rtt_11az_rsta.c : 2843 ] wlan_rtt_11az_rsta_pasn_auth_m1_handler No vdev found %p opmode = %d subopmode = %d 
+7572,i,[ wlan_rtt_11az_rsta.c : 2856 ] wlan_rtt_11az_rsta_pasn_auth_m1_handler Peer already exist peer_type = %d 
+7573,Ii,[ wlan_rtt_11az_rsta.c : 2866 ] wlan_rtt_11az_rsta_pasn_auth_m1_handler resp_ctxt %p session_active = %d 
+7574,IIi,[ wlan_rtt_11az_rsta.c : 2914 ] 11az_process_ranging_ndpa_rx_rsta: resp_ctxt:%p, wal_peer:%p, rsp_subtype:%d 
+7575,III,[ wlan_rtt_11az_rsta.c : 2986 ] rtt_11az_alloc_rsid: pos:%u, allocated rsid:%u, used_rsid_bmap:0x%x 
+7576,Ii,[ wlan_rtt_11az_rsta.c : 2999 ] wlan_rtt_11az_free_rsid: RSID:%u rtt_ctx_id:%d 
+7577,II,[ wlan_rtt_11az_rsta.c : 3026 ] rtt_11az_aggregate_ftm_stop_with_lmr: ERR: resp:%p peer:%p 
+7578,Ii,[ wlan_rtt_11az_rsta.c : 2694 ] wlan_rtt_11az_get_new_resp_ctxt resp_ctxt = %p session_active = %d 
+7579,II,[ wlan_rtt_11az_rsta.c : 2769 ] RTT_11AZ_RSTA_REQ_PEER_SEC_PARAMS NULL ctxt %p or vdev %p 
+7580,i,[ wlan_rtt_11az_rsta.c : 2779 ] RTT_11AZ_RSTA_REQ_PEER_SEC_PARAMS : memory allocation failed %d 
+7581,iIIIIi,[ wlan_rtt_11az_rsta.c : 2809 ] RTT_11AZ_RSTA_REQ_PEER_SEC_PARAMS : vdev_id=%d, dest_mac_addr=%08x%04x self_mac_addr=%08x%04x control_flag=%d 
+7582,II,[ wlan_rtt_pasn.c : 221 ] wlan_rtt_pasn_delete_session(): NULL pasn_session peer_mac 0x%x:0x%x: 
+7583,i,[ wlan_rtt_pasn.c : 254 ] wlan_rtt_pasn_channel_switch_hdlr()  ev_id = %d 
+7584,i,[ wlan_rtt_pasn.c : 311 ] wlan_rtt_pasn_band_change_req_cb event %d 
+7585,II,[ wlan_rtt_pasn.c : 676 ] wlan_rtt_pasn_deauth_cmd_hdlr PEER not found or delete in progress!! (0x%x:0x%x) 
+7586,IIii,[ wlan_rtt_pasn.c : 691 ] wlan_rtt_pasn_deauth_cmd_hdlr peer_mac 0x%x:0x%x curr_chan %d, pasn_channel %d 
+7587,i,[ wlan_rtt_pasn.c : 779 ] wlan_rtt_auth_frame_rx_handler() PASN auth rx, so allow. auth_transaction_seq_no=%d 
+7588,IIiiIi,[ wlan_rtt_pasn.c : 856 ] wlan_rtt_deauth_frame_rx_handler() rx peer_mac:0x%x:0x%x pasn_state %d is_wep: %d buf %p reason %d 
+7589,i,[ wlan_rtt_pasn.c : 896 ] wlan_rtt_pasn_auth_status_cmd_hdlr num_tlv %d 
+7590,IIIIi,[ wlan_rtt_pasn.c : 906 ] wlan_rtt_pasn_auth_status_cmd_hdlr params_TLV: dest_mac_addr=%08x%04x self_mac_addr=%08x%04x status=%d  
+7591,,[ wlan_rtt_pasn.c : 914 ] wlan_rtt_pasn_auth_status_cmd_hdlr PEER not found 
+7592,i,[ wlan_rtt_pasn.c : 1335 ] wlan_rtt_sa_query_rx_handler Invalid frame framelen %d 
+7593,,[ wlan_rtt_pasn.c : 1353 ] wlan_rtt_sa_query_rx_handler NULL session 
+7594,,[ wlan_rtt_pasn.c : 332 ] wlan_rtt_pasn_abort_chnl_switch ocs_req 
+7595,i,[ wlan_rtt_pasn.c : 355 ] wlan_rtt_pasn_post_channel_switch_handler frame_state %d 
+7596,,[ wlan_rtt_pasn.c : 369 ] wlan_rtt_pasn_post_channel_switch_handler Failed to register mac addr !! 
+7597,ii,[ wlan_rtt_pasn.c : 638 ] wlan_rtt_pasn_send_deauth status = %d is_secure = %d 
+7598,IIiII,[ wlan_rtt_pasn.c : 594 ] wlan_rtt_pasn_deauth_completion_hdlr peer_mac 0x%x:0x%x tx_status=%d curr_session=%p pasn_session=%p 
+7599,Iii,[ wlan_rtt_pasn.c : 1131 ] wlan_rtt_pasn_send_sa_query_req %p state = %d curr_trans_id = %d 
+7600,II,[ wlan_rtt_pasn.c : 1138 ] wlan_rtt_pasn_send_sa_query_req NULL vdev = 0x%x peer = 0x%x 
+7601,,[ wlan_rtt_pasn.c : 1155 ] wlan_rtt_pasn_send_sa_query_req NULL abf!! 
+7602,i,[ wlan_rtt_pasn.c : 1171 ] wlan_rtt_pasn_send_sa_query_req tx_status=%d 
+7603,IIi,[ wlan_rtt_pasn.c : 1115 ] wlan_rtt_pasn_sa_query_frame_completion_hdlr peer_mac 0x%x:0x%x tx_status=%d 
+7604,i,[ wlan_rtt_pasn.c : 300 ] wlan_rtt_pasn_channel_switch_req status %d 
+7605,,[ wlan_rtt_pasn.c : 464 ] wlan_rtt_pasn_schedule_session_comp NULL !! 
+7606,i,[ wlan_rtt_pasn.c : 470 ] wlan_rtt_pasn_schedule_session_comp state %d 
+7607,i,[ wlan_rtt_pasn.c : 1189 ] wlan_rtt_pasn_sa_query_req_complete_hdlr sa_query_state %d 
+7608,I,[ wlan_rtt_pasn.c : 504 ] wlan_rtt_pasn_scheduler_timeout curr_session = %p 
+7609,I,[ wlan_rtt_pasn.c : 529 ] wlan_rtt_pasn_scheduler_timeout curr_session %p 
+7610,i,[ wlan_rtt_pasn.c : 716 ] wlan_rtt_pasn_peer_delete_req_event : memory allocation failed %d 
+7611,Iii,[ wlan_rtt_pasn.c : 1060 ] wlan_rtt_pasn_trigger_sa_query_req %p frame_state = %d sa_query_state = %d 
+7612,Ii,[ wlan_rtt_pasn.c : 1207 ] wlan_rtt_pasn_sa_query_timeout_hdlr %p sa_query_state %d 
+7613,,[ wlan_rtt_pasn.c : 1233 ] wlan_rtt_pasn_send_sa_query_rsp not enabled !! 
+7614,II,[ wlan_rtt_pasn.c : 1242 ] wlan_rtt_pasn_send_sa_query_rsp NULL vdev = 0x%x peer = 0x%x 
+7615,,[ wlan_rtt_pasn.c : 1260 ] wlan_rtt_pasn_send_sa_query_rsp NULL abf!! 
+7616,ii,[ wlan_rtt_pasn.c : 1271 ] wlan_rtt_pasn_send_sa_query_rsp tx_status=%d transaction_id %d 
+7617,Iiii,[ wlan_rtt_pasn.c : 1283 ] wlan_rtt_sa_query_rsp_rx_handler %p sa_query_state %d sa_trans_id %d frame_trans_id %d 
+7618,iiii,[ wlan_rtt_tlv_helper.c : 95 ] ERROR: TLV order %d greater than num_of_tlvs:%d for is_req:%d rtt_cmd_event_id: %d 
+7619,ii,[ wlan_rtt_tlv_helper.c : 115 ] ERROR: Didn't found WMI TLV attribute definitions for is_req:%d rtt_cmd_event_id: %d 
+7620,i,[ wlan_rtt_tlv_helper.c : 190 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Couldn't get expected number of TLVs for sub_type=%d
+ 
+7621,ii,[ wlan_rtt_tlv_helper.c : 197 ] RTTTLV_CHECK_AND_PAD_TLVS_if: pdev_id %d num_mac:%d
+ 
+7622,iiiiii,[ wlan_rtt_tlv_helper.c : 222 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Invalid TLV length for sub_type=%d Tag_order=%d buf_idx=%d Tag:%d Len:%d TotalLen:%d
+ 
+7623,ii,[ wlan_rtt_tlv_helper.c : 231 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: No TLV attributes found for sub_type=%d Tag_order=%d
+ 
+7624,iii,[ wlan_rtt_tlv_helper.c : 255 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Can't get  the first TLV Tag ID (tlv_index:%d) for last entered loop start (cnt=%d) for sub_type=%d
+ 
+7625,iiii,[ wlan_rtt_tlv_helper.c : 263 ] RTTTLV_CHECK_AND_PAD_TLVS: WARN: First TLV Tag ID (%d) for last entered loop start (index=%d) doesn't match; skipping this tlv with tag:%d for sub_type=%d 
+7626,iii,[ wlan_rtt_tlv_helper.c : 286 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: TLV has wrong tag in order for sub_type=%d. Given=%d, Expected=%d.
+ 
+7627,iii,[ wlan_rtt_tlv_helper.c : 292 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: TLV has wrong tag in order for sub_type=%d. Given=%d, Expected=%d.
+ 
+7628,ii,[ wlan_rtt_tlv_helper.c : 300 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Wrong TLV length %d for loop end for sub_type:%d 
+7629,i,[ wlan_rtt_tlv_helper.c : 305 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Loop start and End mismatch for sub_type:%d 
+7630,iii,[ wlan_rtt_tlv_helper.c : 328 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Exceeded given max loop count %d, for sub_type:%d tlv_index:%d 
+7631,ii,[ wlan_rtt_tlv_helper.c : 337 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Wrong TLV length %d for loop start for sub_type:%d 
+7632,i,[ wlan_rtt_tlv_helper.c : 342 ] RTTTLV_CHECK_AND_PAD_TLVS: ERROR: Maximum inner loops reached for sub_type:%d 
+7633,i,[ wlan_rtt_tlv_helper.c : 375 ] RTTTLV_CHECK_AND_PAD_TLVS: WARN: ERROR Need to handle this tag ID %d for variable length
+ 
+7634,ii,[ wlan_rtt_tlv_helper.c : 386 ] RTTTLV_CHECK_AND_PAD_TLVS: WARN: TLV truncated. tlv_size_diff=%d, curr_tlv_len=%d
+ 
+7635,i,[ wlan_rtt_tlv_helper.c : 401 ] RTTTLV_CHECK_AND_PAD_TLVS: WARN: TLV needs padding. tlv_size_diff=-%d
+ 
+7636,ii,[ wlan_rtt_tlv_helper.c : 466 ] RTTTLV_CHECK_AND_PAD_TLVS: Some loop(cnt = %d) didn't ended properly for sub_type:%d 
+7637,,[ wlan_cfr.c : 162 ] WMI_PEER_CFR_CAPTURE_EVENTID evt alloc failed 
+7638,,[ wlan_cfr.c : 269 ] wlan_peer_cfr_capture_cmd_handler: csi not runing 
+7639,i,[ wlan_cfr.c : 280 ] wlan_peer_cfr_capture_cmd_handler: mac_id %d invalid or greater than or equal to WLAN_MAC_MAX 
+7640,ii,[ wlan_cfr.c : 531 ] wlan_cfr_init: pm_arb_req create instance failed for mac:%d index:%d 
+7641,iiIIIi,[ wlan_cfr.c : 886 ] wlan_peer_cfr_capture_cmd_handler: request %d periodicity %d peer MAC 0x%08x%02x context 0x%08x status %d 
+7642,III,[ wlan_cfr.c : 1062 ] Space not available read_index = %x,write_index = %x, max_write_index = %x 
+7643,i,[ wlan_cfr.c : 1301 ] gain table index is invalid for chain: %d 
+7644,Ii,[ wlan_cfr.c : 1311 ] Capping gain to %u, Current gain = %d 
+7645,,[ wlan_cfr.c : 1334 ] Invalid gain info. No AoA phase data got captured. 
+7646,I,[ wlan_cfr.c : 1607 ] Invalid CFR capture method %x 
+7647,I,[ wlan_cfr.c : 1785 ] wlan_next_cfr_capture_handler: no capture requests in 0x%08x 
+7648,I,[ wlan_cfr.c : 1823 ] wlan_periodic_cfr_capture_handler: no capture requests in 0x%08x 
+7649,iiii,[ wlan_cfr.c : 1863 ] <<< CFR_UNIT_TEST_CMD, num_args = %d arg0 = %d vdev_id = %d mac_id = %d 
+7650,,[ wlan_cfr.c : 1896 ] CFR_UNIT_TEST_CMD_SET_TA_AND_MASK, there's some missing argument, cannot set here 
+7651,,[ wlan_cfr.c : 1916 ] CFR_UNIT_TEST_CMD_SET_RA_AND_MASK, there's some missing argument, cannot set here 
+7652,,[ wlan_cfr.c : 1938 ] CFR_UNIT_TEST_CMD_SET_EXTRA_PARAMS_CAPTURE_GROUP, there's some missing argument, cannot set here 
+7653,,[ wlan_cfr.c : 1961 ] CFR_UNIT_TEST_CMD_SET_EXTRA_FIXED_PARAM, there's some missing argument, cannot set here 
+7654,,[ wlan_cfr.c : 1981 ] CFR_UNIT_TEST_CMD_WMI_CFR_CAPTURE_FILTER_CMDID, there's some missing argument, cannot set here 
+7655,IIIII,[ wlan_cfr.c : 2006 ] wmi_pdev_id = 0x%x filter_type = 0x%x capture_interval = 0x%x capture_duration = 0x%x filter_group_bitmap = 0x%x 
+7656,IIIIII,[ wlan_cfr.c : 2015 ] filter_group_id = 0x%x filter_set_valid_mask = 0x%x bw_nss_filter = 0x%x mgmt_subtype_filter = 0x%x ctrl_subtype_filter = 0x%x data_subtype_filter = 0x%x  
+7657,IIII,[ wlan_cfr.c : 2022 ] ta_addr.mac_addr31to0 = 0x%x ta_addr.mac_addr47to32 = 0x%x ta_addr_mask.mac_addr31to0 = 0x%x ta_addr_mask.mac_addr47to32 = 0x%x 
+7658,IIII,[ wlan_cfr.c : 2029 ] ra_addr.mac_addr31to0 = 0x%x ra_addr.mac_addr47to32 = 0x%x ra_addr_mask.mac_addr31to0 = 0x%x ra_addr_mask.mac_addr47to32 = 0x%x 
+7659,iIIiI,[ wlan_cfr.c : 104 ] wlan_peer_cfr_capture_done: vdev %d peer MAC 0x%08x%02x status %d at %p 
+7660,ii,[ wlan_cfr.c : 2299 ] wlan_cfr_pm_arb_req(): mac_id: %d state: %d  
+7661,iiIi,[ umac_wmi_events.c : 247 ] Drop mgmt as size = %d limit = %d subtype = 0x%x seq no = %d 
+7662,I,[ umac_wmi_events.c : 346 ] WSI_REMAP MLO TIMESTAMP Invalidate MGMT Packet SeqNum:0x%x 
+7663,IIIi,[ umac_wmi_events.c : 368 ] WSI_REMAP MLO TIMESTAMP : %x 0x%x 0x%x %d 
+7664,ii,[ umac_wmi_events.c : 393 ] BA_DBG ba_params_valid ba_win_size %d reo_win_size %d 
+7665,ii,[ umac_wmi_events.c : 406 ] TWT_IE twt_params_valid %d cur buf_len%d 
+7666,iiiiiii,[ umac_wmi_events.c : 437 ] PN_DBG err status : %d Cur PN : %d %d %d last PN : %d %d %d 
+7667,IIIII,[ umac_wmi_events.c : 467 ] wmi_mgmt_ml_info : hw_link_id = %x, cu_vdev_map_1 = %x, cu_vdev_map_2 = %x, cu_vdev_map_3 = %x, cu_vdev_map_4 = %x 
+7668,Iii,[ umac_wmi_events.c : 470 ] bpcc : hw_link_id : %x, bpcc_info[%d] = %d 
+7669,I,[ umac_wmi_events.c : 650 ] WSI_REMAP MLO TIMESTAMP Invalidate Self consumed MGMT Packet SeqNum:0x%x 
+7670,,[ umac_wmi_events.c : 736 ] BEACON_EVENT_SWBA_SEND_FAILED 
+7671,IIi,[ umac_wmi_events.c : 989 ] WMI_CHAN_INFO_EVENT_ALLOC_FAILURE  EventId = 0x%x chan_freq = 0x%x PendingEvents = %d 
+7672,iiiiiIIii,[ umac_wmi_events.c : 1056 ] STA_KICKOUT_EVENT_SEND vdevid:%d, opmode:%d, subopmode:%d, aid:%d, peer_type:%d, peer_mac: 0x%x 0x%x, peer->inactivity_generation:%d, peerKO_reason:%d 
+7673,iII,[ umac_wmi_events.c : 1087 ] WMI_EVENT_ALLOC_FAILURE vdev_id = %d EventId = 0x%x AssocId/VdevMap = 0x%x 
+7674,II,[ umac_wmi_events.c : 1152 ]  WMI_EVENT_ALLOC_FAILURE EventId = 0x%x AssocId/VdevMap = 0x%x 
+7675,iII,[ umac_wmi_events.c : 1189 ] WMI_EVENT_ALLOC_FAILURE vdev_id = %d EventId = 0x%x AssocId/VdevMap = 0x%x 
+7676,III,[ wlan_wmi.c : 305 ] wlan_wmi_write_tlv: type=%u, length=%u, write_len=%u 
+7677,i,[ wlan_wmi.c : 309 ] wlan_wmi_write_tlv: status=%d (0: success) 
+7678,III,[ wlan_wmi.c : 353 ] wlan_wmi_read_tlv: type=%u, length=%u, read_len=%u 
+7679,i,[ wlan_wmi.c : 357 ] wlan_wmi_read_tlv: status=%d (0: success) 
+7680,,[ wlan_wmi.c : 627 ] WMI_OEM_DATA_CMD_SCHED_PM_SETUP: read TLV failed  
+7681,,[ wlan_wmi.c : 756 ] wal_mlo_recovery no recovery mode for fw all partner chip will crash 
+7682,,[ wlan_wmi.c : 761 ] wal_mlo_recovery recovery mode set to mlo mode1 recovery 
+7683,,[ wlan_wmi.c : 766 ] wal_mlo_recovery recovery mode set to mlo mode2 recovery 
+7684,IIIII,[ wlan_wmi_events.c : 334 ] bdf_version = %x ref_design_id=%x, customer_id=%x, project_id=%x, board_data_rev=%x 
+7685,,[ wlan_wmi_events.c : 527 ] Returning from wmi_dbglog_event :BUFCTX NULL 
+7686,,[ wlan_wmi_events.c : 543 ] wmi_dbglog_event, event NULL 
+7687,,[ wlan_wmi_events.c : 712 ] _wmi_debug_log_fatal_event, event NULL 
+7688,iiii,[ wlan_wmi_events.c : 769 ] wlan_debug_mesg_flush_compete stall_type:%d                         vdev_bmap:%d reason_code1:%d reason_code2:%d 
+7689,ii,[ wlan_wmi_events.c : 797 ] WMITLV_TAG_STRUC_wmi_debug_mesg_fw_cal_failure                           we got values calType:%d calFailureReasonCode:%d 
+7690,II,[ wlan_wmi_events.c : 853 ] WMI handle send WMI evt msg fail, evt_id:0x%x, evt_len:0x%x
+ 
+7691,,[ wlan_wmi_events.c : 926 ] DISPLAY_TPC_STATS: Event size exceeds WMI_SVC_MSG_SIZE!! 
+7692,,[ wlan_wmi_events.c : 934 ] DISPLAY_TPC_STATS: WMI tpc stats evt, allocation failed! 
+7693,III,[ wlan_wmi_events.c : 943 ] DISPLAY_TPC_STATS: 1st event tpcEvSize is %lu wal_pdev_get_reg_array_len is %lu reg_mask is %u 
+7694,III,[ wlan_wmi_events.c : 962 ] DISPLAY_TPC_STATS: 1st event tpcEvSize is %lu wal_pdev_get_reg_array_len is %lu reg_mask is %u 
+7695,,[ wlan_wmi_events.c : 1046 ] DISPLAY_TPC_STATS: Event size exceeds WMI_SVC_MSG_SIZE!! 
+7696,,[ wlan_wmi_events.c : 1053 ] DISPLAY_TPC_STATS: WMI tpc stats evt, allocation failed! 
+7697,I,[ wlan_wmi_events.c : 1062 ] DISPLAY_TPC_STATS: event starting ptr is %lu 
+7698,II,[ wlan_wmi_events.c : 1079 ] DISPLAY_TPC_STATS: event starting ptr is %lu tpcEvSize %u 
+7699,I,[ wlan_wmi_events.c : 1170 ] DISPLAY_TPC_STATS: event3 tpcEvSize %u 
+7700,,[ wlan_wmi_events.c : 1174 ] DISPLAY_TPC_STATS: Event size exceeds WMI_SVC_MSG_SIZE!! 
+7701,,[ wlan_wmi_events.c : 1181 ] DISPLAY_TPC_STATS: WMI tpc stats evt, allocation failed! 
+7702,I,[ wlan_wmi_events.c : 1189 ] DISPLAY_TPC_STATS: event starting ptr is %lu 
+7703,I,[ wlan_wmi_events.c : 1206 ] DISPLAY_TPC_STATS: event starting ptr is %lu 
+7704,I,[ wlan_wmi_events.c : 1482 ] DISPLAY_TPC_STATS: event4 tpcEvSize %u 
+7705,,[ wlan_wmi_events.c : 1485 ] DISPLAY_TPC_STATS: Event size exceeds WMI_SVC_MSG_SIZE!! 
+7706,,[ wlan_wmi_events.c : 1492 ] DISPLAY_TPC_STATS: WMI tpc stats evt, allocation failed! 
+7707,I,[ wlan_wmi_events.c : 1500 ] DISPLAY_TPC_STATS: event starting ptr is %lu 
+7708,I,[ wlan_wmi_events.c : 1516 ] DISPLAY_TPC_STATS: event starting ptr is %lu 
+7709,I,[ wlan_wmi_events.c : 1547 ] DISPLAY_TPC_STATS: wal_pdev_get_ctl_array_len is %lu 
+7710,IIIIIIII,[ wlan_wmi_events.c : 2029 ] WMI Service Ready Ext: wmi_svc_bitmap(ext) = 0x%08x %08x %08x %08x (%08x %08x %08x %08x) 
+7711,ii,[ wlan_wmi_events.c : 2478 ] cust_bdf_ver_major =%d cust_bdf_ver_minor=%d 
+7712,ii,[ wlan_wmi_events.c : 2552 ] PhyId =%d, PowerBoost Enable =%d 
+7713,ii,[ wlan_wmi_events.c : 2573 ] PhyId =%d, MultiGain Rssi Enable =%d 
+7714,iiiii,[ phyrf_afc.c : 3835 ] iwconfig_logs REG TPC: bHomeChan=%d regTxPower=%d twiceAntennaGain=%d twiceLargestAntenna=%d maxRegAllowedPower=%d 
+7715,ii,[ phyrf_afc.c : 3843 ] iwconfig_logs TPC WMI: Updating maxRegAllowedPower6GEIRP[%d]=%d 
+7716,iiii,[ phyrf_ctl.c : 465 ] Sub-Band CTL Enabled 5GHz_RegRule_Index: %d, start_freq: %d, end_freq: %d, CTL_VAL: %d 
+7717,iii,[ phyrf_ctl.c : 501 ] CTL curr_chan : %d,  CTL_VAL: %d, 5GHz_RegRule_Index: %d
+ 
+7718,iiiii,[ phyrf_ctl.c : 525 ] AFC TPC_WMI iwconfig_logs: Eirp %d PSD %d pwrtype %d num_pwr_level %d is_psd_eirp_supported %d 
+7719,iiiiiiii,[ phyrf_ctl.c : 531 ] TPC_WMI iwconfig_logs: PSD cfreq[%d] %d, PSD tx_pwr[%d] %d, eirp_cfreq[%d] %d, eirp_tx_power[%d] %d 
+7720,iiii,[ phyrf_ctl.c : 534 ] AFC TPC_WMI iwconfig_logs: tx_pwr[%d] %d cfreq[%d] %d 
+7721,i,[ phyrf_ctl.c : 547 ] updated tx_power: %d 
+7722,i,[ phyrf_ctl.c : 580 ] iwconfig_logs: AFC TPC_WMI 6G Power type=%d after compliance 
+7723,iiI,[ phyrf_ctl.c : 653 ] RegPwrInfo g_tpc_change[%d][%d] = [%08x] 
+7724,ii,[ phyrf_ctl.c : 691 ] iwconfig_logs: AFC_offchan HALPHY_RESET_SETUP: Home->Scan->Home Restore HomeChan Pwr: maxRegAllowedPower[%d]=%d 
+7725,ii,[ phyrf_ctl.c : 695 ] iwconfig_logs: Home->Scan->Home: Restore maxRDPower6G %d, 6G_pwrType %d 
+7726,ii,[ phyrf_ctl.c : 1527 ] CTL_ENGINE CTLSupportedChanns: cntFreqs %d ,ctl_region %d  
+7727,ii,[ phyrf_ctl.c : 1530 ] CTL_ENGINE CTLSupportedChanns : freq_20Mhz[%d] = %d  
+7728,ii,[ phyrf_ctl.c : 1533 ] CTL_ENGINE GetCTLSupportedChanns : freq_40Mhz[%d] = %d  
+7729,ii,[ phyrf_ctl.c : 1536 ] CTL_ENGINE GetCTLSupportedChanns : freq_80Mhz[%d] = %d  
+7730,ii,[ phyrf_ctl.c : 1539 ] CTL_ENGINE GetCTLSupportedChanns : freq_160Mhz[%d] = %d  
+7731,ii,[ phyrf_ctl.c : 1542 ] CTL_ENGINE GetCTLSupportedChanns : freq_320Mhz[%d] = %d  
+7732,i,[ phyrf_ctl.c : 1771 ] CTL Region %d 
+7733,i,[ phyrf_ctl.c : 1792 ] SKIPPING CTL_ENGINE CTL_BLOB: CTL_BLOB_PUSH_IN_PROGRESS regDmn %d 
+7734,,[ phyrf_ctl.c : 2936 ] Ignore CTL calculation 
+7735,,[ phyrf_ctl.c : 3339 ] CTL_ENGINE: REGRULES match 
+7736,iii,[ phyrf_ctl.c : 3347 ] CTL_ENGINE: Reg Rules Index = %d, Power Rules Index = %d, Array Gain Index = %d 
+7737,,[ phyrf_ctl.c : 3374 ] CTL_ENGINE: Rule NOT FOUND 
+7738,i,[ phyrf_ctl.c : 3463 ] 6G CTL pwrMode %d 
+7739,iii,[ phyrf_ctl.c : 3477 ] CTL_ENGINE: ctlGroup = %d, power_type_6g = %d, ctlRegion = %d 
+7740,iiiiiii,[ phyrf_ctl.c : 3491 ] CTL_ENGINE: freq %d, OCBW ID %d, CTL Region %d, BF %d, Nant %d, NSS %d, 6G_pwrType %d 
+7741,iiiii,[ phyrf_ctl.c : 3568 ] CTL_ENGINE: arrayGainCapExt2 Enabled Array Gain Cap %d Nss %d Nant %d ctlRegionGrp %d ctlRegion %d 
+7742,iii,[ phyrf_ctl.c : 3592 ] CTL_ENGINE: arrayGAinCap %d Nss %d Nant %d 
+7743,iiiiiiii,[ phyrf_ctl.c : 3699 ] CTL_ENGINE: AFC_CTL BwTypesBwId %d - AFC limit<reg limt. OCB ID %d, psd_limit_dbm %d, eirp_limit_dbm %d, isSpCtlFreqExcpAdjDisable[%d][%d][%d] %d 
+7744,iiiiiiii,[ phyrf_ctl.c : 3746 ] CTL_ENGINE: Gant %d Nant %d,Nss %d ocb %d, ag_total %d arrayGainCap %d ag_psd %d ag_eirp %d 
+7745,iiii,[ phyrf_ctl.c : 3780 ] CTL_ENGINE: ant_gain_allowance %d array_gain_for_total %d,array_gain_for_psd %d ,array_gain_for_eirp %d 
+7746,iiiiiiii,[ phyrf_ctl.c : 3813 ] CTL_ENGINE: total_power_limit %d eirp_power_limit %d,psd_power_limit %d,TOCB IDX %d,Total output Power %d Total output Power - Margin = %d,Per Chain Power = %d Nant %d 
+7747,iii,[ phyrf_ctl.c : 3961 ] CTL_ENGINE: CtlException: Freq = %d, OCB_ID = %d, ctlRegion =%d 
+7748,iii,[ phyrf_ctl.c : 3972 ] CTL_ENGINE: CtlException: Freq = %d, OCB_ID = %d, ctlRegion =%d 
+7749,iiiii,[ phyrf_ctl.c : 4104 ] CTL_ENGINE:ctl region=%d ctlGroup_bdf=%d freqSubBand_bdf=%d freq=%d ctl_group=%d 
+7750,i,[ phyrf_ctl.c : 4137 ] CTL_ENGINE: Exception Value = %d 
+7751,iii,[ phyrf_ctl.c : 4213 ] CTL_ENGINE: GetCtlExceptionValue: Freq/Subband = %d, mode = %d, regDmn =%d. Invalid Mode 
+7752,iii,[ phyrf_ctl.c : 4227 ] CTL_ENGINE: GetCtlExceptionValue: Freq/Subband = %d, ctl_group = %d, ctl_region =%d 
+7753,ii,[ phyrf_ctl.c : 4266 ] CTL_ENGINE: GetCtlExceptionValue: cltRegion for exception entry: %d doesn't match with exceptionMgmt value %d 
+7754,i,[ phyrf_ctl.c : 4370 ] CTL_ENGINE: Exception Value = %d 
+7755,i,[ phyrf_ctl.c : 4409 ] CTL_ENGINE: CtlExceptionTableSize No.of Exception Entries %d 
+7756,iiiii,[ phyrf_ctl.c : 4451 ] CTL_ENGINE CtlExceptionParm: index %d, ctlRegion %d, ctlGroup %d, freqSubBand %d , excpValue %d 
+7757,iiiiii,[ phyrf_ctl.c : 4640 ]  CTL_ENGINE SetCtlInfo3 : BDF freq %d Bit15of freq : 0-frq; 1-subBand , subBandIndex %d, supportedCtlRegions %d productCategory %d supported6GCases %d ctlflags(Ul&dlofdma support %d 
+7758,ii,[ phyrf_ctl.c : 4645 ]  CTL_ENGINE SetCtlInfo3 BDF  margin[%d] = %d 
+7759,iiiiii,[ phyrf_ctl.c : 4649 ]  CTL_ENGINESetCtlInfo3 BDF antennaGain[%d] = %d, ctlFccAntGainCap[%d] = %d, ctlEtsiAntGainCap[%d] = %d 
+7760,iiiiii,[ phyrf_ctl.c : 4712 ]  CTL_ENGINE GetCtlInfo2 : BDF freq %d Bit15 of freq 0-frq; 1-subBand, subBandIndex %d,supportedCtlRegions %d productCategory %d supported6GCases %d ctlflags(Ul&dlofdma support %d 
+7761,ii,[ phyrf_ctl.c : 4718 ]  CTL_ENGINE GetCtlInfo2 BDF Margin[%d] = %d 
+7762,iiiiii,[ phyrf_ctl.c : 4722 ]  CTL_ENGINE GetCtlInfo2 BDF antennaGain[%d] = %d ctlFccAntGainCap[%d] = %d ctlEtsiAntGainCap[%d] = %d 
+7763,iii,[ phyrf_ctl.c : 4767 ] CTL_ENGINE CtlSupportedInfo: CTL_Region = %d, CTL_SupportMaxBW = %d, NumTxChain = %d 
+7764,iii,[ phyrf_ctl.c : 4807 ] CTL_ENGINE Nss%d nant %d bf %d 
+7765,iiiii,[ phyrf_ctl.c : 4836 ] CTL_ENGINE regulatoryPSDLimit %d regulatoryPowerLimit %d ctlAntElementGain %d ctlAddedMargin %d ctlArrayGain %d 
+7766,iiii,[ phyrf_ctl.c : 4837 ] CTL_ENGINE debug: ctlEbw = %d, ocbIndex = %d, ctlGroup = %d, ctlNonOfdmaType = %d 
+7767,i,[ phyrf_ctl.c : 4843 ] CTL_ENGINE debug: adjustIndex = %d 
+7768,iii,[ phyrf_ctl.c : 4866 ] CTL_ENGINE debug: freqs = %d, ctlExceptionValue = %d rateIndex = %d 
+7769,iiii,[ phyrf_ctl.c : 4972 ] CTL_ENGINE : HC offset flag - %d, band - %d, BW - %d, Rate - %d 
+7770,iii,[ phyrf_ctl.c : 4980 ] CTL_ENGINE debug: ctlHcOffset %d, ctlExcpValueAdj %d, ctlHeOffset %d 
+7771,i,[ phyrf_ctl.c : 4994 ] CTL_BLOB:: phyId %d 
+ 
+7772,,[ phyrf_ctl.c : 5011 ] CTL_BLOB: CTL DATA push failed. ctlArray is NULL. 
+7773,,[ phyrf_ctl.c : 5019 ] CTL_BLOB:Invalid CTL data size. Please copy CTL blob from beginning with right size. 
+7774,,[ phyrf_ctl.c : 5027 ] CTL_BLOB:CTL data size is not same as BDF NvSection. Please copy CTL blob from beginning with right size 
+7775,iiiiii,[ phyrf_ctl.c : 5046 ] CTL_BLOB:Variables:  seq: %d, endflag: %d, totalLen: %d, ctl_ptr: %d cal_ptr before copy: %d Size copied in this itr: %d 
+7776,ii,[ phyrf_ctl.c : 5049 ] CTL_BLOB:ctl_ptr after copy: %d, Size copied: %d 
+7777,iiiii,[ phyrf_ctl.c : 5064 ] CTL_BLOB:version1 %d version2 %d version3 %d checksum_blob %d checksum_cal_data %d 
+7778,,[ phyrf_ctl.c : 5077 ] CTL_BLOB: checksum mismatched.CTL data not copied to BDF memory 
+7779,iiiIiiiii,[ phyrf_ctl.c : 5115 ] HC DEBUG: HeavyClipOffset mhz = %d, BCFreq1 = %d, band = %d, ctlDmn = 0x%x, 6g_pwrType = %d, ctlGroup = %d, 6g_pwrMode = %d, isSpOrSpCliPwrMode = %d, phyId = %d 
+7780,iiii,[ phyrf_ctl.c : 5180 ] HC DEBUG: HC CtlRegion_map[0] = %d CtlRegion_map[1] = %d Mcs_ctl_region = %d noCtlRegions= %d  
+7781,ii,[ phyrf_ctl.c : 5213 ] HC DEBUG: HC CTL invalid band - %d, phyID - %d 
+7782,ii,[ phyrf_ctl.c : 5221 ] HC DEBUG: Invalid McsOffset value phyId = %d pHCMcsOffsetMap = %d 
+7783,ii,[ phyrf_ctl.c : 5229 ] HC DEBUG: Invalid CTL region or HCoffset BDF value phyId=%d ctlRegionIdx=%d 
+7784,iiii,[ phyrf_ctl.c : 5234 ] HC DEBUG: mcsgroup = %d mcs = %d HC_McsOffset_Map = %d ctlRegionIdx = %d 
+7785,iiiiii,[ phyrf_ctl.c : 5251 ] HC DEBUG 320MHZ: HC_ctl_mcs_offset_pwr=%d, HC_Mcs_ctl_region=%d, 320MHz_center_freq=%d, index=%d, mcsgroup=%d, mcs=%d 
+7786,iiiiii,[ phyrf_ctl.c : 5268 ] HC DEBUG 160MHZ: HC_ctl_mcs_offset_pwr=%d, HC_Mcs_ctl_region=%d, 160MHz_center_freq=%d, index=%d, mcsgroup=%d, mcs=%d 
+7787,iiiiii,[ phyrf_ctl.c : 5284 ] HC DEBUG 80MHZ: HC_ctl_mcs_offset_pwr=%d, HC_Mcs_ctl_region=%d, 80MHz_center_freq=%d, index=%d, mcsgroup=%d, mcs=%d 
+7788,iiiiii,[ phyrf_ctl.c : 5299 ] HC DEBUG 40MHZ: HC_ctl_mcs_offset_pwr=%d, HC_Mcs_ctl_region=%d, 40MHz_center_freq=%d, index=%d, mcsgroup=%d, mcs=%d 
+7789,iiiiii,[ phyrf_ctl.c : 5314 ] HC DEBUG 20MHZ: HC_ctl_mcs_offset_pwr=%d, HC_Mcs_ctl_region=%d, 20MHz_center_freq=%d, index=%d, mcsgroup=%d, mcs=%d 
+7790,i,[ phyrf_ctl.c : 5358 ] HC DEBUG setBandBasedgHcCtlMcsOffset: HC CTL invalid band - %d 
+7791,i,[ phyrf_ctl.c : 5383 ] HC DEBUG: HC CTL Invalid Band %d 
+7792,,[ dfs.c : 562 ] ic is NULL 
+7793,i,[ dfs.c : 840 ] Enabled radar detection on channel %d 
+7794,iiiI,[ dfs_bindetects.c : 191 ] DFS_EXT adding: filter id %d, dur=%d, rssi=%d, ts=%llu 
+7795,iIi,[ dfs_bindetects.c : 238 ] DFS_DUMP VarianceCheckPassed =%d var =%ld pulsevar =%d 
+7796,Ii,[ dfs_bindetects.c : 285 ] DFS_DUMPS Fixed Pattern FOUND filterID=%u thresh=%d 
+7797,iIIIiii,[ dfs_bindetects.c : 390 ] DFS_DUMPS Variable Pattern ext_flag=%d MATCH filter=%u numpulses=%u thresh=%u refdur=%d refpri=%d primargin=%d 
+7798,i,[ dfs_fcc_bin5.c : 110 ] DFS_DUMPS Rejecting pulses as they are not chirp %d
+ 
+7799,i,[ dfs_fcc_bin5.c : 365 ] bin 5 radar detected, bursts=%d
+ 
+7800,i,[ dfs_init.c : 211 ] Min Rssi threshold %d 
+7801,IIII,[ dfs_staggered.c : 313 ] DFS_DUMPS Staggered Type MATCH filter=%u numpulseshigh=%u numpulsesmid= %u thresh=%u 
+7802,,[ phyrf_dfs.c : 229 ] DFS_DUMPS : dfs structure is NULL 
+7803,ii,[ phyrf_dfs.c : 233 ] DFS_DUMPS ch_freq_seg2: %d, ch_freq_seg1: %d 
+7804,ii,[ phyrf_dfs.c : 252 ] DFS_DUMPS cmd received frm host %d bang radar support %d 
+7805,ii,[ phyrf_dfs.c : 271 ] DFS_DUMPS Freq offset %d Chirp = %d  
+7806,IiiiiII,[ phyrf_dfs.c : 276 ] DFS_DUMPS cmd received frm host 0x%x Chan Freq : %d Segment ID: %d Detector ID: %d Freq Offset: %d g_radar_event_data =0x%x,address of the g_radar_event_data =0X%x  
+7807,iii,[ phyrf_dfs.c : 448 ] DFS_DUMPS regdomain %d phyId=%d g_DfsConfiguration=%d 
+7808,,[ phyrf_dfs.c : 566 ] DFS_DUMPS ic is Invalid 
+7809,i,[ phyrf_dfs.c : 580 ] dfs_dmn %d 
+7810,,[ phyrf_dfs.c : 666 ] DFS-UNINT domain 
+7811,,[ phyrf_dfs.c : 690 ] DFS- Radar Detection Enabling Failed 
+7812,,[ phyrf_dfs.c : 712 ] Invalid Channel Number 
+7813,i,[ phyrf_dfs.c : 745 ] Invalid frequency : %d 
+7814,,[ phyrf_dfs.c : 887 ] DFS_DUMPS ic is Invalid 
+7815,I,[ phyrf_dfs.c : 897 ] Allocation of ic_curchan failed %zu 
+7816,iiiii,[ phyrf_dfs.c : 919 ] DFS_DUMPS : req_chan=%d, ic_ieee_chan=%d, center_freq1=%d, center_freq2=%d, chan_width=%d 
+7817,i,[ phyrf_dfs.c : 968 ] Recieved a wrong channel width %d 
+7818,,[ phyrf_dfs.c : 990 ] DFS CHANNEL CONFIGURED 
+7819,I,[ phyrf_dfs.c : 1008 ] Allocation of g_dfs_ic[dfs_detector_id] failed %zu 
+7820,,[ phyrf_dfs.c : 1219 ] DFS- Radar event data memory not allocated 
+7821,ii,[ phyrf_regulatory_v2.c : 138 ] REGDB CCARegion 2G=%d, 5G=%d 
+7822,i,[ phyrf_regulatory_v2.c : 156 ] REGDB CCARegion 6G=%d 
+7823,iii,[ phyrf_regulatory_v2.c : 179 ] REGDB CCARegion 2G=%d, 5G=%d 6G=%d 
+7824,i,[ phyrf_regulatory_v2.c : 183 ] REGDB size/Null check failed for input size=%d 
+7825,iiii,[ phyrf_regulatory_v2.c : 382 ] REGDB: cbp_enable %d isG %d 6g_pwrType %d isCBP %d 
+7826,iiiiiii,[ phyrf_regulatory_v2.c : 591 ] RegDB 2G-Rule%d start %d end %d max_bw %d reg_power %d flags %d phy_id %d 
+7827,iiiiiii,[ phyrf_regulatory_v2.c : 654 ] RegDB 5G-Rule%d start %d end %d max_bw %d reg_power %d flags %d phy_id %d 
+7828,ii,[ phyrf_regulatory_v2.c : 686 ] RegDB Channel Prioritity Supported, FreqIdx=%d Priority Freq=%d 
+7829,i,[ phyrf_regulatory_v2.c : 690 ] RegDB Channel Prioritity Supported but Country Not Supported, FreqIdx=%d 
+7830,,[ phyrf_regulatory_v2.c : 695 ] RegDB Channel Prioritity Not Supported 
+7831,iii,[ phyrf_regulatory_v2.c : 740 ] RegDB-6G MaxBW AP SP %d, LPI %d, VLP %d 
+7832,iii,[ phyrf_regulatory_v2.c : 747 ] RegDB-6G MaxBW CLIENT SP %d, LPI %d, VLP %d 
+7833,iii,[ phyrf_regulatory_v2.c : 789 ] RegDB-6G MinBW AP SP %d, LPI %d, VLP %d 
+7834,iii,[ phyrf_regulatory_v2.c : 796 ] RegDB-6G MinBW CLIENT SP %d, LPI %d, VLP %d 
+7835,iii,[ phyrf_regulatory_v2.c : 838 ] RegDB-6G NumRules AP SP %d, LPI %d, VLP %d 
+7836,iii,[ phyrf_regulatory_v2.c : 845 ] RegDB-6G NumRules CLIENT SP %d, LPI %d, VLP %d 
+7837,iii,[ phyrf_regulatory_v2.c : 854 ] RegDB 6G Rules dmn_id %d num_rules %d phy_id %d 
+7838,iiiiiii,[ phyrf_regulatory_v2.c : 867 ] RegDB 6G-Rule%d start %d end %d max_bw %d tx_power_eirp %d max_psd_eirp %d flags %d 
+7839,iii,[ phyrf_regulatory_v2.c : 895 ] RegDB: Super Dmn Id %d validity %d Idx %d 
+7840,iii,[ phyrf_regulatory_v2.c : 983 ] RegDB-6G domain_code_6G AP SP %d, LPI %d, VLP %d 
+7841,iiii,[ phyrf_regulatory_v2.c : 1007 ] mode %d, Client num %d isClient %d rule num %d 
+7842,,[ phyrf_regulatory_v2.c : 1042 ] 6G RegInfo:mem alloc failure 
+7843,,[ phyrf_regulatory_v2.c : 1064 ] 6G RegInfo:mem alloc failure 
+7844,,[ phyrf_regulatory_v2.c : 1210 ] REGDB: BDF doesn't have valid country_code/domain_code 
+7845,,[ phyrf_regulatory_v2.c : 1217 ] RegDB: Invalid superdomain prgrammed 
+7846,,[ phyrf_regulatory_v2.c : 1228 ] RegDB: neither OTP nor BDF valid value for super dmn_code 
+7847,I,[ phyrf_regulatory_v2.c : 1243 ] RegDB: BDF Reg domain and super dmn 0x%x 
+7848,iii,[ phyrf_regulatory_v2.c : 1502 ] RegDB-Ext Event Status 2G5G %d 6G %d Overall %d 
+7849,iiiiiiii,[ phyrf_regulatory_v2.c : 1503 ] RegDB-Final Result_Ext alpha0 %d alpha1 %d alpha_size %d max_rules %d get_type %d cc_type %d ctryID %d dmnCode %d 
+7850,iiiiiiiii,[ phyrf_regulatory_v2.c : 1504 ] RegDB-Final Result_Ext num_2g_rules %d num_5g_rules %d phybitmap %d dfsregion %d min_bw_2g %d min_bw_5g %d max_bw_2g %d max_bw_5g %d vlp_priority_freq %d 
+7851,,[ phyrf_regulatory_v2.c : 1588 ] REGDB: neither OTP nor BDF valid value for country_code/domain_code. 
+7852,,[ phyrf_regulatory_v2.c : 1595 ] RegDB: Invalid superdomain programmed  
+7853,,[ phyrf_regulatory_v2.c : 1604 ] RegDB: neither OTP nor BDF valid value for country_code/dmn_code 
+7854,iiii,[ phyrf_regulatory_v2.c : 1627 ] REGDB: RegDB-BDF CC %d BDF RD %d BDF SD %d CC Type %d 
+7855,,[ phyrf_regulatory_v2.c : 1670 ] RegDB:Valid 6G super dmn and 5G2G reg pair Combo 
+7856,ii,[ phyrf_regulatory_v2.c : 1710 ] RegDB:6G Super Dmn %d Max BW %d 
+7857,iii,[ phyrf_regulatory_v2.c : 1763 ] RegDB:6G Super Dmn %d Max BW %d BDF SD %d 
+7858,ii,[ phyrf_regulatory_v2.c : 1767 ] RegDB:Valid country ID %d Correspondig RegDmn %d 
+7859,ii,[ phyrf_regulatory_v2.c : 1809 ] RegDB:6G Super Dmn %d Max BW %d 
+7860,ii,[ phyrf_regulatory_v2.c : 1822 ] RegDB Channel Prioritity Supported. FreqIdx %d Priority_freq %d 
+7861,i,[ phyrf_regulatory_v2.c : 1826 ] RegDB Channel Prioritity Supported but Country Not Supported, FreqIdx %d 
+7862,,[ phyrf_regulatory_v2.c : 1831 ] RegDB Channel Prioritity Not Supported 
+7863,ii,[ phyrf_regulatory_v2.c : 1834 ] RegDB-Valid country ID %d Correspondig RegDmn %d 
+7864,i,[ phyrf_regulatory_v2.c : 1845 ] RegDB:-Status %d 
+7865,iiiiiiii,[ phyrf_regulatory_v2.c : 1846 ] RegDB:Final Result alpha0 %d alpha1 %d alpha_size %d max_rules %d get_type %d cc_type %d ctryID %d dmnCode %d 
+7866,iiiiiiiii,[ phyrf_regulatory_v2.c : 1847 ] RegDB:Final Result num_2g_rules %d num_5g_rules %d phybitmap %d dfsregion %d min_bw_2g %d min_bw_5g %d max_bw_2g %d max_bw_5g %d  vlp_priority_freq %d 
+7867,i,[ phyrf_regulatory_v2.c : 1903 ] RegDB:Valid reg dmn pair id %d 
+7868,ii,[ phyrf_regulatory_v2.c : 1918 ] RegDB:Valid domain 2g rules %d 5g rules %d 
+7869,i,[ phyrf_regulatory_v2.c : 1986 ] REGDB: get valid country_code/domain_code from BDF %d. 
+7870,,[ phyrf_regulatory_v2.c : 1989 ] REGDB: neither OTP nor BDF valid value for country_code/domain_code. 
+7871,,[ phyrf_regulatory_v2.c : 2049 ] Invalid country code. Setting to "US". 
+7872,,[ phyrf_regulatory_v2.c : 2136 ] Invalid country_code/domain_code. No currentRD or ctl value change. 
+7873,i,[ phyrf_regulatory_v2.c : 2436 ] isChina %d 
+7874,,[ phyrf_regulatory_v2.c : 2600 ] Invalid Bandwidth configured. Using 20MHz 
+7875,i,[ phyrf_regulatory_v2.c : 2761 ] AFC RegDB Default num sp reg rules: %d 
+7876,Ii,[ phyrf_regulatory_v2.c : 2789 ] RegDB-Test_Super Domain 6G 0x%x %d 
+7877,i,[ phyrf_regulatory_v2.c : 2917 ] AFC RegDB num sp reg rules: %d 
+7878,Ii,[ phyrf_regulatory_v2.c : 2947 ] RegDB-Test_Super Domain 6G 0x%x %d 
+7879,ii,[ phyrf_regulatory_v2.c : 2984 ] start freq %d end freq %d  
+7880,ii,[ phyrf_regulatory_v2.c : 3005 ]  psd %d eirp %d 
+7881,iiiiii,[ phyrf_regulatory_v2.c : 3071 ] iwconfig_logs TPC_WMI: Compute6GRegpwr: bHomeChan %d Eirp %d psd %d num_power_level %d puncture_bitmap %d phy_mode %d 
+7882,ii,[ phyrf_regulatory_v2.c : 3075 ] iwconfig_logs TPC WMI: tx_power[%d] : %d 
+7883,i,[ phyrf_regulatory_v2.c : 3080 ] iwconfig_logs TPC_WMI: tpc_eirp %d 
+7884,iii,[ phyrf_regulatory_v2.c : 3099 ] iwconfig_logs TPC_WMI: min_psd_pwr: %d, PSD pwr_offset: %d, phy_mode: %d 
+7885,i,[ phyrf_regulatory_v2.c : 3105 ] iwconfig_logs TPC_WMI: Final 6G Reg Tx pwr %d 
+7886,iiiiiii,[ phyrf_regulatory_v2.c : 3161 ] Regulatory Query: 6G-Rule %d start %d end %d max_bw %d tx power eirp %d max_psd_eirp %d flags %d 
+7887,iii,[ phyrf_regulatory_v2.c : 3178 ] Regulatory Query: 6G Reg Rules AP: LPI %d SP %d VLP %d 
+7888,iiiiii,[ phyrf_regulatory_v2.c : 3179 ] Regulatory Query: 6G Reg Rules CLIENT1: LPI %d SP %d VLP %d CLIENT2: LPI %d SP %d VLP %d 
+7889,,[ phyrf_regulatory_v2.c : 3182 ] Regulatory Query: AP LPI Rules 
+7890,,[ phyrf_regulatory_v2.c : 3187 ] Regulatory Query: AP SP Rules 
+7891,,[ phyrf_regulatory_v2.c : 3192 ] Regulatory Query: AP VLP Rules 
+7892,,[ phyrf_regulatory_v2.c : 3197 ] Regulatory Query: CLIENT1 LPI Rules 
+7893,,[ phyrf_regulatory_v2.c : 3202 ] Regulatory Query: CLIENT1 SP Rules 
+7894,,[ phyrf_regulatory_v2.c : 3207 ] Regulatory Query: CLIENT1 VLP Rules 
+7895,,[ phyrf_regulatory_v2.c : 3212 ] Regulatory Query: CLIENT2 LPI Rules 
+7896,,[ phyrf_regulatory_v2.c : 3217 ] Regulatory Query: CLIENT2 SP Rules 
+7897,,[ phyrf_regulatory_v2.c : 3222 ] Regulatory Query: CLIENT2 VLP Rules 
+7898,iiiiii,[ phyrf_regulatory_v2.c : 3243 ] Regulatory Query: 5G Domain ID %d ctl_val %d dfs_region %d min_bw %d ant_gain %d num_reg_rules %d 
+7899,iiiiiii,[ phyrf_regulatory_v2.c : 3249 ] Regulatory Query: 5G-Rule %d start %d end %d ctl : %d max_bw %d reg_power %d flags %d 
+7900,iiiiii,[ phyrf_regulatory_v2.c : 3255 ] Regulatory Query: 2G Domain ID %d ctl_val %d dfs_region %d min_bw %d ant_gain %d num_reg_rules %d 
+7901,iiiiii,[ phyrf_regulatory_v2.c : 3259 ] Regulatory Query: 2G-Rule %d start %d end %d max_bw %d reg_power %d flags %d 
+7902,i,[ phyrf_regulatory_v2.c : 3265 ] Regulatory Query: RegDomain Info for regdomain ID %d  
+7903,i,[ phyrf_regulatory_v2.c : 3281 ] Regulatory Query: Querying for Country Code %d 
+7904,i,[ phyrf_regulatory_v2.c : 3286 ] Regulatory Query: Country Code %d is not present in Database 
+7905,IIIII,[ phyrf_regulatory_v2.c : 3292 ] Regulatory Query: Found Country Code in Database %c%c Mapped RegDomain Pair Id %u Max 2G BW %u Max 5G BW %u 
+7906,II,[ phyrf_regulatory_v2.c : 3296 ] Regulatory Query: Super Domain %u mapped to this country, Max 6G BW %u 
+7907,ii,[ phyrf_regulatory_v2.c : 3316 ] Regulatory Query: Regdomain Domain Id input : regdomain pair id %d superdomain id %d 
+7908,ii,[ phyrf_regulatory_v2.c : 3326 ] Regulatory Query: type %d code %d. Unsupported Input Type 
+7909,IIiiiiiii,[ phyrf_regulatory_v2.c : 3336 ] Regulatory Query : Country Code %c%c Country ID %d Regdomain %d Superdomain %d num_rules %d max_bw %d num_rules %d max_bw %d 
+7910,iiiiii,[ phyrf_regulatory_v2.c : 3342 ] Regulatory Query : Regrule 2G : start_freq %d end_freq %d max_bw %d reg_power %d ant_gain %d flags %d 
+7911,ii,[ phyrf_regulatory_v2.c : 3345 ] Regulatory Query : Regdomain 5G : num_rules %d max_bw %d 
+7912,iiiiii,[ phyrf_regulatory_v2.c : 3351 ] Regulatory Query : Regrule 5G : start_freq %d end_freq %d max_bw %d reg_power %d ant_gain %d flags %d 
+7913,i,[ phyrf_regulatory_v2.c : 3368 ] iwconfig_logs TPC_WMI: puncture_cnt %d 
+7914,i,[ phyrf_regulatory_v2.c : 3418 ] iwconfig_logs: TPC_WMI: Invalid puncture BW %d 
+7915,i,[ phyrf_regulatory_v2.c : 3436 ] iwconfig_logs: TPC_WMI: Invalid puncture BW %d 
+7916,i,[ phyrf_regulatory_v2.c : 3457 ] iwconfig_logs: TPC_WMI: Invalid puncture BW %d 
+7917,ii,[ wlan_regdb_offload.c : 194 ] REGDB test command num_args=%d testId=%d 
+7918,Iiiiii,[ wlan_regdb_offload.c : 330 ] set_regdomain 0x%08x %d %d %d, current/new reg domain %d, %d 
+7919,IIIIII,[ wlan_regdb_offload.c : 342 ] REG_DOMAIN CCA_region_2G %x CCA_region_5G %x CCA_region_6G %x pdev_id %x is_2g %x is 6g %x 
+7920,II,[ wlan_regdb_offload.c : 359 ] REG_DOMAIN CCA set_regdomain check %x %x 
+7921,,[ wlan_regdb_offload.c : 798 ] REGDB fail - invalid country code 
+7922,,[ wlan_regdb_offload.c : 802 ] REGDB fail - invalid get type 
+7923,i,[ wlan_regdb_offload.c : 860 ] REGDB send reg rules failed - status=%d 
+7924,,[ wlan_regdb_offload.c : 899 ] REGDB EXT fail - invalid country code input 
+7925,,[ wlan_regdb_offload.c : 903 ] REGDB EXT fail - invalid get type 
+7926,II,[ wlan_regdb_offload.c : 949 ] REGDB send reg rules for alpha2: %c %c 
+7927,i,[ wlan_regdb_offload.c : 1029 ] REGDB send reg rules failed - status=%d 
+7928,ii,[ wlan_regdb_offload.c : 1037 ] chanPrioritySupport=%d vlp_priority_freq=%d 
+7929,i,[ wlan_regdb_offload.c : 1101 ] REGDB EXT send reg rules failed - status=%d 
+7930,IIiiiii,[ wlan_regdb_offload.c : 1224 ] REGDB send reg rules for alpha2: %c %c status_code=%d, ctry_id=%d dom_code=%d, 2g_rules=%d, 5g_rules=%d 
+7931,IIiiiii,[ wlan_regdb_offload.c : 1236 ] REGDB dfs_reg=0x%x, phybitmap=0x%x minbw2g=%d maxbw2g=%d minbw5g=%d maxbw5g=%d evt_len=%d 
+7932,,[ wlan_regdb_offload.c : 1240 ] REGDB wmi buf alloc fail 
+7933,iIII,[ wlan_regdb_offload.c : 1303 ] REGDB ruleIdx=%d freq info=0x%x bw_pwr=0x%x flag=0x%x 
+7934,,[ wlan_regdb_offload.c : 1309 ] REGDB send WMI_REG_CHAN_LIST_CC_EVENTID 
+7935,,[ wlan_regdb_offload.c : 1359 ] LOW_PWR_EXT - WMI - wlan_regdb_offload_append_wmi_blacklist_channels(), USING ADDITIONAL BUFFER 
+7936,I,[ wlan_regdb_offload.c : 1503 ] RegDB wmi buf alloc fail - evt_id = %u 
+7937,ii,[ wlan_regdb_offload.c : 1606 ] RegDB EXT Rules %d > Max_Reg_Rules %d 
+7938,ii,[ wlan_regdb_offload.c : 1730 ] RegDB - Sent WMI_REG_CHAN_LIST_CC_EXT_EVENT evt_len: %d, num_of_channels: %d 
+7939,,[ wlan_regdb_offload.c : 460 ] ####5G CTL Subband feature enable #### 
+7940,,[ wlan_regdb_offload.c : 526 ] WMI_SET_CURRENT_COUNTRY_CMID not support for WIN 
+7941,iiI,[ wlan_regdb_offload.c : 537 ] REGDB set init country command pdev_id=%d, cc_type=%d, cc_value=0x%x 
+7942,iIiiI,[ wlan_regdb_offload.c : 619 ] REGDB AFC HOST RX INDICATION RECEIVED. pdev_id=%d,tlv_header=0x%x, tlv_tag_id_enum = %d,tag_id_rec = %d cmd_type 0x%x 
+7943,I,[ hca_HwComponentRf_bdf_v2.cpp : 333 ] WHAL_ERROR_EEPROM_MACADDR - sum = %lx
+ 
+7944,iiiii,[ hca_HwComponentRf_bdf_v2.cpp : 600 ] xtal GetTargetXtalCalDeltaFromLUT xtalTemp:%d pre_xtalTemp:%d absTempDiff:%d ptr:%d maxXtalTempCompNum:%d 
+7945,iiIi,[ hca_HwComponentRf_bdf_v2.cpp : 799 ] iwconfig_logs:: HomeChan = %d doTpcFlag = %d, resetCause = 0x%x, tpscale = %d 
+7946,iiiiii,[ hca_HwComponentRf_bdf_v2.cpp : 1153 ] SetUserPowerLimit: power %d, perChainPwr %d, flag %d, signedPwr %d, powerLimit2G %d powerLimit5G %d 
+7947,II,[ hca_HwComponentRf_bdf_v2.cpp : 1391 ] sticky Invalid Flag Mask:%x bit Position:%u 
+7948,III,[ hca_HwComponentRf_bdf_v2.cpp : 1428 ] sticky - add 0x%08lx, flag 0x%08lx, val 0x%08lx 
+7949,III,[ hca_HwComponentRf_bdf_v2.cpp : 1644 ] GetRxGainCalData4Chan curFreq %u, closestFreqInBdf[%u] %u 
+7950,iiii,[ hca_HwComponentRf_bdf_v2.cpp : 2042 ] tempCode ch%d = %d, calTemp %d, tempSlope %d
+ 
+7951,ii,[ hca_HwComponentRf_bdf_v2.cpp : 2066 ] RTT - pktBw %d is not valid in dynamicBw %d 
+7952,i,[ hca_HwComponentRf_bdf_v2.cpp : 2166 ] RTT - Invalid preamble: %d; return 0 delays 
+7953,iiiiiiii,[ hca_HwComponentRf_bdf_v2.cpp : 2179 ] RTT - phy%d chainNum: %d txRxIdx: %d, dynBw: %d, preamble: %d, heLtf: %d, pktBw: %d, whalRate: %d 
+7954,i,[ hca_HwComponentRf_bdf_v2.cpp : 2187 ] RTT - base=%d 
+7955,i,[ hca_HwComponentRf_bdf_v2.cpp : 2211 ] RTT - apply 2G 6us offset = %d
+ 
+7956,i,[ hca_HwComponentRf_bdf_v2.cpp : 2216 ] RTT - delayPs=%d ps 
+7957,ii,[ hca_HwComponentRf_bdf_v2.cpp : 2240 ] RTT - freq %d, delta=%d 
+7958,i,[ hca_HwComponentRf_bdf_v2.cpp : 2246 ] RTT - pri20, delta=%d 
+7959,ii,[ hca_HwComponentRf_bdf_v2.cpp : 2257 ] RTT - chain %d delta=%d 
+7960,i,[ hca_HwComponentRf_bdf_v2.cpp : 2264 ] RTT - IQ, delta=%d 
+7961,i,[ hca_HwComponentRf_bdf_v2.cpp : 2270 ] RTT - LPC, delta=%d 
+7962,i,[ hca_HwComponentRf_bdf_v2.cpp : 2286 ] RTT - DPD PEF, delta=%d 
+7963,i,[ hca_HwComponentRf_bdf_v2.cpp : 2291 ] RTT - Tx DAC, delta=%d 
+7964,i,[ hca_HwComponentRf_bdf_v2.cpp : 2296 ] RTT - Tx PADroopComp, delta=%d 
+7965,i,[ hca_HwComponentRf_bdf_v2.cpp : 2301 ] RTT - Tx eDPD condition 2, delta=%d 
+7966,i,[ hca_HwComponentRf_bdf_v2.cpp : 2306 ] RTT - Tx eDPD condition 3, delta=%d 
+7967,i,[ hca_HwComponentRf_bdf_v2.cpp : 2311 ] RTT - Tx eDPD condition 4, delta=%d 
+7968,i,[ hca_HwComponentRf_bdf_v2.cpp : 2329 ] RTT - Ti ADC, delta=%d 
+7969,i,[ hca_HwComponentRf_bdf_v2.cpp : 2334 ] RTT - VSRC, delta=%d 
+7970,i,[ hca_HwComponentRf_bdf_v2.cpp : 2339 ] RTT - spur mit, delta=%d 
+7971,i,[ hca_HwComponentRf_bdf_v2.cpp : 2359 ] RTT - Rx TiAdcGainCorr, delta=%d 
+7972,i,[ hca_HwComponentRf_bdf_v2.cpp : 2364 ] RTT - Rx IcicCorr, delta=%d 
+7973,i,[ hca_HwComponentRf_bdf_v2.cpp : 2369 ] RTT - Rx DcNotchCommonOn, delta=%d 
+7974,i,[ hca_HwComponentRf_bdf_v2.cpp : 2374 ] RTT - Rx VsrcPreFir1On, delta=%d 
+7975,i,[ hca_HwComponentRf_bdf_v2.cpp : 2379 ] RTT - Rx VsrcPreFir2On, delta=%d 
+7976,i,[ hca_HwComponentRf_bdf_v2.cpp : 2384 ] RTT - Rx VsrcPreFir3On, delta=%d 
+7977,i,[ hca_HwComponentRf_bdf_v2.cpp : 2390 ] RTT - Rx DcNotchDetectOff, delta=%d 
+7978,i,[ hca_HwComponentRf_bdf_v2.cpp : 2395 ] RTT - Rx Spur1DetectOn, delta=%d 
+7979,i,[ hca_HwComponentRf_bdf_v2.cpp : 2400 ] RTT - Rx Spur2DetectOn, delta=%d 
+7980,i,[ hca_HwComponentRf_bdf_v2.cpp : 3130 ] FTM CALDB: SkipCalDbRegen = %d
+ 
+7981,iiiiii,[ hca_HwComponentRf_bdf_v2.cpp : 3262 ] iwconfig_logs:: UpdateMaxTxPower start :: bHomeChan=%d Mhz=%d centre1=%d centre2=%d phy_mode=%d chan->max_reg_power=%d 
+7982,iiiii,[ hca_HwComponentRf_bdf_v2.cpp : 3479 ] iwconfig_logs:: UpdateMaxTxPower :: userMaxPowerx2=%d,powerLimit=%d,maxTxPower=%d,bHomeChan=%d,Display power *pMaxTxPower=%d
+ 
+7983,iiiiii,[ hca_HwComponentRf_bdf_v2.cpp : 3535 ] iwconfig_logs:: HdsSetTransmitPower Start:: bHomeChan=%d Mhz=%d centre1=%d centre2=%d phy_mode=%d chan->max_reg_power=%d 
+7984,i,[ hca_HwComponentRf_bdf_v2.cpp : 3603 ] CTL_TIME : Time taken for CTL computation %d 
+7985,,[ hca_HwComponentRf_bdf_v2.cpp : 3651 ] xTal : Skipped programming CapIn and capOut values 
+7986,iIII,[ hca_HwComponentRf_bdf_v2.cpp : 3972 ] GetForcedNfCalChanIndex Band %d, curFreq %u, closestFreqInBdf[%u] %u 
+7987,III,[ hca_HwComponentRf_bdf_v2.cpp : 4324 ] NFCal phyId : %u, cca2FreqOrderMap for pri20Index %u, num20MhzSegment %u 
+7988,IIIII,[ hca_HwComponentRf_bdf_v2.cpp : 4326 ] NFCal phyId : %u, cca2FreqOrderMap 00:%02u, 01:%02u, 02:%02u, 03:%02u 
+7989,IIIII,[ hca_HwComponentRf_bdf_v2.cpp : 4328 ] NFCal phyId : %u, cca2FreqOrderMap 04:%02u, 05:%02u, 06:%02u, 07:%02u 
+7990,IIIII,[ hca_HwComponentRf_bdf_v2.cpp : 4330 ] NFCal phyId : %u, cca2FreqOrderMap 08:%02u, 09:%02u, 10:%02u, 11:%02u 
+7991,IIIII,[ hca_HwComponentRf_bdf_v2.cpp : 4332 ] NFCal phyId : %u, cca2FreqOrderMap 12:%02u, 13:%02u, 14:%02u, 15:%02u 
+7992,iiI,[ hca_HwComponentRf_bdf_v2.cpp : 4698 ] DBGLOG: band - %d, chain - %d, antennaGain -%u 
+7993,IIIIIi,[ hca_HwComponentRf_bdf_v2.cpp : 5592 ] tpcOnepointCal:: chosen phyId %u calFreq[%u] %u curChan %u curChain %u onePointTpcGLUTOffset %d 
+7994,iiiii,[ hca_HwComponentRf_bdf_v2.cpp : 5737 ] tpcOnepointCal::channel:%d chosen_chanid:%d cmask:%d band:%d tpcPowerOffset:%d
+ 
+7995,IIIIIi,[ hca_HwComponentRf_bdf_v2.cpp : 6205 ] tpcOnepointCal:: chosen phyId %u calFreq[%u] %u curChan %u curChain %u onePointThermOffset %d 
+7996,IIIIIII,[ hca_HwComponentRf_bdf_v2.cpp : 6323 ] tpcOnepointCal:: chosen phyId %u alphaThermFreq[%u] %u curChan %u curChain %u tempIdx %u alphaThermValue %u 
+7997,,[ hca_HwComponentRf_bdf_v2.cpp : 6512 ] tpc_flag:: Invalid Input values 
+7998,i,[ hca_HwComponentRf_bdf_v2.cpp : 6514 ] tpcFlag = %d
+ 
+7999,iiiI,[ hca_HwComponentRf_bdf_v2.cpp : 6539 ] UpdateCalDone: phyId - %d, band -%d, cal type - %d, cal done mask - 0x%lX 
+8000,ii,[ hca_HwComponentRf_bdf_v2.cpp : 6930 ] TLMM: GPIO config failed with status %d for freq %d 
+8001,iiii,[ hca_HwComponentRf_bdf_v2.cpp : 7097 ] RxSOP - nfHwInDbm = %d, sensLevel = %d, offsets_added_with_nf = %d, ANI Level = %d,  
+8002,iii,[ hca_HwComponentRf_bdf_v2.cpp : 7347 ] BAND = %d, rssiBypassXlnaThreshold = %d, rssiBypassXlnaOffset = %d
+ 
+8003,ii,[ hca_HwComponentRf_bdf_v2.cpp : 7466 ] CALDB: chlistFlag for Band %d from BDF is : %d 
+8004,ii,[ hca_HwComponentRf_bdf_v2.cpp : 7495 ] CALDB: chlist_repeat_count for Band %d : %d 
+8005,i,[ hca_HwComponentRf_bdf_v2.cpp : 7664 ] Only FPC mode is supported! tpcCalScheme=%d 
+8006,ii,[ hca_HwComponentRf_bdf_v2.cpp : 7673 ] Index Out of Bound, Index=%d, MAX_INDEX=%d
+ 
+8007,ii,[ hca_HwComponentRf_bdf_v2.cpp : 7698 ] Index Out of Bound, Index=%d, MAX_INDEX=%d
+ 
+8008,,[ hca_HwComponentRf_bdf_v2.cpp : 7705 ] _BDF_STRUCT_6G_H_ Flag not defined 
+8009,ii,[ hca_HwComponentRf_bdf_v2.cpp : 7717 ] Index Out of Bound, Index=%d, MAX_INDEX=%d
+ 
+8010,,[ hca_HwComponentRf_bdf_v2.cpp : 7725 ] _BDF_STRUCT_5G_H_ Flag not defined 
+8011,Iiiiii,[ hca_HwComponentRf_bdf_v2.cpp : 8036 ] Get20MhzNfPerChain: chainIdx: %u, rfChain: %d, ccaOrder: %d, dbmOffset: %d, nfPri20WithoutBwOffsetAndSubbandRollOff: %d, freqOrder: %d 
+8012,iiIIi,[ hca_HwComponentRf_bdf_v2.cpp : 8262 ] HC: band: %d, chan %d, perMcs %x, pkttype %x, Nssthr %d 
+8013,ii,[ hca_HwComponentRf_bdf_v2.cpp : 8283 ] ACR : isG[2G=1,5G=0,6G=2]=%d, acrSetting=%d 
+8014,iI,[ hca_HwComponentRf_bdf_v2.cpp : 8400 ] GetCustBoardSpecificFlags flag_word %d flags = 0x%x 
+8015,ii,[ hca_HwComponentRf_bdf_v2.cpp : 8604 ] Powerboost maskmarginoffset[%d] : %d 
+8016,iiiii,[ hca_HwComponentRf_bdf_v2.cpp : 8839 ] MULTIGAIN_RSSI_DUMP_BDF : Region1 = %d, Region2 = %d, Region3 = %d, Region4 = %d, Region5 = %d
+ 
+8017,iiii,[ hca_HwComponentRf_bdf_v2.cpp : 8842 ] MULTIGAIN_RSSI_DUMP_BDF : Channel[%d] = %d, phy_mode[%d] = %d
+ 
+8018,iii,[ hca_HwComponentRf_bdf_v2.cpp : 8896 ] MULTIGAIN_RSSI_DUMP_BDF : multiGainRssiOffsetData2G[%d][%d] = %d
+ 
+8019,i,[ hca_HwComponentTrxMarina_bdf.cpp : 130 ] RTT - Error: unsupported pktBw %d 
+8020,i,[ hca_HwComponentTrxMarina_bdf.cpp : 149 ] RTT - Invalid dynamicBw %d for 2G 
+8021,iii,[ hca_HwComponentTrxMarina_bdf.cpp : 578 ] RTT - CBW cbwBias=%d, bhomechan=%d, dynBw=%d 
+8022,iiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 1207 ] DumpTpc: before maxRegDef p1 bdf val: %d, user antenna gain: 2G: %d - 5G: %d, twiceAntennaGain (max of BDF and user): %d, twiceAntennaReduction: %d,  
+8023,iiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 1219 ] DumpTpc: before maxRegDef powerLimit: %d, userMaxPowerx2: %d, twiceMaxRD: %d, twiceLargestAntenna %d, lowest power: %d 
+8024,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 1224 ] iwconfig_logs :: TPC :: userAllowedPower[%d] = %d 
+8025,iiiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 1244 ] DumpTpc: after maxRegDef default reg pwr: %d pTpcConfig->maxRegAllowedPower[%d]: %d, g_TwiceMultiChainGain[%d]: %d pTpcConfig->maxRegAllowedPower6GEIRP[chIdx] %d 
+8026,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 1349 ]  Invalid Band or BDF pointer: %d, isG : %d 
+8027,,[ hca_HwComponentTrxMarina_bdf.cpp : 2005 ] Invalid Band selected 
+8028,i,[ hca_HwComponentTrxMarina_bdf.cpp : 2152 ] Target pwr mode is invalid %d 
+8029,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 2297 ] CALDB: size = %d for chListEnum = %d
+ 
+8030,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 2459 ] SetDPDTempCfg: eDpdTempRecalCheck: %d, eDpdTempThreshold: %d  
+8031,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 2651 ] Temp Invalid, GetCurrentTempInDegC : phyId = %d, degC = %d 
+8032,iiIiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 2698 ] GetCurrentTempInDegC phyId = %d, band = %d, chIdx = 0x%x, degC = %d, numTemp = %d, IsTempOverride=%d, chosenTempSensor = %d 
+8033,iII,[ hca_HwComponentTrxMarina_bdf.cpp : 2911 ] AOA_DATA freqidx = %d, pIbfCalData= %p for pAoAGrpStopIdx = %p
+ 
+8034,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 3062 ] TLMM::::  GPIO config failed with status %d for freq: %d 
+8035,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 3394 ] perPacketCMFeatureEnable = %d, Debug Log = %d  
+8036,IIiIIii,[ hca_HwComponentTrxMarina_bdf.cpp : 3476 ] GetRssiBypassXlnaOffset : phyId %u, Band %u, rssi %d, rssiByPassXlnaFreqPierIdx %u, rssiByPassXlnaFreqPier2G %u, rssiByPassXlnaSnrThresh2G %d,pRssiByPassXlnaOffset %d 
+8037,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 3482 ] GetRssiBypassXlnaOffset : Invalid Frequency : chan->mhz %d, pRssiByPassXlnaOffset %d  
+8038,,[ hca_HwComponentTrxMarina_bdf.cpp : 3595 ] pHandle is NULL 
+8039,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 3656 ] DumpTpcPerPacket: FW - %d Back off applied [In terms of 0.25dbm] rtIdx=%d 
+8040,iiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 3686 ] DumpTpcPerPacket: HOST - cck_valid=%d, ofdm_valid=%d,start_mcs=%d, end_mcs=%d, pwr_level=%d 
+8041,iii,[ hca_HwComponentTrxMarina_bdf.cpp : 3699 ] DumpTpcPerPacket: HOST - %d Back off applied [In terms of 0.25dbm] rtIdx=%d, mcs=%d 
+8042,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 3706 ] DumpTpcPerPacket: HOST - Back off Not applied rtIdx=%d, mcs=%d 
+8043,i,[ hca_HwComponentTrxMarina_bdf.cpp : 3755 ] GetAllAlphaThermParms: Invalid Band, Supported Band=2G, Band value=%d 
+8044,iii,[ hca_HwComponentTrxMarina_bdf.cpp : 3783 ] GetAllAlphaThermParms: AlphaTherm channel %d alphaThermFreq[iAlphaThermFreq] %d chosenChannelIdx Final:TempOffsetIdx%d 
+8045,iii,[ hca_HwComponentTrxMarina_bdf.cpp : 3872 ] GetRssiBwAdjustment : band =%d, bw =%d, rssiBwAdjustment =%d 
+8046,iiiii,[ hca_HwComponentTrxMarina_bdf.cpp : 4013 ] GDP: Chain %d GDPAoAPhase[%d] %d GDPGainGroupingStopIndex[%d] %d 
+8047,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 4066 ] tpcCal txCalGainIndexes[%d] %d 
+8048,ii,[ hca_HwComponentTrxMarina_bdf.cpp : 4119 ] tpcCal calDataTgtPwr[%d] %d 
+8049,,[ hca_HwComponentTrxMarina_btcoex.cpp : 268 ] TrxMarina_btcoex::SetOverrideGainSetting: Error Cannot Access Register in Sleep 
+8050,iIii,[ hca_HwComponentTrxMarina_btcoex.cpp : 301 ] TrxMarina_btcoex::SetOverrideGainSetting: Read back value of PHYID = %d, ovsVal = 0x%02x WLAN_CONTROL_EN_CH0_OVS = %d, BT_CONTROL_SLNA_L_CH0_OVS = %d 
+8051,II,[ hca_HwComponentTrxMarina_cal.cpp : 197 ] NfCalibration disabled for phyId %u isHomeChan %u 
+8052,IIiII,[ hca_HwComponentTrxMarina_cal.cpp : 227 ] NfCalibration type 0x%x nfCalIterCnt %u trigger status is %d for phyId %u isHomeChan %u 
+8053,,[ hca_HwComponentTrxMarina_cal.cpp : 365 ] NfRegRead failure. NULL point error or inactive phy 
+8054,IIIi,[ hca_HwComponentTrxMarina_cal.cpp : 433 ] NfRegRead nfType: 0x%08x, chainIdx: %u, i20MhzSegment: %u, NFValue: %d 
+8055,III,[ hca_HwComponentTrxMarina_cal.cpp : 655 ] AoA ch%u start_ent %u stop_ent %u 
+8056,iIiiiii,[ hca_HwComponentTrxMarina_cal.cpp : 671 ] AoA - ch%d, gaintblType %u gnIdx %d, dataSz %d, bdfVal %d calVal %d, AoAphase %d 
+8057,,[ hca_HwComponentTrxMarina_cal.cpp : 806 ] pHandle is NULL 
+8058,,[ hca_HwComponentTrxMarina_cal.cpp : 826 ] pHandle is NULL 
+8059,I,[ hca_HwComponentTrxMarina_calDb.cpp : 843 ] CALDB_DEBUG: channel list table dump groupA 2G 20 %u 
+8060,I,[ hca_HwComponentTrxMarina_calDb.cpp : 847 ] CALDB_DEBUG: channel list table dump groupA 2G 40 %u 
+8061,I,[ hca_HwComponentTrxMarina_calDb.cpp : 851 ] CALDB_DEBUG: channel list table dump groupA 5G 20 %u 
+8062,I,[ hca_HwComponentTrxMarina_calDb.cpp : 855 ] CALDB_DEBUG: channel list table dump groupA 5G 40 %u 
+8063,I,[ hca_HwComponentTrxMarina_calDb.cpp : 859 ] CALDB_DEBUG: channel list table dump groupA 5G 80 %u 
+8064,I,[ hca_HwComponentTrxMarina_calDb.cpp : 863 ] CALDB_DEBUG: channel list table dump groupA 5G 160 %u 
+8065,I,[ hca_HwComponentTrxMarina_calDb.cpp : 868 ] CALDB_DEBUG: channel list table dump groupA 5G 320 %u 
+8066,I,[ hca_HwComponentTrxMarina_calDb.cpp : 872 ] CALDB_DEBUG: channel list table dump groupB 2G 20 %u 
+8067,I,[ hca_HwComponentTrxMarina_calDb.cpp : 876 ] CALDB_DEBUG: channel list table dump groupB 2G 40 %u 
+8068,I,[ hca_HwComponentTrxMarina_calDb.cpp : 880 ] CALDB_DEBUG: channel list table dump groupB 5G 20 %u 
+8069,I,[ hca_HwComponentTrxMarina_calDb.cpp : 884 ] CALDB_DEBUG: channel list table dump groupB 5G 40 %u 
+8070,I,[ hca_HwComponentTrxMarina_calDb.cpp : 888 ] CALDB_DEBUG: channel list table dump groupB 5G 80 %u 
+8071,I,[ hca_HwComponentTrxMarina_calDb.cpp : 892 ] CALDB_DEBUG: channel list table dump groupB 5G 160 %u 
+8072,I,[ hca_HwComponentTrxMarina_calDb.cpp : 896 ] CALDB_DEBUG: channel list table dump groupB 5G 320 %u 
+8073,ii,[ hca_HwComponentTrxMarina_calDb.cpp : 900 ] CALDB_DEBUG: groupMapping[%d][1]=%d  
+8074,iIi,[ hca_HwComponentTrxMarina_config.cpp : 103 ] EnableHwDtimSlna: phyId = %d, chainMask = 0x%02x, SLNA_CTRL = %d 
+8075,ii,[ hca_HwComponentTrxMarina_config.cpp : 159 ] RxChainSwitch chainIdx %d enableDisable %d 
+8076,ii,[ hca_HwComponentTrxMarina_efuse.cpp : 240 ] ::XO cdacin %d, cdacout %d 
+8077,ii,[ hca_HwComponentTrxMarina_efuse.cpp : 260 ] ::ReadPerRfa %d, %d 
+8078,iii,[ hca_HwComponentTrxMarina_paprd.cpp : 110 ] pPaprdStruct->paprdType %d dpd_tbl_start_idx %d and dpd_tbl_end_idx %d
+ 
+8079,I,[ hca_HwComponentTrxMarina_paprd.cpp : 127 ] PAPRD:HcaHwComponentTrxMarina_paprd::HwDisable : PhyBase %8x 
+ 
+8080,IIIIII,[ hca_HwComponentTrxMarina_paprd.cpp : 327 ] dpdEnable %u, edpdEnable %u, edpdTrainData 0x%08x, dpdGlutTableEn 0x%08x, edpdDynGlutSel 0x%08x, num_dpd_tables %u 
+8081,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 385 ] valid chain mask %d paprdType %d 
+8082,III,[ hca_HwComponentTrxMarina_paprd.cpp : 559 ] PAPRD: send_cfg_flags 0x%x, mcs %u, ppdu_duration %u 
+8083,i,[ hca_HwComponentTrxMarina_paprd.cpp : 569 ]  PAPRD: XmitTrainingFrame failed. Status %d 
+ 
+8084,i,[ hca_HwComponentTrxMarina_paprd.cpp : 572 ]  PAPRD: XmitTrainingFrame tx_count %d
+ 
+8085,iii,[ hca_HwComponentTrxMarina_paprd.cpp : 665 ] phy_paprd_device_PopulatePaprdTables : chain %d tableIndex %d paprdType %d 
+8086,i,[ hca_HwComponentTrxMarina_paprd.cpp : 748 ] PAPRD table index %d; skipping chain 
+ 
+8087,i,[ hca_HwComponentTrxMarina_paprd.cpp : 763 ] PAPRD ChangeTrainingIndex dpdTable %d violates regulary or an invalid GLUT; skipping table 
+8088,iiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 787 ] PAPRD_ChangeTrainingIndex: Channel %d chainIdx %d glutIdx %d gainIdx %d temp %d 
+8089,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 909 ] HwComponentTrxMarina_paprd::FtmControl : channel %d dpd_enable %d 
+ 
+8090,iiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 957 ] PAPRD PHY ID %d start %d end %d chan start %d chan end %d 
+ 
+8091,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 977 ] PAPRD PHY ID %d GetDPDEnable() DPD enable %d 
+8092,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 1204 ] PAPRD: Aborting Excess Retries. retry_dpd %d, Tx_Err %d 
+8093,iii,[ hca_HwComponentTrxMarina_paprd.cpp : 1248 ] PAPRD: eDPD PAPRD_CAL_SM_DPD_TRAINING_PROCESS_DATA Triggered for chain:%d phyId :%d bg thread status %d 
+8094,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1273 ] PAPRD: PAPRD_CAL_SM_DPD_TRAINING_PROCESS_DATA hwPaPrdStatus(fail) retry_dpd %d 
+8095,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1315 ] PAPRD PAPRD_CAL_SM_MEM_DPD_POST_PROC_DATA. thread status %d 
+8096,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1327 ] PAPRD mem dpd retry count %d  
+8097,,[ hca_HwComponentTrxMarina_paprd.cpp : 1370 ] PAPRD: PAPRD_CAL_SM_TEARDOWN_TRAINING : DPD ABORT 
+8098,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1391 ] PAPRD: PAPRDTUNING DONE. total_caltime %d 
+8099,iii,[ hca_HwComponentTrxMarina_paprd.cpp : 1394 ] PAPRD: isExtn %d lastcalTime %d, current_time %d 
+8100,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 1401 ] PAPRD CAL DONE: complete_mask %d and paprdType %d
+ 
+8101,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 1420 ] PAPRD Calibration : Cancel Timer channel %d home chan %d 
+8102,iii,[ hca_HwComponentTrxMarina_paprd.cpp : 1456 ] PAPRD: Timer Handler %d  current channel conntext is different from timer channel context [%d %d] 
+8103,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1462 ] PAPRD: Start Calibration : %d ms Timer expired  
+8104,iiiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1513 ] PAPRD: DPD calibration aborted on chain %d, tableIdx %d, channel %d, state %d, new_channel_change_request %d home %d  
+8105,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1525 ] PAPRD: DPD calibration aborted on channel %d 
+8106,iiiiiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1568 ] PAPRD: phyrf_mc_SendTxCompletion(phy %d) : channel %d, txchain %d, table %d, new_channel_change_request %d, cal abort_ppdu %d, status %d, retry_cnt %d 
+8107,iiiiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1581 ] PAPRD: new_channel_change_request : channel %d, txchain %d, table %d, new_channel_change_request %d, cal abort_ppdu %d, status %d, retry_cnt %d 
+8108,iiiiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1589 ] PAPRD: Status %d, whal_tx_err_status_t %d, Flush_req_reason %d, tx_ctxt_flags %d, pdev_paused %d sch_cmd_result %d 
+8109,i,[ hca_HwComponentTrxMarina_paprd.cpp : 1599 ] PAPRD: TBTT Flush condition hit , flush_req_reason = %d 
+8110,iiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1605 ] PAPRD: Tx Completion Status %d, whal_tx_err_status_t = %d , retrying (chain %d table %d) 
+8111,iII,[ hca_HwComponentTrxMarina_paprd.cpp : 1658 ] PAPRD: pPaprdStruct->paprd_done[%d] is %x GlutTable = 0x%X 
+8112,Ii,[ hca_HwComponentTrxMarina_paprd.cpp : 1668 ] PAPRD: dpd_num_tbl_mask=0x%x g_paprd_fail_case_bmask=%d 
+8113,iiii,[ hca_HwComponentTrxMarina_paprd.cpp : 1704 ] PAPRD: Paprd Done status = %d phyId = %d pPaprdStruct->recover_dpd = %d and pPaprdStruct->dpd_recovery_count = %d
+ 
+8114,ii,[ hca_HwComponentTrxMarina_paprd.cpp : 1826 ] PAPRD : maxTxPowerMCS9 %d, regulatoryPower %d 
+8115,I,[ hca_HwComponentTrxMarina_paprd.cpp : 1840 ] GetCalEnableMask: calEnableMask = 0x%x 
+8116,i,[ hca_HwComponentTrxMarina_tpc.cpp : 215 ] TPC_DBG: EnableCLPC=%d SKIP_PDET 
+8117,iiiiiiiii,[ hca_HwComponentTrxMarina_tpc.cpp : 376 ] TPC_DBG:tpc glut Reset struct->curr_tbl_idx : %d chainIdx:%d channel:%d glutIdxEnd:%d i:%d txGainIdx:%d measPwr:%d minDacGain:%d uClpcError:%d  
+8118,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 419 ] TPC_DBG:force glut: chain%d, gainindex%d: dacgain=%d
+ 
+8119,i,[ hca_HwComponentTrxMarina_tpc.cpp : 522 ] TPC_DBG: GetLatestAccumulatedCLPCError :%d 
+8120,,[ hca_HwComponentTrxMarina_tpc.cpp : 543 ] TPC_ERR: OLPC_TEMP_COMP: Invalid latestThermValue!
+ 
+8121,I,[ hca_HwComponentTrxMarina_tpc.cpp : 548 ] TPC_DBG: OLPC_TEMP_COMP: latestThermValue = %u
+ 
+8122,II,[ hca_HwComponentTrxMarina_tpc.cpp : 602 ] TPC_DUMP: PrimaryChan %u, SecondaryChan %u 
+ 
+8123,IIIII,[ hca_HwComponentTrxMarina_tpc.cpp : 647 ] TPC_DUMP_BDF : tpcchan %3u | tpcChainIdx %3u | gainIdx %3u | txgainIdx %3u | meas_pwr %10d | 
+8124,III,[ hca_HwComponentTrxMarina_tpc.cpp : 767 ] TPC_DUMP_CTLARRAY, isHome %u, phyId %u, pwr_mode %u 
+8125,,[ hca_HwComponentTrxMarina_tpc.cpp : 768 ] TPC_DUMP_CTLARRAY, NUMCHAINS , BF , OCB_IDX , NSS , CTL_Power  
+8126,IIIIi,[ hca_HwComponentTrxMarina_tpc.cpp : 779 ] TPC_DUMP_CTLARRAY, numChains %u, bf %u, ocbIdx %u, nss %u, CTLPwr %d 
+8127,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 794 ] TPC_DUMP_HC_OFFSET: 2G CTL HC OFFSET for Bw=%d,mcs=%d is=%d 
+8128,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 797 ] TPC_DUMP_HC_OFFSET: 5G CTL HC OFFSET for Bw=%d,mcs=%d is=%d 
+8129,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 816 ] DebugCmdCtlHcOffset BDF DUMP : HC_CtlRegion_map[0] %d HC_CtlRegion_map[1] %d HC_offset_ext_feature_enable %d 
+8130,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 820 ] DebugCmdCtlHcOffset BDF DUMP : NDP_MCS_Index=%d NonHtOffsetPower=%d phyID=%d 
+8131,ii,[ hca_HwComponentTrxMarina_tpc.cpp : 826 ] DebugCmdCtlHcOffset BDF DUMP : mcsgroup=%d HC_McsOffset_Map=%d 
+8132,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 833 ] DebugCmdCtlHcOffset BDF DUMP : bwIndex=%d, HC_Freq_Start_Index_2G=%d, HC_Freq_End_Index_2G=%d 
+8133,ii,[ hca_HwComponentTrxMarina_tpc.cpp : 839 ] DebugCmdCtlHcOffset BDF DUMP : chIndex=%d, HC_Channel_Index_Map_2G=%d 
+8134,iii,[ hca_HwComponentTrxMarina_tpc.cpp : 845 ] DebugCmdCtlHcOffset BDF DUMP : bwIndex=%d, HC_Freq_Start_Index_5G=%d, HC_Freq_End_Index_5G=%d 
+8135,ii,[ hca_HwComponentTrxMarina_tpc.cpp : 851 ] DebugCmdCtlHcOffset BDF DUMP : chIndex=%d, HC_Channel_Index_Map_5G=%d 
+8136,IIIII,[ hca_HwComponentTrxMarina_tpc.cpp : 904 ] TPC_DUMP_BDF : tpcchan %3u | tpcChainIdx %3u | gainIdx %3u | pdadc_read %3u | meas_pwr %10d | 
+8137,I,[ hca_HwComponentTrxMarina_tpc.cpp : 1020 ] TPC_DUMP_BDF : No matching entry for given freq %u 
+8138,ii,[ hca_HwComponentTrxMarina_tpc.cpp : 1072 ] TPC_DUMP_RATEARRAY : rateIdx:%d ratesArray_cck_ofdm:%d 
+8139,IIiI,[ hca_HwComponentTrxMarina_tpc.cpp : 1083 ] TPC_DUMP_RATEARRAY : Mode:%u phyMode:%u , MCS:%d ratesArray 0x%x 
+8140,IiI,[ hca_HwComponentTrxMarina_tpc.cpp : 1093 ] TPC_DUMP_RATEARRAY : Mode:%u , MCS:%d rate2power_ofdma 0x%x 
+8141,ii,[ hca_HwComponentTrxMarina_tpc.cpp : 1103 ] TPC_DUMP_RATEARRAY_OFFSETS : DPD_BACK_OFF CCK/OFDM rateIdx:%d dpd_bo_cck_ofdm_offsetrates:%d 
+8142,IiI,[ hca_HwComponentTrxMarina_tpc.cpp : 1111 ] TPC_DUMP_RATEARRAY_OFFSETS : DPD_BACK_OFF Mode:%u , MCS:%d dpd_offset 0x%x 
+8143,IiI,[ hca_HwComponentTrxMarina_tpc.cpp : 1122 ] TPC_DUMP_RATEARRAY_OFFSETS : ANN_POWERBOOST Mode:%u , MCS:%d pwrboost_offset 0x%x 
+8144,IiI,[ hca_HwComponentTrxMarina_tpc.cpp : 1133 ] TPC_DUMP_RATEARRAY_OFFSETS : BDF_PWR_OFFSETS Mode:%u , MCS:%d ratesArray_pwrOffset 0x%x 
+8145,iIii,[ hca_HwComponentTrxMarina_tpc.cpp : 1189 ] TPC_DBG: UpdateCalEnableFlag::returning calFlagOut:%d, resetCause:0x%x, phyId:%d FCS:%d 
+8146,Ii,[ hca_HwComponentTrxMarina_xtalCal.cpp : 111 ] XTAL CAL mode - 0x%x, gain index - %d 
+8147,iiII,[ HwComponentTrxMarina_calSmBwFilter.c : 284 ] calSmBwFilter: invoke TxBBF cal: isSBSmode=%d, chainIdx=%d, txChainMask=%x, phyInput->txChMask=%x
+ 
+8148,iiII,[ HwComponentTrxMarina_calSmBwFilter.c : 350 ] calSmBwFilter: invoke RxBBF cal: isSBSmode=%d, chainIdx=%d, rxChainMask=%x, phyInput->txChMask=%x 
+8149,I,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 164 ] FINALCASE out finalCase 		=%x 
+ 
+8150,iI,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 210 ] ADC ::: save TablePtr chain:%d = %p 
+8151,iIIII,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 220 ] regIdx:%d, Radix_out: 0x%x, cdac_1l: 0x%x, cdac_1s: 0x%x, Ra_gain: 0x%x
+ 
+8152,i,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 225 ] NEED_TO_DO_CAL:: cannot update ADC caldb for chainIdx = %d! 
+8153,iI,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 242 ] ADC ::: save TablePtr chain:%d = %p 
+8154,iIIII,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 252 ] regIdx:%d, Radix_out: 0x%x, cdac_1l: 0x%x, cdac_1s: 0x%x, Ra_gain: 0x%x
+ 
+8155,i,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 257 ] NEED_TO_DO_CAL:: cannot update ADC caldb for chainIdx = %d! 
+8156,IIIIII,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 283 ] FC_HANDLE pHandle = %x, phyInput = %x, adcInput = %x, adcOutput = %x, finalCase = %x, rfChainMask = %x
+ 
+8157,iI,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 310 ] calSmAdc: restore invoked cal on chainIdx = %d pADCData:0x%x 
+8158,iI,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 339 ] calSmAdc: save invoked on chainIdx = %d pADCData:0x%x 
+8159,,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 345 ] ADC ::: CAL_SAVE failed
+ 
+8160,i,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 360 ] calSmAdc: RECIPE status : %d
+ 
+8161,i,[ hca_HwComponentTrxMarina_calSmAdc.cpp : 441 ] CalSM: ADC cal end new Standalone 	phyId=%d 
+8162,iii,[ hca_HwComponentTrxMarina_calSmComb.cpp : 391 ] SCAN: Comb Cal Status - SMARTMON:%d, HigherMCSSCAN:%d CaldbEnable:%d 
+8163,,[ hca_HwComponentTrxMarina_calSmComb.cpp : 398 ] return upon SCAN: disable 
+8164,,[ hca_HwComponentTrxMarina_calSmComb.cpp : 408 ] ::::return upon back to same home channel from scan or from previous home channel wakeup: enable only
+ 
+8165,,[ hca_HwComponentTrxMarina_calSmComb.cpp : 413 ] :::: bypass FCS check, continue use calDB to determine action
+ 
+8166,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 670 ] cannot update rxiq table in caldb for chainIdx = %d!
+ 
+8167,iII,[ hca_HwComponentTrxMarina_calSmComb.cpp : 674 ] combCal_SM_restore: RXIQ: chainIdx=%d, pStartRxIq=%p, pStartRxIqGainMap32=%p
+ 
+8168,iI,[ hca_HwComponentTrxMarina_calSmComb.cpp : 800 ] combCal_SM_restore: TXIQ: chainIdx=%d,  pStartTxIq=%p
+ 
+8169,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 811 ] cannot update txiq table in caldb for chainIdx = %d!
+ 
+8170,iI,[ hca_HwComponentTrxMarina_calSmComb.cpp : 850 ] combCal_SM_restore: TXLO: chainIdx=%d,  pStartTxLo=%p
+ 
+8171,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 878 ] cannot update txlo table in caldb for chainIdx = %d!
+ 
+8172,iII,[ hca_HwComponentTrxMarina_calSmComb.cpp : 958 ] combCal_SM_save: RXIQ: chainIdx=%d,  pStartRxIq=%p pStartRxIqGainMap32=%p
+ 
+8173,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 960 ] combCal_SM_save:  RXIQ: pStartIqDpd=%p 
+8174,iII,[ hca_HwComponentTrxMarina_calSmComb.cpp : 963 ] combCal_SM_save: TXLO: chainIdx=%d,  pStartTxLo=%p, TXIQ: pStartTxIq=%p
+ 
+8175,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1112 ] cannot update txiq table in caldb for chainIdx = %d!
+ 
+8176,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1193 ] cannot update txlo table in caldb for chainIdx = %d!
+ 
+8177,iiiIiIii,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1312 ] cur_tbl_idx=%d, hwsBw=%d, freq1=%d, tMask=%x, concMode=%d, pwrMask=%x, isSBSmode=%d, loadIniMask=%d
+ 
+8178,ii,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1374 ] FC_HANDLE  finalCase before switch statement		=%d, CombIQ->localtxloValid=%d
+ 
+8179,,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1536 ]  GDP: cal failure observed 
+8180,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1558 ] CAL_COMMON_PARAM pHandle 	=%p
+ 
+8181,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1559 ] CAL_COMMON_PARAM isRestoreOnly 	=%d
+ 
+8182,iii,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1560 ] CAL_COMMON_PARAM reserved 	=%d %d %d
+ 
+8183,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1561 ] CAL_COMMON_PARAM (pIn->pHandle).phyId 	=%x
+ 
+8184,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1565 ] PHYDEVLIB_PHY_INPUT phyMode 	=%d
+ 
+8185,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1566 ] PHYDEVLIB_PHY_INPUT rxChMask 	=%x
+ 
+8186,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1567 ] PHYDEVLIB_PHY_INPUT phyBase 	=%x
+ 
+8187,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1568 ] PHYDEVLIB_PHY_INPUT phyBaseExt 	=%x
+ 
+8188,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1569 ] PHYDEVLIB_PHY_INPUT concMode 	=%d
+ 
+8189,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1570 ] PHYDEVLIB_PHY_INPUT dynPriChan 	=%d
+ 
+8190,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1571 ] PHYDEVLIB_PHY_INPUT pwrMask 		=%d
+ 
+8191,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1572 ] PHYDEVLIB_PHY_INPUT extLNA 		=%d
+ 
+8192,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1573 ] PHYDEVLIB_PHY_INPUT extPA 		=%d
+ 
+8193,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1574 ] PHYDEVLIB_PHY_INPUT isSBSmode 	=%d
+ 
+8194,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1575 ] PHYDEVLIB_PHY_INPUT loType 		=%d
+ 
+8195,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1576 ] PHYDEVLIB_PHY_INPUT dpdMode 	=%d
+ 
+8196,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1577 ] PHYDEVLIB_PHY_INPUT loadIniMask 	=%d
+ 
+8197,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1578 ] PHYDEVLIB_PHY_INPUT calMask 	=%d
+ 
+8198,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1580 ] CCAL_INPUT calCmdId		=%d
+ 
+8199,I,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1581 ] CCAL_INPUT cal_chain_mask		=%x
+ 
+8200,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1582 ] CCAL_INPUT cal_mode		=%d
+ 
+8201,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1583 ] CCAL_INPUT mode (80p80 mode)		=%d
+ 
+8202,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1584 ] CCAL_INPUT fixed_gain		=%d
+ 
+8203,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1585 ] CCAL_INPUT engineSharing		=%d
+ 
+8204,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1586 ] CCAL_INPUT driveTxGLUTIdx		=%d
+ 
+8205,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1587 ] CCAL_INPUT enableBlockAccAvg		=%d
+ 
+8206,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1588 ] CCAL_INPUT blockSize[0]		=%d
+ 
+8207,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1589 ] CCAL_INPUT dcEstWindowSize		=%d
+ 
+8208,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1590 ] CCAL_INPUT numOfBlocks		=%d
+ 
+8209,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1591 ] CCAL_INPUT numSamplesToReadback[0]	=%d
+ 
+8210,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1592 ] CCAL_INPUT numSamplesToReadback[1]	=%d
+ 
+8211,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1593 ] CCAL_INPUT numSamplesToReadback[2]	=%d
+ 
+8212,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1594 ] CCAL_INPUT rxGainSettlingTime		=%d
+ 
+8213,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1595 ] CCAL_INPUT txGainSettlingTime		=%d
+ 
+8214,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1596 ] CCAL_INPUT txShiftSettlingTime		=%d
+ 
+8215,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1597 ] CCAL_INPUT calModeSettlingTime	=%d
+ 
+8216,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1598 ] CCAL_INPUT loopbackSettlingTime	=%d
+ 
+8217,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1599 ] CCAL_INPUT txResidueSettlingTime	=%d
+ 
+8218,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1600 ] CCAL_INPUT numTaps[0] 		=%d
+ 
+8219,i,[ hca_HwComponentTrxMarina_calSmComb.cpp : 1601 ] CCAL_INPUT numTaps[1] 		=%d
+ 
+8220,I,[ hca_HwComponentTrxMarina_calSmDac.cpp : 174 ] FINALCASE out finalCase 		=%x 
+ 
+8221,iI,[ hca_HwComponentTrxMarina_calSmDac.cpp : 232 ] DAC ::: save TablePtr chain:%d = %p 
+8222,i,[ hca_HwComponentTrxMarina_calSmDac.cpp : 239 ] NEED_TO_DO_CAL:: cannot update DAC caldb for chainIdx = %d! 
+8223,iI,[ hca_HwComponentTrxMarina_calSmDac.cpp : 254 ] DAC ::: Restore TablePtr chain:%d = %p 
+8224,i,[ hca_HwComponentTrxMarina_calSmDac.cpp : 261 ] NEED_TO_DO_CAL:: cannot update DAC caldb for chainIdx = %d! 
+8225,IIIIIi,[ hca_HwComponentTrxMarina_calSmDac.cpp : 288 ] FC_HANDLE pHandle = %x, phyInput = %x, dacInput = %x, dacOutput = %x, rfChainMask = %x, finalCase =%d 
+8226,iiI,[ hca_HwComponentTrxMarina_calSmDac.cpp : 315 ] calSmDac: restore invoked cal on chainIdx = %d bandcode=%d pDACData:0x%x 
+8227,iiI,[ hca_HwComponentTrxMarina_calSmDac.cpp : 345 ] calSmDac: save invoked on chainIdx = %d bandcode= %d pDACData:0x%x 
+8228,,[ hca_HwComponentTrxMarina_calSmDac.cpp : 351 ] DAC ::: CAL_SAVE failed
+ 
+8229,i,[ hca_HwComponentTrxMarina_calSmDac.cpp : 367 ] calSmDac: RECIPE : %d
+ 
+8230,i,[ hca_HwComponentTrxMarina_calSmDpdMemory.cpp : 52 ] Invalid channel %d
+ 
+8231,iii,[ hca_HwComponentTrxMarina_calSmDpdMemory.cpp : 91 ] PAPRD: Not triggered for bHomeChan %d  channel %d workingChannel %d returning 
+8232,,[ hca_HwComponentTrxMarina_calSmDpdMemory.cpp : 117 ] PAPRD: DPD disabled for this range of frequency 
+8233,Ii,[ hca_HwComponentTrxMarina_calSmDpdMemory.cpp : 127 ] DPD Cal::: phyRfMode = %x, cannot do cal - BDF disabled for DPD(Memory), phy %d 
+8234,i,[ hca_HwComponentTrxMarina_calSmDpdMemory.cpp : 143 ] PAPRD: Memory DPD , paprdType %d 
+8235,i,[ hca_HwComponentTrxMarina_calSmDpdMemoryLess.cpp : 81 ] Invalid channel %d
+ 
+8236,,[ hca_HwComponentTrxMarina_calSmDpdMemoryLess.cpp : 128 ] PAPRD: background thread is active(eDPD is running) 
+8237,Ii,[ hca_HwComponentTrxMarina_calSmDpdMemoryLess.cpp : 158 ] DPD Cal::: phyRfMode = %x, cannot do cal - BDF disabled for DPD Type(MemLess), phy %d 
+8238,,[ hca_HwComponentTrxMarina_calSmIm2.cpp : 113 ] IM2CAL:  completed 
+8239,I,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 98 ] calSmPadroop: Resolve FINALCASE out finalCase 		=%x 
+ 
+8240,iI,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 141 ] calSmPadroop ::: save TablePtr chain:%d = %p 
+8241,i,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 150 ] calSmPadroop: NEED_TO_DO_CAL:: cannot update PADROOP caldb for chainIdx = %d! 
+8242,iI,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 167 ] calSmPadroop ::: Restore TablePtr chain:%d = %p 
+8243,i,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 176 ] NEED_TO_DO_CAL:: cannot update PADROOP caldb for chainIdx = %d! 
+8244,Iiii,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 263 ] calSmPadroop: PADROOP cal handleFinalCase end. finalCase 		=%x chan: %d  chainIdx = %d status = %d
+ 
+8245,ii,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 322 ] calSmPadroop: callingContext = %d, PDC cal cmd id = %d
+ 
+8246,i,[ hca_HwComponentTrxMarina_calSmPadroop.cpp : 469 ] CalSM: PADROOP cal end new Standalone 	phyId=%d 
+8247,,[ hca_HwComponentTrxMarina_calSmPdet.cpp : 187 ] Welcome, cal SM for Pdet Cal will be created
+ 
+8248,i,[ hca_HwComponentTrxMarina_calSmPdet.cpp : 245 ] calSmDET: PDET_Standalone callingContext = %d 
+8249,i,[ hca_HwComponentTrxMarina_calSmPdet.cpp : 283 ] calSmDET: invoke PDET cal on chainMask = %d 
+8250,iI,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 240 ] RXDCO ::: restore TablePtr chain:%d = %p 
+8251,,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 261 ] APPLICALBE_RESUBMISSION_ONLY:: failure on not getting pStart (= NULL) from caldb! 
+8252,iI,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 284 ] RXDCO ::: save TablePtr chain:%d = %p 
+8253,i,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 309 ] NEED_TO_DO_CAL:: cannot update rxdco caldb for chainIdx = %d! 
+8254,Ii,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 356 ] RxDCO:: bwCode = %x, cur_tbl_idx: %d
+ 
+8255,Ii,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 456 ] FINALCASE out finalCase 		=%x for calMode=%d
+ 
+8256,ii,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 496 ] FC_HANDLE  finalCase before switch statement=%d, rxDCO->localrxDcoValid=%d
+ 
+8257,i,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 528 ] rxdcoHandleFinalCase starts @ *finalCase=%d
+ 
+8258,i,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 577 ] RXDCO ::: CAL_RESTORE phyRxDCOCal status :: %d 
+8259,ii,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 650 ] rxdcoHandleFinalCase: end of  final case handling, *finalCase=%d, callingContext=%d ,  calls phyRxDCOCal
+ 
+8260,iIi,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 801 ] RxDCO cal return: foundHomeIdx:%d rxdcoCalFCSAllowance:0x%x , rxDcoRetryCntV3: %d 
+8261,i,[ hca_HwComponentTrxMarina_calSmRxDco.cpp : 862 ] RxDCO:: Switch back to same homeChannel skip RxDCO. homeCh:%d 
+8262,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 125 ] HcaHwComponentTrxMarina_calSmRxSpur::Standalone:
+ 
+8263,ii,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 148 ] sizeof(PHYDEVLIB_RXSPUR_CAL_INPUT)=%d, sizeof(PHYDEVLIB_RXSPUR_CAL_OUTPUT)=%d, sizeof(PHYDEVLIB_PHY_INPUT)
+ 
+8264,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 160 ] HcaHwComponentTrxMarina_calSmRxSpur::Standalone after checking
+ 
+8265,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 184 ] RXSPUR Calling context FORCE_CAL
+ 
+8266,i,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 186 ] FC_HANDLE finalCase before switch statement=%d
+ 
+8267,i,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 212 ] rxSpurCalHandleFinalCase starts @ *finalCase=%d
+ 
+8268,i,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 221 ] path to call disable due to APPLICABLE_FORCE_CAL_DISABLE, cal_mode=%d
+ 
+8269,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 229 ] path to call enable due to CALTABLE_IS_IN_HW
+ 
+8270,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 246 ] path to call cal due to NEED_TO_DO_CAL 
+8271,,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 248 ] NEED_TO_DO_CAL
+ 
+8272,iiiIi,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 265 ] RxDCO phyRxSpurCal calCmdId=%d RC=0x%d foundHomeIdx:%d rxspurCalFCSAllowance:0x%x rxSpurRetryCntV3:%d 
+8273,ii,[ hca_HwComponentTrxMarina_calSmRxSpur.cpp : 297 ] handle RXSPUR Callingcontext = %d, finalCase = %d
+ 
+8274,,[ htc.c : 1730 ] WRONG_ENDPOINT or HTC_PIPE_NULL 
+8275,,[ htc.c : 1777 ] LEAK HTC BUFFER 
+8276,IiIi,[ wmi_svc.c : 2444 ] WMI_EVT_SEND EvtId=0x%x ep=%d pEvt=%p len=%d 
+8277,IIIIIIII,[ wmi_svc.c : 529 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 
+8278,I,[ wmi_svc.c : 534 ] WMI_CMD_PARAMS 0x%08x 
+8279,II,[ wmi_svc.c : 537 ] WMI_CMD_PARAMS 0x%08x 0x%08x 
+8280,III,[ wmi_svc.c : 540 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 
+8281,IIII,[ wmi_svc.c : 543 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 0x%08x 
+8282,IIIII,[ wmi_svc.c : 546 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 
+8283,IIIIII,[ wmi_svc.c : 549 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 
+8284,IIIIIII,[ wmi_svc.c : 552 ] WMI_CMD_PARAMS 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 
+8285,Ii,[ wmi_svc.c : 688 ] WMI_CMD_RX CmdId=0x%x Len=%d 
+8286,IIII,[ wmi_svc.c : 695 ] Logging debug stats tot_drops 0x%x resume_cnts 0x%x, suspend_cnts 0x%x, ovrload_cnt 0x%x 
+8287,I,[ wmi_svc.c : 709 ] WMI_SEND_EVENT_WRONG_TLV CmdId/EventId = 0x%x 
+8288,I,[ wmi_svc.c : 2536 ]  pending EventId = 0x%x 
+8289,II,[ wmi_svc.c : 2549 ] WMI_EVENT_SEND drop EventId = 0x%x, action:0x%x 
+8290,iii,[ evt_tracer.c : 1079 ] suspend_en:%d, module %d, evt_trace_in_suspend %d 
+8291,,[ platform_license_mgmt.c : 93 ] Callback FID status update Failed 
+8292,ii,[ platform_license_mgmt.c : 125 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8293,ii,[ platform_license_mgmt.c : 131 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8294,ii,[ platform_license_mgmt.c : 137 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8295,ii,[ platform_license_mgmt.c : 143 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8296,ii,[ platform_license_mgmt.c : 149 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8297,ii,[ platform_license_mgmt.c : 155 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8298,ii,[ platform_license_mgmt.c : 161 ] Callback Registration Failed | FID will be disabled by default - FID: %d, Status: %d 
+8299,,[ platform_license_mgmt.c : 168 ] MAC HW_PEP-SKU Reg read API failed 
+8300,,[ platform_license_mgmt.c : 175 ] PHY HW_PEP-SKU Reg read API failed 
+8301,IIIIIIII,[ prof_test.c : 138 ] CPU_PROF:   (counters = (%lu, %lu, %lu, %lu, %lu, %lu, %lu, %lu), 
+8302,II,[ prof_test.c : 141 ] CPU_PROF:   timer_ticks = %lu, core_pcycles = %lu), 
+8303,,[ platform_ce.c : 128 ] platform_ce_send_use_hif: Sending msg to HIF thread to do SYNC CE copy 
+8304,i,[ platform_bdf_and_cal.c : 200 ] QMI Platform: Cal Update remaining bytes = %d, 
+8305,I,[ platform_bdf_and_cal.c : 293 ] QMI Platform: Cal download REQ received, seg_id 0x%x 
+8306,i,[ platform_bdf_and_cal.c : 512 ] platorm_idx= %d, 
+8307,i,[ platform_bdf_and_cal.c : 602 ] platform_proc_bdf_download_req: BDF download curr_size = %d, 
+8308,i,[ platform_bdf_and_cal.c : 649 ] platform_proc_bdf_download_req: BDF download done, current_size = %d, 
+8309,i,[ platform_bdf_and_cal.c : 684 ] platorm_idx__download_req= %d, 
+8310,,[ platform_bdf_and_cal.c : 1413 ] sending cal_done indication before changing state 
+8311,,[ platform_bdf_and_cal.c : 1429 ] QMI Platform: Sending FW READY ind... 
+8312,,[ platform_bdf_and_cal.c : 1440 ] QMI Platform: Cold Cal done signal received 
+8313,,[ platform_bdf_and_cal.c : 1487 ] QMI Platform: Sending FW READY ind... 
+8314,i,[ platform_ABTimeout.c : 147 ] NOC Error: ERRLOG0_HIGH: %d 
+8315,i,[ platform_ABTimeout.c : 149 ] NOC Error: ERRLOG0_LOW: %d 
+8316,i,[ platform_ABTimeout.c : 151 ] NOC Error: ERRLOG1_HIGH: %d 
+8317,i,[ platform_ABTimeout.c : 153 ] NOC Error: ERRLOG1_LOW: %d 
+8318,i,[ platform_ABTimeout.c : 155 ] NOC Error: ERRLOG2_HIGH: %d 
+8319,i,[ platform_ABTimeout.c : 157 ] NOC Error: ERRLOG2_LOW: %d 
+8320,i,[ platform_ABTimeout.c : 159 ] NOC Error: ERRLOG3_HIGH: %d 
+8321,i,[ platform_ABTimeout.c : 161 ] NOC Error: ERRLOG3_LOW: %d 
+8322,i,[ platform_ABTimeout.c : 163 ] NOC Error: ERRVLD: %d 
+8323,ii,[ platform_ABTimeout.c : 187 ] ABTimeout: Bus %d  hang; Syndrome ID: %d 
+8324,ii,[ platform_ABTimeout.c : 189 ] ABTimeout: Bus %d  hang; Syndrome ADDR0: %d 
+8325,ii,[ platform_ABTimeout.c : 191 ] ABTimeout: Bus %d  hang; Syndrome ADDR1: %d 
+8326,ii,[ platform_ABTimeout.c : 193 ] ABTimeout: Bus %d  hang; Syndrome HREADY: %d 
+8327,ii,[ platform_ABTimeout.c : 195 ] ABTimeout: Bus %d  hang; Number of Slaves: %d 
+8328,,[ platform_NOC_error.c : 148 ] Invalid Interrupt Vector! 
+8329,Ii,[ platform_NOC_error.c : 168 ] %s ERROR: ERRLOG0_LOW = %d 
+8330,Ii,[ platform_NOC_error.c : 180 ] %s ERROR: ERRLOG0_HIGH = %d 
+8331,Ii,[ platform_NOC_error.c : 193 ] %s ERROR: ERRLOG1_LOW = %d 
+8332,Ii,[ platform_NOC_error.c : 205 ] %s ERROR: ERRLOG1_HIGH = %d 
+8333,Ii,[ platform_NOC_error.c : 218 ] %s ERROR: ERRLOG2_LOW = %d 
+8334,Ii,[ platform_NOC_error.c : 230 ] %s ERROR: ERRLOG2_HIGH = %d 
+8335,Ii,[ platform_NOC_error.c : 242 ] %s ERROR: ERRLOG3_LOW = %d 
+8336,Ii,[ platform_NOC_error.c : 254 ] %s ERROR: ERRLOG3_HIGH = %d 
+8337,Iii,[ platform_NOC_error.c : 271 ] %s ERROR: SBM%d FAULTINSTATUS0_LOW = %d 
+8338,Iii,[ platform_NOC_error.c : 285 ] %s ERROR: SBM%d FAULTINSTATUS0_HIGH = %d 
+8339,,[ rt_thread.c : 375 ] BTFM wakeup interrupt was received 
+8340,,[ rt_thread.c : 382 ] BTFM IPC wakeup interrupt was received 
+8341,i,[ syssw_dbg.c : 39 ] SYSSW: CPU frequency in KHz: %d 
+8342,iiI,[ syssw_dbg.c : 72 ] SYSSW: Setting wdiag level to %d (from %d) for module 0x%x. 
+8343,i,[ syssw_dbg.c : 84 ] SYSSW: CPU frequency calculated in KHz: %d 
+8344,i,[ syssw_dbg.c : 141 ] SYSSW: Command %d not supported 
+8345,,[ aes_gcm.c : 318 ] GCM: Tag mismatch 
+8346,i,[ cmnos_timer.c : 750 ] cmnos timer thread_id %d 
+8347,III,[ cmnos_intmux.c : 44 ] cmnos_intmux_dsr_attach error: handler = %p, pinum = %p, pparg=%p 
+8348,IIII,[ cmnos_allocram.c : 612 ] unknown proxy_flag:0x%x, ret:0x%x, ret1:0x%x,ret2:0x%x 
+8349,IiII,[ cmnos_allocram.c : 305 ] arena_flags: 0x%x, bytes:%d, call1:0x%x, call2:0x%x
+ 
+8350,II,[ cmnos_assert.c : 327 ] assert:r0=0x%x, r1=0x%x
+ 
+8351,,[ cmnos_thread.c : 1823 ] cmnos_threads_delete
+ 
+8352,I,[ cmnos_thread.c : 1830 ] cmnos_threads_delete: send exit to 0x%x thread app id
+ 
+8353,I,[ cmnos_thread.c : 1843 ] cmnos_threads_delete: wait for thread app id 0x%x to exit
+ 
+8354,I,[ cmnos_thread.c : 1846 ] cmnos_threads_delete: thread app id 0x%x is done
+ 
+8355,,[ cmnos_thread.c : 1896 ] cmnos_threads_delete: clean up mutex locks
+ 
+8356,,[ cmnos_thread.c : 1905 ] cmnos_threads_delete: clean up thread barriers
+ 
+8357,,[ cmnos_thread.c : 1916 ] cmnos_threads_delete: do global cleanups
+ 
+8358,iii,[ cmnos_thread.c : 1987 ] APP THREAD ID %d thread stack: %dB used, %dB unused
+ 
+8359,ii,[ cmnos_thread.c : 3983 ] CMNOS_Buf_Alloc_Failure Buffer_Full_thread_id = %d Current_thread_id = %d 
+ 
+8360,ii,[ cmnos_thread.c : 4012 ] CMNOS_Buf_Alloc_Failure Buffer_Full_thread_id = %d Current_thread_id = %d 
+ 
+8361,Iiiii,[ cmnos_thread.c : 3884 ] LACK ROOM IN %s THREAD'S MSG QUEUE FIFO (need %d, have %d); readIndex=%d writeIndex=%d 
+8362,,[ platform_init.c : 60 ] WLAN Platform: Starting wlan tasks... 
+8363,,[ platform_init.c : 169 ] QMI Platform: Sending msg to RT thread to do cold cal init... 
+8364,,[ platform_deinit.c : 39 ] QMI Platform: Deinit started... 
+8365,,[ platform_deinit.c : 70 ] QMI Platform: Threads killed... 
+8366,ii,[ platform_common.c : 155 ] plat_set_one_ce_service_map_cfg: ERROR - idx %d > PIPE_TO_CE_MAP_CNT %d 
+8367,,[ platform_athdiag.c : 183 ] plat_athdiag_white_list_add: only support limited security area 
+8368,,[ platform_athdiag.c : 242 ] plat_athdiag_proc_read_req: Sending msg to RT thread to do athdiag read 
+8369,IIi,[ platform_athdiag.c : 357 ] QMI Platform: Athdiag read REQ received...offset = 0x%x | mem_type = 0x%x | data_len = %d 
+8370,IIi,[ platform_athdiag.c : 443 ] QMI Platform: Athdiag write REQ received...offset = 0x%x | mem_type = 0x%x | data_len = %d 
+8371,i,[ qmi_platform.c : 209 ] qmi_plat_check_state: error - received HOST_CAP_REQ at wrong state %d 
+8372,i,[ qmi_platform.c : 220 ] qmi_plat_check_state: WARNING: wrong state to send remote ddr mem cfg indication, state = %d 
+8373,iI,[ qmi_platform.c : 229 ] qmi_plat_check_state: ERROR: wrong state %d to receive msg_id 0x%x 
+8374,iI,[ qmi_platform.c : 238 ] qmi_plat_check_state: ERROR: wrong state %d to receive msg_id 0x%x 
+8375,i,[ qmi_platform.c : 248 ] qmi_plat_check_state: error - received CAPABILITY REQ at wrong state %d 
+8376,i,[ qmi_platform.c : 268 ] qmi_plat_check_state: error - received CAPABILITY REQ at wrong state %d 
+8377,i,[ qmi_platform.c : 302 ] qmi_plat_check_state: error - received BDF DOWNLOAD REQ at wrong state %d 
+8378,i,[ qmi_platform.c : 315 ] qmi_plat_check_state: error - received CAL_REPORT REQ at wrong state %d 
+8379,i,[ qmi_platform.c : 329 ] qmi_plat_check_state: error - received M3_INFO REQ at wrong state %d 
+8380,i,[ qmi_platform.c : 367 ] qmi_plat_check_state: error - send FW INIT Done at wrong state %d 
+8381,Ii,[ qmi_platform.c : 399 ] qmi_plat_check_state: error - Try to send FW Ready ind at wrong mode 0x%x and wrong state %d 
+8382,i,[ qmi_platform.c : 409 ] qmi_plat_check_state: error - received CFG REQ at wrong state %d 
+8383,Ii,[ qmi_platform.c : 427 ] qmi_plat_check_state: error - received MODE REQ w/ mode = 0x%x at wrong state %d 
+8384,Ii,[ qmi_platform.c : 441 ] qmi_plat_check_state: error - received MODE REQ w/ mode = 0x%x at wrong state %d 
+8385,Ii,[ qmi_platform.c : 452 ] qmi_plat_check_state: error - received MODE REQ w/ mode = 0x%x at wrong state %d 
+8386,i,[ qmi_platform.c : 466 ] qmi_plat_check_state: error - Try to send CAL Done Ind at wrong state %d 
+8387,Ii,[ qmi_platform.c : 474 ] qmi_plat_check_state: error - Try to send Cal Done Ind at wrong mode 0x%x and wrong state %d 
+8388,III,[ qmi_platform.c : 501 ] qmi_event_history_log: msg_id = 0x%x, event = 0x%x, tick = 0x%x 
+8389,II,[ qmi_platform.c : 597 ] Ind with id 0x%x sent to client handle 0x%x 
+8390,II,[ qmi_platform.c : 609 ] Setting fw_status_mask in handle 0x%x with FW READY; new value = 0x%x 
+8391,II,[ qmi_platform.c : 616 ] Handle 0x%x, fw_status_mask = 0x%x 
+8392,II,[ qmi_platform.c : 622 ] Indication sent failed. Err code = 0x%x id = 0x%x 
+8393,II,[ qmi_platform.c : 627 ] Ind with id 0x%x not sent to client handle 0x%x 
+8394,I,[ qmi_platform.c : 707 ] Client with handle 0x%x connected 
+8395,I,[ qmi_platform.c : 737 ] Client with handle 0x%x disconnected 
+8396,II,[ qmi_platform.c : 835 ] Error code 0x%x in msg_id 0x%x 
+8397,i,[ qmi_platform.c : 1390 ] platform_proc_fw_ini_cfg_download_req_int: FW INI cfg download curr_size = %d, 
+8398,i,[ qmi_platform.c : 1402 ] platform_proc_fw_ini_cfg_download_req_int: FW INI cfg download done, current_size = %d, 
+8399,,[ qmi_platform.c : 1555 ] QMI Platform: Ind register REQ received 
+8400,I,[ qmi_platform.c : 1589 ] Client with unique ID 0x%x registering 
+8401,I,[ qmi_platform.c : 1594 ] Client with unique ID 0x%x found in client_list 
+8402,iii,[ qmi_platform.c : 2381 ] QMI Platform: QMI_WLFW_FILE_DATA_RESP_V01 sent,  data %d, end %d, ret %d 
+8403,,[ qmi_platform.c : 2484 ] I shouldn't have been called F 
+8404,,[ qmi_platform.c : 2541 ] WHY DID YOU CALL ME 
+8405,,[ qmi_platform.c : 3234 ] MLO reconfig req: QMI response 
+8406,,[ qmi_platform.c : 3265 ] MLO_RECOVERY Partner Power State Change QMI response 
+8407,II,[ qmi_platform.c : 3587 ] qmi_id 0x%x response value 0x%x 
+8408,iIi,[ qmi_platform.c : 3677 ] qmi_csi_send_ind returns error %d, msg_id = 0x%x, len = %d 
+8409,II,[ qmi_platform.c : 984 ] wlfw_handle_host_cap_req: num_clients=%x, nm_modem=%x 
+8410,i,[ qmi_platform.c : 1662 ] wlfw_handle_remote_ddr_mem_req: INFO: num_mem_cfg = %d 
+8411,,[ qmi_platform.c : 2672 ] QMI Platform: Cap REQ received 
+8412,,[ qmi_platform.c : 1957 ] QMI Platform: Wlan Cfg REQ received 
+8413,i,[ qmi_platform.c : 2022 ] wlfw_handle_wlan_cfg_req: svc_cfg_len - %d 
+8414,i,[ qmi_platform.c : 2075 ] wlfw_handle_wlan_cfg_req: ext_svc_cfg_len - %d 
+8415,i,[ qmi_platform.c : 2136 ] QMI Platform: INI REQ received, debug mode = %d 
+8416,ii,[ qmi_platform.c : 2154 ] QMI Platform: recieved INI REQ, enablefwlog_valid = %d, enablefwlog = %d 
+8417,ii,[ qmi_platform.c : 2158 ] QMI Platform: recieved INI REQ, enablefwlog_valid = %d, enablefwlog = %d 
+8418,ii,[ qmi_platform.c : 2165 ] QMI Platform: recieved INI REQ, enablefwlog_valid = %d, enablefwlog = %d 
+8419,ii,[ qmi_platform.c : 2169 ] QMI Platform: Did not recieve INI REQ, enablefwlog_valid = %d, enablefwlog = %d 
+8420,I,[ qmi_platform.c : 1739 ] QMI Platform: Wlan mode REQ received, mode = 0x%x 
+8421,,[ qmi_platform.c : 2698 ] QMI Platform: Cal report REQ received 
+8422,I,[ qmi_platform.c : 2254 ] QMI Platform: BDF download REQ received, seg_id 0x%x 
+8423,Ii,[ qmi_platform.c : 2605 ] QMI Platform: M3 download REQ received, paddr = %ul, size = %d 
+8424,,[ qmi_platform.c : 2720 ] QMI Platform: MAC addr REQ received 
+8425,IIIIII,[ qmi_platform.c : 2767 ] Valid mac addr received from modem NV: %x : %x : %x : %x : %x : %x 
+8426,,[ qmi_platform.c : 2783 ] QMI Platform: Shutdown req recvd 
+8427,i,[ qmi_platform.c : 2803 ] QMI Platform: platform state %d 
+8428,I,[ qmi_platform.c : 2970 ] QDSS mode REQ received, mode = 0x%x 
+8429,,[ qmi_platform.c : 3254 ] MLO_RECOVERY Partner Power State Change QMI received from host 
+8430,IIi,[ pmu.c : 204 ] PMU: During (%lu us, %lu cycles), %dx 64 bits counters for 
+8431,IIII,[ pmu.c : 207 ] PMU:   events (%u, %u, %u, %u) = 
+8432,IIII,[ pmu.c : 210 ] PMU:   (%lu, %lu, %lu, %lu) 
+8433,IIi,[ pmu.c : 228 ] PMU: During (%lu us, %lu cycles), %dx 32 bits counters for 
+8434,IIIIIIII,[ pmu.c : 232 ] PMU:   events (%u, %u, %u, %u, %u, %u, %u, %u) = 
+8435,IIIIIIII,[ pmu.c : 236 ] PMU:   (%u, %u, %u, %u, %u, %u, %u, %u) 
+8436,I,[ pool_mgr_api.c : 468 ] product resulting in buffer overflow: num_of_elem * elem_sz = 0x%x 
+8437,i,[ latency_profile.c : 585 ] profile_report: #profiles enabled > WMI limit (=%d) 
+8438,i,[ latency_profile.c : 621 ] profile_report: could not alloc, size=%d 
+8439,i,[ latency_profile.c : 1993 ] profile value %d >= PROF_MAX_ID in latency_profile_enter 
+8440,i,[ latency_profile.c : 2060 ] profile value %d >= PROF_MAX_ID in latency_profile_exit 
+8441,IIIi,[ sm.c : 348 ] SM: %x:%x:%p : allocation from event pool failed for event %d 
+8442,IIIi,[ sm.c : 226 ] SM: %x:%x:%p : invalid event %d 

--- a/feeds/qca-wifi-7/ipq54xx/base-files/etc/_inittab
+++ b/feeds/qca-wifi-7/ipq54xx/base-files/etc/_inittab
@@ -1,0 +1,18 @@
+# Copyright (c) 2013, 2020, The Linux Foundation. All rights reserved.
+# Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+::sysinit:/etc/init.d/rcS S boot
+::shutdown:/etc/init.d/rcS K shutdown
+ttyMSM0::askfirst:/usr/libexec/login.sh

--- a/feeds/qca-wifi-7/ipq54xx/base-files/etc/uci-defaults/30-uboot-envtools
+++ b/feeds/qca-wifi-7/ipq54xx/base-files/etc/uci-defaults/30-uboot-envtools
@@ -1,0 +1,53 @@
+[ -e /etc/config/ubootenv ] && rm /etc/config/ubootenv
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_mtdinfo () {
+	UBOOTENV_PART=$(cat /proc/mtd | grep APPSBLENV)
+	mtd_dev=$(echo $UBOOTENV_PART | awk '{print $1}' | sed 's/:$//')
+	mtd_size=$(echo $UBOOTENV_PART | awk '{print "0x"$2}')
+	mtd_erase=$(echo $UBOOTENV_PART | awk '{print "0x"$3}')
+	nor_flash=$(find /sys/bus/spi/devices/*/mtd -name ${mtd_dev})
+    	found_emmc=0
+    
+         if [ -z "$UBOOTENV_PART" ]; then
+                mtd_dev=$(echo $(find_mmc_part "0:APPSBLENV") | sed 's/^.\{5\}//')
+                if [ -n "$mtd_dev" ]; then
+                        EMMC_UBOOTENV_PART=$(cat /proc/partitions | grep $mtd_dev)
+                        #convert block to bytes
+                        emmc_ubootenv_size=`expr $(echo $EMMC_UBOOTENV_PART | awk '{print $3}') \* 1024`
+                        ubootenv_size=0x`printf "%x" $emmc_ubootenv_size`
+			found_emmc=1
+                fi
+                mtd_erase=""
+        
+	elif [ -n "$nor_flash" ]; then
+		ubootenv_size=$mtd_size
+	else
+		# size is fixed to 0x40000 in u-boot
+		ubootenv_size=0x40000
+	fi
+	if [ $found_emmc -eq 0 ]; then
+                sectors=$(printf '0x%x' $(( $ubootenv_size / $mtd_erase )))
+                echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+	else
+                echo /dev/$mtd_dev 0x0 $ubootenv_size
+	fi
+
+}
+
+case "$board" in
+*)
+	ubootenv_add_uci_config $(ubootenv_mtdinfo)
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/feeds/qca-wifi-7/ipq54xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq54xx/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,6 @@
 . /lib/functions/system.sh
 
-RAMFS_COPY_BIN='fw_printenv fw_setenv'
+RAMFS_COPY_BIN='fw_printenv fw_setenv dumpimage'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 find_mmc_part() {
@@ -35,28 +35,71 @@ do_flash_emmc() {
 	tar Oxf $tar_file ${board_dir}/$part | dd of=${emmcblock}
 }
 
+do_flash_bootconfig_emmc() {
+	local bin=$1
+	local emmcblock=$2
+
+	dd if=/dev/zero of=${emmcblock} &> /dev/null
+	dd if=/tmp/${bin}.bin of=${emmcblock}
+}
+
+do_flash_partition() {
+	local bin=$1
+	local mtdname=$2
+	local emmcblock="$(find_mmc_part "$mtdname")"
+
+	if [ -e "$emmcblock" ]; then
+		do_flash_bootconfig_emmc $bin $emmcblock
+	fi
+}
+
+do_flash_bootconfig() {
+	local mtdname=$1
+	local bin=bootconfig
+
+	#flash bootconfig with updated boot-info
+	if [ -f /tmp/bootconfig.bin ]; then
+		do_flash_partition $bin $mtdname
+	else
+		echo " Bootconfig binary is missing.... "
+		return 1
+	fi
+}
+
+get_upgrade_bank() {
+	local mtdname=$1
+	local boot_set=$(grep "Boot-set" /tmp/bootconfig_members.txt | awk -F: '{print $2}')
+	local image_status=$(grep "Image-set-status" /tmp/bootconfig_members.txt | awk -F: '{print $2}')
+	local current_bank=0
+
+	if [ "$boot_set" -eq 0 ] && [ "$image_status" -ne 1 ]; then
+		mtdname="${mtdname}_1"
+		current_bank=1
+	elif [ "$boot_set" -eq 1 ] && [ "$image_status" -eq 2 ]; then
+		mtdname="${mtdname}_1"
+		current_bank=1
+	fi
+
+	if [[ -z "$mtdname" || "$mtdname" == "_1" ]]; then
+		echo $current_bank
+	else
+		echo $mtdname
+	fi
+}
+
 spi_nor_emmc_do_upgrade_bootconfig() {
 	local tar_file="$1"
 
 	local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
 	board_dir=${board_dir%/}
-	[ -f /proc/boot_info/bootconfig0/getbinary_bootconfig ] || {
-		echo "bootconfig does not exist"
-		exit
-	}
-	CI_ROOTPART="$(cat /proc/boot_info/bootconfig0/rootfs/upgradepartition)"
-	CI_KERNPART="$(cat /proc/boot_info/bootconfig0/0:HLOS/upgradepartition)"
+
+	CI_ROOTPART="$(get_upgrade_bank "rootfs")"
+	CI_KERNPART="$(get_upgrade_bank "0:HLOS")"
 
 	[ -n "$CI_KERNPART" -a -n "$CI_ROOTPART" ] || {
 		echo "kernel or rootfs partition is unknown"
 		exit
 	}
-
-	local primary="0"
-	[ "$(cat /proc/boot_info/bootconfig0/rootfs/primaryboot)" = "0" ] && primary="1"
-	echo "$primary" > /proc/boot_info/bootconfig0/rootfs/primaryboot 2>/dev/null
-	echo "$primary" > /proc/boot_info/bootconfig0/0:HLOS/primaryboot 2>/dev/null
-	cp /proc/boot_info/bootconfig0/getbinary_bootconfig /tmp/bootconfig
 
 	do_flash_emmc $tar_file $CI_KERNPART $board_dir kernel
 	do_flash_emmc $tar_file $CI_ROOTPART $board_dir root
@@ -65,20 +108,6 @@ spi_nor_emmc_do_upgrade_bootconfig() {
 	if [ -e "$emmcblock" ]; then
 		mkfs.ext4 -F "$emmcblock"
 	fi
-
-	for part in "0:BOOTCONFIG" "0:BOOTCONFIG1"; do
-				local mtdchar=$(echo $(find_mtd_chardev $part) | sed 's/^.\{5\}//')
-				if [ -n "$mtdchar" ]; then
-						echo start to update $mtdchar
-						mtd -qq write /proc/boot_info/bootconfig0/getbinary_bootconfig "/dev/${mtdchar}" 2>/dev/null && echo update mtd $mtdchar
-			   else
-						emmcblock=$(find_mmc_part $part)
-						echo erase ${emmcblock}
-						dd if=/dev/zero of=${emmcblock} 2> /dev/null
-						echo update $emmcblock
-						dd if=/tmp/bootconfig of=${emmcblock} 2> /dev/null
-				fi
-	done
 }
 
 emmc_do_upgrade() {
@@ -101,6 +130,18 @@ platform_check_image() {
 	return 1
 }
 
+extract_bootconfig() {
+	local mtdname=$1
+	local mtdpart=$(grep "\"${mtdname}\"" /proc/mtd | awk -F: '{print $1}')
+	local emmcblock="$(find_mmc_part "$mtdname")"
+
+	if [ -e "$emmcblock" ]; then
+		dd if=${emmcblock} of=/tmp/bootconfig.bin
+	else
+		dd if=/dev/${mtdpart} of=/tmp/bootconfig.bin
+	fi
+}
+
 platform_do_upgrade() {
 	CI_UBIPART="rootfs"
 	CI_ROOTPART="ubi_rootfs"
@@ -108,10 +149,22 @@ platform_do_upgrade() {
 	block_kernel="0:HLOS"
 	block_rootfs="rootfs"
 
+	extract_bootconfig "0:BOOTCONFIG"
+	# Parse bootconfig members and update /tmp/bootconfig_members.txt
+	dumpimage -b 5
+
+	if [[ "$?" == 1 ]];then
+		echo "bootconfig functionality failed, rebooting.."
+		return 1
+	fi
+
 	board=$(board_name)
 	case $board in
 	cig,wf197)
-		# TODO Add image upgrade and bootconfig function
+		spi_nor_emmc_do_upgrade_bootconfig $1
 		;;
 	esac
+	# Finalize bootconfig and prepare for flashing
+	dumpimage -b 0
+	do_flash_bootconfig "0:BOOTCONFIG"
 }

--- a/feeds/qca-wifi-7/ipq54xx/generic/target.mk
+++ b/feeds/qca-wifi-7/ipq54xx/generic/target.mk
@@ -22,4 +22,5 @@ DEFAULT_PACKAGES += \
 	uboot-2025-ipq5424-debug-mmc \
 	uboot-2025-ipq5424-debug-norplusmmc \
 	uboot-2025-ipq5424-debug-norplusnand \
-	uboot-2025-ipq5424-debug-nand
+	uboot-2025-ipq5424-debug-nand \
+	dumpimage

--- a/feeds/qca-wifi-7/ipq54xx/modules.mk
+++ b/feeds/qca-wifi-7/ipq54xx/modules.mk
@@ -2,7 +2,7 @@ define KernelPackage/bootconfig
   SUBMENU:=Other modules
   TITLE:=Bootconfig partition for failsafe
   KCONFIG:=CONFIG_BOOTCONFIG_PARTITION
-  FILES:=$(LINUX_DIR)/drivers/platform/ipq/bootconfig.ko@ge6.1
+  FILES:=$(LINUX_DIR)/drivers/platform/ipq/bootconfig.ko@ge6.6
   AUTOLOAD:=$(call AutoLoad,56,bootconfig,1)
 endef
 

--- a/feeds/qca-wifi-7/iwinfo/Makefile
+++ b/feeds/qca-wifi-7/iwinfo/Makefile
@@ -108,7 +108,7 @@ define Package/libiwinfo-data/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/devices.txt $(1)/usr/share/libiwinfo/devices.txt
 endef
 
-ifeq ($(CONFIG_TARGET_ipq95xx)$(CONFIG_TARGET_ipq53xx),y)
+ifeq ($(CONFIG_TARGET_ipq95xx)$(CONFIG_TARGET_ipq53xx)$(CONFIG_TARGET_ipq54xx),y)
 define Package/iwinfo/install
 	$(CP) ./files-iwinfo/* $(1)
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/feeds/qca-wifi-7/mac80211/ath.mk
+++ b/feeds/qca-wifi-7/mac80211/ath.mk
@@ -36,6 +36,7 @@ config-$(CONFIG_ATH_USER_REGD) += ATH_USER_REGD ATH_REG_DYNAMIC_USER_REG_HINTS
 config-$(CONFIG_ATH11K_THERMAL) += ATH11K_THERMAL
 
 config-$(CONFIG_TARGET_ipq53xx) += ATH12K_AHB ATH12K_POWER_OPTIMIZATION
+config-$(CONFIG_TARGET_ipq54xx) += ATH12K_AHB
 
 config-$(call config_package,ath11k-qca) += ATH11K ATH11K_AHB ATH11K_PCI
 config-$(call config_package,ath12k-qca) += ATH12K

--- a/feeds/qca-wifi-7/qca-ssdk-qca/patches/0006-qca-ssdk-sfp-use-gpio_get_value_cansleep-for-SFP-GPIO.patch
+++ b/feeds/qca-wifi-7/qca-ssdk-qca/patches/0006-qca-ssdk-sfp-use-gpio_get_value_cansleep-for-SFP-GPIO.patch
@@ -1,0 +1,47 @@
+From 42dc970279d7fb047d145bdea7414d31ef479bd2 Mon Sep 17 00:00:00 2001
+From: guoxijun <guoxijun@cigtech.com>
+Date: Fri, 15 May 2026 10:52:37 +0800
+Subject: [PATCH] qca-ssdk: sfp: use gpio_get_value_cansleep for SFP GPIO
+
+SFP GPIO pins may be on an I2C-based GPIO expander that can sleep.
+Using gpio_get_value() in such context can trigger a might_sleep()
+warning. Switch to gpio_get_value_cansleep() which is safe for both
+sleepable and non-sleepable GPIO controllers.
+---
+ src/hsl/phy/sfp_phy.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/hsl/phy/sfp_phy.c b/src/hsl/phy/sfp_phy.c
+index be0f74c..426f0ce 100644
+--- a/src/hsl/phy/sfp_phy.c
++++ b/src/hsl/phy/sfp_phy.c
+@@ -932,7 +932,7 @@ sfp_phy_rx_los_status_get(a_uint32_t dev_id, a_uint32_t port_id,
+ 	{
+ 		return SW_NOT_SUPPORTED;
+ 	}
+-	*rx_los_status = gpio_get_value(rx_los_pin);
++	*rx_los_status = gpio_get_value_cansleep(rx_los_pin);
+ 	SSDK_DEBUG("port%d sfp rx_los_pin is %d, the rx_los_status is %d",
+ 		port_id, rx_los_pin, *rx_los_status);
+ 
+@@ -985,7 +985,7 @@ sfp_phy_tx_dis_status_get(a_uint32_t dev_id, a_uint32_t port_id,
+ 	{
+ 		return SW_NOT_SUPPORTED;
+ 	}
+-	*tx_dis_status = gpio_get_value(tx_dis_pin);
++	*tx_dis_status = gpio_get_value_cansleep(tx_dis_pin);
+ 	SSDK_DEBUG("port%d sfp tx_dis_pin is %d, the tx_dis_status is %d",
+ 		port_id, tx_dis_pin, *tx_dis_status);
+ 
+@@ -1007,7 +1007,7 @@ sfp_phy_mod_present_status_get(a_uint32_t dev_id, a_uint32_t port_id,
+ 	{
+ 		return SW_NOT_SUPPORTED;
+ 	}
+-	mod_present_pin_status = gpio_get_value(mod_present_pin);
++	mod_present_pin_status = gpio_get_value_cansleep(mod_present_pin);
+ 	SSDK_DEBUG("port%d sfp mod_present_pin is %d, mod_present_pin_status is %d",
+ 		port_id, mod_present_pin, mod_present_pin_status);
+ 	if(mod_present_pin_status)
+-- 
+2.34.1
+

--- a/patches-25.12/0043-ucode-add-lib-nl80211-support-for-QCA-wifi-6-7-nl802.patch
+++ b/patches-25.12/0043-ucode-add-lib-nl80211-support-for-QCA-wifi-6-7-nl802.patch
@@ -22,7 +22,7 @@ diff --git a/package/utils/ucode/Makefile b/package/utils/ucode/Makefile
 index b38579b837..aa2cd8c4df 100644
 --- a/package/utils/ucode/Makefile
 +++ b/package/utils/ucode/Makefile
-@@ -56,6 +56,30 @@ CMAKE_HOST_OPTIONS += \
+@@ -56,6 +56,31 @@ CMAKE_HOST_OPTIONS += \
  	-DZLIB_SUPPORT=ON \
  	-DDIGEST_SUPPORT=OFF
  
@@ -31,9 +31,10 @@ index b38579b837..aa2cd8c4df 100644
 +	CONFIG_TARGET_ipq60xx \
 +	CONFIG_TARGET_ipq807x \
 +	CONFIG_TARGET_ipq53xx \
++	CONFIG_TARGET_ipq54xx \
 +	CONFIG_TARGET_ipq95xx
 +
-+ifeq ($(CONFIG_TARGET_ipq95xx)$(CONFIG_TARGET_ipq53xx),y)
++ifeq ($(CONFIG_TARGET_ipq95xx)$(CONFIG_TARGET_ipq53xx)$(CONFIG_TARGET_ipq54xx),y)
 +TARGET_CFLAGS += -DQCA_WIFI_7
 +
 +define Build/Prepare

--- a/patches-25.12/0106-ipq54xx-use-kernel-6.6.88.patch
+++ b/patches-25.12/0106-ipq54xx-use-kernel-6.6.88.patch
@@ -1,0 +1,26 @@
+From 1decdadcb139a752ca9d5a271e75d93a51228933 Mon Sep 17 00:00:00 2001
+From: "Justin.Guo" <guoxijun@actiontec.com>
+Date: Wed, 1 Apr 2026 15:34:01 +0800
+Subject: [PATCH] ipq54xx use kernel 6.6.88
+
+Signed-off-by: Justin.Guo <guoxijun@actiontec.com>
+---
+ include/kernel-6.6 | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/include/kernel-6.6 b/include/kernel-6.6
+index 08753e357b..dfb5c9ae73 100644
+--- a/include/kernel-6.6
++++ b/include/kernel-6.6
+@@ -5,3 +5,8 @@ ifeq ($(CONFIG_TARGET_ipq53xx),y)
+ LINUX_VERSION-6.6 = .88
+ LINUX_KERNEL_HASH-6.6.88 = 19df89b63ef7e950de7297dabfac0569183bf87636f4c300a25336c7da490650
+ endif
++
++ifeq ($(CONFIG_TARGET_ipq54xx),y)
++LINUX_VERSION-6.6 = .88
++LINUX_KERNEL_HASH-6.6.88 = 19df89b63ef7e950de7297dabfac0569183bf87636f4c300a25336c7da490650
++endif
+-- 
+2.34.1
+

--- a/patches-25.12/0111-dumpimage-add-CONFIG_SYSUPGRADE_HELPER-support-for-i.patch
+++ b/patches-25.12/0111-dumpimage-add-CONFIG_SYSUPGRADE_HELPER-support-for-i.patch
@@ -1,0 +1,2556 @@
+From 90dccdcfeb15d81c5b2517061c7ebc378ca5bcfc Mon Sep 17 00:00:00 2001
+From: "Justin.Guo" <guoxijun@actiontec.com>
+Date: Fri, 15 May 2026 17:04:05 +0800
+Subject: [PATCH] dumpimage: add CONFIG_SYSUPGRADE_HELPER support for ipq54xx
+
+Add code to support ipq54xx bootconfig updates
+
+Signed-off-by: Justin.Guo <guoxijun@actiontec.com>
+---
+ package/boot/uboot-tools/Makefile             |    4 +
+ ...ools-dumpimage-add-sysupgrade-helper.patch | 2518 +++++++++++++++++
+ 2 files changed, 2522 insertions(+)
+ create mode 100644 package/boot/uboot-tools/patches/015-tools-dumpimage-add-sysupgrade-helper.patch
+
+diff --git a/package/boot/uboot-tools/Makefile b/package/boot/uboot-tools/Makefile
+index 4407d9c182..0da86df37f 100644
+--- a/package/boot/uboot-tools/Makefile
++++ b/package/boot/uboot-tools/Makefile
+@@ -75,6 +75,10 @@ MAKE_FLAGS += \
+ 	NO_PYTHON=1 \
+ 	V=$(if $(findstring c,$(OPENWRT_VERBOSE)),1,)
+ 
++ifeq ($(BOARD),ipq54xx)
++MAKE_FLAGS += CONFIG_SYSUPGRADE_HELPER=y
++endif
++
+ define Build/Compile
+ 
+ ifneq ($(CONFIG_PACKAGE_uboot-envtools),)
+diff --git a/package/boot/uboot-tools/patches/015-tools-dumpimage-add-sysupgrade-helper.patch b/package/boot/uboot-tools/patches/015-tools-dumpimage-add-sysupgrade-helper.patch
+new file mode 100644
+index 0000000000..e253bcde36
+--- /dev/null
++++ b/package/boot/uboot-tools/patches/015-tools-dumpimage-add-sysupgrade-helper.patch
+@@ -0,0 +1,2518 @@
++From 61f0e93d86b8277bae1d5c8b58ba2639ef34a9bb Mon Sep 17 00:00:00 2001
++From: guoxijun <guoxijun@cigtech.com>
++Date: Fri, 15 May 2026 16:47:20 +0800
++Subject: [PATCH] tools: dumpimage: add CONFIG_SYSUPGRADE_HELPER support for
++ ipq54xx
++
++Add sysupgrade helper functionality to the dumpimage tool for use on
++Qualcomm IPQ54xx platforms. When CONFIG_SYSUPGRADE_HELPER is defined at
++compile time, dumpimage gains two new options:
++  -c <image>     Perform board upgrade check on a firmware image
++  -b [key] [val] Update or invalidate bootconfig entries
++
++Signed-off-by: guoxijun <guoxijun@cigtech.com>
++---
++ tools/Makefile     |    5 +
++ tools/dumpimage.c  |   32 +-
++ tools/sysupgrade.c | 2176 ++++++++++++++++++++++++++++++++++++++++++++
++ tools/sysupgrade.h |  224 +++++
++ 4 files changed, 2436 insertions(+), 1 deletion(-)
++ create mode 100644 tools/sysupgrade.c
++ create mode 100644 tools/sysupgrade.h
++
++diff --git a/tools/Makefile b/tools/Makefile
++index 44ef5c8..47ba141 100644
++--- a/tools/Makefile
+++++ b/tools/Makefile
++@@ -182,6 +182,12 @@ dumpimage-mkimage-objs := aisimage.o \
++ 			$(RSA_OBJS-y) \
++ 			$(AES_OBJS-y)
++ 
+++# Add sysupgrade.o if CONFIG_SYSUPGRADE_HELPER is enabled
+++ifdef CONFIG_SYSUPGRADE_HELPER
+++dumpimage-mkimage-objs += sysupgrade.o
+++HOSTCFLAGS_dumpimage.o += -DCONFIG_SYSUPGRADE_HELPER
+++endif
+++
++ dumpimage-objs := $(dumpimage-mkimage-objs) dumpimage.o
++ mkimage-objs   := $(dumpimage-mkimage-objs) mkimage.o
++ fit_info-objs   := $(dumpimage-mkimage-objs) fit_info.o
++diff --git a/tools/dumpimage.c b/tools/dumpimage.c
++index 4791dd0..66e359f 100644
++--- a/tools/dumpimage.c
+++++ b/tools/dumpimage.c
++@@ -8,6 +8,9 @@
++ #include "dumpimage.h"
++ #include <image.h>
++ #include <version.h>
+++#ifdef CONFIG_SYSUPGRADE_HELPER
+++#include "sysupgrade.h"
+++#endif
++ 
++ static void usage(void);
++ 
++@@ -72,7 +75,11 @@ int main(int argc, char **argv)
++ 
++ 	params.cmdname = *argv;
++ 
++-	while ((opt = getopt(argc, argv, "hlo:T:p:V")) != -1) {
+++	while ((opt = getopt(argc, argv, "hlo:T:p:V"
+++#ifdef CONFIG_SYSUPGRADE_HELPER
+++				     "b:c:"
+++#endif
+++				     )) != -1) {
++ 		switch (opt) {
++ 		case 'l':
++ 			params.lflag = 1;
++@@ -101,6 +108,19 @@ int main(int argc, char **argv)
++ 		case 'V':
++ 			printf("dumpimage version %s\n", PLAIN_VERSION);
++ 			exit(EXIT_SUCCESS);
+++#ifdef CONFIG_SYSUPGRADE_HELPER
+++		case 'c':
+++			return do_board_upgrade_check(optarg);
+++		case 'b':
+++			if (argc > 4) {
+++				fprintf(stderr, "Invalid arguments for -b option\n");
+++				exit(EXIT_FAILURE);
+++			} else if (optind < argc && argv[optind] != NULL) {
+++				return update_bootconfig(argv[optind - 1], argv[optind]);
+++			} else {
+++				return invalidate_bootconfig(atoi(optarg));
+++			}
+++#endif
++ 		case 'h':
++ 		default:
++ 			usage();
++@@ -217,6 +237,16 @@ static void usage(void)
++ 	fprintf(stderr,
++ 		"       %s -V ==> print version information and exit\n",
++ 		params.cmdname);
+++#ifdef CONFIG_SYSUPGRADE_HELPER
+++	fprintf(stderr,
+++		"       %s -b ==> To update bootconfig entries\n"
+++		"          Usage: -b [member-name] [value]\n",
+++		params.cmdname);
+++	fprintf(stderr,
+++		"       %s -c image\n"
+++		"          -c ==> do board upgrade check\n",
+++		params.cmdname);
+++#endif
++ 
++ 	exit(EXIT_SUCCESS);
++ }
++diff --git a/tools/sysupgrade.c b/tools/sysupgrade.c
++new file mode 100644
++index 0000000..3b2cc97
++--- /dev/null
+++++ b/tools/sysupgrade.c
++@@ -0,0 +1,2176 @@
+++/*
+++ * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
+++ *
+++ * Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+++ *
+++ * This program is free software; you can redistribute it and/or modify
+++ * it under the terms of the GNU General Public License version 2 and
+++ * only version 2 as published by the Free Software Foundation.
+++ *
+++ * This program is distributed in the hope that it will be useful,
+++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+++ * GNU General Public License for more details.
+++ */
+++
+++#include <sysupgrade.h>
+++
+++#define SBL_VERSION_FILE       "sbl_version"
+++#define TZ_VERSION_FILE        "tz_version"
+++#define HLOS_VERSION_FILE      "hlos_version"
+++#define APPSBL_VERSION_FILE    "appsbl_version"
+++#define RPM_VERSION_FILE       "rpm_version"
+++#define DEVCFG_VERSION_FILE	"devcfg_version"
+++#define APDP_VERSION_FILE	"apdp_version"
+++#define XBL_VERSION_FILE	"xbl_sc_version"
+++#define XBLCONFIG_VERSION_FILE	"xbl_cfg_version"
+++#define VERSION_FILE_BASENAME  "/sys/devices/system/qfprom/qfprom0/"
+++#define AUTHENTICATE_FILE	"/sys/devices/system/qfprom/qfprom0/authenticate"
+++#define SEC_AUTHENTICATE_FILE  "/sys/sec_upgrade/sec_auth"
+++#define ROOTFS_AUTH		"/sys/sec_upgrade/rootfs_auth"
+++#define ATF_AUTH		"/sys/kernel/debug/qcom_socinfo/tz/name"
+++#define TEMP_KERNEL_PATH	"/tmp/tmp_kernel.bin"
+++#define TEMP_ROOTFS_PATH	"/tmp/rootfs_tmp.bin"
+++#define TEMP_METADATA_PATH	"/tmp/metadata.bin"
+++#define TEMP_BOOTCONF_PATH	"/tmp/bootconfig.bin"
+++#define TEMP_BOOTMEM_PATH	"/tmp/bootconfig_members.txt"
+++#define TEMP_SHA_KEY_PATH	"/tmp/sha_keyXXXXXX"
+++#define ROOTFS_OFFSET		65536
+++#define MAX_SBL_VERSION	11
+++#define MAX_HLOS_VERSION	32
+++#define MAX_TZ_VERSION		14
+++#define MAX_APPSBL_VERSION	14
+++#define MAX_RPM_VERSION	8
+++#define MAX_DEVCFG_VERSION	11
+++#define MAX_APDP_VERSION	8
+++#define HASH_P_FLAG		0x02200000
+++#define TMP_FILE_DIR		"/tmp/"
+++#define CERT_SIZE		2048
+++#define PRESENT		1
+++#define MBN_HDR_SIZE		40
+++#define SBL_HDR_SIZE		80
+++#define SIG_SIZE		256
+++#define NOT_PRESENT		0
+++#define SIG_CERT_2_SIZE	4352
+++#define SIG_CERT_3_SIZE	6400
+++#define SBL_NAND_PREAMBLE	10240
+++#define SBL_HDR_RESERVED	12
+++#define UBI_EC_HDR_MAGIC  0x55424923
+++#define UBI_VID_HDR_MAGIC 0x55424921
+++#define NO_OF_PROGRAM_HDRS   3
+++#define DO_CRC_BE(x) crc = tab[ ((crc >> 24) ^ (x)) & 255] ^ (crc<<8)
+++
+++struct image_section sections[] = {
+++	{
+++		.section_type		= UBOOT_TYPE,
+++#ifdef IPQ54XX
+++		.type                   = "appsbl",
+++#else
+++		.type			= "u-boot",
+++#endif
+++		.max_version		= MAX_APPSBL_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= APPSBL_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x9"
+++	},
+++	{
+++		.section_type		= HLOS_TYPE,
+++		.type			= "hlos",
+++		.max_version		= MAX_HLOS_VERSION,
+++		.tmp_file		= TMP_FILE_DIR,
+++		.pre_op			= parse_elf_image_phdr,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= HLOS_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++#ifdef IPQ54XX
+++		.img_code		= "0x71"
+++#else
+++		.img_code               = "0x17"
+++#endif
+++	},
+++	{
+++		.section_type		= HLOS_TYPE,
+++		.type			= "rootfs",
+++		.max_version		= MAX_HLOS_VERSION,
+++		.tmp_file		= TMP_FILE_DIR,
+++		.pre_op			= compute_sha_hash,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= HLOS_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++#ifdef IPQ54XX
+++		.img_code               = "0x67"
+++#else
+++		.img_code		= "0x17"
+++#endif
+++	},
+++	{
+++		.section_type		= HLOS_TYPE,
+++		.type			= "ubi",
+++		.tmp_file		= TMP_FILE_DIR,
+++		.pre_op			= extract_binary,
+++		.max_version		= MAX_HLOS_VERSION,
+++		.file			= TEMP_KERNEL_PATH,
+++		.version_file		= HLOS_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++#ifdef IPQ54XX
+++		.img_code               = "0x71"
+++#else
+++		.img_code		= "0x17"
+++#endif
+++	},
+++	{
+++		.section_type		= TZ_TYPE,
+++#ifdef IPQ54XX
+++		.type                   = "qsee",
+++#else
+++		.type			= "tz",
+++#endif
+++		.max_version		= MAX_TZ_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= TZ_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x7"
+++	},
+++#ifdef IPQ54XX
+++	{
+++		.section_type           = SBL_TYPE,
+++		.type                   = "xbl-",
+++		.max_version            = MAX_SBL_VERSION,
+++		.file                   = TMP_FILE_DIR,
+++		.version_file           = XBL_VERSION_FILE,
+++		.is_present             = NOT_PRESENT,
+++		.img_code               = "0x36"
+++	},
+++	{
+++		.section_type           = SBL_TYPE,
+++		.type                   = "xblconfig-",
+++		.max_version            = MAX_SBL_VERSION,
+++		.file                   = TMP_FILE_DIR,
+++		.version_file           = XBLCONFIG_VERSION_FILE,
+++		.is_present             = NOT_PRESENT,
+++		.img_code               = "0x25"
+++	},
+++#endif
+++	{
+++		.section_type		= SBL_TYPE,
+++		.type			= "sbl1",
+++		.max_version		= MAX_SBL_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= SBL_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x0"
+++	},
+++	{
+++		.section_type		= SBL_TYPE,
+++		.type			= "sbl2",
+++		.max_version		= MAX_SBL_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= SBL_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x5"
+++	},
+++	{
+++		.section_type		= SBL_TYPE,
+++		.type			= "sbl3",
+++		.max_version		= MAX_SBL_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= SBL_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x6"
+++	},
+++	{
+++		.section_type		= RPM_TYPE,
+++		.type			= "rpm",
+++		.max_version		= MAX_RPM_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= RPM_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0xA"
+++	},
+++	{
+++		.section_type		= DEVCFG_TYPE,
+++		.type			= "devcfg",
+++		.max_version		= MAX_DEVCFG_VERSION,
+++		.file			= TMP_FILE_DIR,
+++		.version_file		= DEVCFG_VERSION_FILE,
+++		.is_present		= NOT_PRESENT,
+++		.img_code		= "0x5"
+++	},
+++	{
+++		.section_type           = APDP_TYPE,
+++		.type                   = "apdp",
+++		.max_version            = MAX_APDP_VERSION,
+++		.file                   = TMP_FILE_DIR,
+++		.version_file           = APDP_VERSION_FILE,
+++		.is_present             = NOT_PRESENT,
+++		.img_code               = "0x200"
+++	},
+++};
+++
+++#define NO_OF_SECTIONS	ARRAY_SIZE(sections)
+++int src_size;
+++
+++int check_mbn_elf(struct image_section **sec)
+++{
+++	int fd = open((*sec)->file, O_RDONLY);
+++	struct stat sb;
+++	uint8_t *fp;
+++	Elf32_Ehdr *elf;
+++
+++	if (fd < 0) {
+++		perror((*sec)->file);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	elf = (Elf32_Ehdr *)fp;
+++	if (!strncmp((char *)&(elf->e_ident[1]), "ELF", 3)) {
+++		/* EI_CLASS Check for 32/64-bit */
+++		if( ((int)(elf->e_ident[4])) == 2) {
+++			(*sec)->get_sw_id = get_sw_id_from_component_bin_elf64;
+++			(*sec)->split_components = split_code_signature_cert_from_component_bin_elf64;
+++		} else {
+++			(*sec)->get_sw_id = get_sw_id_from_component_bin_elf;
+++			(*sec)->split_components = split_code_signature_cert_from_component_bin_elf;
+++		}
+++	} else if (!strncmp((char *)&(((Elf32_Ehdr *)(fp + SBL_NAND_PREAMBLE))->e_ident[1]), "ELF", 3)) {
+++		if( ((int)(elf->e_ident[4])) == 2) {
+++			(*sec)->get_sw_id = get_sw_id_from_component_bin_elf64;
+++			(*sec)->split_components = split_code_signature_cert_from_component_bin_elf64;
+++		} else {
+++			(*sec)->get_sw_id = get_sw_id_from_component_bin_elf;
+++			(*sec)->split_components = split_code_signature_cert_from_component_bin_elf;
+++		}
+++	} else {
+++		(*sec)->get_sw_id = get_sw_id_from_component_bin;
+++		(*sec)->split_components = split_code_signature_cert_from_component_bin;
+++	}
+++
+++	return 1;
+++}
+++
+++int get_sections(void)
+++{
+++	DIR *dir = opendir(TMP_FILE_DIR);
+++	struct dirent *file;
+++	int i,data_size;
+++	struct image_section *sec;
+++
+++	if (dir == NULL) {
+++		printf("Error accessing the image directory\n");
+++		return 0;
+++	}
+++
+++	data_size = find_mtd_part_size("kernel");
+++	while ((file = readdir(dir)) != NULL) {
+++		for (i = 0, sec = &sections[0]; i < NO_OF_SECTIONS; i++, sec++) {
+++			/* Skip loading of ubi section if board is not from nand boot */
+++			if (data_size == -1 && !strncmp(sec->type, "ubi", strlen("ubi")))
+++				continue;
+++			if (!strncmp(file->d_name, sec->type, strlen(sec->type))) {
+++				strlcat(sec->file, file->d_name, sizeof(sec->file));
+++				if (sec->pre_op) {
+++					strlcat(sec->tmp_file, file->d_name,
+++							sizeof(sec->tmp_file));
+++					if (!sec->pre_op(sec)) {
+++						printf("Error extracting kernel from ubi\n");
+++						return 0;
+++					}
+++				}
+++				if (!check_mbn_elf(&sec)) {
+++					closedir(dir);
+++					return 0;
+++				}
+++				if (!sec->get_sw_id(sec)) {
+++					closedir(dir);
+++					return 0;
+++				}
+++				get_local_image_version(sec);
+++				sec->is_present = PRESENT;
+++				break;
+++			}
+++		}
+++	}
+++	closedir(dir);
+++	return 1;
+++}
+++
+++int load_sections(void)
+++{
+++	DIR *dir;
+++	int i,data_size;
+++	struct dirent *file;
+++	struct image_section *sec;
+++
+++	dir = opendir(TMP_FILE_DIR);
+++	if (dir == NULL) {
+++		printf("Error accessing the %s image directory\n", TMP_FILE_DIR);
+++		return 0;
+++	}
+++
+++	data_size = find_mtd_part_size("kernel");
+++	while ((file = readdir(dir)) != NULL) {
+++		for (i = 0, sec = &sections[0]; i < NO_OF_SECTIONS; i++, sec++) {
+++			/* Skip loading of ubi section if board is not from nand boot */
+++			if (data_size == -1 && !strncmp(sec->type, "ubi", strlen("ubi")))
+++				continue;
+++			if (!strncmp(file->d_name, sec->type, strlen(sec->type))) {
+++				strlcat(sec->file, file->d_name, sizeof(sec->file));
+++				if (sec->pre_op) {
+++					strlcat(sec->tmp_file, file->d_name,
+++							sizeof(sec->tmp_file));
+++					if (!sec->pre_op(sec)) {
+++						printf("Error extracting %s from ubi\n",
+++									   sec->tmp_file);
+++						closedir(dir);
+++						return 0;
+++					}
+++				}
+++				sec->is_present = PRESENT;
+++				break;
+++			}
+++		}
+++	}
+++	closedir(dir);
+++	return 1;
+++}
+++
+++/**
+++ * is_authentication_check_enabled() - checks whether installed image is
+++ * secure(1) or not(0)
+++ *
+++ */
+++int is_authentication_check_enabled(void)
+++{
+++	int fd = open(AUTHENTICATE_FILE, O_RDONLY);
+++	char authenticate_string[4];
+++	int len;
+++
+++	if (fd == -1) {
+++		perror(AUTHENTICATE_FILE);
+++		return 0;
+++	}
+++
+++	len = read(fd, authenticate_string, 1);
+++	close(fd);
+++
+++	if (len > 0 && authenticate_string[0] == '0') {
+++		return 0;
+++	}
+++
+++	return 1;
+++}
+++
+++int is_tz_authentication_enabled(void)
+++{
+++	struct stat sb;
+++
+++	if (stat(SEC_AUTHENTICATE_FILE, &sb) == -1) {
+++		perror("stat");
+++		return 0;
+++	}
+++	return 1;
+++}
+++
+++int is_rootfs_auth_enabled(void)
+++{
+++	FILE *file;
+++	char buf[10];
+++	char command[36];
+++	int retval;
+++
+++	file = fopen(ROOTFS_AUTH, "r");
+++	if (file != NULL) {
+++		while (fgets(buf, sizeof(buf), file) != NULL) {
+++			if (!strncmp(buf, "Enabled", 7)) {
+++				fclose(file);
+++				return 1;
+++			}
+++		}
+++		fclose(file);
+++	} else {
+++		printf("Error: Unable to open sysfs file, checking ENV...\n");
+++	}
+++
+++	snprintf(command, sizeof(command), "fw_printenv | grep -q rootfs_auth");
+++	retval = system(command);
+++	if (retval == 0) {
+++		return 1;
+++	}
+++
+++	return 0;
+++}
+++
+++int is_atf_auth_enabled(void)
+++{
+++	FILE *file;
+++	char *buf = NULL;
+++	size_t len = 0;
+++	ssize_t read;
+++	int is_atf = 0;
+++
+++
+++	file = fopen(ATF_AUTH, "r");
+++	if (file == NULL) {
+++		printf("Error: Unable to open sysfs file\n");
+++		return 0;
+++	}
+++
+++	while ((read = getline(&buf, &len, file)) != -1) {
+++		if (strstr(buf, "WIN.ATF") != NULL) {
+++			is_atf = 1;
+++			break;
+++		}
+++	}
+++
+++	fclose(file);
+++	free(buf);
+++	return is_atf;
+++}
+++
+++/**
+++ * get_local_image_version() check the version file & if it exists, read the
+++ * value & save it into global variable local_version
+++ *
+++ */
+++int get_local_image_version(struct image_section *section)
+++{
+++	int len, fd;
+++	char local_version_string[16], version_file[64];
+++	struct stat st;
+++
+++	snprintf(version_file, sizeof(version_file), "%s%s", VERSION_FILE_BASENAME, section->version_file);
+++	fd = open(version_file, O_RDONLY);
+++	if (fd == -1) {
+++		perror(version_file);
+++		return 0;
+++	}
+++
+++	memset(&st, 0, sizeof(struct stat));
+++	fstat(fd, &st);
+++
+++	len = st.st_size < sizeof(local_version_string) - 1 ? st.st_size :
+++							sizeof(local_version_string) - 1;
+++	if (read(fd, local_version_string, len) == -1) {
+++		close(fd);
+++		return 0;
+++	}
+++	local_version_string[len] = '\0';
+++	close(fd);
+++
+++	section->local_version = atoi(local_version_string);
+++	printf("Local image version:%s\n", local_version_string);
+++
+++	return 1;
+++}
+++
+++/**
+++ * set_local_image_version() update the version of the image by writing the version
+++ * to the version file
+++ *
+++ */
+++int set_local_image_version(struct image_section *section)
+++{
+++	int fd;
+++	char version_string[16], version_file[64];
+++	int len;
+++
+++	snprintf(version_file, sizeof(version_file), "%s%s", TMP_FILE_DIR, section->version_file);
+++	fd = open(version_file, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+++	if (fd == -1) {
+++		perror(version_file);
+++		return 0;
+++	}
+++
+++	len = snprintf(version_string, 8, "%d", section->img_version);
+++	if (len < 0) {
+++		printf("Error in formatting the version string");
+++		return 0;
+++	}
+++
+++	printf("Version to be updated:%s\n", version_string);
+++	if (write(fd, version_string, len) == -1) {
+++		printf("Error writing version to %s\n", version_file);
+++		close(fd);
+++		return 0;
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++/**
+++ * is_version_check_enabled() checks whether version check is
+++ * enabled(non-zero value) or not
+++ *
+++ */
+++int is_version_check_enabled()
+++{
+++	if (get_local_image_version(&sections[0]) != -1) {
+++		printf("Returning 1 from is_version_check_enabled because local_version_string is non-ZERO\n");
+++		return 1;
+++	}
+++
+++	return 0;
+++}
+++
+++char *find_value(char *buffer, char *search, int size)
+++{
+++	char *value = malloc(size * sizeof(char));
+++	int i, j;
+++
+++	if (value == NULL) {
+++		return NULL;
+++	}
+++
+++	for (i = 0; i < CERT_SIZE; i++) {
+++		for (j = 0; search[j] && (buffer[i + j] == search[j]); j++);
+++		if (search[j] == '\0') {
+++			strlcpy(value, &buffer[i - size], size);
+++			value[size - 1] = '\0';
+++			return value;
+++		}
+++	}
+++	free(value);
+++	return NULL;
+++}
+++
+++/**
+++ * check_nand_preamble() compares first 12 bytes of section with
+++ * pre defined PREAMBLE value and returns 0 if both value matches
+++ */
+++int check_nand_preamble(uint8_t *mfp)
+++{
+++	char magic[12] = { 0xd1, 0xdc, 0x4b, 0x84,
+++			   0x34, 0x10, 0xd7, 0x73,
+++			   0x5a, 0x43, 0x0b, 0x7d };
+++	return memcmp(magic, mfp, sizeof(magic));
+++}
+++
+++/**
+++ * get_sw_id_from_component_bin() parses the MBN header & checks image size v/s
+++ * code size. If both differ, it means signature & certificates are
+++ * appended at end.
+++ * Extract the attestation certificate & read the Subject & retreive the SW_ID.
+++ *
+++ * @bin_file: struct image_section *
+++ */
+++int get_sw_id_from_component_bin(struct image_section *section)
+++{
+++	Mbn_Hdr *mbn_hdr;
+++	int fd = open(section->file, O_RDONLY);
+++	struct stat sb;
+++	uint8_t *fp;
+++	int cert_offset;
+++	char *sw_version;
+++	int sig_cert_size;
+++
+++	if (fd == -1) {
+++		perror(section->file);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	mbn_hdr = (Mbn_Hdr *)fp;
+++	if (strstr(section->file, sections[4].type)) {
+++		uint32_t preamble = !check_nand_preamble(fp) ? SBL_NAND_PREAMBLE : 0;
+++		Sbl_Hdr *sbl_hdr = (Sbl_Hdr *)(fp + preamble);
+++
+++		sig_cert_size = sbl_hdr->image_size - sbl_hdr->code_size;
+++		cert_offset = preamble + sbl_hdr->cert_ptr - sbl_hdr->image_dest_ptr +
+++				SBL_HDR_SIZE;
+++	} else {
+++		sig_cert_size = mbn_hdr->image_size - mbn_hdr->code_size;
+++		cert_offset = mbn_hdr->cert_ptr - mbn_hdr->image_dest_ptr + 40;
+++	}
+++	if (sig_cert_size != SIG_CERT_2_SIZE && sig_cert_size != SIG_CERT_3_SIZE) {
+++		printf("WARNING: signature certificate size is different\n");
+++		// ipq807x has certificate size as dynamic, hence ignore this check
+++	}
+++
+++	printf("Image with version information\n");
+++	sw_version = find_value((char *)(fp + cert_offset), "SW_ID", 17);
+++	if (sw_version != NULL) {
+++		sw_version[8] = '\0';
+++		sscanf(sw_version, "%x", &section->img_version);
+++		printf("SW ID:%d\n", section->img_version);
+++		free(sw_version);
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++int process_elf(char *bin_file, uint8_t **fp, Elf32_Ehdr **elf, Elf32_Phdr **phdr, Mbn_Hdr **mbn_hdr)
+++{
+++	int fd = open(bin_file, O_RDONLY);
+++	struct stat sb;
+++	int version = 0;
+++	int i = 0;
+++
+++	if (fd < 0) {
+++		perror(bin_file);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	*fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (*fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	*elf = (Elf32_Ehdr *)*fp;
+++	while (strncmp((char *)&((*elf)->e_ident[1]), "ELF", 3)) {
+++		*fp = (uint8_t *)((char *)(*fp) + SBL_NAND_PREAMBLE);
+++		*elf = (Elf32_Ehdr *)*fp;
+++	}
+++
+++	*phdr = (Elf32_Phdr *)(*fp + (*elf)->e_phoff);
+++	for (i = 0; i < (*elf)->e_phnum; i++, (*phdr)++) {
+++		if ((*phdr)->p_flags == HASH_P_FLAG) {
+++			*mbn_hdr = (Mbn_Hdr *)(*fp + (*phdr)->p_offset);
+++			if ((*mbn_hdr)->image_size != (*mbn_hdr)->code_size) {
+++				version = 1;
+++				break;
+++			} else {
+++				printf("Error: Image without version information\n");
+++				close(fd);
+++				return 0;
+++			}
+++		}
+++	}
+++
+++	if (version != 1) {
+++		printf("Error: Image without version information\n");
+++		return 0;
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++int process_elf64(char *bin_file, uint8_t **fp, Elf64_Ehdr **elf, Elf64_Phdr **phdr, Mbn_Hdr **mbn_hdr)
+++{
+++	struct stat sb;
+++	int i, fd, version = 0;
+++
+++	fd = open(bin_file, O_RDONLY);
+++	if (fd < 0) {
+++		perror(bin_file);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	*fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (*fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	*elf = (Elf64_Ehdr *)*fp;
+++	while (strncmp((char *)&((*elf)->e_ident[1]), "ELF", 3)) {
+++		*fp = (uint8_t *)((char *)(*fp) + SBL_NAND_PREAMBLE);
+++		*elf = (Elf64_Ehdr *)*fp;
+++	}
+++
+++	*phdr = (Elf64_Phdr *)(*fp + (*elf)->e_phoff);
+++	for (i = 0; i < (*elf)->e_phnum; i++, (*phdr)++) {
+++		if ((*phdr)->p_flags == HASH_P_FLAG) {
+++			*mbn_hdr = (Mbn_Hdr *)(*fp + (*phdr)->p_offset);
+++			if ((*mbn_hdr)->image_size != (*mbn_hdr)->code_size) {
+++				version = 1;
+++				break;
+++			} else {
+++				printf("Error: Image without version information\n");
+++				close(fd);
+++				return 0;
+++			}
+++		}
+++	}
+++
+++	if (version != 1) {
+++		printf("Error: Image without version information\n");
+++		return 0;
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++/**
+++ * get_sw_id_from_component_bin_elf() parses the ELF header to get the MBN header
+++ * of the hash table segment. Parses the MBN header of hash table segment & checks
+++ * total size v/s actual component size. If both differ, it means signature &
+++ * certificates are appended at end.
+++ * Extract the attestation certificate & read the Subject & retreive the SW_ID.
+++ *
+++ * @bin_file: struct image_section *
+++ */
+++int get_sw_id_from_component_bin_elf(struct image_section *section)
+++{
+++	Elf32_Ehdr *elf;
+++	Elf32_Phdr *phdr;
+++	Mbn_Hdr *mbn_hdr;
+++	uint8_t *fp;
+++	int cert_offset;
+++	char *sw_version;
+++
+++	if (!process_elf(section->file, &fp, &elf, &phdr, &mbn_hdr)) {
+++		return 0;
+++	}
+++
+++	cert_offset = mbn_hdr->cert_ptr - mbn_hdr->image_dest_ptr + 40;
+++	printf("Image with version information\n");
+++	sw_version = find_value((char *)(fp + phdr->p_offset + cert_offset), "SW_ID", 17);
+++	if (sw_version) {
+++		sw_version[8] = '\0';
+++		sscanf(sw_version, "%x", &section->img_version);
+++		printf("SW ID:%d\n", section->img_version);
+++		free(sw_version);
+++	}
+++
+++	return 1;
+++}
+++
+++/**
+++ * get_sw_id_from_component_bin_elf64() parses the ELF64 header to get the MBN header
+++ * of the hash table segment. Parses the MBN header of hash table segment & checks
+++ * total size v/s actual component size. If both differ, it means signature &
+++ * certificates are appended at end.
+++ * Extract the attestation certificate & read the Subject & retreive the SW_ID.
+++ *
+++ 32_Phdr *phdr;* @bin_file: struct image_section *
+++ */
+++int get_sw_id_from_component_bin_elf64(struct image_section *section)
+++{
+++	Elf64_Ehdr *elf;
+++	Elf64_Phdr *phdr;
+++	Mbn_Hdr *mbn_hdr;
+++	uint8_t *fp;
+++	int cert_offset;
+++	char *sw_version;
+++
+++	if (!process_elf64(section->file, &fp, &elf, &phdr, &mbn_hdr)) {
+++		return 0;
+++	}
+++
+++	cert_offset = mbn_hdr->code_size + mbn_hdr->sig_sz + 40;
+++	printf("Image with version information64\n");
+++	sw_version = find_value((char *)(fp + phdr->p_offset + cert_offset), "SW_ID", 17);
+++	if (sw_version) {
+++		sw_version[8] = '\0';
+++		sscanf(sw_version, "%x", &section->img_version);
+++		printf("SW ID:%d\n", section->img_version);
+++		free(sw_version);
+++	}
+++
+++	return 1;
+++}
+++
+++int find_mtd_part_size(char *mtdname)
+++{
+++	char prefix[] = "/dev/mtd";
+++	char dev[PATH_MAX];
+++	int i = -1, fd;
+++	int vol_size;
+++	int flag = 0;
+++	char mtd_part[256];
+++	FILE *fp = fopen("/proc/mtd", "r");
+++	mtd_info_t mtd_dev_info = {0};
+++
+++	if (fp == NULL) {
+++		printf("Error finding mtd part\n");
+++		return -1;
+++	}
+++
+++	while (fgets(dev, sizeof(dev), fp)) {
+++		if (strstr(dev, mtdname)) {
+++			flag = 1;
+++			break;
+++		}
+++		i++;
+++	}
+++	fclose(fp);
+++
+++	if (flag != 1) {
+++		printf("%s block not found\n", mtdname);
+++		return -1;
+++	}
+++
+++	snprintf(mtd_part, sizeof(mtd_part), "%s%d", prefix, i);
+++
+++	fd = open(mtd_part, O_RDWR);
+++	if (fd == -1) {
+++		return -1;
+++	}
+++
+++	if (ioctl(fd, MEMGETINFO, &mtd_dev_info) == -1) {
+++		printf("Error getting block size\n");
+++		close(fd);
+++		return -1;
+++	}
+++
+++	vol_size = mtd_dev_info.erasesize;
+++	close(fd);
+++
+++	return vol_size;
+++}
+++
+++/**
+++ * Helper function to dynamically get volume id
+++ */
+++int get_ubi_volume_id(char *vol_name)
+++{
+++	int i, number_of_ubi_volumes;
+++	char ubi_vol_count[] = "/sys/class/ubi/ubi0/volumes_count";
+++	char prefix[] = "/sys/class/ubi/ubi0_";
+++	char suffix[] = "/name";
+++	char ubi_vol[256];
+++	char ubi_vol_name[256];
+++	char current_ubi_volumes_count[256];
+++	FILE *fp;
+++
+++	fp = fopen(ubi_vol_count, "r");
+++	if (fp == NULL) {
+++		printf("Error finding volumes count\n");
+++		return 0;
+++	}
+++
+++	if (fgets(current_ubi_volumes_count, sizeof(current_ubi_volumes_count), fp) == NULL) {
+++		printf(" Failed to get ubi volumes count \n");
+++		return 0;
+++	}
+++	number_of_ubi_volumes = atoi(current_ubi_volumes_count);
+++	printf("number of ubi volumes = %d\n", number_of_ubi_volumes);
+++
+++	for (i = 0; i < number_of_ubi_volumes; i++)
+++	{
+++		snprintf(ubi_vol, sizeof(ubi_vol), "%s%d%s", prefix, i, suffix);
+++		fp = fopen(ubi_vol, "r");
+++		if (fp == NULL) {
+++			printf("Error opening ubi volumes count\n");
+++			return 0;
+++		}
+++		if (fgets(ubi_vol_name, sizeof(ubi_vol_name), fp) == NULL) {
+++			printf(" Failed to get ubi volume name \n");
+++			return 0;
+++		}
+++		if (strstr(ubi_vol_name, vol_name)) {
+++			printf("%s volume id = %d\n", vol_name, i);
+++			fclose(fp);
+++			return i;
+++		}
+++	}
+++
+++	return -1;
+++}
+++
+++/**
+++ * For NAND image, kernel and rootfs image is ubinized.
+++ * Hence need to un-ubinize the ubi image and extract both kernel
+++ * and rootfs images. Kernel image section and volume name are passed as
+++ * argument in extract_kernel_binary(). After kernel extraction,
+++ * parse_elf_image_phdr() is called which parses the ELF32 program header
+++ * to get the ELF header of rootfs metadata.
+++ */
+++
+++int extract_binary(struct image_section *section)
+++{
+++	extract_kernel_binary(section, "kernel");
+++	parse_elf_image_phdr(section);
+++	return 1;
+++}
+++
+++/**
+++ * In case of NAND image, Kernel image is ubinized & version information is
+++ * part of Kernel image. Hence need to un-ubinize the image.
+++ * To get the kernel image, Find the volume with kernel's volume id. Kernel image
+++ * is fragmented and hence we need to assemble it to get complete image.
+++ * In UBI image, first look for UBI#, which is the magic number used to identify
+++ * each eraseble block. Parse the UBI header, which starts with UBI# & get
+++ * the VID(volume ID) header offset as well as Data offset.
+++ * Traverse to VID header offset & check the volume ID. If it is matching with
+++ * kernel Volume id extracted based on ubi sysfs, Kernel image is stored in
+++ * this volume. Use Data offset to extract the Kernel image.
+++ *
+++ * @bin_file: struct image_section *
+++ */
+++
+++int extract_kernel_binary(struct image_section *section, char *volname)
+++{
+++	char *ifname, *ofname;
+++
+++	strlcpy(section->file, TEMP_KERNEL_PATH, sizeof(TEMP_KERNEL_PATH));
+++	ifname = section->tmp_file;
+++	ofname = section->file;
+++
+++	if (extract_ubi_volume(volname, ifname, ofname) != 1) {
+++		printf("Image extraction failed\n");
+++		return 0;
+++	}
+++	return 1;
+++}
+++
+++/**
+++ * extract_ubi_volume() extracts both kernel image and rootfs image
+++ * from UBI image. extract_kernel_binary() passes volume name,
+++ * UBI image as Input file name, kernel or rootfs as Output file name.
+++ * This function finds respective UBI volume ID, identifies each eraseble
+++ * block. Parses UBI header and gets Volume ID header offset as well as
+++ * Data offset. When volume ID matches for kernel and rootfs, Uses data offset
+++ * to extract both images separately.
+++ */
+++
+++int extract_ubi_volume(char *vol_name, char *if_name, char *of_name)
+++{
+++	struct ubi_ec_hdr *ubi_ec;
+++	struct ubi_vid_hdr *ubi_vol;
+++	uint8_t *fp;
+++	int fd, ofd, magic, data_size, vid_hdr_offset, data_offset;
+++	int ret_vol_id, curr_vol_id;
+++	struct stat sb;
+++
+++	if (if_name == NULL) {
+++		return 0;
+++	}
+++
+++	fd = open(if_name, O_RDONLY);
+++	if (fd < 0) {
+++		perror(if_name);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	ofd = open(of_name, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+++	if (ofd == -1) {
+++		perror(of_name);
+++		close(fd);
+++		return 0;
+++	}
+++
+++	data_size = find_mtd_part_size(vol_name);
+++	if (data_size == -1) {
+++		printf("Error finding data size\n");
+++		return 0;
+++	}
+++
+++	ret_vol_id = get_ubi_volume_id(vol_name);
+++	if (ret_vol_id == -1) {
+++		printf("Wrong ubi volume id for kernel\n");
+++		return 0;
+++	}
+++
+++	ubi_ec = (struct ubi_ec_hdr *)fp;
+++	magic = be32_to_cpu(ubi_ec->magic);
+++	while (magic == UBI_EC_HDR_MAGIC) {
+++		vid_hdr_offset = be32_to_cpu(ubi_ec->vid_hdr_offset);
+++		data_offset = be32_to_cpu(ubi_ec->data_offset);
+++		ubi_vol = (struct ubi_vid_hdr *)((uint8_t *)ubi_ec + vid_hdr_offset);
+++		magic = be32_to_cpu(ubi_vol->magic);
+++		if (magic != UBI_VID_HDR_MAGIC) {
+++			printf("Wrong ubi format\n");
+++			close(ofd);
+++			close(fd);
+++			return 0;
+++		}
+++		curr_vol_id = be32_to_cpu(ubi_vol->vol_id);
+++		if (curr_vol_id == ret_vol_id) {
+++			if (write(ofd, (void *)((uint8_t *)ubi_ec + data_offset), data_size) == -1) {
+++				printf("Write error\n");
+++				close(fd);
+++				close(ofd);
+++				return 0;
+++			}
+++		}
+++		ubi_ec = (struct ubi_ec_hdr *)((uint8_t *)ubi_ec + data_offset + data_size);
+++		magic = be32_to_cpu(ubi_ec->magic);
+++	}
+++	if (munmap(fp, sb.st_size) == -1) {
+++		perror("munmap");
+++		close(ofd);
+++		close(fd);
+++		return 0;
+++	}
+++	close(ofd);
+++	close(fd);
+++	if (!strncmp(vol_name, "ubi_rootfs", strlen("ubi_rootfs"))) {
+++		extract_rootfs_binary(of_name);
+++	}
+++	printf("%s extracted from ubi image\n", vol_name);
+++	return 1;
+++}
+++
+++/**
+++ * check_image_exist() used to check whether the ubi image for NAND
+++ * or rootfs image for EMMC are available in /tmp directory.
+++ * If respective image was found, the filename will be passed. If
+++ * not found, it returns NULL
+++ */
+++
+++char * check_image_exist(char *imgname) {
+++	DIR* FD;
+++	struct dirent* in_file;
+++	char extension[256] = "/tmp/";
+++
+++	/* Scanning the in directory */
+++	if (NULL == (FD = opendir ("/tmp")))
+++	{
+++		fprintf(stderr, "Error : Failed to open input directory\n");
+++		return NULL;
+++	}
+++
+++	while ((in_file = readdir(FD)))
+++	{
+++		if (strstr(in_file->d_name, imgname)) {
+++			printf("%s file found\n", in_file->d_name);
+++			strlcat(extension, in_file->d_name, sizeof(extension));
+++			strlcpy(in_file->d_name, extension, sizeof(extension));
+++			return in_file->d_name;
+++		}
+++	}
+++	return NULL;
+++}
+++
+++/**
+++ * In case of EMMC, extract_rootfs_binary() extracts the rootfs image
+++ * till Deadcode from existing rootfs image. After extraction, the new rootfs
+++ * image will replace old rootfs image. This function removes padded
+++ * binaries and helps to authenticate rootfs image using sec_auth
+++ */
+++
+++int extract_rootfs_binary(char *filename)
+++{
+++	int ifd;
+++	uint8_t *fp;
+++	struct stat sb;
+++
+++	if (filename == NULL) {
+++		return 0;
+++	}
+++
+++	ifd = open(filename, O_RDWR);
+++	if (ifd < 0) {
+++		perror(filename);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(ifd, &sb) == -1) {
+++		perror("fstat");
+++		close(ifd);
+++		return 0;
+++	}
+++
+++	fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, ifd, 0);
+++	if (fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(ifd);
+++		return 0;
+++	}
+++
+++	int offset = 0,dead_off = sb.st_size;
+++	while (offset <= (sb.st_size - 3))
+++	{
+++		if ((fp[offset] == 0xde) && (fp[offset+1] == 0xad) && (fp[offset+2] == 0xc0) && (fp[offset+3] == 0xde)) {
+++			dead_off=offset;
+++			break;
+++		}
+++		offset += ROOTFS_OFFSET;
+++	}
+++
+++	if (munmap(fp, sb.st_size) == -1) {
+++		perror("munmap");
+++		close(ifd);
+++		return 0;
+++	}
+++
+++	close(ifd);
+++	if (truncate(filename, dead_off) == -1) {
+++		printf(" Failed to extract rootfs \n");
+++		return 0;
+++	}
+++	return 1;
+++}
+++
+++/**
+++ * The digest functions output the message digest of a supplied file and
+++ * write sha-hash key to /tmp/sha_keyXXXXXX file
+++ */
+++int compute_sha_hash(struct image_section *section)
+++{
+++	char sha_hash[] = TEMP_SHA_KEY_PATH;
+++	char command[300]={0};
+++	int retval=0;
+++
+++#ifdef USE_SHA384
+++	retval = snprintf(command, sizeof(command),
+++		"openssl dgst -sha384 -binary -out %s %s", sha_hash, section->tmp_file);
+++#endif
+++#ifdef USE_SHA256
+++	retval = snprintf(command, sizeof(command),
+++		"openssl dgst -sha256 -binary -out %s %s", sha_hash, section->tmp_file);
+++#endif
+++	if (retval < 0) {
+++		return retval;
+++	}
+++	retval = system(command);
+++	if (retval != 0) {
+++		printf("Error generating sha-hash, command : %s\n",command);
+++		return 0;
+++	}
+++
+++	printf("sha_hash file is created: %s \n",sha_hash);
+++	return 1;
+++}
+++/**
+++ * is_image_version_higher() iterates through each component and check
+++ * versions against locally installed version.
+++ * If newer component version is lower than locally insatlled image,
+++ * abort the FW upgrade process.
+++ *
+++ * @img: char *
+++ */
+++int is_image_version_higher(void)
+++{
+++	int i;
+++	for (i = 0; i < NO_OF_SECTIONS; i++) {
+++		if (!sections[i].is_present) {
+++			continue;
+++		}
+++
+++		if (sections[i].local_version > sections[i].img_version) {
+++			printf("Version of image %s (%d) is lower than minimal supported version(%d)\n",
+++					sections[i].file,
+++					sections[i].img_version,
+++					sections[i].local_version);
+++			return 0;
+++		}
+++
+++		if (sections[i].img_version > sections[i].max_version) {
+++			printf("Version of image %s (%d) is higher than maximum supported version(%d)\n",
+++					sections[i].file,
+++					sections[i].img_version,
+++					sections[i].max_version);
+++		}
+++	}
+++
+++	return 1;
+++}
+++
+++/**
+++ * Update the version information file based on currently SW_ID being installed.
+++ *
+++ */
+++int update_version(void)
+++{
+++	int i;
+++	for (i = 0; i < NO_OF_SECTIONS; i++) {
+++		if (!sections[i].is_present) {
+++			continue;
+++		}
+++
+++		if (set_local_image_version(&sections[i]) != 1) {
+++			printf("Error updating version of %s\n", sections[i].file);
+++			return 0;
+++		}
+++	}
+++
+++	return 1;
+++}
+++
+++int check_image_version(void)
+++{
+++	if (is_version_check_enabled() == 0) {
+++		printf("Version check is not enabled, upgrade to continue !!!\n");
+++		return 1;
+++	}
+++
+++	if (is_image_version_higher() == 0) {
+++		printf("New image versions are lower than existing image, upgrade to STOP !!!\n");
+++		return 0;
+++	}
+++
+++	if (update_version() != 1) {
+++		printf("Error while updating verison information\n");
+++		return 0;
+++	}
+++	printf("Update completed!\n");
+++
+++	return 1;
+++}
+++
+++/**
+++ * split_code_signature_cert_from_component_bin splits the component
+++ * binary by splitting into code(including MBN header), signature file &
+++ * attenstation certificate.
+++ *
+++ * @bin_file: char *
+++ * @src: char *
+++ * @sig: char *
+++ * @cert: char *
+++ */
+++int split_code_signature_cert_from_component_bin(struct image_section *section,
+++		char **src, char **sig, char **cert)
+++{
+++	Mbn_Hdr *mbn_hdr;
+++	Sbl_Hdr *sbl_hdr;
+++	int fd = open(section->file, O_RDONLY);
+++	uint8_t *fp;
+++	int sig_offset = 0;
+++	int src_offset = 0;
+++	int cert_offset = 0;
+++	struct stat sb;
+++	int sig_cert_size;
+++
+++	if (fd == -1) {
+++		perror(section->file);
+++		return 0;
+++	}
+++
+++	memset(&sb, 0, sizeof(struct stat));
+++	if (fstat(fd, &sb) == -1) {
+++		perror("fstat");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++	if (fp == MAP_FAILED) {
+++		perror("mmap");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	mbn_hdr = (Mbn_Hdr *)fp;
+++	if (strstr(section->file, sections[4].type)) {
+++		uint32_t preamble = !check_nand_preamble(fp) ? SBL_NAND_PREAMBLE : 0;
+++
+++		sbl_hdr = (Sbl_Hdr *)(fp + preamble);
+++		src_offset = preamble;
+++		sig_offset = preamble + sbl_hdr->sig_ptr - sbl_hdr->image_dest_ptr +
+++				SBL_HDR_SIZE;
+++		cert_offset = preamble + sbl_hdr->cert_ptr - sbl_hdr->image_dest_ptr +
+++				SBL_HDR_SIZE;
+++		sig_cert_size = sbl_hdr->image_size - sbl_hdr->code_size;
+++		src_size = sbl_hdr->sig_ptr - sbl_hdr->image_dest_ptr + SBL_HDR_SIZE;
+++	} else {
+++		sig_cert_size = mbn_hdr->image_size - mbn_hdr->code_size;
+++		src_size = mbn_hdr->sig_ptr - mbn_hdr->image_dest_ptr + MBN_HDR_SIZE;
+++		sig_offset += mbn_hdr->sig_ptr - mbn_hdr->image_dest_ptr + MBN_HDR_SIZE;
+++		cert_offset += mbn_hdr->cert_ptr - mbn_hdr->image_dest_ptr + MBN_HDR_SIZE;
+++	}
+++
+++	if (sig_cert_size != SIG_CERT_2_SIZE && sig_cert_size != SIG_CERT_3_SIZE) {
+++		printf("WARNING: signature certificate size is different\n");
+++	}
+++        *src = malloc(src_size + 1);
+++	if (*src == NULL) {
+++		close(fd);
+++		return 0;
+++	}
+++	memcpy(*src, fp + src_offset, src_size);
+++	(*src)[src_size] = '\0';
+++
+++	*sig = malloc((SIG_SIZE + 1) * sizeof(char));
+++	if (*sig == NULL) {
+++		free(*src);
+++		return 0;
+++	}
+++	memcpy(*sig, fp + sig_offset, SIG_SIZE);
+++	(*sig)[SIG_SIZE] = '\0';
+++
+++	*cert = malloc((CERT_SIZE + 1) * sizeof(char));
+++	if (*cert == NULL) {
+++		free(*src);
+++		free(*sig);
+++		return 0;
+++	}
+++	memcpy(*cert, fp + cert_offset, CERT_SIZE);
+++	(*cert)[CERT_SIZE] = '\0';
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++/**
+++ * split_code_signature_cert_from_component_bin_elf splits the component
+++ * binary by splitting into code(including ELF header), signature file &
+++ * attenstation certificate.
+++ *
+++ * @bin_file: char *
+++ * @src: char *
+++ * @sig: char *
+++ * @cert: char *
+++ */
+++int split_code_signature_cert_from_component_bin_elf(struct image_section *section,
+++		char **src, char **sig, char **cert)
+++{
+++	Elf32_Ehdr *elf;
+++	Elf32_Phdr *phdr;
+++	Mbn_Hdr *mbn_hdr;
+++	uint8_t *fp;
+++	int sig_offset;
+++	int cert_offset;
+++	int len;
+++
+++	if (!process_elf(section->file, &fp, &elf, &phdr, &mbn_hdr)) {
+++		return 0;
+++	}
+++
+++	sig_offset = mbn_hdr->sig_ptr - mbn_hdr->image_dest_ptr + MBN_HDR_SIZE;
+++	len = sig_offset;
+++	*src = malloc((len + 1) * sizeof(char));
+++	if (*src == NULL) {
+++		return 0;
+++	}
+++	memcpy(*src, fp + phdr->p_offset, len);
+++	src_size = len;
+++	(*src)[len] = '\0';
+++
+++	*sig = malloc((SIG_SIZE + 1) * sizeof(char));
+++	if (*sig == NULL) {
+++		free(*src);
+++		return 0;
+++	}
+++	memcpy(*sig, fp + phdr->p_offset + sig_offset, SIG_SIZE);
+++	(*sig)[SIG_SIZE] = '\0';
+++
+++	cert_offset = mbn_hdr->cert_ptr - mbn_hdr->image_dest_ptr + MBN_HDR_SIZE;
+++	*cert = malloc((CERT_SIZE + 1) * sizeof(char));
+++	if (*cert == NULL) {
+++		free(*src);
+++		free(*sig);
+++		return 0;
+++	}
+++	memcpy(*cert, fp + phdr->p_offset + cert_offset, CERT_SIZE);
+++	(*cert)[CERT_SIZE] = '\0';
+++
+++	return 1;
+++}
+++
+++/**
+++ * split_code_signature_cert_from_component_bin_elf64 splits the component
+++ * binary by splitting into code(including ELF header), signature file &
+++ * attenstation certificate.
+++ *
+++ * @bin_file: char *
+++ * @src: char *
+++ * @sig: char *
+++ * @cert: char *
+++ */
+++int split_code_signature_cert_from_component_bin_elf64(struct image_section *section,
+++                char **src, char **sig, char **cert)
+++{
+++	Elf64_Ehdr *elf;
+++	Elf64_Phdr *phdr;
+++	Mbn_Hdr *mbn_hdr;
+++	uint8_t *fp;
+++	int len, sig_offset, cert_offset;
+++
+++	if (!process_elf64(section->file, &fp, &elf, &phdr, &mbn_hdr)) {
+++		return 0;
+++	}
+++
+++	sig_offset = mbn_hdr->code_size + MBN_HDR_SIZE;
+++	len = sig_offset;
+++	*src = malloc((len + 1) * sizeof(char));
+++	if (*src == NULL) {
+++		return 0;
+++	}
+++
+++	memcpy(*src, fp + phdr->p_offset, len);
+++	src_size = len;
+++	(*src)[len] = '\0';
+++
+++	*sig = malloc((SIG_SIZE + 1) * sizeof(char));
+++	if (*sig == NULL) {
+++		free(*src);
+++		return 0;
+++	}
+++
+++	memcpy(*sig, fp + phdr->p_offset + sig_offset, SIG_SIZE);
+++	(*sig)[SIG_SIZE] = '\0';
+++
+++	cert_offset = mbn_hdr->code_size + mbn_hdr->sig_sz + MBN_HDR_SIZE;
+++	*cert = malloc((CERT_SIZE + 1) * sizeof(char));
+++	if (*cert == NULL) {
+++		free(*src);
+++		free(*sig);
+++		return 0;
+++	}
+++	memcpy(*cert, fp + phdr->p_offset + cert_offset, CERT_SIZE);
+++	(*cert)[CERT_SIZE] = '\0';
+++
+++	return 1;
+++}
+++
+++/**
+++ * parse_elf_image_phdr() parses the ELF32 program header to get the
+++ * ELF header of rootfs metadata. It parses the metadata and writes
+++ * to a new /tmp/metadata.bin file.
+++ */
+++int parse_elf_image_phdr(struct image_section *section)
+++{
+++	Elf32_Ehdr *ehdr; /* Elf header structure pointer */
+++	Elf32_Phdr *phdr; /* Program header structure pointer */
+++        struct stat sb;
+++        uint8_t *fp;
+++	int i;
+++
+++	if (!is_rootfs_auth_enabled()) {
+++		return 1;
+++	}
+++
+++        int fd = open(section->file, O_RDONLY);
+++
+++        if (fd < 0) {
+++                perror(section->file);
+++                return 0;
+++        }
+++
+++        memset(&sb, 0, sizeof(struct stat));
+++        if (fstat(fd, &sb) == -1) {
+++                perror("fstat");
+++                close(fd);
+++                return 0;
+++        }
+++
+++        fp = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+++        if (fp == MAP_FAILED) {
+++                perror("mmap");
+++                close(fd);
+++                return 0;
+++        }
+++
+++        ehdr = (Elf32_Ehdr *)fp;
+++	phdr = (Elf32_Phdr *)(((char*)fp) + ehdr->e_phoff);
+++	printf(" ELF headers are initialized\n");
+++
+++	if (ehdr->e_type != ET_EXEC) {
+++		printf("Not a valid elf image\n");
+++		close(fd);
+++		return 0;
+++	}
+++
+++	/* Load each program header */
+++	for (i = 0; i < NO_OF_PROGRAM_HDRS; ++i) {
+++		if(phdr->p_type == PT_LOAD) {
+++			printf(" PT_LOAD Segment Found\n");
+++			printf("Parsing img_info load addr 0x%x offset 0x%x size 0x%x type 0x%x\n",
+++			phdr->p_paddr, phdr->p_offset, phdr->p_filesz, phdr->p_type);
+++
+++			int size = sb.st_size - (phdr->p_offset + phdr->p_filesz );
+++			create_file(TEMP_METADATA_PATH, (char *)(fp + phdr->p_offset + phdr->p_filesz), size);
+++			printf("rootfs meta data file: %s created with size:%x\n",TEMP_METADATA_PATH, size);
+++
+++			close(fd);
+++			return 1;
+++		}
+++		++phdr;
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++/**
+++ * being used to calculate the image hash
+++ *
+++ */
+++#define SW_MASK		0x3636363636363636ull
+++
+++void generate_swid_ipad(char *sw_id, unsigned long long *swid_xor_ipad)
+++{
+++	unsigned long long int val;
+++
+++	val = strtoull(sw_id, NULL, 16);
+++	*swid_xor_ipad = val ^ SW_MASK;
+++
+++	printf("%llx\n", *swid_xor_ipad);
+++}
+++
+++/**
+++ * being used to calculate the image hash
+++ *
+++ */
+++#define HW_ID_MASK		0x5c5c5c5cull
+++#define OEM_ID_MASK		0x00005c5cull
+++#define OEM_MODEL_ID_MASK	0x00005c5cull
+++
+++void generate_hwid_opad(char *hw_id, char *oem_id, char *oem_model_id,
+++					unsigned long long *hwid_xor_opad)
+++{
+++	unsigned long long val;
+++
+++	val = strtoull(hw_id, NULL, 16);
+++	*hwid_xor_opad = (((val >> 32) ^ HW_ID_MASK) << 32);
+++
+++	val = strtoul(oem_id, NULL, 16);
+++	*hwid_xor_opad |= ((val ^ OEM_ID_MASK) << 16);
+++
+++	val = strtoul(oem_model_id, NULL, 16);
+++	*hwid_xor_opad |= (val ^ OEM_MODEL_ID_MASK) & 0xffff;
+++
+++	printf("%llx\n", *hwid_xor_opad);
+++}
+++
+++int create_file(char *name, char *buffer, int size)
+++{
+++	int fd;
+++
+++	fd = open(name, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+++	if (fd == -1) {
+++		perror(name);
+++		return 0;
+++	}
+++
+++	if (write(fd, buffer, size) == -1) {
+++		close(fd);
+++		return 0;
+++	}
+++
+++	close(fd);
+++	return 1;
+++}
+++
+++char *create_xor_ipad_opad(char *f_xor, unsigned long long *xor_buffer)
+++{
+++	int fd;
+++	char *file;
+++	unsigned long long sw_id, sw_id_be;
+++
+++	file = mkdtemp(f_xor);
+++	if (file == NULL) {
+++		printf("Error creating directory\n");
+++		return 0;
+++	}
+++
+++	fd = open(file, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+++	if (fd == -1) {
+++		perror(file);
+++		return NULL;
+++	}
+++
+++	sw_id = *xor_buffer;
+++	sw_id_be = htobe64(sw_id);
+++	if (!write(fd, &sw_id_be, sizeof(sw_id_be))) {
+++		printf(" Write Failed \n");
+++		return NULL;
+++	}
+++	close(fd);
+++	return file;
+++}
+++
+++char *read_file(char *file_name, size_t *file_size)
+++{
+++	int fd;
+++	struct stat st;
+++	char *buffer;
+++
+++	fd = open(file_name, O_RDONLY);
+++	if (fd == -1) {
+++		perror(file_name);
+++		return NULL;
+++	}
+++
+++	memset(&st, 0, sizeof(struct stat));
+++	fstat(fd, &st);
+++	buffer = malloc(st.st_size * sizeof(char));
+++	if (buffer == NULL) {
+++		close(fd);
+++		return NULL;
+++	}
+++
+++	if (read(fd, buffer, st.st_size) == -1) {
+++		close(fd);
+++		return NULL;
+++	}
+++
+++	*file_size = (size_t) st.st_size;
+++	close(fd);
+++	return buffer;
+++}
+++
+++int generate_hash(char *cert, char *sw_file, char *hw_file)
+++{
+++	unsigned long long swid_xor_ipad, hwid_xor_opad;
+++	char *tmp;
+++	char *sw_id_str = find_value(cert, "SW_ID", 17);
+++	char *hw_id_str = find_value(cert, "HW_ID", 17);
+++	char *oem_id_str = find_value(cert, "OEM_ID", 5);
+++	char *oem_model_id_str = find_value(cert, "MODEL_ID", 5);
+++	char f_sw_xor[] = "/tmp/swid_xor_XXXXXX";
+++	char f_hw_xor[] = "/tmp/hwid_xor_XXXXXX";
+++
+++	if (sw_id_str == NULL || hw_id_str == NULL || oem_id_str == NULL || oem_model_id_str == NULL) {
+++		if (sw_id_str != NULL) {
+++			free(sw_id_str);
+++		}
+++		if (hw_id_str != NULL) {
+++			free(hw_id_str);
+++		}
+++		if (oem_id_str != NULL) {
+++			free(oem_id_str);
+++		}
+++		if (oem_model_id_str != NULL) {
+++			free(oem_model_id_str);
+++		}
+++		return 0;
+++	}
+++	printf("sw_id=%s\thw_id=%s\t", sw_id_str, hw_id_str);
+++	printf("oem_id=%s\toem_model_id=%s\n", oem_id_str, oem_model_id_str);
+++
+++	sw_id_str[16] = '\0';
+++	generate_swid_ipad(sw_id_str, &swid_xor_ipad);
+++	tmp = create_xor_ipad_opad(f_sw_xor, &swid_xor_ipad);
+++	if (tmp == NULL) {
+++		free(sw_id_str);
+++		free(hw_id_str);
+++		free(oem_id_str);
+++		free(oem_model_id_str);
+++		return 0;
+++	}
+++	strlcpy(sw_file, tmp, 32);
+++
+++	hw_id_str[16] = '\0';
+++	generate_hwid_opad(hw_id_str, oem_id_str, oem_model_id_str, &hwid_xor_opad);
+++	tmp = create_xor_ipad_opad(f_hw_xor, &hwid_xor_opad);
+++	if (tmp == NULL) {
+++		free(sw_id_str);
+++		free(hw_id_str);
+++		free(oem_id_str);
+++		free(oem_model_id_str);
+++		return 0;
+++	}
+++	strlcpy(hw_file, tmp, 32);
+++
+++	free(sw_id_str);
+++	free(hw_id_str);
+++	free(oem_id_str);
+++	free(oem_model_id_str);
+++
+++	return 1;
+++}
+++
+++void remove_file(char *sw_file, char *hw_file, char *code_file, char *pub_file)
+++{
+++	remove(sw_file);
+++	remove(hw_file);
+++	remove(code_file);
+++	remove(pub_file);
+++	remove("src");
+++	remove("sig");
+++	remove("cert");
+++}
+++
+++/**
+++ * is_component_authenticated() usage the code, signature & public key retrieved
+++ * for each component.
+++ *
+++ * @src: char *
+++ * @sig: char *
+++ * @cert: char *
+++ */
+++int is_component_authenticated(char *src, char *sig, char *cert)
+++{
+++	char command[256];
+++	char *computed_hash;
+++	char *reference_hash;
+++	char pub_key[] = "/tmp/pub_keyXXXXXX", *pub_file;
+++	char code_hash[] = "/tmp/code_hash_XXXXXX", *code_file;
+++	char tmp_hash[] = "/tmp/tmp_hash_XXXXXX", *tmp_file;
+++	char f_computed_hash[] = "/tmp/computed_hash_XXXXXX", *computed_file;
+++	char f_reference_hash[] = "/tmp/reference_hash_XXXXXX", *reference_file;
+++	char sw_file[32],hw_file[32];
+++	int retval;
+++	size_t comp_hash_size, ref_hash_size;
+++
+++	if (!create_file("src", src, src_size) || !create_file("sig", sig, SIG_SIZE) ||
+++			!create_file("cert", cert, CERT_SIZE)) {
+++		return 0;
+++	}
+++
+++	pub_file = mkdtemp(pub_key);
+++	if (pub_file == NULL) {
+++		printf("Error getting public key\n");
+++		return 0;
+++	}
+++
+++	snprintf(command, sizeof(command),
+++		"openssl x509 -in cert -pubkey -inform DER -noout > %s", pub_file);
+++	retval = system(command);
+++	if (retval != 0) {
+++		remove("src");
+++		remove("sig");
+++		remove("cert");
+++		printf("Error generating public key\n");
+++		return 0;
+++	}
+++
+++	retval = generate_hash(cert, sw_file, hw_file);
+++	if (retval == 0) {
+++		return 0;
+++	}
+++
+++	code_file = mkdtemp(code_hash);
+++	snprintf(command, sizeof(command),
+++		"openssl dgst -sha256 -binary -out %s src", code_file);
+++	retval = system(command);
+++	if (retval != 0) {
+++		remove_file(sw_file, hw_file, code_file, pub_file);
+++		printf("Error in openssl digest\n");
+++		return 0;
+++	}
+++
+++	tmp_file = mkdtemp(tmp_hash);
+++	snprintf(command, sizeof(command),
+++		"cat %s %s | openssl dgst -sha256 -binary -out %s",
+++						sw_file, code_file, tmp_file);
+++	retval = system(command);
+++	if (retval != 0) {
+++		remove_file(sw_file, hw_file, code_file, pub_file);
+++		remove(tmp_file);
+++		printf("Error generating temp has\n");
+++		return 0;
+++	}
+++
+++	computed_file = mkdtemp(f_computed_hash);
+++	snprintf(command, sizeof(command),
+++		"cat %s %s | openssl dgst -sha256 -binary -out %s",
+++						hw_file, tmp_file, computed_file);
+++	retval = system(command);
+++	if (retval != 0) {
+++		remove_file(sw_file, hw_file, code_file, pub_file);
+++		remove(tmp_file);
+++		remove(computed_file);
+++		printf("Error generating hash\n");
+++		return 0;
+++	}
+++
+++	reference_file = mkdtemp(f_reference_hash);
+++	snprintf(command, sizeof(command),
+++		"openssl rsautl -in sig -pubin -inkey %s -verify > %s",
+++						pub_file, reference_file);
+++	retval = system(command);
+++	if (retval != 0) {
+++		remove_file(sw_file, hw_file, code_file, pub_file);
+++		remove(tmp_file);
+++		remove(computed_file);
+++		remove(reference_file);
+++		printf("Error generating reference hash\n");
+++		return 0;
+++	}
+++
+++	computed_hash = read_file(computed_file, &comp_hash_size);
+++	reference_hash = read_file(reference_file, &ref_hash_size);
+++	if (computed_hash == NULL || reference_hash == NULL) {
+++		remove_file(sw_file, hw_file, code_file, pub_file);
+++		remove(tmp_file);
+++		remove(computed_file);
+++		remove(reference_file);
+++		free(computed_hash?computed_hash:reference_hash);
+++		return 0;
+++	}
+++
+++	remove_file(sw_file, hw_file, code_file, pub_file);
+++	remove(tmp_file);
+++	remove(computed_file);
+++	remove(reference_file);
+++	if (memcmp(computed_hash, reference_hash, ref_hash_size) ||
+++			(comp_hash_size != ref_hash_size)) {
+++		free(computed_hash);
+++		free(reference_hash);
+++		printf("Error: Hash or file_size not equal\n");
+++		return 0;
+++	}
+++	free(computed_hash);
+++	free(reference_hash);
+++	return 1;
+++}
+++
+++/**
+++ * is_image_authenticated() iterates through each component and check
+++ * whether individual component is authenticated. If not, abort the FW
+++ * upgrade process.
+++ *
+++ * @img: char *
+++ */
+++int is_image_authenticated(void)
+++{
+++	int i;
+++	char *src, *sig, *cert;
+++	for (i = 0; i < NO_OF_SECTIONS; i++) {
+++		if (!sections[i].is_present) {
+++			continue;
+++		}
+++		if (!sections[i].split_components(&sections[i], &src, &sig, &cert)) {
+++			printf("Error while splitting code/signature/Certificate from %s\n",
+++					sections[i].file);
+++			return 0;
+++		}
+++		if (!is_component_authenticated(src, sig, cert)) {
+++			printf("Error while authenticating %s\n", sections[i].file);
+++			return 0;
+++		}
+++	}
+++
+++	return 1;
+++}
+++
+++int sec_image_auth(void)
+++{
+++	int fd, i, len;
+++	char *buf = NULL;
+++
+++	fd = open(SEC_AUTHENTICATE_FILE, O_RDWR);
+++	if (-1 == fd) {
+++		perror(SEC_AUTHENTICATE_FILE);
+++		return 1;
+++	}
+++	buf = (char*)malloc(SIG_SIZE);
+++	if (buf == NULL) {
+++		perror("Memory allocation failed\n");
+++		close(fd);
+++		return 1;
+++	}
+++	for (i = 0; i < NO_OF_SECTIONS; i++) {
+++		if (!sections[i].is_present) {
+++			continue;
+++		}
+++#ifdef IPQ54XX
+++		if (!strncmp(sections[i].type, "qsee", strlen("qsee"))) {
+++			if(is_atf_auth_enabled()) {
+++				char imgcode[6];
+++				strlcpy(imgcode, "0x1E", sizeof(imgcode));
+++				imgcode[5] = '\0';
+++				sections[i].img_code = imgcode;
+++			}
+++		}
+++#endif
+++		len = snprintf(buf, SIG_SIZE, "%s %s", sections[i].img_code, sections[i].file);
+++		if (!strncmp(sections[i].type, "rootfs", strlen("rootfs"))) {
+++			struct stat sb;
+++			if (stat(TEMP_METADATA_PATH, &sb) == -1)
+++				continue;
+++
+++			len = snprintf(buf, SIG_SIZE, "%s %s %s", sections[i].img_code,
+++						TEMP_METADATA_PATH, TEMP_SHA_KEY_PATH);
+++		}
+++
+++		if (len < 0 || len > SIG_SIZE) {
+++			perror("Array out of Index\n");
+++			free(buf);
+++			close(fd);
+++			return 1;
+++		}
+++		if (write(fd, buf, len) != len) {
+++			perror("write");
+++			printf("%s Image authentication failed\n", buf);
+++			free(buf);
+++			close(fd);
+++			return 1;
+++		}
+++	}
+++	close(fd);
+++	free(buf);
+++	remove_file(TEMP_KERNEL_PATH,TEMP_ROOTFS_PATH, TEMP_METADATA_PATH, TEMP_SHA_KEY_PATH);
+++	return 0;
+++}
+++
+++/* print_boot_info() to print the values of bootconfig
+++ * structure members and store the values in a text file
+++ * for sysupgrade process
+++*/
+++int read_bootinfo(struct flash_dual_boot_info *info)
+++{
+++	printf("magic: %x\n", info->magic);
+++	printf("image_set_status: %u\n", info->image_set_status);
+++	printf("owner: %u\n", info->owner);
+++	printf("boot_set: %u\n", info->boot_set);
+++	printf("crc: %x\n", info->crc);
+++
+++	int bfd = open(TEMP_BOOTMEM_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0777);
+++	if (bfd == -1) {
+++		perror("Failed to open bootconfig_members.txt");
+++		return 0;
+++	}
+++
+++	char buffer[256];
+++	int length = snprintf(buffer, sizeof(buffer),
+++				"magic:%x\nowner:%u\nImage-set-status:%u\nBoot-set:%u\nCRC:%x\n",
+++				info->magic, info->owner, info->image_set_status, info->boot_set, info->crc);
+++
+++	if (length < 0 || length >= sizeof(buffer)) {
+++		perror("Boot-info data is higher than file size");
+++		close(bfd);
+++		return 0;
+++	}
+++
+++	if (write(bfd, buffer, length) == -1) {
+++		perror("Failed to write to bootconfig_members.txt");
+++		close(bfd);
+++		return 0;
+++	}
+++
+++	close(bfd);
+++	return 1;
+++}
+++
+++/* update_boot_info() to update the values of image_set_status member
+++ * based on the boot_set member value for sysupgrade process.
+++*/
+++int update_bootinfo(struct flash_dual_boot_info *info, uint32_t value)
+++{
+++	if (value == 2) {
+++		if (info->boot_set == 0x0 && info->image_set_status == 0) {
+++			info->image_set_status = 0x2;
+++		} else if (info->boot_set == 0x1 && info->image_set_status == 0) {
+++			info->image_set_status = 0x1;
+++		}
+++	} else {
+++		if ((info->boot_set == 0x0) && (info->image_set_status == 0x2)) {
+++			info->boot_set = 0x1;
+++		} else if ((info->boot_set == 0x1) && (info->image_set_status == 0x1)) {
+++			info->boot_set = 0x0;
+++		}
+++		info->image_set_status = 0x0;
+++	}
+++	return 1;
+++}
+++
+++uint32_t crc32_be(uint8_t const *addr, size_t size)
+++{
+++	uint32_t i, crc = 0;
+++	const uint32_t *tab = crc32_table;
+++
+++	for (i = 0; i < size; ++i) {
+++		DO_CRC_BE(*addr++);
+++	}
+++
+++	return crc;
+++}
+++
+++int do_board_upgrade_check(char *img)
+++{
+++	if (is_tz_authentication_enabled()) {
+++		/* If image is having signed rootfs image, then extract kernel and rootfs binary for parsing metadata. */
+++		if (is_rootfs_auth_enabled()) {
+++			printf("rootfs image authentication is enabled ...\n");
+++			extract_rootfs_binary(check_image_exist("rootfs-"));
+++			extract_ubi_volume("ubi_rootfs", check_image_exist("ubi-"), TEMP_ROOTFS_PATH);
+++		}
+++		printf("TZ authentication enabled ...\n");
+++		if (!load_sections()) {
+++			printf("Error: Failed to load sections from image: %s\n", img);
+++			return 1;
+++		}
+++		return sec_image_auth();
+++	} else if (is_authentication_check_enabled()) {
+++		if (!get_sections()) {
+++			printf("Error: %s is not a signed image\n", img);
+++			return 1;
+++		}
+++
+++		if (!is_image_authenticated()) {
+++			printf("Error: \"%s\" couldn't be authenticated. Abort...\n", img);
+++			return 1;
+++		}
+++
+++		if (!check_image_version()) {
+++			printf("Error: \"%s\" couldn't be upgraded. Abort...\n", img);
+++			return 1;
+++		}
+++	}
+++
+++	return 0;
+++}
+++
+++/* invalidate_bootconfig() to parse the bootconfig binary extracted and stored
+++ * in /tmp directory. This function help to parse the bootconfig structure
+++ * print and update the member values
+++*/
+++int invalidate_bootconfig(int arg)
+++{
+++	struct flash_dual_boot_info info;
+++	int fd = open(TEMP_BOOTCONF_PATH, O_RDWR);
+++	if (fd == -1) {
+++		perror("Failed to open file");
+++		return 1;
+++	}
+++
+++	if (read(fd, &info, sizeof(struct flash_dual_boot_info)) < 0) {
+++		perror("Failed to read structure");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	read_bootinfo(&info);
+++
+++	//Integrity check for CRC
+++	uint32_t crc_result = crc32_be((uint8_t const *)&info, sizeof(info) - sizeof(info.crc));
+++	if (info.crc == crc_result) {
+++		printf(" CRC matched proceeding to upgrade....\n");
+++	} else {
+++		printf(" CRC does not match, rebooting.....\n");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	if ( arg == 5 ) {
+++		uint32_t value = 0x2;
+++		update_bootinfo(&info,value);
+++		info.owner = 0x2;
+++	} else if ( arg == 4 ) {
+++		read_bootinfo(&info);
+++	} else {
+++		uint32_t value = 0x0;
+++		update_bootinfo(&info,value);
+++	}
+++
+++	crc_result = crc32_be((uint8_t const *)&info, sizeof(info) - sizeof(info.crc));
+++	info.crc = crc_result;
+++	read_bootinfo(&info);
+++
+++	if (lseek(fd, 0, SEEK_SET) == -1) {
+++		perror("Failed to seek");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	if (write(fd, &info, sizeof(struct flash_dual_boot_info)) < 0) {
+++		perror("Failed to write bootconfig");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	close(fd);
+++	return 0;
+++}
+++
+++int update_bootconfig(char *member,char *arg)
+++{
+++	struct flash_dual_boot_info info;
+++	int fd = open(TEMP_BOOTCONF_PATH, O_RDWR);
+++	if (fd == -1) {
+++		perror("Failed to open file");
+++		return 1;
+++	}
+++
+++	if (read(fd, &info, sizeof(struct flash_dual_boot_info)) < 0) {
+++		perror("Failed to read structure");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	read_bootinfo(&info);
+++
+++	//Integrity check for CRC
+++	uint32_t crc_result = crc32_be((uint8_t const *)&info, sizeof(info) - sizeof(info.crc));
+++	if (info.crc == crc_result) {
+++		printf(" CRC matched\n");
+++	} else {
+++		printf(" CRC does not match\n");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	if (strcmp(member, "magic") == 0) {
+++		sscanf(arg, "%x", &info.magic);
+++        } else if (strcmp(member, "image_set_status") == 0) {
+++		int value = atoi(arg);
+++		info.image_set_status = value;
+++	} else if (strcmp(member, "owner") == 0) {
+++		int value = atoi(arg);
+++		info.owner = value;
+++	} else if (strcmp(member, "boot_set") == 0) {
+++		int value = atoi(arg);
+++		info.boot_set = value;
+++	} else if (strcmp(member, "reserved1") == 0) {
+++		int value = atoi(arg);
+++		info.reserved1 = value;
+++	} else if (strcmp(member, "reserved2") == 0) {
+++		int value = atoi(arg);
+++		info.reserved2 = value;
+++	} else if (strcmp(member, "crc") == 0) {
+++		sscanf(arg, "%x", &info.crc);
+++	} else {
+++		printf("Member name not found\n");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	info.owner = 0x2;
+++	crc_result = crc32_be((uint8_t const *)&info, sizeof(info) - sizeof(info.crc));
+++	info.crc = crc_result;
+++	read_bootinfo(&info);
+++
+++	if (lseek(fd, 0, SEEK_SET) == -1) {
+++		perror("Failed to seek");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	if (write(fd, &info, sizeof(struct flash_dual_boot_info)) < 0) {
+++		perror("Failed to write bootconfig");
+++		close(fd);
+++		return 1;
+++	}
+++
+++	close(fd);
+++	return 0;
+++}
++diff --git a/tools/sysupgrade.h b/tools/sysupgrade.h
++new file mode 100644
++index 0000000..a231f77
++--- /dev/null
+++++ b/tools/sysupgrade.h
++@@ -0,0 +1,224 @@
+++/*
+++ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+++ *
+++ * Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+++ *
+++ * This program is free software; you can redistribute it and/or modify
+++ * it under the terms of the GNU General Public License version 2 and
+++ * only version 2 as published by the Free Software Foundation.
+++ *
+++ * This program is distributed in the hope that it will be useful,
+++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+++ * GNU General Public License for more details.
+++ */
+++
+++#include <dumpimage.h>
+++#include <elf.h>
+++#include <dirent.h>
+++#include <sys/ioctl.h>
+++#include <mtd/mtd-user.h>
+++#include <limits.h>
+++#include <linux/string.h>
+++#include <linux/types.h>
+++
+++typedef enum {HLOS_TYPE, UBOOT_TYPE, SBL_TYPE, TZ_TYPE, RPM_TYPE, DEVCFG_TYPE, APDP_TYPE}type;
+++
+++struct image_section {
+++	type section_type;
+++	int max_version;
+++	char file[256];
+++	char *type;
+++	char tmp_file[256];
+++	int img_version;
+++	int local_version;
+++	char *version_file;
+++	int is_present;
+++	char *img_code;
+++	int (*pre_op)(struct image_section *);
+++	int (*get_sw_id)(struct image_section *);
+++	int (*split_components)(struct image_section *, char **, char**, char**);
+++};
+++
+++typedef struct mbn_header {
+++	uint32_t image_id;
+++	uint32_t ver_num;
+++	uint32_t image_src;
+++	uint8_t *image_dest_ptr;
+++	uint32_t image_size;
+++	uint32_t code_size;
+++	uint8_t *sig_ptr;
+++	uint32_t sig_sz;
+++	uint8_t *cert_ptr;
+++	uint32_t cert_sz;
+++}Mbn_Hdr;
+++
+++struct ubi_ec_hdr {
+++	__be32  magic;
+++	__u8    version;
+++	__u8    padding1[3];
+++	__be64  ec; /* Warning: the current limit is 31-bit anyway! */
+++	__be32  vid_hdr_offset;
+++	__be32  data_offset;
+++	__be32  image_seq;
+++	__u8    padding2[32];
+++	__be32  hdr_crc;
+++};
+++
+++struct ubi_vid_hdr {
+++	__be32  magic;
+++	__u8    version;
+++	__u8    vol_type;
+++	__u8    copy_flag;
+++	__u8    compat;
+++	__be32  vol_id;
+++	__be32  lnum;
+++	__u8    padding1[4];
+++	__be32  data_size;
+++	__be32  used_ebs;
+++	__be32  data_pad;
+++	__be32  data_crc;
+++	__u8    padding2[4];
+++	__be64  sqnum;
+++	__u8    padding3[12];
+++	__be32  hdr_crc;
+++};
+++
+++typedef struct {
+++	uint32_t  codeword;
+++	uint32_t  magic;
+++	uint32_t  RESERVED_0;
+++	uint32_t  RESERVED_1;
+++	uint32_t  RESERVED_2;
+++	uint32_t  image_src;
+++	uint8_t  *image_dest_ptr;
+++	uint32_t  image_size;
+++	uint32_t  code_size;
+++	uint8_t  *sig_ptr;
+++	uint32_t  sig_size;
+++	uint8_t  *cert_ptr;
+++	uint32_t  cert_size;
+++	uint32_t  root_cert_sel;
+++	uint32_t  num_root_certs;
+++	uint32_t  RESERVED_5;
+++	uint32_t  RESERVED_6;
+++	uint32_t  RESERVED_7;
+++	uint32_t  RESERVED_8;
+++	uint32_t  RESERVED_9;
+++} Sbl_Hdr;
+++
+++static const uint32_t crc32_table[] = {
+++        (0x00000000L), (0x04c11db7L), (0x09823b6eL), (0x0d4326d9L),
+++        (0x130476dcL), (0x17c56b6bL), (0x1a864db2L), (0x1e475005L),
+++        (0x2608edb8L), (0x22c9f00fL), (0x2f8ad6d6L), (0x2b4bcb61L),
+++        (0x350c9b64L), (0x31cd86d3L), (0x3c8ea00aL), (0x384fbdbdL),
+++        (0x4c11db70L), (0x48d0c6c7L), (0x4593e01eL), (0x4152fda9L),
+++        (0x5f15adacL), (0x5bd4b01bL), (0x569796c2L), (0x52568b75L),
+++        (0x6a1936c8L), (0x6ed82b7fL), (0x639b0da6L), (0x675a1011L),
+++        (0x791d4014L), (0x7ddc5da3L), (0x709f7b7aL), (0x745e66cdL),
+++        (0x9823b6e0L), (0x9ce2ab57L), (0x91a18d8eL), (0x95609039L),
+++        (0x8b27c03cL), (0x8fe6dd8bL), (0x82a5fb52L), (0x8664e6e5L),
+++        (0xbe2b5b58L), (0xbaea46efL), (0xb7a96036L), (0xb3687d81L),
+++        (0xad2f2d84L), (0xa9ee3033L), (0xa4ad16eaL), (0xa06c0b5dL),
+++        (0xd4326d90L), (0xd0f37027L), (0xddb056feL), (0xd9714b49L),
+++        (0xc7361b4cL), (0xc3f706fbL), (0xceb42022L), (0xca753d95L),
+++        (0xf23a8028L), (0xf6fb9d9fL), (0xfbb8bb46L), (0xff79a6f1L),
+++        (0xe13ef6f4L), (0xe5ffeb43L), (0xe8bccd9aL), (0xec7dd02dL),
+++        (0x34867077L), (0x30476dc0L), (0x3d044b19L), (0x39c556aeL),
+++        (0x278206abL), (0x23431b1cL), (0x2e003dc5L), (0x2ac12072L),
+++        (0x128e9dcfL), (0x164f8078L), (0x1b0ca6a1L), (0x1fcdbb16L),
+++        (0x018aeb13L), (0x054bf6a4L), (0x0808d07dL), (0x0cc9cdcaL),
+++        (0x7897ab07L), (0x7c56b6b0L), (0x71159069L), (0x75d48ddeL),
+++        (0x6b93dddbL), (0x6f52c06cL), (0x6211e6b5L), (0x66d0fb02L),
+++        (0x5e9f46bfL), (0x5a5e5b08L), (0x571d7dd1L), (0x53dc6066L),
+++        (0x4d9b3063L), (0x495a2dd4L), (0x44190b0dL), (0x40d816baL),
+++        (0xaca5c697L), (0xa864db20L), (0xa527fdf9L), (0xa1e6e04eL),
+++        (0xbfa1b04bL), (0xbb60adfcL), (0xb6238b25L), (0xb2e29692L),
+++        (0x8aad2b2fL), (0x8e6c3698L), (0x832f1041L), (0x87ee0df6L),
+++        (0x99a95df3L), (0x9d684044L), (0x902b669dL), (0x94ea7b2aL),
+++        (0xe0b41de7L), (0xe4750050L), (0xe9362689L), (0xedf73b3eL),
+++        (0xf3b06b3bL), (0xf771768cL), (0xfa325055L), (0xfef34de2L),
+++        (0xc6bcf05fL), (0xc27dede8L), (0xcf3ecb31L), (0xcbffd686L),
+++        (0xd5b88683L), (0xd1799b34L), (0xdc3abdedL), (0xd8fba05aL),
+++        (0x690ce0eeL), (0x6dcdfd59L), (0x608edb80L), (0x644fc637L),
+++        (0x7a089632L), (0x7ec98b85L), (0x738aad5cL), (0x774bb0ebL),
+++        (0x4f040d56L), (0x4bc510e1L), (0x46863638L), (0x42472b8fL),
+++        (0x5c007b8aL), (0x58c1663dL), (0x558240e4L), (0x51435d53L),
+++        (0x251d3b9eL), (0x21dc2629L), (0x2c9f00f0L), (0x285e1d47L),
+++        (0x36194d42L), (0x32d850f5L), (0x3f9b762cL), (0x3b5a6b9bL),
+++        (0x0315d626L), (0x07d4cb91L), (0x0a97ed48L), (0x0e56f0ffL),
+++        (0x1011a0faL), (0x14d0bd4dL), (0x19939b94L), (0x1d528623L),
+++        (0xf12f560eL), (0xf5ee4bb9L), (0xf8ad6d60L), (0xfc6c70d7L),
+++        (0xe22b20d2L), (0xe6ea3d65L), (0xeba91bbcL), (0xef68060bL),
+++        (0xd727bbb6L), (0xd3e6a601L), (0xdea580d8L), (0xda649d6fL),
+++        (0xc423cd6aL), (0xc0e2d0ddL), (0xcda1f604L), (0xc960ebb3L),
+++        (0xbd3e8d7eL), (0xb9ff90c9L), (0xb4bcb610L), (0xb07daba7L),
+++        (0xae3afba2L), (0xaafbe615L), (0xa7b8c0ccL), (0xa379dd7bL),
+++        (0x9b3660c6L), (0x9ff77d71L), (0x92b45ba8L), (0x9675461fL),
+++        (0x8832161aL), (0x8cf30badL), (0x81b02d74L), (0x857130c3L),
+++        (0x5d8a9099L), (0x594b8d2eL), (0x5408abf7L), (0x50c9b640L),
+++        (0x4e8ee645L), (0x4a4ffbf2L), (0x470cdd2bL), (0x43cdc09cL),
+++        (0x7b827d21L), (0x7f436096L), (0x7200464fL), (0x76c15bf8L),
+++        (0x68860bfdL), (0x6c47164aL), (0x61043093L), (0x65c52d24L),
+++        (0x119b4be9L), (0x155a565eL), (0x18197087L), (0x1cd86d30L),
+++        (0x029f3d35L), (0x065e2082L), (0x0b1d065bL), (0x0fdc1becL),
+++        (0x3793a651L), (0x3352bbe6L), (0x3e119d3fL), (0x3ad08088L),
+++        (0x2497d08dL), (0x2056cd3aL), (0x2d15ebe3L), (0x29d4f654L),
+++        (0xc5a92679L), (0xc1683bceL), (0xcc2b1d17L), (0xc8ea00a0L),
+++        (0xd6ad50a5L), (0xd26c4d12L), (0xdf2f6bcbL), (0xdbee767cL),
+++        (0xe3a1cbc1L), (0xe760d676L), (0xea23f0afL), (0xeee2ed18L),
+++        (0xf0a5bd1dL), (0xf464a0aaL), (0xf9278673L), (0xfde69bc4L),
+++        (0x89b8fd09L), (0x8d79e0beL), (0x803ac667L), (0x84fbdbd0L),
+++        (0x9abc8bd5L), (0x9e7d9662L), (0x933eb0bbL), (0x97ffad0cL),
+++        (0xafb010b1L), (0xab710d06L), (0xa6322bdfL), (0xa2f33668L),
+++        (0xbcb4666dL), (0xb8757bdaL), (0xb5365d03L), (0xb1f740b4L)
+++};
+++
+++struct flash_dual_boot_info
+++{
+++	uint32_t magic;	/* Magic number for identification when reading from flash */
+++	uint32_t image_set_status; /* Represents the health status of a Bank A*/
+++	uint32_t owner; /* Indicates which component updated the health status of a Bank */
+++	uint32_t boot_set;    /* Indicates the current active Bank*/
+++	uint32_t reserved1;  /* Indicates the max no. of attempts for n-times trial boot feature*/
+++	uint32_t reserved2;  /* Indicates the max no. of attempts for n-times trial boot feature*/
+++	uint32_t crc;  /* CRC field for fields above */
+++};
+++
+++size_t strlcpy(char *, const char *, size_t);
+++size_t strlcat(char *, const char *, size_t);
+++int get_sections(void);
+++int is_authentication_check_enabled(void);
+++int get_local_image_version(struct image_section *);
+++int set_local_image_version(struct image_section *);
+++int is_version_check_enabled(void);
+++int get_sw_id_from_component_bin(struct image_section *);
+++int get_sw_id_from_component_bin_elf(struct image_section *);
+++int get_sw_id_from_component_bin_elf64(struct image_section *);
+++int extract_binary(struct image_section *);
+++int extract_kernel_binary(struct image_section *, char *);
+++int extract_ubi_volume(char *, char *, char *);
+++int extract_rootfs_binary(char *);
+++int is_image_version_higher(void);
+++int update_version(void);
+++int check_image_version(void);
+++int split_code_signature_cert_from_component_bin(struct image_section *, char **, char **, char **);
+++int split_code_signature_cert_from_component_bin_elf(struct image_section *, char **, char **, char **);
+++int split_code_signature_cert_from_component_bin_elf64(struct image_section *, char **, char **, char **);
+++void generate_swid_ipad(char *, unsigned long long *);
+++void generate_hwid_opad(char *, char *, char *, unsigned long long *);
+++int generate_hash(char *, char *, char *);
+++int is_component_authenticated(char *, char *, char *);
+++int is_image_authenticated(void);
+++int do_board_upgrade_check(char *);
+++int check_nand_preamble(uint8_t *);
+++int find_mtd_part_size(char *);
+++int create_file(char *, char *, int );
+++int parse_elf_image_phdr(struct image_section *);
+++int compute_sha_hash(struct image_section *);
+++char *check_image_exist(char *);
+++int invalidate_bootconfig(int );
+++int update_bootconfig(char *,char *);
+++int update_bootinfo(struct flash_dual_boot_info *, uint32_t );
+++int read_bootinfo(struct flash_dual_boot_info *);
+++uint32_t crc32_be(uint8_t const *, size_t );
++-- 
++2.34.1
++
+-- 
+2.34.1
+


### PR DESCRIPTION
platform.sh: add bootconfig-based dual-bank upgrade support; replace /proc/boot_info reads with dumpimage -b calls

patches-25.12/0111: u-boot dumpimage CONFIG_SYSUPGRADE_HELPER support for bootconfig updates(ported from QCA sdk)

uci-defaults/30-uboot-envtools: add uboot-envtools uci-defaults initialization script

base-files/_inittab: add serial console inittab

modules.mk: update bootconfig.ko to kernel ge6.6

mac80211/ath.mk: enable ATH12K_AHB for ipq54xx

iwinfo: add ipq54xx to nl80211 QCA support

patches-25.12/0106: switch ipq54xx to kernel 6.6.88

qca-ssdk-qca/patches/0006:Switch to gpio_get_value_cansleep() which is safe for both sleepable and non-sleepable GPIO controllers.

ath12k-firmware: add IPQ5424/Data.msc