### PR TITLE
mediatek: mac80211: decrease passive scan channel time

### DIFF
--- a/patches-25.12/0112-mediatek-mac80211-decrease-passive-scan-chan-time.patch
+++ b/patches-25.12/0112-mediatek-mac80211-decrease-passive-scan-chan-time.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mateusz Bajorski <mbajorski@shasta.cloud>
+Date: Mon, 15 Dec 2025 13:11:26 +0100
+Subject: [PATCH] mediatek: mac80211: decrease passive scan channel time
+
+Compensate for FW channel switch and wiphy_delayed_work scheduling
+overhead in kernel 6.x by subtracting a fixed overhead from passive
+scan dwell time.
+
+Fixes: SW-4949, SW-5898
+
+Signed-off-by: Mateusz Bajorski <mbajorski@shasta.cloud>
+Signed-off-by: Marek Kwaczynski <marek@shasta.cloud>
+---
+ .../subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch | 28 +
+ 1 file changed, 28 insertions(+)
+ create mode 100644 package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
+
+diff --git a/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch b/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
+new file mode 100644
+--- /dev/null
++++ b/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
+@@ -0,0 +1,28 @@
++Index: backports-6.12.6/net/mac80211/scan.c
++===================================================================
++--- backports-6.12.6.orig/net/mac80211/scan.c
+++++ backports-6.12.6/net/mac80211/scan.c
++@@ -29,6 +29,9 @@
++ #define IEEE80211_CHANNEL_TIME (HZ / 33)
++ #define IEEE80211_PASSIVE_CHANNEL_TIME (HZ / 9)
++
+++/*  Overhead compensation for FW channel switch and wiphy_delayed_work scheduling */
+++#define IEEE80211_PASSIVE_MIN_CHANNEL_TIME (HZ / 25)
+++
++ void ieee80211_rx_bss_put(struct ieee80211_local *local,
++ 			  struct ieee80211_bss *bss)
++ {
++@@ -1015,8 +1018,11 @@ set_channel:
++ 	 */
++ 	if ((chan->flags & (IEEE80211_CHAN_NO_IR | IEEE80211_CHAN_RADAR)) ||
++ 	    !scan_req->n_ssids) {
++-		*next_delay = max(msecs_to_jiffies(scan_req->duration),
++-				  IEEE80211_PASSIVE_CHANNEL_TIME);
+++		unsigned long duration = msecs_to_jiffies(scan_req->duration);
+++
+++		*next_delay = duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME ?
+++		duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME : 0;
+++
++ 		local->next_scan_state = SCAN_DECISION;
++ 		if (scan_req->n_ssids)
++ 			set_bit(SCAN_BEACON_WAIT, &local->scanning);
+--
+2.43.0


### PR DESCRIPTION
Compensate for FW channel switch and wiphy_delayed_work scheduling overhead in kernel 6.x by subtracting a fixed overhead from passive scan dwell time.

Fixes: WIFI-14822