### PR TITLE
radio.uc: Skip match_htmode() for HaLow band to avoid warning reject

### DIFF
--- a/feeds/ucentral/ucentral-schema/patches/004-radio-skip-htmode-for-halow.patch
+++ b/feeds/ucentral/ucentral-schema/patches/004-radio-skip-htmode-for-halow.patch
@@ -1,0 +1,11 @@
+--- a/renderer/templates/radio.uc
++++ b/renderer/templates/radio.uc
+@@ -195,7 +195,7 @@
+ # Wireless Configuration
+ {% for (let phy in phys): %}
+ {%  let reconf = phy.no_reconf ? 0 : 1 %}
+-{%  let htmode = match_htmode(phy, radio) %}
++{%  let htmode = (radio.band != "HaLow") ? match_htmode(phy, radio) : "" %}
+ set wireless.{{ phy.section }}.disabled={{ exists(radio, 'enable') ? b(!radio.enable) : 0 }}
+ set wireless.{{ phy.section }}.ucentral_path={{ s(location) }}
+ {%  if (radio.band != "HaLow"): %}


### PR DESCRIPTION
radio.uc: Skip match_htmode() for HaLow band to avoid warning reject
("Selected radio does not support requested HT mode HE80, falling back to VHT160")

Fixes: WIFI-15497