### PR TITLE
batman-adv: backport bridged-in VLAN/TT-VID fixes for QCA + MTK targets

### DIFF
--- a/feeds/batman/batman-adv/Config.in
+++ b/feeds/batman/batman-adv/Config.in
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2007-2019  B.A.T.M.A.N. contributors:
+#
+# Marek Lindner, Simon Wunderlich
+
+#
+# B.A.T.M.A.N meshing protocol
+#
+
+config BATMAN_ADV_BATMAN_V
+	bool "B.A.T.M.A.N. V protocol"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables the B.A.T.M.A.N. V protocol, the successor
+	  of the currently used B.A.T.M.A.N. IV protocol. The main
+	  changes include splitting of the OGM protocol into a neighbor
+	  discovery protocol (Echo Location Protocol, ELP) and a new OGM
+	  Protocol OGMv2 for flooding protocol information through the
+	  network, as well as a throughput based metric.
+	  B.A.T.M.A.N. V is currently considered experimental and not
+	  compatible to B.A.T.M.A.N. IV networks.
+
+config BATMAN_ADV_BLA
+	bool "Bridge Loop Avoidance"
+	depends on PACKAGE_kmod-batman-adv
+	select PACKAGE_kmod-lib-crc16
+	default y
+	help
+	  This option enables BLA (Bridge Loop Avoidance), a mechanism
+	  to avoid Ethernet frames looping when mesh nodes are connected
+	  to both the same LAN and the same mesh. If you will never use
+	  more than one mesh node in the same LAN, you can safely remove
+	  this feature and save some space.
+
+config BATMAN_ADV_DAT
+	bool "Distributed ARP Table"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables DAT (Distributed ARP Table), a DHT based
+	  mechanism that increases ARP reliability on sparse wireless
+	  mesh networks. If you think that your network does not need
+	  this option you can safely remove it and save some space.
+
+config BATMAN_ADV_NC
+	bool "Network Coding"
+	depends on PACKAGE_kmod-batman-adv
+	help
+	  This option enables network coding, a mechanism that aims to
+	  increase the overall network throughput by fusing multiple
+	  packets in one transmission.
+	  Note that interfaces controlled by batman-adv must be manually
+	  configured to have promiscuous mode enabled in order to make
+	  network coding work.
+	  If you think that your network does not need this feature you
+	  can safely disable it and save some space.
+
+config BATMAN_ADV_MCAST
+	bool "Multicast optimisation"
+	depends on PACKAGE_kmod-batman-adv
+	default y
+	help
+	  This option enables the multicast optimisation which aims to
+	  reduce the air overhead while improving the reliability of
+	  multicast messages.
+
+config BATMAN_ADV_DEBUG
+	bool "B.A.T.M.A.N. debugging"
+	depends on PACKAGE_kmod-batman-adv
+	help
+	  This is an option for use by developers; most people should
+	  say N here. This enables compilation of support for
+	  outputting debugging information to the debugfs log or tracing
+	  buffer. The output is controlled via the batadv netdev specific
+	  log_level setting.
+
+config BATMAN_ADV_TRACING
+	bool "B.A.T.M.A.N. tracing support"
+	depends on PACKAGE_kmod-batman-adv
+	select KERNEL_FTRACE
+	select KERNEL_ENABLE_DEFAULT_TRACERS
+	help
+	  This is an option for use by developers; most people should
+	  say N here. Select this option to gather traces like the debug
+	  messages using the generic tracing infrastructure of the kernel.
+	  BATMAN_ADV_DEBUG must also be selected to get trace events for
+	  batadv_dbg.

--- a/feeds/batman/batman-adv/Makefile
+++ b/feeds/batman/batman-adv/Makefile
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=batman-adv
+PKG_VERSION:=2023.1
+PKG_RELEASE:=12
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
+PKG_HASH:=f46a7286660a5ec3506a1be7ef60b471c51ac70550597d598040479ab7b936b8
+PKG_EXTMOD_SUBDIRS:=net/batman-adv
+
+PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
+PKG_LICENSE:=GPL-2.0-only MIT
+PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT
+
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+PKG_CONFIG_DEPENDS += \
+	CONFIG_BATMAN_ADV_BATMAN_V \
+	CONFIG_BATMAN_ADV_BLA \
+	CONFIG_BATMAN_ADV_DAT \
+	CONFIG_BATMAN_ADV_NC \
+	CONFIG_BATMAN_ADV_MCAST \
+	CONFIG_BATMAN_ADV_DEBUG \
+	CONFIG_BATMAN_ADV_TRACING
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/batman-adv
+  SUBMENU:=Network Support
+  TITLE:=B.A.T.M.A.N. Adv
+  URL:=https://www.open-mesh.org/
+  DEPENDS:=+BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-lib-crc32c +kmod-cfg80211 +batctl
+  FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
+  AUTOLOAD:=$(call AutoProbe,batman-adv)
+endef
+
+define KernelPackage/batman-adv/description
+  B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
+  a routing protocol for multi-hop ad-hoc mesh networks. The
+  networks may be wired or wireless. See
+  https://www.open-mesh.org/ for more information and user space
+  tools. This package builds version $(PKG_VERSION) of the kernel
+  module.
+endef
+
+define KernelPackage/batman-adv/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Package/kmod-batman-adv/conffiles
+/etc/config/batman-adv
+endef
+
+PKG_EXTRA_KCONFIG:= \
+	CONFIG_BATMAN_ADV=m \
+	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_BATMAN_ADV_DEBUG),y,n) \
+	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_BATMAN_ADV_BLA),y,n) \
+	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_BATMAN_ADV_DAT),y,n) \
+	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_BATMAN_ADV_MCAST),y,n) \
+	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_BATMAN_ADV_NC),y,n) \
+	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_BATMAN_ADV_BATMAN_V),y,n) \
+	CONFIG_BATMAN_ADV_TRACING=$(if $(CONFIG_BATMAN_ADV_TRACING),y,n) \
+
+PKG_EXTRA_CFLAGS:= \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(PKG_EXTRA_KCONFIG)))) \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
+
+NOSTDINC_FLAGS = \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR)/net/batman-adv \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-I$(PKG_BUILD_DIR)/include/ \
+	-include backport/autoconf.h \
+	-include backport/backport.h \
+	-include $(PKG_BUILD_DIR)/compat-hacks.h \
+	-DBATADV_SOURCE_VERSION=\\\"$(PKG_VERSION)-openwrt-$(PKG_RELEASE)\\\"
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)/net/batman-adv" \
+		$(PKG_EXTRA_KCONFIG) \
+		EXTRA_CFLAGS="$(PKG_EXTRA_CFLAGS)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+define KernelPackage/batman-adv/install
+	$(CP) ./files/. $(1)/
+endef
+
+$(eval $(call KernelPackage,batman-adv))

--- a/feeds/batman/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
+++ b/feeds/batman/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This UCI-Defaults script will split the batadv proto network interfaces
+# in batadv_hardif and batadv proto. The configuration options from
+# /etc/config/batman-adv will be moved to the latter.
+
+. /lib/functions.sh
+
+proto_batadv_to_batadv_hardif() {
+    local section="$1"
+    local proto
+    local mesh
+    local routing_algo
+
+    config_get proto "${section}" proto
+    config_get mesh "${section}" mesh
+    config_get routing_algo "${section}" routing_algo
+
+    if [ -z "$mesh" -o "${proto}" != "batadv" ]; then
+        continue
+    fi
+
+    uci set network."${section}".proto="batadv_hardif"
+    uci rename network."${section}".mesh="master"
+    uci delete network."${section}".routing_algo
+
+    # create new section or adjust existing one
+    uci set network."${mesh}"=interface
+    uci set network."${mesh}".proto=batadv
+    [ -n "${routing_algo}" ]  && uci set network."${mesh}".routing_algo="${routing_algo}"
+}
+
+mv_batadv_config_section() {
+    local section="$1"
+    local aggregated_ogms
+    local ap_isolation
+    local bonding
+    local bridge_loop_avoidance
+    local distributed_arp_table
+    local fragmentation
+    local gw_bandwidth
+    local gw_mode
+    local gw_sel_class
+    local hop_penalty
+    local isolation_mark
+    local log_level
+    local multicast_mode
+    local network_coding
+    local orig_interval
+
+    config_get aggregated_ogms "${section}" aggregated_ogms
+    config_get ap_isolation "${section}" ap_isolation
+    config_get bonding "${section}" bonding
+    config_get bridge_loop_avoidance "${section}" bridge_loop_avoidance
+    config_get distributed_arp_table "${section}" distributed_arp_table
+    config_get fragmentation "${section}" fragmentation
+    config_get gw_bandwidth "${section}" gw_bandwidth
+    config_get gw_mode "${section}" gw_mode
+    config_get gw_sel_class "${section}" gw_sel_class
+    config_get hop_penalty "${section}" hop_penalty
+    config_get isolation_mark "${section}" isolation_mark
+    config_get log_level "${section}" log_level
+    config_get multicast_mode "${section}" multicast_mode
+    config_get network_coding "${section}" network_coding
+    config_get orig_interval "${section}" orig_interval
+
+    # update section in case it exists
+    [ -n "${aggregated_ogms}" ]  && uci set network."${section}".aggregated_ogms="${aggregated_ogms}"
+    [ -n "${ap_isolation}" ]  && uci set network."${section}".ap_isolation="${ap_isolation}"
+    [ -n "${bonding}" ]  && uci set network."${section}".bonding="${bonding}"
+    [ -n "${bridge_loop_avoidance}" ]  && uci set network."${section}".bridge_loop_avoidance="${bridge_loop_avoidance}"
+    [ -n "${distributed_arp_table}" ]  && uci set network."${section}".distributed_arp_table="${distributed_arp_table}"
+    [ -n "${fragmentation}" ]  && uci set network."${section}".fragmentation="${fragmentation}"
+    [ -n "${gw_bandwidth}" ]  && uci set network."${section}".gw_bandwidth="${gw_bandwidth}"
+    [ -n "${gw_mode}" ]  && uci set network."${section}".gw_mode="${gw_mode}"
+    [ -n "${gw_sel_class}" ]  && uci set network."${section}".gw_sel_class="${gw_sel_class}"
+    [ -n "${hop_penalty}" ]  && uci set network."${section}".hop_penalty="${hop_penalty}"
+    [ -n "${isolation_mark}" ]  && uci set network."${section}".isolation_mark="${isolation_mark}"
+    [ -n "${log_level}" ]  && uci set network."${section}".log_level="${log_level}"
+    [ -n "${multicast_mode}" ]  && uci set network."${section}".multicast_mode="${multicast_mode}"
+    [ -n "${network_coding}" ]  && uci set network."${section}".network_coding="${network_coding}"
+    [ -n "${orig_interval}" ]  && uci set network."${section}".orig_interval="${orig_interval}"
+}
+
+if [ -f /etc/config/batman-adv ]; then
+    config_load network
+    config_foreach proto_batadv_to_batadv_hardif 'interface'
+    uci commit network
+
+    config_load batman-adv
+    config_foreach mv_batadv_config_section 'mesh'
+    uci commit network
+
+    rm -f /etc/config/batman-adv
+fi
+
+exit 0

--- a/feeds/batman/batman-adv/files/lib/netifd/proto/batadv.sh
+++ b/feeds/batman/batman-adv/files/lib/netifd/proto/batadv.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_batadv_init_config() {
+	no_device=1
+	available=1
+
+	proto_config_add_boolean 'aggregated_ogms:bool'
+	proto_config_add_boolean 'ap_isolation:bool'
+	proto_config_add_boolean 'bonding:bool'
+	proto_config_add_boolean 'bridge_loop_avoidance:bool'
+	proto_config_add_boolean 'distributed_arp_table:bool'
+	proto_config_add_boolean 'fragmentation:bool'
+	proto_config_add_string 'gw_bandwidth'
+	proto_config_add_string 'gw_mode'
+	proto_config_add_int 'gw_sel_class'
+	proto_config_add_int 'hop_penalty'
+	proto_config_add_string 'isolation_mark'
+	proto_config_add_string 'log_level'
+	proto_config_add_int 'multicast_fanout'
+	proto_config_add_boolean 'multicast_mode:bool'
+	proto_config_add_boolean 'network_coding:bool'
+	proto_config_add_int 'orig_interval'
+	proto_config_add_string 'routing_algo'
+}
+
+proto_batadv_setup() {
+	local config="$1"
+	local iface="$config"
+
+	local aggregated_ogms
+	local ap_isolation
+	local bonding
+	local bridge_loop_avoidance
+	local distributed_arp_table
+	local fragmentation
+	local gw_bandwidth
+	local gw_mode
+	local gw_sel_class
+	local hop_penalty
+	local isolation_mark
+	local log_level
+	local multicast_fanout
+	local multicast_mode
+	local network_coding
+	local orig_interval
+	local routing_algo
+
+	json_get_vars aggregated_ogms
+	json_get_vars ap_isolation
+	json_get_vars bonding
+	json_get_vars bridge_loop_avoidance
+	json_get_vars distributed_arp_table
+	json_get_vars fragmentation
+	json_get_vars gw_bandwidth
+	json_get_vars gw_mode
+	json_get_vars gw_sel_class
+	json_get_vars hop_penalty
+	json_get_vars isolation_mark
+	json_get_vars log_level
+	json_get_vars multicast_fanout
+	json_get_vars multicast_mode
+	json_get_vars network_coding
+	json_get_vars orig_interval
+	json_get_vars routing_algo
+
+	set_default routing_algo 'BATMAN_IV'
+
+	batctl routing_algo "$routing_algo"
+	batctl meshif "$iface" interface create
+
+	[ -n "$aggregated_ogms" ] && batctl meshif "$iface" aggregation "$aggregated_ogms"
+	[ -n "$ap_isolation" ] && batctl meshif "$iface" ap_isolation "$ap_isolation"
+	[ -n "$bonding" ] && batctl meshif "$iface" bonding "$bonding"
+	[ -n "$bridge_loop_avoidance" ] &&  batctl meshif "$iface" bridge_loop_avoidance "$bridge_loop_avoidance" 2>&-
+	[ -n "$distributed_arp_table" ] && batctl meshif "$iface" distributed_arp_table "$distributed_arp_table" 2>&-
+	[ -n "$fragmentation" ] && batctl meshif "$iface" fragmentation "$fragmentation"
+
+	case "$gw_mode" in
+	server)
+		if [ -n "$gw_bandwidth" ]; then
+			batctl meshif "$iface" gw_mode "server" "$gw_bandwidth"
+		else
+			batctl meshif "$iface" gw_mode "server"
+		fi
+		;;
+	client)
+		if [ -n "$gw_sel_class" ]; then
+			batctl meshif "$iface" gw_mode "client" "$gw_sel_class"
+		else
+			batctl meshif "$iface" gw_mode "client"
+		fi
+		;;
+	*)
+		batctl meshif "$iface" gw_mode "off"
+		;;
+	esac
+
+	[ -n "$hop_penalty" ] && batctl meshif "$iface" hop_penalty "$hop_penalty"
+	[ -n "$isolation_mark" ] && batctl meshif "$iface" isolation_mark "$isolation_mark"
+	[ -n "$multicast_fanout" ] && batctl meshif "$iface" multicast_fanout "$multicast_fanout"
+	[ -n "$multicast_mode" ] && batctl meshif "$iface" multicast_mode "$multicast_mode" 2>&-
+	[ -n "$network_coding" ] && batctl meshif "$iface" network_coding "$network_coding" 2>&-
+	[ -n "$log_level" ] && batctl meshif "$iface" loglevel "$log_level" 2>&-
+	[ -n "$orig_interval" ] && batctl meshif "$iface" orig_interval "$orig_interval"
+
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+proto_batadv_teardown() {
+	local config="$1"
+	local iface="$config"
+
+	batctl meshif "$iface" interface destroy
+}
+
+add_protocol batadv

--- a/feeds/batman/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
+++ b/feeds/batman/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_batadv_hardif_init_config() {
+	proto_config_add_int 'elp_interval'
+	proto_config_add_int 'hop_penalty'
+	proto_config_add_string "master"
+	proto_config_add_string 'throughput_override'
+}
+
+proto_batadv_hardif_setup() {
+	local config="$1"
+	local iface="$2"
+
+	local elp_interval
+	local hop_penalty
+	local master
+	local throughput_override
+
+	json_get_vars elp_interval
+	json_get_vars hop_penalty
+	json_get_vars master
+	json_get_vars throughput_override
+
+	( proto_add_host_dependency "$config" '' "$master" )
+
+	batctl meshif "$master" interface -M add "$iface"
+
+	[ -n "$elp_interval" ] && batctl hardif "$iface" elp_interval "$elp_interval"
+	[ -n "$hop_penalty" ] && batctl hardif "$iface" hop_penalty "$hop_penalty"
+	[ -n "$throughput_override" ] && batctl hardif "$iface" throughput_override "$throughput_override"
+
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+proto_batadv_hardif_teardown() {
+	local config="$1"
+	local iface="$2"
+
+	local master
+
+	json_get_vars master
+
+	batctl meshif "$master" interface -M del "$iface" || true
+}
+
+add_protocol batadv_hardif

--- a/feeds/batman/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+++ b/feeds/batman/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. ../netifd-proto.sh
+init_proto "$@"
+
+proto_batadv_vlan_init_config() {
+	proto_config_add_boolean 'ap_isolation:bool'
+}
+
+proto_batadv_vlan_setup() {
+	local config="$1"
+	local iface="$2"
+
+	# batadv_vlan options
+	local ap_isolation
+
+	json_get_vars ap_isolation
+
+	[ -n "$ap_isolation" ] && batctl vlan "$iface" ap_isolation "$ap_isolation"
+	proto_init_update "$iface" 1
+	proto_send_update "$config"
+}
+
+proto_batadv_vlan_teardown() {
+	local cfg="$1"
+}
+
+add_protocol batadv_vlan

--- a/feeds/batman/batman-adv/patches/0001-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
+++ b/feeds/batman/batman-adv/patches/0001-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
@@ -1,0 +1,270 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Fri, 6 May 2022 22:03:29 +0200
+Subject: Revert "batman-adv: Migrate to linux/container_of.h"
+
+This reverts commit 043ae5634bdfd4c4dd8b95a22890752495080bb5.
+
+--- a/compat-include/linux/container_of.h
++++ /dev/null
+@@ -1,20 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/* Copyright (C) B.A.T.M.A.N. contributors:
+- *
+- * Marek Lindner, Simon Wunderlich
+- *
+- * This file contains macros for maintaining compatibility with older versions
+- * of the Linux kernel.
+- */
+-
+-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_
+-#define _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_
+-
+-#include <linux/version.h>
+-#if LINUX_VERSION_IS_GEQ(5, 16, 0)
+-#include_next <linux/container_of.h>
+-#else
+-#include <linux/kernel.h>
+-#endif
+-
+-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_ */
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -13,13 +13,13 @@
+ #include <linux/bug.h>
+ #include <linux/byteorder/generic.h>
+ #include <linux/cache.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/if_ether.h>
+ #include <linux/init.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -10,13 +10,13 @@
+ #include <linux/atomic.h>
+ #include <linux/bitops.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/ethtool.h>
+ #include <linux/gfp.h>
+ #include <linux/if_ether.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/minmax.h>
+ #include <linux/netdevice.h>
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -9,12 +9,12 @@
+ 
+ #include <linux/atomic.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/if_ether.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/bridge_loop_avoidance.c
++++ b/net/batman-adv/bridge_loop_avoidance.c
+@@ -10,7 +10,6 @@
+ #include <linux/atomic.h>
+ #include <linux/byteorder/generic.h>
+ #include <linux/compiler.h>
+-#include <linux/container_of.h>
+ #include <linux/crc16.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+--- a/net/batman-adv/distributed-arp-table.c
++++ b/net/batman-adv/distributed-arp-table.c
+@@ -11,7 +11,6 @@
+ #include <linux/atomic.h>
+ #include <linux/bitops.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+@@ -21,6 +20,7 @@
+ #include <linux/in.h>
+ #include <linux/ip.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/netlink.h>
+--- a/net/batman-adv/gateway_client.c
++++ b/net/batman-adv/gateway_client.c
+@@ -9,7 +9,6 @@
+ 
+ #include <linux/atomic.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -9,12 +9,12 @@
+ 
+ #include <linux/atomic.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/gfp.h>
+ #include <linux/if.h>
+ #include <linux/if_arp.h>
+ #include <linux/if_ether.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/limits.h>
+ #include <linux/list.h>
+--- a/net/batman-adv/main.c
++++ b/net/batman-adv/main.c
+@@ -9,7 +9,6 @@
+ #include <linux/atomic.h>
+ #include <linux/build_bug.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/crc32c.h>
+ #include <linux/device.h>
+ #include <linux/errno.h>
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -11,7 +11,6 @@
+ #include <linux/bitops.h>
+ #include <linux/bug.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+--- a/net/batman-adv/network-coding.c
++++ b/net/batman-adv/network-coding.c
+@@ -11,7 +11,6 @@
+ #include <linux/bitops.h>
+ #include <linux/byteorder/generic.h>
+ #include <linux/compiler.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+@@ -20,6 +19,7 @@
+ #include <linux/init.h>
+ #include <linux/jhash.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/originator.c
++++ b/net/batman-adv/originator.c
+@@ -8,11 +8,11 @@
+ #include "main.h"
+ 
+ #include <linux/atomic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/send.c
++++ b/net/batman-adv/send.c
+@@ -10,13 +10,13 @@
+ #include <linux/atomic.h>
+ #include <linux/bug.h>
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/if.h>
+ #include <linux/if_ether.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/netdevice.h>
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -11,7 +11,6 @@
+ #include <linux/byteorder/generic.h>
+ #include <linux/cache.h>
+ #include <linux/compiler.h>
+-#include <linux/container_of.h>
+ #include <linux/cpumask.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+@@ -20,6 +19,7 @@
+ #include <linux/if_ether.h>
+ #include <linux/if_vlan.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/tp_meter.c
++++ b/net/batman-adv/tp_meter.c
+@@ -12,13 +12,13 @@
+ #include <linux/byteorder/generic.h>
+ #include <linux/cache.h>
+ #include <linux/compiler.h>
+-#include <linux/container_of.h>
+ #include <linux/err.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/if_ether.h>
+ #include <linux/init.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/kthread.h>
+ #include <linux/limits.h>
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -13,7 +13,6 @@
+ #include <linux/byteorder/generic.h>
+ #include <linux/cache.h>
+ #include <linux/compiler.h>
+-#include <linux/container_of.h>
+ #include <linux/crc32c.h>
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+@@ -22,6 +21,7 @@
+ #include <linux/init.h>
+ #include <linux/jhash.h>
+ #include <linux/jiffies.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
+--- a/net/batman-adv/tvlv.c
++++ b/net/batman-adv/tvlv.c
+@@ -7,10 +7,10 @@
+ #include "main.h"
+ 
+ #include <linux/byteorder/generic.h>
+-#include <linux/container_of.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
+ #include <linux/if_ether.h>
++#include <linux/kernel.h>
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>

--- a/feeds/batman/batman-adv/patches/0002-fix-batadv_is_cfg80211_netdev.patch
+++ b/feeds/batman/batman-adv/patches/0002-fix-batadv_is_cfg80211_netdev.patch
@@ -1,0 +1,19 @@
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Thu, 6 Apr 2023 18:05:50 -0500
+Subject: fix batadv_is_cfg80211_netdev
+
+Replace CONFIG_CFG80211 with CPTCFG_CFG80211, which is the correct
+macro to use when building under backports.
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -307,8 +307,7 @@ static bool batadv_is_cfg80211_netdev(st
+ {
+ 	if (!net_device)
+ 		return false;
+-
+-#if IS_ENABLED(CONFIG_CFG80211)
++#if IS_ENABLED(CPTCFG_CFG80211)
+ 	/* cfg80211 drivers have to set ieee80211_ptr */
+ 	if (net_device->ieee80211_ptr)
+ 		return true;

--- a/feeds/batman/batman-adv/patches/0003-batman-adv-Broken-sync-while-rescheduling-delayed-wo.patch
+++ b/feeds/batman/batman-adv/patches/0003-batman-adv-Broken-sync-while-rescheduling-delayed-wo.patch
@@ -1,0 +1,48 @@
+From: Vladislav Efanov <VEfanov@ispras.ru>
+Date: Fri, 26 May 2023 19:16:32 +0300
+Subject: batman-adv: Broken sync while rescheduling delayed work
+
+Syzkaller got a lot of crashes like:
+KASAN: use-after-free Write in *_timers*
+
+All of these crashes point to the same memory area:
+
+The buggy address belongs to the object at ffff88801f870000
+ which belongs to the cache kmalloc-8k of size 8192
+The buggy address is located 5320 bytes inside of
+ 8192-byte region [ffff88801f870000, ffff88801f872000)
+
+This area belongs to :
+        batadv_priv->batadv_priv_dat->delayed_work->timer_list
+
+The reason for these issues is the lack of synchronization. Delayed
+work (batadv_dat_purge) schedules new timer/work while the device
+is being deleted. As the result new timer/delayed work is set after
+cancel_delayed_work_sync() was called. So after the device is freed
+the timer list contains pointer to already freed memory.
+
+Found by Linux Verification Center (linuxtesting.org) with syzkaller.
+
+Fixes: f6badf9eb582 ("batman-adv: Distributed ARP Table - implement local storage")
+Signed-off-by: Vladislav Efanov <VEfanov@ispras.ru>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/177ba85fb2d4ca2ecd30ca16803560e80e916fac
+
+--- a/net/batman-adv/distributed-arp-table.c
++++ b/net/batman-adv/distributed-arp-table.c
+@@ -101,7 +101,6 @@ static void batadv_dat_purge(struct work
+  */
+ static void batadv_dat_start_timer(struct batadv_priv *bat_priv)
+ {
+-	INIT_DELAYED_WORK(&bat_priv->dat.work, batadv_dat_purge);
+ 	queue_delayed_work(batadv_event_workqueue, &bat_priv->dat.work,
+ 			   msecs_to_jiffies(10000));
+ }
+@@ -819,6 +818,7 @@ int batadv_dat_init(struct batadv_priv *
+ 	if (!bat_priv->dat.hash)
+ 		return -ENOMEM;
+ 
++	INIT_DELAYED_WORK(&bat_priv->dat.work, batadv_dat_purge);
+ 	batadv_dat_start_timer(bat_priv);
+ 
+ 	batadv_tvlv_handler_register(bat_priv, batadv_dat_tvlv_ogm_handler_v1,

--- a/feeds/batman/batman-adv/patches/0004-batman-adv-compat-Use-native-kstrtox.h-for-5.10.185.patch
+++ b/feeds/batman/batman-adv/patches/0004-batman-adv-compat-Use-native-kstrtox.h-for-5.10.185.patch
@@ -1,0 +1,29 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 11 Jul 2023 11:46:30 +0200
+Subject: batman-adv: compat: Use native kstrtox.h for 5.10.185
+
+Upstream stable commit 6e2e551e39fd ("kernel.h: split out kstrtox() and
+simple_strtox() to a separate header") backported the support for
+linux/kstrtox.h. Unfortunately, the compat support via linux/kernel.h was
+dropped and thus references to kstrtou64 caused build errors
+
+  batman-adv/net/batman-adv/gateway_common.c: In function ‘batadv_parse_throughput’:
+  batman-adv/net/batman-adv/gateway_common.c:55:15: error: implicit declaration of function ‘kstrtou64’ [-Werror=implicit-function-declaration]
+     55 |         ret = kstrtou64(buff, 10, &lthroughput);
+        |               ^~~~~~~~~
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/8924adbdf993cd0521f9d0024b43e3b23af5114f
+
+--- a/compat-include/linux/kstrtox.h
++++ b/compat-include/linux/kstrtox.h
+@@ -11,7 +11,8 @@
+ #define _NET_BATMAN_ADV_COMPAT_LINUX_KSTRTOX_H_
+ 
+ #include <linux/version.h>
+-#if LINUX_VERSION_IS_GEQ(5, 14, 0)
++#if (LINUX_VERSION_IS_GEQ(5, 10, 185) && LINUX_VERSION_IS_LESS(5, 11, 0)) || \
++    LINUX_VERSION_IS_GEQ(5, 14, 0)
+ #include_next <linux/kstrtox.h>
+ #else
+ #include <linux/kernel.h>

--- a/feeds/batman/batman-adv/patches/0005-batman-adv-Do-not-get-eth-header-before-batadv_check.patch
+++ b/feeds/batman/batman-adv/patches/0005-batman-adv-Do-not-get-eth-header-before-batadv_check.patch
@@ -1,0 +1,111 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 28 Jul 2023 15:38:50 +0200
+Subject: batman-adv: Do not get eth header before batadv_check_management_packet
+
+If received skb in batadv_v_elp_packet_recv or batadv_v_ogm_packet_recv
+is either cloned or non linearized then its data buffer will be
+reallocated by batadv_check_management_packet when skb_cow or
+skb_linearize get called. Thus geting ethernet header address inside
+skb data buffer before batadv_check_management_packet had any chance to
+reallocate it could lead to the following kernel panic:
+
+  Unable to handle kernel paging request at virtual address ffffff8020ab069a
+  Mem abort info:
+    ESR = 0x96000007
+    EC = 0x25: DABT (current EL), IL = 32 bits
+    SET = 0, FnV = 0
+    EA = 0, S1PTW = 0
+    FSC = 0x07: level 3 translation fault
+  Data abort info:
+    ISV = 0, ISS = 0x00000007
+    CM = 0, WnR = 0
+  swapper pgtable: 4k pages, 39-bit VAs, pgdp=0000000040f45000
+  [ffffff8020ab069a] pgd=180000007fffa003, p4d=180000007fffa003, pud=180000007fffa003, pmd=180000007fefe003, pte=0068000020ab0706
+  Internal error: Oops: 96000007 [#1] SMP
+  Modules linked in: ahci_mvebu libahci_platform libahci dvb_usb_af9035 dvb_usb_dib0700 dib0070 dib7000m dibx000_common ath11k_pci ath10k_pci ath10k_core mwl8k_new nf_nat_sip nf_conntrack_sip xhci_plat_hcd xhci_hcd nf_nat_pptp nf_conntrack_pptp at24 sbsa_gwdt
+  CPU: 1 PID: 16 Comm: ksoftirqd/1 Not tainted 5.15.42-00066-g3242268d425c-dirty #550
+  Hardware name: A8k (DT)
+  pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : batadv_is_my_mac+0x60/0xc0
+  lr : batadv_v_ogm_packet_recv+0x98/0x5d0
+  sp : ffffff8000183820
+  x29: ffffff8000183820 x28: 0000000000000001 x27: ffffff8014f9af00
+  x26: 0000000000000000 x25: 0000000000000543 x24: 0000000000000003
+  x23: ffffff8020ab0580 x22: 0000000000000110 x21: ffffff80168ae880
+  x20: 0000000000000000 x19: ffffff800b561000 x18: 0000000000000000
+  x17: 0000000000000000 x16: 0000000000000000 x15: 00dc098924ae0032
+  x14: 0f0405433e0054b0 x13: ffffffff00000080 x12: 0000004000000001
+  x11: 0000000000000000 x10: 0000000000000000 x9 : 0000000000000000
+  x8 : 0000000000000000 x7 : ffffffc076dae000 x6 : ffffff8000183700
+  x5 : ffffffc00955e698 x4 : ffffff80168ae000 x3 : ffffff80059cf000
+  x2 : ffffff800b561000 x1 : ffffff8020ab0696 x0 : ffffff80168ae880
+  Call trace:
+   batadv_is_my_mac+0x60/0xc0
+   batadv_v_ogm_packet_recv+0x98/0x5d0
+   batadv_batman_skb_recv+0x1b8/0x244
+   __netif_receive_skb_core.isra.0+0x440/0xc74
+   __netif_receive_skb_one_core+0x14/0x20
+   netif_receive_skb+0x68/0x140
+   br_pass_frame_up+0x70/0x80
+   br_handle_frame_finish+0x108/0x284
+   br_handle_frame+0x190/0x250
+   __netif_receive_skb_core.isra.0+0x240/0xc74
+   __netif_receive_skb_list_core+0x6c/0x90
+   netif_receive_skb_list_internal+0x1f4/0x310
+   napi_complete_done+0x64/0x1d0
+   gro_cell_poll+0x7c/0xa0
+   __napi_poll+0x34/0x174
+   net_rx_action+0xf8/0x2a0
+   _stext+0x12c/0x2ac
+   run_ksoftirqd+0x4c/0x7c
+   smpboot_thread_fn+0x120/0x210
+   kthread+0x140/0x150
+   ret_from_fork+0x10/0x20
+  Code: f9403844 eb03009f 54fffee1 f94
+
+Thus ethernet header address should only be fetched after
+batadv_check_management_packet has been called.
+
+Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/670971ac7e9a47ee952848e0ea9128180e8fb991
+
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -505,7 +505,7 @@ int batadv_v_elp_packet_recv(struct sk_b
+ 	struct batadv_priv *bat_priv = netdev_priv(if_incoming->soft_iface);
+ 	struct batadv_elp_packet *elp_packet;
+ 	struct batadv_hard_iface *primary_if;
+-	struct ethhdr *ethhdr = (struct ethhdr *)skb_mac_header(skb);
++	struct ethhdr *ethhdr;
+ 	bool res;
+ 	int ret = NET_RX_DROP;
+ 
+@@ -513,6 +513,7 @@ int batadv_v_elp_packet_recv(struct sk_b
+ 	if (!res)
+ 		goto free_skb;
+ 
++	ethhdr = eth_hdr(skb);
+ 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+ 		goto free_skb;
+ 
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -985,7 +985,7 @@ int batadv_v_ogm_packet_recv(struct sk_b
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(if_incoming->soft_iface);
+ 	struct batadv_ogm2_packet *ogm_packet;
+-	struct ethhdr *ethhdr = eth_hdr(skb);
++	struct ethhdr *ethhdr;
+ 	int ogm_offset;
+ 	u8 *packet_pos;
+ 	int ret = NET_RX_DROP;
+@@ -999,6 +999,7 @@ int batadv_v_ogm_packet_recv(struct sk_b
+ 	if (!batadv_check_management_packet(skb, if_incoming, BATADV_OGM2_HLEN))
+ 		goto free_skb;
+ 
++	ethhdr = eth_hdr(skb);
+ 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+ 		goto free_skb;
+ 

--- a/feeds/batman/batman-adv/patches/0006-batman-adv-Trigger-events-for-auto-adjusted-MTU.patch
+++ b/feeds/batman/batman-adv/patches/0006-batman-adv-Trigger-events-for-auto-adjusted-MTU.patch
@@ -1,0 +1,28 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 19 Jul 2023 10:15:05 +0200
+Subject: batman-adv: Trigger events for auto adjusted MTU
+
+If an interface changes the MTU, it is expected that an NETDEV_PRECHANGEMTU
+and NETDEV_CHANGEMTU notification events is triggered. This worked fine for
+.ndo_change_mtu based changes because core networking code took care of it.
+But for auto-adjustments after hard-interfaces changes, these events were
+simply missing.
+
+Due to this problem, non-batman-adv components weren't aware of MTU changes
+and thus couldn't perform their own tasks correctly.
+
+Fixes: 8009e9f7ac4f ("set bat0 MTU according to the MTUs of the hard interfaces")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/27c4d7c1c7fa39d71ea6ccf1c23bcb4773243800
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -629,7 +629,7 @@ out:
+  */
+ void batadv_update_min_mtu(struct net_device *soft_iface)
+ {
+-	soft_iface->mtu = batadv_hardif_min_mtu(soft_iface);
++	dev_set_mtu(soft_iface, batadv_hardif_min_mtu(soft_iface));
+ 
+ 	/* Check if the local translate table should be cleaned up to match a
+ 	 * new (and smaller) MTU.

--- a/feeds/batman/batman-adv/patches/0007-batman-adv-Don-t-increase-MTU-when-set-by-user.patch
+++ b/feeds/batman/batman-adv/patches/0007-batman-adv-Don-t-increase-MTU-when-set-by-user.patch
@@ -1,0 +1,71 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 19 Jul 2023 10:15:06 +0200
+Subject: batman-adv: Don't increase MTU when set by user
+
+If the user set an MTU value, it usually means that there are special
+requirements for the MTU. But if an interface gots activated, the MTU was
+always recalculated and then the user set value was overwritten.
+
+The only reason why this user set value has to be overwritten, is when the
+MTU has to be decreased because batman-adv is not able to transfer packets
+with the user specified size.
+
+Fixes: 88861ea9acb7 ("[batman-adv] replacing if up/down timer with kernel notifications")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/2745af592150b758ee96abf9329dd5f42cf22c25
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -629,7 +629,19 @@ out:
+  */
+ void batadv_update_min_mtu(struct net_device *soft_iface)
+ {
+-	dev_set_mtu(soft_iface, batadv_hardif_min_mtu(soft_iface));
++	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
++	int limit_mtu;
++	int mtu;
++
++	mtu = batadv_hardif_min_mtu(soft_iface);
++
++	if (bat_priv->mtu_set_by_user)
++		limit_mtu = bat_priv->mtu_set_by_user;
++	else
++		limit_mtu = ETH_DATA_LEN;
++
++	mtu = min(mtu, limit_mtu);
++	dev_set_mtu(soft_iface, mtu);
+ 
+ 	/* Check if the local translate table should be cleaned up to match a
+ 	 * new (and smaller) MTU.
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -153,11 +153,14 @@ static int batadv_interface_set_mac_addr
+ 
+ static int batadv_interface_change_mtu(struct net_device *dev, int new_mtu)
+ {
++	struct batadv_priv *bat_priv = netdev_priv(dev);
++
+ 	/* check ranges */
+ 	if (new_mtu < 68 || new_mtu > batadv_hardif_min_mtu(dev))
+ 		return -EINVAL;
+ 
+ 	dev->mtu = new_mtu;
++	bat_priv->mtu_set_by_user = new_mtu;
+ 
+ 	return 0;
+ }
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1547,6 +1547,12 @@ struct batadv_priv {
+ 	struct net_device *soft_iface;
+ 
+ 	/**
++	 * @mtu_set_by_user: MTU was set once by user
++	 * protected by rtnl_lock
++	 */
++	int mtu_set_by_user;
++
++	/**
+ 	 * @bat_counters: mesh internal traffic statistic counters (see
+ 	 *  batadv_counters)
+ 	 */

--- a/feeds/batman/batman-adv/patches/0008-batman-adv-Fix-TT-global-entry-leak-when-client-roam.patch
+++ b/feeds/batman/batman-adv/patches/0008-batman-adv-Fix-TT-global-entry-leak-when-client-roam.patch
@@ -1,0 +1,76 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 4 Aug 2023 11:39:36 +0200
+Subject: batman-adv: Fix TT global entry leak when client roamed back
+
+When a client roamed back to a node before it got time to destroy the
+pending local entry (i.e. within the same originator interval) the old
+global one is directly removed from hash table and left as such.
+
+But because this entry had an extra reference taken at lookup (i.e using
+batadv_tt_global_hash_find) there is no way its memory will be reclaimed
+at any time causing the following memory leak:
+
+  unreferenced object 0xffff0000073c8000 (size 18560):
+    comm "softirq", pid 0, jiffies 4294907738 (age 228.644s)
+    hex dump (first 32 bytes):
+      06 31 ac 12 c7 7a 05 00 01 00 00 00 00 00 00 00  .1...z..........
+      2c ad be 08 00 80 ff ff 6c b6 be 08 00 80 ff ff  ,.......l.......
+    backtrace:
+      [<00000000ee6e0ffa>] kmem_cache_alloc+0x1b4/0x300
+      [<000000000ff2fdbc>] batadv_tt_global_add+0x700/0xe20
+      [<00000000443897c7>] _batadv_tt_update_changes+0x21c/0x790
+      [<000000005dd90463>] batadv_tt_update_changes+0x3c/0x110
+      [<00000000a2d7fc57>] batadv_tt_tvlv_unicast_handler_v1+0xafc/0xe10
+      [<0000000011793f2a>] batadv_tvlv_containers_process+0x168/0x2b0
+      [<00000000b7cbe2ef>] batadv_recv_unicast_tvlv+0xec/0x1f4
+      [<0000000042aef1d8>] batadv_batman_skb_recv+0x25c/0x3a0
+      [<00000000bbd8b0a2>] __netif_receive_skb_core.isra.0+0x7a8/0xe90
+      [<000000004033d428>] __netif_receive_skb_one_core+0x64/0x74
+      [<000000000f39a009>] __netif_receive_skb+0x48/0xe0
+      [<00000000f2cd8888>] process_backlog+0x174/0x344
+      [<00000000507d6564>] __napi_poll+0x58/0x1f4
+      [<00000000b64ef9eb>] net_rx_action+0x504/0x590
+      [<00000000056fa5e4>] _stext+0x1b8/0x418
+      [<00000000878879d6>] run_ksoftirqd+0x74/0xa4
+  unreferenced object 0xffff00000bae1a80 (size 56):
+    comm "softirq", pid 0, jiffies 4294910888 (age 216.092s)
+    hex dump (first 32 bytes):
+      00 78 b1 0b 00 00 ff ff 0d 50 00 00 00 00 00 00  .x.......P......
+      00 00 00 00 00 00 00 00 50 c8 3c 07 00 00 ff ff  ........P.<.....
+    backtrace:
+      [<00000000ee6e0ffa>] kmem_cache_alloc+0x1b4/0x300
+      [<00000000d9aaa49e>] batadv_tt_global_add+0x53c/0xe20
+      [<00000000443897c7>] _batadv_tt_update_changes+0x21c/0x790
+      [<000000005dd90463>] batadv_tt_update_changes+0x3c/0x110
+      [<00000000a2d7fc57>] batadv_tt_tvlv_unicast_handler_v1+0xafc/0xe10
+      [<0000000011793f2a>] batadv_tvlv_containers_process+0x168/0x2b0
+      [<00000000b7cbe2ef>] batadv_recv_unicast_tvlv+0xec/0x1f4
+      [<0000000042aef1d8>] batadv_batman_skb_recv+0x25c/0x3a0
+      [<00000000bbd8b0a2>] __netif_receive_skb_core.isra.0+0x7a8/0xe90
+      [<000000004033d428>] __netif_receive_skb_one_core+0x64/0x74
+      [<000000000f39a009>] __netif_receive_skb+0x48/0xe0
+      [<00000000f2cd8888>] process_backlog+0x174/0x344
+      [<00000000507d6564>] __napi_poll+0x58/0x1f4
+      [<00000000b64ef9eb>] net_rx_action+0x504/0x590
+      [<00000000056fa5e4>] _stext+0x1b8/0x418
+      [<00000000878879d6>] run_ksoftirqd+0x74/0xa4
+
+Releasing the extra reference from batadv_tt_global_hash_find even at
+roam back when batadv_tt_global_free is called fixes this memory leak.
+
+Cc: stable@vger.kernel.org
+Fixes: 2443ba383c7d ("batman-adv: roaming handling mechanism redesign")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/26fce59c70729e07034de966ac5fd2d5c1f2d597
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -774,7 +774,6 @@ check_roaming:
+ 		if (roamed_back) {
+ 			batadv_tt_global_free(bat_priv, tt_global,
+ 					      "Roaming canceled");
+-			tt_global = NULL;
+ 		} else {
+ 			/* The global entry has to be marked as ROAMING and
+ 			 * has to be kept for consistency purpose

--- a/feeds/batman/batman-adv/patches/0009-batman-adv-Fix-batadv_v_ogm_aggr_send-memory-leak.patch
+++ b/feeds/batman/batman-adv/patches/0009-batman-adv-Fix-batadv_v_ogm_aggr_send-memory-leak.patch
@@ -1,0 +1,47 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Wed, 9 Aug 2023 17:29:13 +0200
+Subject: batman-adv: Fix batadv_v_ogm_aggr_send memory leak
+
+When batadv_v_ogm_aggr_send is called for an inactive interface, the skb
+is silently dropped by batadv_v_ogm_send_to_if() but never freed causing
+the following memory leak:
+
+  unreferenced object 0xffff00000c164800 (size 512):
+    comm "kworker/u8:1", pid 2648, jiffies 4295122303 (age 97.656s)
+    hex dump (first 32 bytes):
+      00 80 af 09 00 00 ff ff e1 09 00 00 75 01 60 83  ............u.`.
+      1f 00 00 00 b8 00 00 00 15 00 05 00 da e3 d3 64  ...............d
+    backtrace:
+      [<0000000007ad20f6>] __kmalloc_track_caller+0x1a8/0x310
+      [<00000000d1029e55>] kmalloc_reserve.constprop.0+0x70/0x13c
+      [<000000008b9d4183>] __alloc_skb+0xec/0x1fc
+      [<00000000c7af5051>] __netdev_alloc_skb+0x48/0x23c
+      [<00000000642ee5f5>] batadv_v_ogm_aggr_send+0x50/0x36c
+      [<0000000088660bd7>] batadv_v_ogm_aggr_work+0x24/0x40
+      [<0000000042fc2606>] process_one_work+0x3b0/0x610
+      [<000000002f2a0b1c>] worker_thread+0xa0/0x690
+      [<0000000059fae5d4>] kthread+0x1fc/0x210
+      [<000000000c587d3a>] ret_from_fork+0x10/0x20
+
+Free the skb in that case to fix this leak.
+
+Cc: stable@vger.kernel.org
+Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9024db261180f73fc687a9ecc7e79e3b0ccf50dc
+
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -123,8 +123,10 @@ static void batadv_v_ogm_send_to_if(stru
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(hard_iface->soft_iface);
+ 
+-	if (hard_iface->if_status != BATADV_IF_ACTIVE)
++	if (hard_iface->if_status != BATADV_IF_ACTIVE) {
++		kfree_skb(skb);
+ 		return;
++	}
+ 
+ 	batadv_inc_counter(bat_priv, BATADV_CNT_MGMT_TX);
+ 	batadv_add_counter(bat_priv, BATADV_CNT_MGMT_TX_BYTES,

--- a/feeds/batman/batman-adv/patches/0010-batman-adv-Hold-rtnl-lock-during-MTU-update-via-netl.patch
+++ b/feeds/batman/batman-adv/patches/0010-batman-adv-Hold-rtnl-lock-during-MTU-update-via-netl.patch
@@ -1,0 +1,35 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 21 Aug 2023 21:48:48 +0200
+Subject: batman-adv: Hold rtnl lock during MTU update via netlink
+
+The automatic recalculation of the maximum allowed MTU is usually triggered
+by code sections which are already rtnl lock protected by callers outside
+of batman-adv. But when the fragmentation setting is changed via
+batman-adv's own batadv genl family, then the rtnl lock is not yet taken.
+
+But dev_set_mtu requires that the caller holds the rtnl lock because it
+uses netdevice notifiers. And this code will then fail the check for this
+lock:
+
+  RTNL: assertion failed at net/core/dev.c (1953)
+
+Cc: stable@vger.kernel.org
+Reported-by: syzbot+f8812454d9b3ac00d282@syzkaller.appspotmail.com
+Fixes: 27c4d7c1c7fa ("batman-adv: Trigger events for auto adjusted MTU")
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/aeb35331aa9a17f9affd84c1a5b020aeb4a976f4
+
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -495,7 +495,10 @@ static int batadv_netlink_set_mesh(struc
+ 		attr = info->attrs[BATADV_ATTR_FRAGMENTATION_ENABLED];
+ 
+ 		atomic_set(&bat_priv->fragmentation, !!nla_get_u8(attr));
++
++		rtnl_lock();
+ 		batadv_update_min_mtu(bat_priv->soft_iface);
++		rtnl_unlock();
+ 	}
+ 
+ 	if (info->attrs[BATADV_ATTR_GW_BANDWIDTH_DOWN]) {

--- a/feeds/batman/batman-adv/patches/0011-batman-adv-Avoid-infinite-loop-trying-to-resize-loca.patch
+++ b/feeds/batman/batman-adv/patches/0011-batman-adv-Avoid-infinite-loop-trying-to-resize-loca.patch
@@ -1,0 +1,59 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 12 Feb 2024 14:32:13 +0100
+Subject: batman-adv: Avoid infinite loop trying to resize local TT
+
+If the MTU of one of an attached interface becomes too small to transmit
+the local translation table then it must be resized to fit inside all
+fragments (when enabled) or a single packet.
+
+But if the MTU becomes too low to transmit even the header + the VLAN
+specific part then the resizing of the local TT will never succeed. This
+can for example happen when the usable space is 110 bytes and 11 VLANs are
+on top of batman-adv. In this case, at least 116 byte would be needed.
+There will just be an endless spam of
+
+   batman_adv: batadv0: Forced to purge local tt entries to fit new maximum fragment MTU (110)
+
+in the log but the function will never finish. Problem here is that the
+timeout will be halved all the time and will then stagnate at 0 and
+therefore never be able to reduce the table even more.
+
+There are other scenarios possible with a similar result. The number of
+BATADV_TT_CLIENT_NOPURGE entries in the local TT can for example be too
+high to fit inside a packet. Such a scenario can therefore happen also with
+only a single VLAN + 7 non-purgable addresses - requiring at least 120
+bytes.
+
+While this should be handled proactively when:
+
+* interface with too low MTU is added
+* VLAN is added
+* non-purgeable local mac is added
+* MTU of an attached interface is reduced
+* fragmentation setting gets disabled (which most likely requires dropping
+  attached interfaces)
+
+not all of these scenarios can be prevented because batman-adv is only
+consuming events without the the possibility to prevent these actions
+(non-purgable MAC address added, MTU of an attached interface is reduced).
+It is therefore necessary to also make sure that the code is able to handle
+also the situations when there were already incompatible system
+configuration are present.
+
+Cc: stable@vger.kernel.org
+Fixes: f7f2fe494388 ("batman-adv: limit local translation table max size")
+Reported-by: syzbot+a6a4b5bb3da165594cff@syzkaller.appspotmail.com
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/05f6eadbbddc834669249ae204026c383445b571
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -3948,7 +3948,7 @@ void batadv_tt_local_resize_to_mtu(struc
+ 
+ 	spin_lock_bh(&bat_priv->tt.commit_lock);
+ 
+-	while (true) {
++	while (timeout) {
+ 		table_size = batadv_tt_local_table_transmit_size(bat_priv);
+ 		if (packet_size_max >= table_size)
+ 			break;

--- a/feeds/batman/batman-adv/patches/0012-batman-adv-Don-t-accept-TT-entries-for-out-of-spec-V.patch
+++ b/feeds/batman/batman-adv/patches/0012-batman-adv-Don-t-accept-TT-entries-for-out-of-spec-V.patch
@@ -1,0 +1,79 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sat, 4 May 2024 22:27:21 +0200
+Subject: batman-adv: Don't accept TT entries for out-of-spec VIDs
+
+The internal handling of VLAN IDs in batman-adv is only specified for
+following encodings:
+
+* VLAN is used
+  - bit 15 is 1
+  - bit 11 - bit 0 is the VLAN ID (0-4095)
+  - remaining bits are 0
+* No VLAN is used
+  - bit 15 is 0
+  - remaining bits are 0
+
+batman-adv was only preparing new translation table entries (based on its
+soft interface information) using this encoding format. But the receive
+path was never checking if entries in the roam or TT TVLVs were also
+following this encoding.
+
+It was therefore possible to create more than the expected maximum of 4096
++ 1 entries in the originator VLAN list. Simply by setting the "remaining
+bits" to "random" values in corresponding TVLV.
+
+Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/aa68ccb56023394b08929718645760dcc501f2d9
+
+--- a/net/batman-adv/originator.c
++++ b/net/batman-adv/originator.c
+@@ -11,6 +11,7 @@
+ #include <linux/errno.h>
+ #include <linux/etherdevice.h>
+ #include <linux/gfp.h>
++#include <linux/if_vlan.h>
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
+@@ -132,6 +133,29 @@ batadv_orig_node_vlan_get(struct batadv_
+ }
+ 
+ /**
++ * batadv_vlan_id_valid() - check if vlan id is in valid batman-adv encoding
++ * @vid: the VLAN identifier
++ *
++ * Return: true when either no vlan is set or if VLAN is in correct range,
++ *  false otherwise
++ */
++static bool batadv_vlan_id_valid(unsigned short vid)
++{
++	unsigned short non_vlan = vid & ~(BATADV_VLAN_HAS_TAG | VLAN_VID_MASK);
++
++	if (vid == 0)
++		return true;
++
++	if (!(vid & BATADV_VLAN_HAS_TAG))
++		return false;
++
++	if (non_vlan)
++		return false;
++
++	return true;
++}
++
++/**
+  * batadv_orig_node_vlan_new() - search and possibly create an orig_node_vlan
+  *  object
+  * @orig_node: the originator serving the VLAN
+@@ -149,6 +173,9 @@ batadv_orig_node_vlan_new(struct batadv_
+ {
+ 	struct batadv_orig_node_vlan *vlan;
+ 
++	if (!batadv_vlan_id_valid(vid))
++		return NULL;
++
+ 	spin_lock_bh(&orig_node->vlan_list_lock);
+ 
+ 	/* first look if an object for this vid already exists */

--- a/feeds/batman/batman-adv/patches/0013-batman-adv-Do-not-send-uninitialized-TT-changes.patch
+++ b/feeds/batman/batman-adv/patches/0013-batman-adv-Do-not-send-uninitialized-TT-changes.patch
@@ -1,0 +1,64 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 22 Nov 2024 16:52:48 +0100
+Subject: batman-adv: Do not send uninitialized TT changes
+
+The number of TT changes can be less than initially expected in
+batadv_tt_tvlv_container_update() (changes can be removed by
+batadv_tt_local_event() in ADD+DEL sequence between reading
+tt_diff_entries_num and actually iterating the change list under lock).
+
+Thus tt_diff_len could be bigger than the actual changes size that need
+to be sent. Because batadv_send_my_tt_response sends the whole
+packet, uninitialized data can be interpreted as TT changes on other
+nodes leading to weird TT global entries on those nodes such as:
+
+ * 00:00:00:00:00:00   -1 [....] (  0) 88:12:4e:ad:7e:ba (179) (0x45845380)
+ * 00:00:00:00:78:79 4092 [.W..] (  0) 88:12:4e:ad:7e:3c (145) (0x8ebadb8b)
+
+All of the above also applies to OGM tvlv container buffer's tvlv_len.
+
+Remove the extra allocated space to avoid sending uninitialized TT
+changes in batadv_send_my_tt_response() and batadv_v_ogm_send_softif().
+
+Fixes: 8405301b9794 ("batman-adv: tvlv - convert tt data sent within OGMs")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/5fe3a7a48ea6374280dc855db7b802d70b1870c6
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -990,6 +990,7 @@ static void batadv_tt_tvlv_container_upd
+ 	int tt_diff_len, tt_change_len = 0;
+ 	int tt_diff_entries_num = 0;
+ 	int tt_diff_entries_count = 0;
++	size_t tt_extra_len = 0;
+ 	u16 tvlv_len;
+ 
+ 	tt_diff_entries_num = atomic_read(&bat_priv->tt.local_changes);
+@@ -1027,6 +1028,9 @@ static void batadv_tt_tvlv_container_upd
+ 	}
+ 	spin_unlock_bh(&bat_priv->tt.changes_list_lock);
+ 
++	tt_extra_len = batadv_tt_len(tt_diff_entries_num -
++				     tt_diff_entries_count);
++
+ 	/* Keep the buffer for possible tt_request */
+ 	spin_lock_bh(&bat_priv->tt.last_changeset_lock);
+ 	kfree(bat_priv->tt.last_changeset);
+@@ -1035,6 +1039,7 @@ static void batadv_tt_tvlv_container_upd
+ 	tt_change_len = batadv_tt_len(tt_diff_entries_count);
+ 	/* check whether this new OGM has no changes due to size problems */
+ 	if (tt_diff_entries_count > 0) {
++		tt_diff_len -= tt_extra_len;
+ 		/* if kmalloc() fails we will reply with the full table
+ 		 * instead of providing the diff
+ 		 */
+@@ -1047,6 +1052,8 @@ static void batadv_tt_tvlv_container_upd
+ 	}
+ 	spin_unlock_bh(&bat_priv->tt.last_changeset_lock);
+ 
++	/* Remove extra packet space for OGM */
++	tvlv_len -= tt_extra_len;
+ container_register:
+ 	batadv_tvlv_container_register(bat_priv, BATADV_TVLV_TT, 1, tt_data,
+ 				       tvlv_len);

--- a/feeds/batman/batman-adv/patches/0014-batman-adv-Remove-uninitialized-data-in-full-table-T.patch
+++ b/feeds/batman/batman-adv/patches/0014-batman-adv-Remove-uninitialized-data-in-full-table-T.patch
@@ -1,0 +1,101 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 22 Nov 2024 16:52:49 +0100
+Subject: batman-adv: Remove uninitialized data in full table TT response
+
+The number of entries filled by batadv_tt_tvlv_generate() can be less
+than initially expected in batadv_tt_prepare_tvlv_{global,local}_data()
+(changes can be removed by batadv_tt_local_event() in ADD+DEL sequence
+in the meantime as the lock held during the whole tvlv global/local data
+generation).
+
+Thus tvlv_len could be bigger than the actual TT entry size that need
+to be sent so full table TT_RESPONSE could hold invalid TT entries such
+as below.
+
+ * 00:00:00:00:00:00   -1 [....] (  0) 88:12:4e:ad:7e:ba (179) (0x45845380)
+ * 00:00:00:00:78:79 4092 [.W..] (  0) 88:12:4e:ad:7e:3c (145) (0x8ebadb8b)
+
+Remove the extra allocated space to avoid sending uninitialized entries
+for full table TT_RESPONSE in both batadv_send_other_tt_response() and
+batadv_send_my_tt_response().
+
+Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/095c3965bdc29e43546a9cdd21f179f952e01f48
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -2754,14 +2754,16 @@ static bool batadv_tt_global_valid(const
+  *
+  * Fills the tvlv buff with the tt entries from the specified hash. If valid_cb
+  * is not provided then this becomes a no-op.
++ *
++ * Return: Remaining unused length in tvlv_buff.
+  */
+-static void batadv_tt_tvlv_generate(struct batadv_priv *bat_priv,
+-				    struct batadv_hashtable *hash,
+-				    void *tvlv_buff, u16 tt_len,
+-				    bool (*valid_cb)(const void *,
+-						     const void *,
+-						     u8 *flags),
+-				    void *cb_data)
++static u16 batadv_tt_tvlv_generate(struct batadv_priv *bat_priv,
++				   struct batadv_hashtable *hash,
++				   void *tvlv_buff, u16 tt_len,
++				   bool (*valid_cb)(const void *,
++						    const void *,
++						    u8 *flags),
++				   void *cb_data)
+ {
+ 	struct batadv_tt_common_entry *tt_common_entry;
+ 	struct batadv_tvlv_tt_change *tt_change;
+@@ -2775,7 +2777,7 @@ static void batadv_tt_tvlv_generate(stru
+ 	tt_change = tvlv_buff;
+ 
+ 	if (!valid_cb)
+-		return;
++		return tt_len;
+ 
+ 	rcu_read_lock();
+ 	for (i = 0; i < hash->size; i++) {
+@@ -2801,6 +2803,8 @@ static void batadv_tt_tvlv_generate(stru
+ 		}
+ 	}
+ 	rcu_read_unlock();
++
++	return batadv_tt_len(tt_tot - tt_num_entries);
+ }
+ 
+ /**
+@@ -3076,10 +3080,11 @@ static bool batadv_send_other_tt_respons
+ 			goto out;
+ 
+ 		/* fill the rest of the tvlv with the real TT entries */
+-		batadv_tt_tvlv_generate(bat_priv, bat_priv->tt.global_hash,
+-					tt_change, tt_len,
+-					batadv_tt_global_valid,
+-					req_dst_orig_node);
++		tvlv_len -= batadv_tt_tvlv_generate(bat_priv,
++						    bat_priv->tt.global_hash,
++						    tt_change, tt_len,
++						    batadv_tt_global_valid,
++						    req_dst_orig_node);
+ 	}
+ 
+ 	/* Don't send the response, if larger than fragmented packet. */
+@@ -3203,9 +3208,11 @@ static bool batadv_send_my_tt_response(s
+ 			goto out;
+ 
+ 		/* fill the rest of the tvlv with the real TT entries */
+-		batadv_tt_tvlv_generate(bat_priv, bat_priv->tt.local_hash,
+-					tt_change, tt_len,
+-					batadv_tt_local_valid, NULL);
++		tvlv_len -= batadv_tt_tvlv_generate(bat_priv,
++						    bat_priv->tt.local_hash,
++						    tt_change, tt_len,
++						    batadv_tt_local_valid,
++						    NULL);
+ 	}
+ 
+ 	tvlv_tt_data->flags = BATADV_TT_RESPONSE;

--- a/feeds/batman/batman-adv/patches/0015-batman-adv-Do-not-let-TT-changes-list-grows-indefini.patch
+++ b/feeds/batman/batman-adv/patches/0015-batman-adv-Do-not-let-TT-changes-list-grows-indefini.patch
@@ -1,0 +1,63 @@
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 22 Nov 2024 16:52:50 +0100
+Subject: batman-adv: Do not let TT changes list grows indefinitely
+
+When TT changes list is too big to fit in packet due to MTU size, an
+empty OGM is sent expected other node to send TT request to get the
+changes. The issue is that tt.last_changeset was not built thus the
+originator was responding with previous changes to those TT requests
+(see batadv_send_my_tt_response). Also the changes list was never
+cleaned up effectively never ending growing from this point onwards,
+repeatedly sending the same TT response changes over and over, and
+creating a new empty OGM every OGM interval expecting for the local
+changes to be purged.
+
+When there is more TT changes that can fit in packet, drop all changes,
+send empty OGM and wait for TT request so we can respond with a full
+table instead.
+
+Fixes: 8405301b9794 ("batman-adv: tvlv - convert tt data sent within OGMs")
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Acked-by: Antonio Quartulli <Antonio@mandelbit.com>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/4d49d6e9d60c41a6da727108518cb8fb33295537
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -990,6 +990,7 @@ static void batadv_tt_tvlv_container_upd
+ 	int tt_diff_len, tt_change_len = 0;
+ 	int tt_diff_entries_num = 0;
+ 	int tt_diff_entries_count = 0;
++	bool drop_changes = false;
+ 	size_t tt_extra_len = 0;
+ 	u16 tvlv_len;
+ 
+@@ -997,10 +998,17 @@ static void batadv_tt_tvlv_container_upd
+ 	tt_diff_len = batadv_tt_len(tt_diff_entries_num);
+ 
+ 	/* if we have too many changes for one packet don't send any
+-	 * and wait for the tt table request which will be fragmented
++	 * and wait for the tt table request so we can reply with the full
++	 * (fragmented) table.
++	 *
++	 * The local change history should still be cleaned up so the next
++	 * TT round can start again with a clean state.
+ 	 */
+-	if (tt_diff_len > bat_priv->soft_iface->mtu)
++	if (tt_diff_len > bat_priv->soft_iface->mtu) {
+ 		tt_diff_len = 0;
++		tt_diff_entries_num = 0;
++		drop_changes = true;
++	}
+ 
+ 	tvlv_len = batadv_tt_prepare_tvlv_local_data(bat_priv, &tt_data,
+ 						     &tt_change, &tt_diff_len);
+@@ -1009,7 +1017,7 @@ static void batadv_tt_tvlv_container_upd
+ 
+ 	tt_data->flags = BATADV_TT_OGM_DIFF;
+ 
+-	if (tt_diff_len == 0)
++	if (!drop_changes && tt_diff_len == 0)
+ 		goto container_register;
+ 
+ 	spin_lock_bh(&bat_priv->tt.changes_list_lock);

--- a/feeds/batman/batman-adv/patches/0016-batman-adv-fix-panic-during-interface-removal.patch
+++ b/feeds/batman/batman-adv/patches/0016-batman-adv-fix-panic-during-interface-removal.patch
@@ -1,0 +1,71 @@
+From: Andy Strohman <andrew@andrewstrohman.com>
+Date: Thu, 9 Jan 2025 02:27:56 +0000
+Subject: batman-adv: fix panic during interface removal
+
+Reference counting is used to ensure that
+batadv_hardif_neigh_node and batadv_hard_iface
+are not freed before/during
+batadv_v_elp_throughput_metric_update work is
+finished.
+
+But there isn't a guarantee that the hard if will
+remain associated with a soft interface up until
+the work is finished.
+
+This fixes a crash triggered by reboot that looks
+like this:
+
+Call trace:
+ batadv_v_mesh_free+0xd0/0x4dc [batman_adv]
+ batadv_v_elp_throughput_metric_update+0x1c/0xa4
+ process_one_work+0x178/0x398
+ worker_thread+0x2e8/0x4d0
+ kthread+0xd8/0xdc
+ ret_from_fork+0x10/0x20
+
+(the batadv_v_mesh_free call is misleading,
+and does not actually happen)
+
+I was able to make the issue happen more reliably
+by changing hardif_neigh->bat_v.metric_work work
+to be delayed work. This allowed me to track down
+and confirm the fix.
+
+Fixes: 5c3245172c01 ("batman-adv: ELP - compute the metric based on the estimated throughput")
+Signed-off-by: Andy Strohman <andrew@andrewstrohman.com>
+[sven@narfation.org: prevent entering batadv_v_elp_get_throughput without
+ soft_iface]
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/1d7c8ac629678b8cd23ef9def7c7b111cb9e8ed5
+
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -66,12 +66,19 @@ static void batadv_v_elp_start_timer(str
+ static u32 batadv_v_elp_get_throughput(struct batadv_hardif_neigh_node *neigh)
+ {
+ 	struct batadv_hard_iface *hard_iface = neigh->if_incoming;
++	struct net_device *soft_iface = hard_iface->soft_iface;
+ 	struct ethtool_link_ksettings link_settings;
+ 	struct net_device *real_netdev;
+ 	struct station_info sinfo;
+ 	u32 throughput;
+ 	int ret;
+ 
++	/* don't query throughput when no longer associated with any
++	 * batman-adv interface
++	 */
++	if (!soft_iface)
++		return BATADV_THROUGHPUT_DEFAULT_VALUE;
++
+ 	/* if the user specified a customised value for this interface, then
+ 	 * return it directly
+ 	 */
+@@ -141,7 +148,7 @@ static u32 batadv_v_elp_get_throughput(s
+ 
+ default_throughput:
+ 	if (!(hard_iface->bat_v.flags & BATADV_WARNING_DEFAULT)) {
+-		batadv_info(hard_iface->soft_iface,
++		batadv_info(soft_iface,
+ 			    "WiFi driver or ethtool info does not provide information about link speeds on interface %s, therefore defaulting to hardcoded throughput values of %u.%1u Mbps. Consider overriding the throughput manually or checking your driver.\n",
+ 			    hard_iface->net_dev->name,
+ 			    BATADV_THROUGHPUT_DEFAULT_VALUE / 10,

--- a/feeds/batman/batman-adv/patches/0017-batman-adv-Ignore-neighbor-throughput-metrics-in-err.patch
+++ b/feeds/batman/batman-adv/patches/0017-batman-adv-Ignore-neighbor-throughput-metrics-in-err.patch
@@ -1,0 +1,127 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 22 Jan 2025 21:51:20 +0100
+Subject: batman-adv: Ignore neighbor throughput metrics in error case
+
+If a temporary error happened in the evaluation of the neighbor throughput
+information, then the invalid throughput result should not be stored in the
+throughtput EWMA.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/ce8b40b7bdcc7f011191acda4c2d3067566eef54
+
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -59,11 +59,13 @@ static void batadv_v_elp_start_timer(str
+ /**
+  * batadv_v_elp_get_throughput() - get the throughput towards a neighbour
+  * @neigh: the neighbour for which the throughput has to be obtained
++ * @pthroughput: calculated throughput towards the given neighbour in multiples
++ *  of 100kpbs (a value of '1' equals 0.1Mbps, '10' equals 1Mbps, etc).
+  *
+- * Return: The throughput towards the given neighbour in multiples of 100kpbs
+- *         (a value of '1' equals 0.1Mbps, '10' equals 1Mbps, etc).
++ * Return: true when value behind @pthroughput was set
+  */
+-static u32 batadv_v_elp_get_throughput(struct batadv_hardif_neigh_node *neigh)
++static bool batadv_v_elp_get_throughput(struct batadv_hardif_neigh_node *neigh,
++					u32 *pthroughput)
+ {
+ 	struct batadv_hard_iface *hard_iface = neigh->if_incoming;
+ 	struct net_device *soft_iface = hard_iface->soft_iface;
+@@ -77,14 +79,16 @@ static u32 batadv_v_elp_get_throughput(s
+ 	 * batman-adv interface
+ 	 */
+ 	if (!soft_iface)
+-		return BATADV_THROUGHPUT_DEFAULT_VALUE;
++		return false;
+ 
+ 	/* if the user specified a customised value for this interface, then
+ 	 * return it directly
+ 	 */
+ 	throughput =  atomic_read(&hard_iface->bat_v.throughput_override);
+-	if (throughput != 0)
+-		return throughput;
++	if (throughput != 0) {
++		*pthroughput = throughput;
++		return true;
++	}
+ 
+ 	/* if this is a wireless device, then ask its throughput through
+ 	 * cfg80211 API
+@@ -111,19 +115,24 @@ static u32 batadv_v_elp_get_throughput(s
+ 			 * possible to delete this neighbor. For now set
+ 			 * the throughput metric to 0.
+ 			 */
+-			return 0;
++			*pthroughput = 0;
++			return true;
+ 		}
+ 		if (ret)
+ 			goto default_throughput;
+ 
+-		if (sinfo.filled & BIT(NL80211_STA_INFO_EXPECTED_THROUGHPUT))
+-			return sinfo.expected_throughput / 100;
++		if (sinfo.filled & BIT(NL80211_STA_INFO_EXPECTED_THROUGHPUT)) {
++			*pthroughput = sinfo.expected_throughput / 100;
++			return true;
++		}
+ 
+ 		/* try to estimate the expected throughput based on reported tx
+ 		 * rates
+ 		 */
+-		if (sinfo.filled & BIT(NL80211_STA_INFO_TX_BITRATE))
+-			return cfg80211_calculate_bitrate(&sinfo.txrate) / 3;
++		if (sinfo.filled & BIT(NL80211_STA_INFO_TX_BITRATE)) {
++			*pthroughput = cfg80211_calculate_bitrate(&sinfo.txrate) / 3;
++			return true;
++		}
+ 
+ 		goto default_throughput;
+ 	}
+@@ -142,8 +151,10 @@ static u32 batadv_v_elp_get_throughput(s
+ 			hard_iface->bat_v.flags &= ~BATADV_FULL_DUPLEX;
+ 
+ 		throughput = link_settings.base.speed;
+-		if (throughput && throughput != SPEED_UNKNOWN)
+-			return throughput * 10;
++		if (throughput && throughput != SPEED_UNKNOWN) {
++			*pthroughput = throughput * 10;
++			return true;
++		}
+ 	}
+ 
+ default_throughput:
+@@ -157,7 +168,8 @@ default_throughput:
+ 	}
+ 
+ 	/* if none of the above cases apply, return the base_throughput */
+-	return BATADV_THROUGHPUT_DEFAULT_VALUE;
++	*pthroughput = BATADV_THROUGHPUT_DEFAULT_VALUE;
++	return true;
+ }
+ 
+ /**
+@@ -169,15 +181,21 @@ void batadv_v_elp_throughput_metric_upda
+ {
+ 	struct batadv_hardif_neigh_node_bat_v *neigh_bat_v;
+ 	struct batadv_hardif_neigh_node *neigh;
++	u32 throughput;
++	bool valid;
+ 
+ 	neigh_bat_v = container_of(work, struct batadv_hardif_neigh_node_bat_v,
+ 				   metric_work);
+ 	neigh = container_of(neigh_bat_v, struct batadv_hardif_neigh_node,
+ 			     bat_v);
+ 
+-	ewma_throughput_add(&neigh->bat_v.throughput,
+-			    batadv_v_elp_get_throughput(neigh));
++	valid = batadv_v_elp_get_throughput(neigh, &throughput);
++	if (!valid)
++		goto put_neigh;
++
++	ewma_throughput_add(&neigh->bat_v.throughput, throughput);
+ 
++put_neigh:
+ 	/* decrement refcounter to balance increment performed before scheduling
+ 	 * this task
+ 	 */

--- a/feeds/batman/batman-adv/patches/0018-batman-adv-Drop-unmanaged-ELP-metric-worker.patch
+++ b/feeds/batman/batman-adv/patches/0018-batman-adv-Drop-unmanaged-ELP-metric-worker.patch
@@ -1,0 +1,239 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 22 Jan 2025 21:51:21 +0100
+Subject: batman-adv: Drop unmanaged ELP metric worker
+
+The ELP worker needs to calculate new metric values for all neighbors
+"reachable" over an interface. Some of the used metric sources require
+locks which might need to sleep. This sleep is incompatible with the RCU
+list iterator used for the recorded neighbors. The initial approach to work
+around of this problem was to queue another work item per neighbor and then
+run this in a new context.
+
+Even when this solved the RCU vs might_sleep() conflict, it has a major
+problems: Nothing was stopping the work item in case it is not needed
+anymore - for example because one of the related interfaces was removed or
+the batman-adv module was unloaded - resulting in potential invalid memory
+accesses.
+
+Directly canceling the metric worker also has various problems:
+
+* cancel_work_sync for a to-be-deactivated interface is called with
+  rtnl_lock held. But the code in the ELP metric worker also tries to use
+  rtnl_lock() - which will never return in this case. This also means that
+  cancel_work_sync would never return because it is waiting for the worker
+  to finish.
+* iterating over the neighbor list for the to-be-deactivated interface is
+  currently done using the RCU specific methods. Which means that it is
+  possible to miss items when iterating over it without the associated
+  spinlock - a behaviour which is acceptable for a periodic metric check
+  but not for a cleanup routine (which must "stop" all still running
+  workers)
+
+The better approch is to get rid of the per interface neighbor metric
+worker and handle everything in the interface worker. The original problems
+are solved by:
+
+* creating a list of neighbors which require new metric information inside
+  the RCU protected context, gathering the metric according to the new list
+  outside the RCU protected context
+* only use rcu_trylock inside metric gathering code to avoid a deadlock
+  when the cancel_delayed_work_sync is called in the interface removal code
+  (which is called with the rtnl_lock held)
+
+Fixes: 5c3245172c01 ("batman-adv: ELP - compute the metric based on the estimated throughput")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/405d49a20a205799ec453cadb3d078dc2808d563
+
+--- a/net/batman-adv/bat_v.c
++++ b/net/batman-adv/bat_v.c
+@@ -113,8 +113,6 @@ static void
+ batadv_v_hardif_neigh_init(struct batadv_hardif_neigh_node *hardif_neigh)
+ {
+ 	ewma_throughput_init(&hardif_neigh->bat_v.throughput);
+-	INIT_WORK(&hardif_neigh->bat_v.metric_work,
+-		  batadv_v_elp_throughput_metric_update);
+ }
+ 
+ /**
+--- a/net/batman-adv/bat_v_elp.c
++++ b/net/batman-adv/bat_v_elp.c
+@@ -18,6 +18,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/kref.h>
++#include <linux/list.h>
+ #include <linux/minmax.h>
+ #include <linux/netdevice.h>
+ #include <linux/nl80211.h>
+@@ -26,6 +27,7 @@
+ #include <linux/rcupdate.h>
+ #include <linux/rtnetlink.h>
+ #include <linux/skbuff.h>
++#include <linux/slab.h>
+ #include <linux/stddef.h>
+ #include <linux/string.h>
+ #include <linux/types.h>
+@@ -42,6 +44,18 @@
+ #include "send.h"
+ 
+ /**
++ * struct batadv_v_metric_queue_entry - list of hardif neighbors which require
++ *  and metric update
++ */
++struct batadv_v_metric_queue_entry {
++	/** @hardif_neigh: hardif neighbor scheduled for metric update */
++	struct batadv_hardif_neigh_node *hardif_neigh;
++
++	/** @list: list node for metric_queue */
++	struct list_head list;
++};
++
++/**
+  * batadv_v_elp_start_timer() - restart timer for ELP periodic work
+  * @hard_iface: the interface for which the timer has to be reset
+  */
+@@ -137,10 +151,17 @@ static bool batadv_v_elp_get_throughput(
+ 		goto default_throughput;
+ 	}
+ 
++	/* only use rtnl_trylock because the elp worker will be cancelled while
++	 * the rntl_lock is held. the cancel_delayed_work_sync() would otherwise
++	 * wait forever when the elp work_item was started and it is then also
++	 * trying to rtnl_lock
++	 */
++	if (!rtnl_trylock())
++		return false;
++
+ 	/* if not a wifi interface, check if this device provides data via
+ 	 * ethtool (e.g. an Ethernet adapter)
+ 	 */
+-	rtnl_lock();
+ 	ret = __ethtool_get_link_ksettings(hard_iface->net_dev, &link_settings);
+ 	rtnl_unlock();
+ 	if (ret == 0) {
+@@ -175,31 +196,19 @@ default_throughput:
+ /**
+  * batadv_v_elp_throughput_metric_update() - worker updating the throughput
+  *  metric of a single hop neighbour
+- * @work: the work queue item
++ * @neigh: the neighbour to probe
+  */
+-void batadv_v_elp_throughput_metric_update(struct work_struct *work)
++static void
++batadv_v_elp_throughput_metric_update(struct batadv_hardif_neigh_node *neigh)
+ {
+-	struct batadv_hardif_neigh_node_bat_v *neigh_bat_v;
+-	struct batadv_hardif_neigh_node *neigh;
+ 	u32 throughput;
+ 	bool valid;
+ 
+-	neigh_bat_v = container_of(work, struct batadv_hardif_neigh_node_bat_v,
+-				   metric_work);
+-	neigh = container_of(neigh_bat_v, struct batadv_hardif_neigh_node,
+-			     bat_v);
+-
+ 	valid = batadv_v_elp_get_throughput(neigh, &throughput);
+ 	if (!valid)
+-		goto put_neigh;
++		return;
+ 
+ 	ewma_throughput_add(&neigh->bat_v.throughput, throughput);
+-
+-put_neigh:
+-	/* decrement refcounter to balance increment performed before scheduling
+-	 * this task
+-	 */
+-	batadv_hardif_neigh_put(neigh);
+ }
+ 
+ /**
+@@ -273,14 +282,16 @@ batadv_v_elp_wifi_neigh_probe(struct bat
+  */
+ static void batadv_v_elp_periodic_work(struct work_struct *work)
+ {
++	struct batadv_v_metric_queue_entry *metric_entry;
++	struct batadv_v_metric_queue_entry *metric_safe;
+ 	struct batadv_hardif_neigh_node *hardif_neigh;
+ 	struct batadv_hard_iface *hard_iface;
+ 	struct batadv_hard_iface_bat_v *bat_v;
+ 	struct batadv_elp_packet *elp_packet;
++	struct list_head metric_queue;
+ 	struct batadv_priv *bat_priv;
+ 	struct sk_buff *skb;
+ 	u32 elp_interval;
+-	bool ret;
+ 
+ 	bat_v = container_of(work, struct batadv_hard_iface_bat_v, elp_wq.work);
+ 	hard_iface = container_of(bat_v, struct batadv_hard_iface, bat_v);
+@@ -316,6 +327,8 @@ static void batadv_v_elp_periodic_work(s
+ 
+ 	atomic_inc(&hard_iface->bat_v.elp_seqno);
+ 
++	INIT_LIST_HEAD(&metric_queue);
++
+ 	/* The throughput metric is updated on each sent packet. This way, if a
+ 	 * node is dead and no longer sends packets, batman-adv is still able to
+ 	 * react timely to its death.
+@@ -340,16 +353,28 @@ static void batadv_v_elp_periodic_work(s
+ 
+ 		/* Reading the estimated throughput from cfg80211 is a task that
+ 		 * may sleep and that is not allowed in an rcu protected
+-		 * context. Therefore schedule a task for that.
++		 * context. Therefore add it to metric_queue and process it
++		 * outside rcu protected context.
+ 		 */
+-		ret = queue_work(batadv_event_workqueue,
+-				 &hardif_neigh->bat_v.metric_work);
+-
+-		if (!ret)
++		metric_entry = kzalloc(sizeof(*metric_entry), GFP_ATOMIC);
++		if (!metric_entry) {
+ 			batadv_hardif_neigh_put(hardif_neigh);
++			continue;
++		}
++
++		metric_entry->hardif_neigh = hardif_neigh;
++		list_add(&metric_entry->list, &metric_queue);
+ 	}
+ 	rcu_read_unlock();
+ 
++	list_for_each_entry_safe(metric_entry, metric_safe, &metric_queue, list) {
++		batadv_v_elp_throughput_metric_update(metric_entry->hardif_neigh);
++
++		batadv_hardif_neigh_put(metric_entry->hardif_neigh);
++		list_del(&metric_entry->list);
++		kfree(metric_entry);
++	}
++
+ restart_timer:
+ 	batadv_v_elp_start_timer(hard_iface);
+ out:
+--- a/net/batman-adv/bat_v_elp.h
++++ b/net/batman-adv/bat_v_elp.h
+@@ -10,7 +10,6 @@
+ #include "main.h"
+ 
+ #include <linux/skbuff.h>
+-#include <linux/workqueue.h>
+ 
+ int batadv_v_elp_iface_enable(struct batadv_hard_iface *hard_iface);
+ void batadv_v_elp_iface_disable(struct batadv_hard_iface *hard_iface);
+@@ -19,6 +18,5 @@ void batadv_v_elp_iface_activate(struct
+ void batadv_v_elp_primary_iface_set(struct batadv_hard_iface *primary_iface);
+ int batadv_v_elp_packet_recv(struct sk_buff *skb,
+ 			     struct batadv_hard_iface *if_incoming);
+-void batadv_v_elp_throughput_metric_update(struct work_struct *work);
+ 
+ #endif /* _NET_BATMAN_ADV_BAT_V_ELP_H_ */
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -596,9 +596,6 @@ struct batadv_hardif_neigh_node_bat_v {
+ 	 *  neighbor
+ 	 */
+ 	unsigned long last_unicast_tx;
+-
+-	/** @metric_work: work queue callback item for metric update */
+-	struct work_struct metric_work;
+ };
+ 
+ /**

--- a/feeds/batman/batman-adv/patches/0019-batman-adv-Ignore-own-maximum-aggregation-size-durin.patch
+++ b/feeds/batman/batman-adv/patches/0019-batman-adv-Ignore-own-maximum-aggregation-size-durin.patch
@@ -1,0 +1,46 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 2 Feb 2025 17:04:13 +0100
+Subject: batman-adv: Ignore own maximum aggregation size during RX
+
+An OGMv1 and OGMv2 packet receive processing were not only limited by the
+number of bytes in the received packet but also by the nodes maximum
+aggregation packet size limit. But this limit is relevant for TX and not
+for RX. It must not be enforced by batadv_(i)v_ogm_aggr_packet to avoid
+loss of information in case of a different limit for sender and receiver.
+
+This has a minor side effect for B.A.T.M.A.N. IV because the
+batadv_iv_ogm_aggr_packet is also used for the preprocessing for the TX.
+But since the aggregation code itself will not allow more than
+BATADV_MAX_AGGREGATION_BYTES bytes, this check was never triggering (in
+this context) prior of removing it.
+
+Fixes: b780db96954a ("add packet aggregation add jitter for rebroadcast of packets if aggregation is disabled")
+Fixes: 667996ebeab4 ("batman-adv: OGMv2 - implement originators logic")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/7e6b4d0619fe2754787078c23c16c6a7ddb126eb
+
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -324,8 +324,7 @@ batadv_iv_ogm_aggr_packet(int buff_pos,
+ 	/* check if there is enough space for the optional TVLV */
+ 	next_buff_pos += ntohs(ogm_packet->tvlv_len);
+ 
+-	return (next_buff_pos <= packet_len) &&
+-	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
++	return next_buff_pos <= packet_len;
+ }
+ 
+ /* send a batman ogm to a given interface */
+--- a/net/batman-adv/bat_v_ogm.c
++++ b/net/batman-adv/bat_v_ogm.c
+@@ -839,8 +839,7 @@ batadv_v_ogm_aggr_packet(int buff_pos, i
+ 	/* check if there is enough space for the optional TVLV */
+ 	next_buff_pos += ntohs(ogm2_packet->tvlv_len);
+ 
+-	return (next_buff_pos <= packet_len) &&
+-	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
++	return next_buff_pos <= packet_len;
+ }
+ 
+ /**

--- a/feeds/batman/batman-adv/patches/0020-batman-adv-fix-duplicate-MAC-address-check.patch
+++ b/feeds/batman/batman-adv/patches/0020-batman-adv-fix-duplicate-MAC-address-check.patch
@@ -1,0 +1,105 @@
+From: Matthias Schiffer <mschiffer@universe-factory.net>
+Date: Wed, 16 Apr 2025 20:37:56 +0200
+Subject: batman-adv: fix duplicate MAC address check
+
+batadv_check_known_mac_addr() is both too lenient and too strict:
+
+- It is called from batadv_hardif_add_interface(), which means that it
+  checked interfaces that are not used for batman-adv at all. Move it
+  to batadv_hardif_enable_interface(). Also, restrict it to hardifs of
+  the same mesh interface; different mesh interfaces should not interact
+  at all. The batadv_check_known_mac_addr() argument is changed from
+  `struct net_device` to `struct batadv_hard_iface` to achieve this.
+- The check only cares about hardifs in BATADV_IF_ACTIVE and
+  BATADV_IF_TO_BE_ACTIVATED states, but interfaces in BATADV_IF_INACTIVE
+  state should be checked as well, or the following steps will not
+  result in a warning then they should:
+
+  - Add two interfaces in down state with different MAC addresses to
+    a mesh as hardifs
+  - Change the MAC addresses so they conflict
+  - Set interfaces to up state
+
+  Now there will be two active hardifs with the same MAC address, but no
+  warning. Fix by only ignoring hardifs in BATADV_IF_NOT_IN_USE state.
+
+The RCU lock can be dropped, as we're holding RTNL anyways when the
+function is called.
+
+Fixes: c7560658b16b ("[batman-adv] print a warning when an existing mac address is added again")
+Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 4a2b85600c38876b6c76eb7e75d76aef2c60a055)
+
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -504,28 +504,32 @@ batadv_hardif_is_iface_up(const struct b
+ 	return false;
+ }
+ 
+-static void batadv_check_known_mac_addr(const struct net_device *net_dev)
++static void batadv_check_known_mac_addr(const struct batadv_hard_iface *hard_iface)
+ {
+-	const struct batadv_hard_iface *hard_iface;
++	const struct net_device *soft_iface = hard_iface->soft_iface;
++	const struct batadv_hard_iface *tmp_hard_iface;
+ 
+-	rcu_read_lock();
+-	list_for_each_entry_rcu(hard_iface, &batadv_hardif_list, list) {
+-		if (hard_iface->if_status != BATADV_IF_ACTIVE &&
+-		    hard_iface->if_status != BATADV_IF_TO_BE_ACTIVATED)
++	if (!soft_iface)
++		return;
++
++	list_for_each_entry(tmp_hard_iface, &batadv_hardif_list, list) {
++		if (tmp_hard_iface == hard_iface)
++			continue;
++
++		if (tmp_hard_iface->soft_iface != soft_iface)
+ 			continue;
+ 
+-		if (hard_iface->net_dev == net_dev)
++		if (tmp_hard_iface->if_status == BATADV_IF_NOT_IN_USE)
+ 			continue;
+ 
+-		if (!batadv_compare_eth(hard_iface->net_dev->dev_addr,
+-					net_dev->dev_addr))
++		if (!batadv_compare_eth(tmp_hard_iface->net_dev->dev_addr,
++					hard_iface->net_dev->dev_addr))
+ 			continue;
+ 
+ 		pr_warn("The newly added mac address (%pM) already exists on: %s\n",
+-			net_dev->dev_addr, hard_iface->net_dev->name);
++			hard_iface->net_dev->dev_addr, tmp_hard_iface->net_dev->name);
+ 		pr_warn("It is strongly recommended to keep mac addresses unique to avoid problems!\n");
+ 	}
+-	rcu_read_unlock();
+ }
+ 
+ /**
+@@ -758,6 +762,8 @@ int batadv_hardif_enable_interface(struc
+ 			    hard_iface->net_dev->name, hard_iface->net_dev->mtu,
+ 			    ETH_DATA_LEN + max_header_len);
+ 
++	batadv_check_known_mac_addr(hard_iface);
++
+ 	if (batadv_hardif_is_iface_up(hard_iface))
+ 		batadv_hardif_activate_interface(hard_iface);
+ 	else
+@@ -896,7 +902,6 @@ batadv_hardif_add_interface(struct net_d
+ 
+ 	batadv_v_hardif_init(hard_iface);
+ 
+-	batadv_check_known_mac_addr(hard_iface->net_dev);
+ 	kref_get(&hard_iface->refcount);
+ 	list_add_tail_rcu(&hard_iface->list, &batadv_hardif_list);
+ 	batadv_hardif_generation++;
+@@ -988,7 +993,7 @@ static int batadv_hard_if_event(struct n
+ 		if (hard_iface->if_status == BATADV_IF_NOT_IN_USE)
+ 			goto hardif_put;
+ 
+-		batadv_check_known_mac_addr(hard_iface->net_dev);
++		batadv_check_known_mac_addr(hard_iface);
+ 
+ 		bat_priv = netdev_priv(hard_iface->soft_iface);
+ 		bat_priv->algo_ops->iface.update_mac(hard_iface);

--- a/feeds/batman/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
+++ b/feeds/batman/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
@@ -1,0 +1,397 @@
+From 2112a502a97b3b7196faeeb8d48dcc3a1fbb0796 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 13:51:37 +0100
+Subject: [PATCH] batman-adv: add dynamic, bridged-in TT VID detection support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far, if we wanted to bridge VLAN tagged frames into the mesh one would
+need to manually create an according VLAN interface on top of bat0
+first, to trigger batman-adv to create the according structures
+for a VID.
+
+With this change the VLAN from bridged-in clients is now automatically
+detected and added to the translation table on the fly.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/hard-interface.c    |   2 +-
+ net/batman-adv/multicast.c         |   8 +-
+ net/batman-adv/soft-interface.c    | 123 ++++++++++++++++-------------
+ net/batman-adv/soft-interface.h    |   6 +-
+ net/batman-adv/translation-table.c |  19 ++---
+ net/batman-adv/translation-table.h |   4 +-
+ 6 files changed, 91 insertions(+), 71 deletions(-)
+
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 41c1ad33..f4828248 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -928,7 +928,7 @@ static int batadv_hard_if_event_softif(unsigned long event,
+ 	switch (event) {
+ 	case NETDEV_REGISTER:
+ 		bat_priv = netdev_priv(net_dev);
+-		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
++		batadv_softif_create_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 		break;
+ 	}
+ 
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 27511a06..4a6079db 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -692,6 +692,7 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ {
+ 	struct batadv_hw_addr *mcast_entry;
+ 	struct hlist_node *tmp;
++	int ret;
+ 
+ 	if (!mcast_list)
+ 		return;
+@@ -701,9 +702,10 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ 						  &bat_priv->mcast.mla_list))
+ 			continue;
+ 
+-		if (!batadv_tt_local_add(bat_priv->soft_iface,
+-					 mcast_entry->addr, BATADV_NO_FLAGS,
+-					 BATADV_NULL_IFINDEX, BATADV_NO_MARK))
++		ret = batadv_tt_local_add(bat_priv->soft_iface,
++					  mcast_entry->addr, BATADV_NO_FLAGS,
++					  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++		if (ret <= 0)
+ 			continue;
+ 
+ 		hlist_del(&mcast_entry->list);
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index d3fdf822..079d030e 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -141,6 +141,10 @@ static int batadv_interface_set_mac_addr(struct net_device *dev, void *p)
+ 
+ 	rcu_read_lock();
+ 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
++		/* we don't use this VID ourself, avoid adding us to it */
++		if (!batadv_is_my_client(bat_priv, old_addr, vlan->vid))
++			continue;
++
+ 		batadv_tt_local_remove(bat_priv, old_addr, vlan->vid,
+ 				       "mac address changed", false);
+ 		batadv_tt_local_add(dev, addr->sa_data, vlan->vid,
+@@ -543,13 +547,15 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ }
+ 
+ /**
+- * batadv_softif_create_vlan() - allocate the needed resources for a new vlan
++ * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
+  *
+- * Return: 0 on success, a negative error otherwise.
++ * Return: a pointer to a newly allocated softif vlan struct on success, NULL
++ * otherwise.
+  */
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++static struct batadv_softif_vlan *
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ {
+ 	struct batadv_softif_vlan *vlan;
+ 
+@@ -557,55 +563,94 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 	if (vlan) {
+-		batadv_softif_vlan_put(vlan);
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -EEXIST;
++		return vlan;
+ 	}
+ 
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -ENOMEM;
++		return NULL;
+ 	}
+ 
+ 	vlan->bat_priv = bat_priv;
+ 	vlan->vid = vid;
++	/* hold only one refcount, caller will store a reference to us in
++	 * tt_local->vlan without releasing any refcount
++	 */
+ 	kref_init(&vlan->refcount);
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
+-	kref_get(&vlan->refcount);
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
++	return vlan;
++}
++
++/**
++ * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
++ * @bat_priv: the batpriv ith all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Return : the softif vlan struct if found or created, NULL otherwise
++ */
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid)
++{
++	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
++
++	if (vlan)
++		return vlan;
++
++	return batadv_softif_create_vlan(bat_priv, vid);
++}
++
++/**
++ * batadv_softif_create_vlan_own() - add our own softif to the local TT
++ * @bat_priv: the bat priv with all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Adds the MAC address of our own mesh interface with the given VLAN ID as
++ * a permanent local TT entry.
++ *
++ * Return: 0 on success, a negative error otherwise.
++ */
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid)
++{
++	int ret;
++
+ 	/* add a new TT local entry. This one will be marked with the NOPURGE
+ 	 * flag
+ 	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++	ret = batadv_tt_local_add(bat_priv->soft_iface,
++				  bat_priv->soft_iface->dev_addr, vid,
++				  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+ 
+-	/* don't return reference to new softif_vlan */
+-	batadv_softif_vlan_put(vlan);
++	if (ret < 0)
++		return ret;
+ 
+ 	return 0;
+ }
+ 
+ /**
+- * batadv_softif_destroy_vlan() - remove and destroy a softif_vlan object
++ * batadv_softif_destroy_vlan_own() - remove our own softif from the local TT
+  * @bat_priv: the bat priv with all the soft interface information
+- * @vlan: the object to remove
++ * @vid: the VLAN identifier
++ *
++ * Removes the MAC address of our own soft interface with the given VLAN ID from
++ * the local TT.
+  */
+-static void batadv_softif_destroy_vlan(struct batadv_priv *bat_priv,
+-				       struct batadv_softif_vlan *vlan)
++static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
++					   unsigned short vid)
+ {
+ 	/* explicitly remove the associated TT local entry because it is marked
+ 	 * with the NOPURGE flag
+ 	 */
+-	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr,
+-			       vlan->vid, "vlan interface destroyed", false);
+-
+-	batadv_softif_vlan_put(vlan);
++	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr, vid,
++			       "vlan interface destroyed", false);
+ }
+ 
+ /**
+@@ -623,7 +668,6 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -633,25 +677,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+-	/* if a new vlan is getting created and it already exists, it means that
+-	 * it was not deleted yet. batadv_softif_vlan_get() increases the
+-	 * refcount in order to revive the object.
+-	 *
+-	 * if it does not exist then create it.
+-	 */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
+-	if (!vlan)
+-		return batadv_softif_create_vlan(bat_priv, vid);
+-
+-	/* add a new TT local entry. This one will be marked with the NOPURGE
+-	 * flag. This must be added again, even if the vlan object already
+-	 * exists, because the entry was deleted by kill_vid()
+-	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+-
+-	return 0;
++	return batadv_softif_create_vlan_own(bat_priv, vid);
+ }
+ 
+ /**
+@@ -670,7 +696,6 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -678,15 +703,8 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
+-	vlan = batadv_softif_vlan_get(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+-	if (!vlan)
+-		return -ENOENT;
+-
+-	batadv_softif_destroy_vlan(bat_priv, vlan);
+-
+-	/* finally free the vlan object */
+-	batadv_softif_vlan_put(vlan);
+ 
++	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+ }
+ 
+@@ -1080,7 +1098,6 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	list_for_each_entry(hard_iface, &batadv_hardif_list, list) {
+ 		if (hard_iface->soft_iface == soft_iface)
+@@ -1088,11 +1105,7 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ 	}
+ 
+ 	/* destroy the "untagged" VLAN */
+-	vlan = batadv_softif_vlan_get(bat_priv, BATADV_NO_FLAGS);
+-	if (vlan) {
+-		batadv_softif_destroy_vlan(bat_priv, vlan);
+-		batadv_softif_vlan_put(vlan);
+-	}
++	batadv_softif_destroy_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 
+ 	unregister_netdevice_queue(soft_iface, head);
+ }
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 9f2003f1..7050ccd3 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -21,10 +21,14 @@ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct batadv_orig_node *orig_node);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid);
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid);
+ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 36ca3125..a66be4f7 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -632,8 +632,8 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+  *
+  * Return: true if the client was successfully added, false otherwise.
+  */
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark)
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+@@ -645,10 +645,10 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	struct hlist_head *head;
+ 	struct batadv_tt_orig_list_entry *orig_entry;
+ 	int hash_added, table_size, packet_size_max;
+-	bool ret = false;
+ 	bool roamed_back = false;
+ 	u8 remote_flags;
+ 	u32 match_mark;
++	int ret = 0;
+ 
+ 	if (ifindex != BATADV_NULL_IFINDEX)
+ 		in_dev = dev_get_by_index(net, ifindex);
+@@ -699,21 +699,22 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 		net_ratelimited_function(batadv_info, soft_iface,
+ 					 "Local translation table size (%i) exceeds maximum packet size (%i); Ignoring new local tt entry: %pM\n",
+ 					 table_size, packet_size_max, addr);
++		ret = -E2BIG;
+ 		goto out;
+ 	}
+ 
+ 	tt_local = kmem_cache_alloc(batadv_tl_cache, GFP_ATOMIC);
+-	if (!tt_local)
++	if (!tt_local) {
++		ret = -ENOMEM;
+ 		goto out;
++	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
+ 	if (!vlan) {
+-		net_ratelimited_function(batadv_info, soft_iface,
+-					 "adding TT local entry %pM to non-existent VLAN %d\n",
+-					 addr, batadv_print_vid(vid));
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
++		ret = -ENOMEM;
+ 		goto out;
+ 	}
+ 
+@@ -811,7 +812,7 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	if (remote_flags ^ (tt_local->common.flags & BATADV_TT_REMOTE_MASK))
+ 		batadv_tt_local_event(bat_priv, tt_local, BATADV_NO_FLAGS);
+ 
+-	ret = true;
++	ret = 1;
+ out:
+ 	batadv_hardif_put(in_hardif);
+ 	dev_put(in_dev);
+diff --git a/net/batman-adv/translation-table.h b/net/batman-adv/translation-table.h
+index d18740d9..bbdda848 100644
+--- a/net/batman-adv/translation-table.h
++++ b/net/batman-adv/translation-table.h
+@@ -16,8 +16,8 @@
+ #include <linux/types.h>
+ 
+ int batadv_tt_init(struct batadv_priv *bat_priv);
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark);
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark);
+ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv,
+ 			   const u8 *addr, unsigned short vid,
+ 			   const char *message, bool roaming);
+-- 
+2.52.0
+

--- a/feeds/batman/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
+++ b/feeds/batman/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
@@ -1,0 +1,248 @@
+From f142435963da7d4c32c64f3f7c59b3dfaaa962fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:13:49 +0100
+Subject: [PATCH] batman-adv: limit number of learned VLANs from bridged-in
+ clients
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently with batman-adv compatibility version 15 each added VLAN
+increases the OGM protocol overhead of this node considerably. Therefore
+adding a configurable knob to limit the number of learned, snooped VLANs
+from traffic from bridged-in clients.
+
+There are currently also still issues in the BLA code that would
+temporarily break any broadcast transmissions with every newly learned
+VLAN. Therefore setting the default limit for externally learned VLANs to
+zero for now.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ include/uapi/linux/batman_adv.h    |  6 ++++++
+ net/batman-adv/netlink.c           | 15 ++++++++++++++
+ net/batman-adv/soft-interface.c    | 33 ++++++++++++++++++++++++++----
+ net/batman-adv/soft-interface.h    |  4 ++--
+ net/batman-adv/translation-table.c |  3 ++-
+ net/batman-adv/types.h             |  6 ++++++
+ 6 files changed, 60 insertions(+), 7 deletions(-)
+
+diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+index 35dc016c..44018dd6 100644
+--- a/include/uapi/linux/batman_adv.h
++++ b/include/uapi/linux/batman_adv.h
+@@ -481,6 +481,12 @@ enum batadv_nl_attrs {
+ 	 */
+ 	BATADV_ATTR_MULTICAST_FANOUT,
+ 
++	/**
++	 * @BATADV_ATTR_VLAN_DYN_MAX: defines the maximum number of allowed
++	 * learned VLANs from bridged-in clients.
++	 */
++	BATADV_ATTR_VLAN_DYN_MAX,
++
+ 	/* add attributes above here, update the policy in netlink.c */
+ 
+ 	/**
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index 07f21cdb..afbd1446 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -131,6 +131,7 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+ 	[BATADV_ATTR_MCAST_FLAGS]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_MCAST_FLAGS_PRIV]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_VLANID]			= { .type = NLA_U16 },
++	[BATADV_ATTR_VLAN_DYN_MAX]		= { .type = NLA_U16 },
+ 	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+@@ -359,6 +360,10 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+ 			atomic_read(&bat_priv->orig_interval)))
+ 		goto nla_put_failure;
+ 
++	if (nla_put_u16(msg, BATADV_ATTR_VLAN_DYN_MAX,
++			bat_priv->softif_vlan_dyn_max))
++		goto nla_put_failure;
++
+ 	batadv_hardif_put(primary_if);
+ 
+ 	genlmsg_end(msg, hdr);
+@@ -613,6 +618,16 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+ 		atomic_set(&bat_priv->orig_interval, orig_interval);
+ 	}
+ 
++	if (info->attrs[BATADV_ATTR_VLAN_DYN_MAX]) {
++		u16 vlan_dyn_max;
++
++		attr = info->attrs[BATADV_ATTR_VLAN_DYN_MAX];
++		vlan_dyn_max = nla_get_u16(attr);
++		vlan_dyn_max = min_t(u16, vlan_dyn_max, VLAN_N_VID);
++
++		bat_priv->softif_vlan_dyn_max = vlan_dyn_max;
++	}
++
+ 	batadv_netlink_notify_mesh(bat_priv);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index 079d030e..a04b4978 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -23,6 +23,7 @@
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
++#include <linux/net.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/percpu.h>
+@@ -46,6 +47,7 @@
+ #include "distributed-arp-table.h"
+ #include "gateway_client.h"
+ #include "hard-interface.h"
++#include "log.h"
+ #include "multicast.h"
+ #include "network-coding.h"
+ #include "send.h"
+@@ -550,13 +552,16 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+  * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return: a pointer to a newly allocated softif vlan struct on success, NULL
+  * otherwise.
+  */
+ static struct batadv_softif_vlan *
+-batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid,
++			  bool own)
+ {
++	unsigned short vlan_dyn_max, vlan_dyn_count;
+ 	struct batadv_softif_vlan *vlan;
+ 
+ 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -567,6 +572,19 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 		return vlan;
+ 	}
+ 
++	vlan_dyn_max = bat_priv->softif_vlan_dyn_max;
++	vlan_dyn_count = bat_priv->softif_vlan_dyn_count;
++
++	if (vid & BATADV_VLAN_HAS_TAG && !own &&
++	    vlan_dyn_max <= vlan_dyn_count) {
++		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
++
++		net_ratelimited_function(batadv_info, bat_priv->soft_iface,
++					 "not adding VLAN %d, already learned %hu VID(s)\n",
++					 batadv_print_vid(vid), vlan_dyn_max);
++		return NULL;
++	}
++
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -582,6 +600,9 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
++	if (vid & BATADV_VLAN_HAS_TAG && !own)
++		bat_priv->softif_vlan_dyn_count++;
++
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
+@@ -591,20 +612,22 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ /**
+  * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
+  * @bat_priv: the batpriv ith all the mesh interface information
++ * @addr: the MAC address of the client to add
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return : the softif vlan struct if found or created, NULL otherwise
+  */
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid)
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own)
+ {
+ 	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 
+ 	if (vlan)
+ 		return vlan;
+ 
+-	return batadv_softif_create_vlan(bat_priv, vid);
++	return batadv_softif_create_vlan(bat_priv, vid, own);
+ }
+ 
+ /**
+@@ -805,6 +828,8 @@ static int batadv_softif_init_late(struct net_device *dev)
+ 	bat_priv->tt.last_changeset_len = 0;
+ 	bat_priv->isolation_mark = 0;
+ 	bat_priv->isolation_mark_mask = 0;
++	bat_priv->softif_vlan_dyn_max = 20;
++	bat_priv->softif_vlan_dyn_count = 0;
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 7050ccd3..6ce30fe9 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -27,8 +27,8 @@ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid);
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index a66be4f7..a88b462c 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -635,6 +635,7 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 			unsigned short vid, int ifindex, u32 mark)
+ {
++	bool own = (ifindex == BATADV_NULL_IFINDEX) ? true : false;
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+ 	struct batadv_tt_global_entry *tt_global = NULL;
+@@ -710,7 +711,7 @@ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, addr, vid, own);
+ 	if (!vlan) {
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index ca9449ec..416b4e2f 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1695,6 +1695,12 @@ struct batadv_priv {
+ 	/** @softif_vlan_list_lock: lock protecting softif_vlan_list */
+ 	spinlock_t softif_vlan_list_lock;
+ 
++	/** @softif_vlan_dyn_max: maximum number of allowed learned VLANs */
++	unsigned short softif_vlan_dyn_max;
++
++	/** @softif_vlan_dyn_count: current number of learned VLANs */
++	unsigned short softif_vlan_dyn_count;
++
+ #ifdef CONFIG_BATMAN_ADV_BLA
+ 	/** @bla: bridge loop avoidance data */
+ 	struct batadv_priv_bla bla;
+-- 
+2.52.0
+

--- a/feeds/batman/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
+++ b/feeds/batman/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
@@ -1,0 +1,191 @@
+From 6ab36677fa236fcba7875f4d4583fd4b7047bad2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:21:23 +0100
+Subject: [PATCH] batman-adv: avoid adding bridge VLAN IDs through
+ ndo_vlan_rx_add_vid()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Linux bridge by default adds the PVID of a port (default VID 1) and
+by that triggers our ndo_vlan_rx_add_vid() handler. The PVID is
+for ingress traffic from bat0 to the bridge and other bridge ports.
+However this makes no statement about what is received or send on bat0
+itself, bat0 might as well be an untagged access port, even with a PVID
+configured. Therefore ignoring here when a bridge is involved.
+
+Also, similarly a "bridge vlan add vid 42 dev bat0 untagged" would call
+this handler with VID 42. Even though we wouldn't be interested in this
+VLAN as its traffic would be untagged on our side.
+
+The issue is that any extra VLAN currently increases our own
+OGM protocol overhead quite a bit, so we want to avoid that
+by only adding VLANs that we are sure someone will be using.
+So only add VLANs through snooping of actual, VLAN tagged
+traffic, not through kernel internal network events
+if we have a bridge on top.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/multicast.c      | 29 ++-------------------
+ net/batman-adv/soft-interface.c | 46 +++++++++++++++++++++++++++++++++
+ net/batman-adv/soft-interface.h |  1 +
+ 3 files changed, 49 insertions(+), 27 deletions(-)
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 4a6079db..541c0c4d 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -72,31 +72,6 @@ static void batadv_mcast_start_timer(struct batadv_priv *bat_priv)
+ 			   msecs_to_jiffies(BATADV_MCAST_WORK_PERIOD));
+ }
+ 
+-/**
+- * batadv_mcast_get_bridge() - get the bridge on top of the softif if it exists
+- * @soft_iface: netdev struct of the mesh interface
+- *
+- * If the given soft interface has a bridge on top then the refcount
+- * of the according net device is increased.
+- *
+- * Return: NULL if no such bridge exists. Otherwise the net device of the
+- * bridge.
+- */
+-static struct net_device *batadv_mcast_get_bridge(struct net_device *soft_iface)
+-{
+-	struct net_device *upper = soft_iface;
+-
+-	rcu_read_lock();
+-	do {
+-		upper = netdev_master_upper_dev_get_rcu(upper);
+-	} while (upper && !netif_is_bridge_master(upper));
+-
+-	dev_hold(upper);
+-	rcu_read_unlock();
+-
+-	return upper;
+-}
+-
+ /**
+  * batadv_mcast_mla_rtr_flags_softif_get_ipv4() - get mcast router flags from
+  *  node for IPv4
+@@ -258,7 +233,7 @@ batadv_mcast_mla_flags_get(struct batadv_priv *bat_priv)
+ 	struct batadv_mcast_mla_flags mla_flags;
+ 	struct net_device *bridge;
+ 
+-	bridge = batadv_mcast_get_bridge(dev);
++	bridge = batadv_softif_get_bridge(dev);
+ 
+ 	memset(&mla_flags, 0, sizeof(mla_flags));
+ 	mla_flags.enabled = 1;
+@@ -499,7 +474,7 @@ batadv_mcast_mla_softif_get(struct net_device *dev,
+ 			    struct hlist_head *mcast_list,
+ 			    struct batadv_mcast_mla_flags *flags)
+ {
+-	struct net_device *bridge = batadv_mcast_get_bridge(dev);
++	struct net_device *bridge = batadv_softif_get_bridge(dev);
+ 	int ret4, ret6 = 0;
+ 
+ 	if (bridge)
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index a04b4978..90501c09 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -676,6 +676,31 @@ static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
+ 			       "vlan interface destroyed", false);
+ }
+ 
++/**
++ * batadv_softif_get_bridge() - get the bridge on top of the softif if it exists
++ * @mesh_iface: netdev struct of the mesh interface
++ *
++ * If the given mesh interface has a bridge on top then the refcount
++ * of the according net device is increased.
++ *
++ * Return: NULL if no such bridge exists. Otherwise the net device of the
++ * bridge.
++ */
++struct net_device *batadv_softif_get_bridge(struct net_device *mesh_iface)
++{
++	struct net_device *upper = mesh_iface;
++
++	rcu_read_lock();
++	do {
++		upper = netdev_master_upper_dev_get_rcu(upper);
++	} while (upper && !netif_is_bridge_master(upper));
++
++	dev_hold(upper);
++	rcu_read_unlock();
++
++	return upper;
++}
++
+ /**
+  * batadv_interface_add_vid() - ndo_add_vid API implementation
+  * @dev: the netdev of the mesh interface
+@@ -691,6 +716,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -698,6 +724,20 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	/* The Linux bridge adds the PVID of a port (default VID 1) and
++	 * triggers this handler. The PVID is for ingress traffic from
++	 * bat0 to the bridge and other bridge ports. However this makes no
++	 * statement about what is received or send on bat0 itself, bat0
++	 * might as well be an untagged access port, even with a PVID
++	 * configured. Therefore ignoring here when a bridge is involved.
++	 * Instead learn VLANs on the fly from traffic.
++	 */
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
++
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+ 	return batadv_softif_create_vlan_own(bat_priv, vid);
+@@ -719,6 +759,7 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -726,6 +767,11 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
+ 
+ 	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 6ce30fe9..b2784ecf 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -19,6 +19,7 @@ int batadv_skb_head_push(struct sk_buff *skb, unsigned int len);
+ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct sk_buff *skb, int hdr_size,
+ 			 struct batadv_orig_node *orig_node);
++struct net_device *batadv_softif_get_bridge(struct net_device *soft_iface);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+ int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
+-- 
+2.52.0
+

--- a/feeds/batman/batman-adv/src/compat-hacks.h
+++ b/feeds/batman/batman-adv/src/compat-hacks.h
@@ -1,0 +1,121 @@
+/* Please avoid adding hacks here - instead add it to mac80211/backports.git */
+
+#undef CONFIG_MODULE_STRIPPED
+
+#include <linux/version.h>	/* LINUX_VERSION_CODE */
+#include <linux/types.h>
+
+#if LINUX_VERSION_IS_LESS(6, 0, 0)
+
+#define __vstring(item, fmt, ap) __dynamic_array(char, item, 256)
+#define __assign_vstr(dst, fmt, va) \
+	WARN_ON_ONCE(vsnprintf(__get_dynamic_array(dst), 256, fmt, *va) >= 256)
+
+#endif /* LINUX_VERSION_IS_LESS(6, 0, 0) */
+
+#if LINUX_VERSION_IS_LESS(6, 2, 0)
+
+#include <linux/random.h>
+
+#define genl_split_ops genl_ops
+
+static inline u32 batadv_get_random_u32_below(u32 ep_ro)
+{
+	return prandom_u32_max(ep_ro);
+}
+
+#define get_random_u32_below batadv_get_random_u32_below
+
+#endif /* LINUX_VERSION_IS_LESS(6, 2, 0) */
+
+#if LINUX_VERSION_IS_LESS(6, 4, 0) && \
+    !(LINUX_VERSION_IS_GEQ(5, 10, 205) && LINUX_VERSION_IS_LESS(5, 11, 0)) && \
+    !(LINUX_VERSION_IS_GEQ(5, 15, 144) && LINUX_VERSION_IS_LESS(5, 16, 0)) && \
+    !(LINUX_VERSION_IS_GEQ(6, 1, 69) && LINUX_VERSION_IS_LESS(6, 2, 0))
+
+#include <linux/if_vlan.h>
+
+/* Prefer this version in TX path, instead of
+ * skb_reset_mac_header() + vlan_eth_hdr()
+ */
+static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
+{
+	return (struct vlan_ethhdr *)skb->data;
+}
+
+#endif /* LINUX_VERSION_IS_LESS(6, 4, 0) */
+
+/* <DECLARE_EWMA> */
+
+#include <linux/version.h>
+#include_next <linux/average.h>
+
+#include <linux/bug.h>
+
+#ifdef DECLARE_EWMA
+#undef DECLARE_EWMA
+#endif /* DECLARE_EWMA */
+
+/*
+ * Exponentially weighted moving average (EWMA)
+ *
+ * This implements a fixed-precision EWMA algorithm, with both the
+ * precision and fall-off coefficient determined at compile-time
+ * and built into the generated helper funtions.
+ *
+ * The first argument to the macro is the name that will be used
+ * for the struct and helper functions.
+ *
+ * The second argument, the precision, expresses how many bits are
+ * used for the fractional part of the fixed-precision values.
+ *
+ * The third argument, the weight reciprocal, determines how the
+ * new values will be weighed vs. the old state, new values will
+ * get weight 1/weight_rcp and old values 1-1/weight_rcp. Note
+ * that this parameter must be a power of two for efficiency.
+ */
+
+#define DECLARE_EWMA(name, _precision, _weight_rcp)			\
+	struct ewma_##name {						\
+		unsigned long internal;					\
+	};								\
+	static inline void ewma_##name##_init(struct ewma_##name *e)	\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		/*							\
+		 * Even if you want to feed it just 0/1 you should have	\
+		 * some bits for the non-fractional part...		\
+		 */							\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+		e->internal = 0;					\
+	}								\
+	static inline unsigned long					\
+	ewma_##name##_read(struct ewma_##name *e)			\
+	{								\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+		return e->internal >> (_precision);			\
+	}								\
+	static inline void ewma_##name##_add(struct ewma_##name *e,	\
+					     unsigned long val)		\
+	{								\
+		unsigned long internal = READ_ONCE(e->internal);	\
+		unsigned long weight_rcp = ilog2(_weight_rcp);		\
+		unsigned long precision = _precision;			\
+									\
+		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+		BUILD_BUG_ON((_precision) > 30);			\
+		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+									\
+		WRITE_ONCE(e->internal, internal ?			\
+			(((internal << weight_rcp) - internal) +	\
+				(val << precision)) >> weight_rcp :	\
+			(val << precision));				\
+	}
+
+/* </DECLARE_EWMA> */

--- a/feeds/ipq807x_v5.4/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
+++ b/feeds/ipq807x_v5.4/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
@@ -1,0 +1,397 @@
+From 2112a502a97b3b7196faeeb8d48dcc3a1fbb0796 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 13:51:37 +0100
+Subject: [PATCH] batman-adv: add dynamic, bridged-in TT VID detection support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far, if we wanted to bridge VLAN tagged frames into the mesh one would
+need to manually create an according VLAN interface on top of bat0
+first, to trigger batman-adv to create the according structures
+for a VID.
+
+With this change the VLAN from bridged-in clients is now automatically
+detected and added to the translation table on the fly.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/hard-interface.c    |   2 +-
+ net/batman-adv/multicast.c         |   8 +-
+ net/batman-adv/soft-interface.c    | 123 ++++++++++++++++-------------
+ net/batman-adv/soft-interface.h    |   6 +-
+ net/batman-adv/translation-table.c |  19 ++---
+ net/batman-adv/translation-table.h |   4 +-
+ 6 files changed, 91 insertions(+), 71 deletions(-)
+
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 41c1ad33..f4828248 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -928,7 +928,7 @@ static int batadv_hard_if_event_softif(unsigned long event,
+ 	switch (event) {
+ 	case NETDEV_REGISTER:
+ 		bat_priv = netdev_priv(net_dev);
+-		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
++		batadv_softif_create_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 		break;
+ 	}
+ 
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 27511a06..4a6079db 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -692,6 +692,7 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ {
+ 	struct batadv_hw_addr *mcast_entry;
+ 	struct hlist_node *tmp;
++	int ret;
+ 
+ 	if (!mcast_list)
+ 		return;
+@@ -701,9 +702,10 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ 						  &bat_priv->mcast.mla_list))
+ 			continue;
+ 
+-		if (!batadv_tt_local_add(bat_priv->soft_iface,
+-					 mcast_entry->addr, BATADV_NO_FLAGS,
+-					 BATADV_NULL_IFINDEX, BATADV_NO_MARK))
++		ret = batadv_tt_local_add(bat_priv->soft_iface,
++					  mcast_entry->addr, BATADV_NO_FLAGS,
++					  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++		if (ret <= 0)
+ 			continue;
+ 
+ 		hlist_del(&mcast_entry->list);
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index d3fdf822..079d030e 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -141,6 +141,10 @@ static int batadv_interface_set_mac_addr(struct net_device *dev, void *p)
+ 
+ 	rcu_read_lock();
+ 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
++		/* we don't use this VID ourself, avoid adding us to it */
++		if (!batadv_is_my_client(bat_priv, old_addr, vlan->vid))
++			continue;
++
+ 		batadv_tt_local_remove(bat_priv, old_addr, vlan->vid,
+ 				       "mac address changed", false);
+ 		batadv_tt_local_add(dev, addr->sa_data, vlan->vid,
+@@ -543,13 +547,15 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ }
+ 
+ /**
+- * batadv_softif_create_vlan() - allocate the needed resources for a new vlan
++ * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
+  *
+- * Return: 0 on success, a negative error otherwise.
++ * Return: a pointer to a newly allocated softif vlan struct on success, NULL
++ * otherwise.
+  */
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++static struct batadv_softif_vlan *
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ {
+ 	struct batadv_softif_vlan *vlan;
+ 
+@@ -557,55 +563,94 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 	if (vlan) {
+-		batadv_softif_vlan_put(vlan);
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -EEXIST;
++		return vlan;
+ 	}
+ 
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -ENOMEM;
++		return NULL;
+ 	}
+ 
+ 	vlan->bat_priv = bat_priv;
+ 	vlan->vid = vid;
++	/* hold only one refcount, caller will store a reference to us in
++	 * tt_local->vlan without releasing any refcount
++	 */
+ 	kref_init(&vlan->refcount);
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
+-	kref_get(&vlan->refcount);
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
++	return vlan;
++}
++
++/**
++ * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
++ * @bat_priv: the batpriv ith all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Return : the softif vlan struct if found or created, NULL otherwise
++ */
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid)
++{
++	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
++
++	if (vlan)
++		return vlan;
++
++	return batadv_softif_create_vlan(bat_priv, vid);
++}
++
++/**
++ * batadv_softif_create_vlan_own() - add our own softif to the local TT
++ * @bat_priv: the bat priv with all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Adds the MAC address of our own mesh interface with the given VLAN ID as
++ * a permanent local TT entry.
++ *
++ * Return: 0 on success, a negative error otherwise.
++ */
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid)
++{
++	int ret;
++
+ 	/* add a new TT local entry. This one will be marked with the NOPURGE
+ 	 * flag
+ 	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++	ret = batadv_tt_local_add(bat_priv->soft_iface,
++				  bat_priv->soft_iface->dev_addr, vid,
++				  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+ 
+-	/* don't return reference to new softif_vlan */
+-	batadv_softif_vlan_put(vlan);
++	if (ret < 0)
++		return ret;
+ 
+ 	return 0;
+ }
+ 
+ /**
+- * batadv_softif_destroy_vlan() - remove and destroy a softif_vlan object
++ * batadv_softif_destroy_vlan_own() - remove our own softif from the local TT
+  * @bat_priv: the bat priv with all the soft interface information
+- * @vlan: the object to remove
++ * @vid: the VLAN identifier
++ *
++ * Removes the MAC address of our own soft interface with the given VLAN ID from
++ * the local TT.
+  */
+-static void batadv_softif_destroy_vlan(struct batadv_priv *bat_priv,
+-				       struct batadv_softif_vlan *vlan)
++static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
++					   unsigned short vid)
+ {
+ 	/* explicitly remove the associated TT local entry because it is marked
+ 	 * with the NOPURGE flag
+ 	 */
+-	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr,
+-			       vlan->vid, "vlan interface destroyed", false);
+-
+-	batadv_softif_vlan_put(vlan);
++	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr, vid,
++			       "vlan interface destroyed", false);
+ }
+ 
+ /**
+@@ -623,7 +668,6 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -633,25 +677,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+-	/* if a new vlan is getting created and it already exists, it means that
+-	 * it was not deleted yet. batadv_softif_vlan_get() increases the
+-	 * refcount in order to revive the object.
+-	 *
+-	 * if it does not exist then create it.
+-	 */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
+-	if (!vlan)
+-		return batadv_softif_create_vlan(bat_priv, vid);
+-
+-	/* add a new TT local entry. This one will be marked with the NOPURGE
+-	 * flag. This must be added again, even if the vlan object already
+-	 * exists, because the entry was deleted by kill_vid()
+-	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+-
+-	return 0;
++	return batadv_softif_create_vlan_own(bat_priv, vid);
+ }
+ 
+ /**
+@@ -670,7 +696,6 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -678,15 +703,8 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
+-	vlan = batadv_softif_vlan_get(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+-	if (!vlan)
+-		return -ENOENT;
+-
+-	batadv_softif_destroy_vlan(bat_priv, vlan);
+-
+-	/* finally free the vlan object */
+-	batadv_softif_vlan_put(vlan);
+ 
++	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+ }
+ 
+@@ -1080,7 +1098,6 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	list_for_each_entry(hard_iface, &batadv_hardif_list, list) {
+ 		if (hard_iface->soft_iface == soft_iface)
+@@ -1088,11 +1105,7 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ 	}
+ 
+ 	/* destroy the "untagged" VLAN */
+-	vlan = batadv_softif_vlan_get(bat_priv, BATADV_NO_FLAGS);
+-	if (vlan) {
+-		batadv_softif_destroy_vlan(bat_priv, vlan);
+-		batadv_softif_vlan_put(vlan);
+-	}
++	batadv_softif_destroy_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 
+ 	unregister_netdevice_queue(soft_iface, head);
+ }
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 9f2003f1..7050ccd3 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -21,10 +21,14 @@ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct batadv_orig_node *orig_node);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid);
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid);
+ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 36ca3125..a66be4f7 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -632,8 +632,8 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+  *
+  * Return: true if the client was successfully added, false otherwise.
+  */
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark)
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+@@ -645,10 +645,10 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	struct hlist_head *head;
+ 	struct batadv_tt_orig_list_entry *orig_entry;
+ 	int hash_added, table_size, packet_size_max;
+-	bool ret = false;
+ 	bool roamed_back = false;
+ 	u8 remote_flags;
+ 	u32 match_mark;
++	int ret = 0;
+ 
+ 	if (ifindex != BATADV_NULL_IFINDEX)
+ 		in_dev = dev_get_by_index(net, ifindex);
+@@ -699,21 +699,22 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 		net_ratelimited_function(batadv_info, soft_iface,
+ 					 "Local translation table size (%i) exceeds maximum packet size (%i); Ignoring new local tt entry: %pM\n",
+ 					 table_size, packet_size_max, addr);
++		ret = -E2BIG;
+ 		goto out;
+ 	}
+ 
+ 	tt_local = kmem_cache_alloc(batadv_tl_cache, GFP_ATOMIC);
+-	if (!tt_local)
++	if (!tt_local) {
++		ret = -ENOMEM;
+ 		goto out;
++	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
+ 	if (!vlan) {
+-		net_ratelimited_function(batadv_info, soft_iface,
+-					 "adding TT local entry %pM to non-existent VLAN %d\n",
+-					 addr, batadv_print_vid(vid));
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
++		ret = -ENOMEM;
+ 		goto out;
+ 	}
+ 
+@@ -811,7 +812,7 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	if (remote_flags ^ (tt_local->common.flags & BATADV_TT_REMOTE_MASK))
+ 		batadv_tt_local_event(bat_priv, tt_local, BATADV_NO_FLAGS);
+ 
+-	ret = true;
++	ret = 1;
+ out:
+ 	batadv_hardif_put(in_hardif);
+ 	dev_put(in_dev);
+diff --git a/net/batman-adv/translation-table.h b/net/batman-adv/translation-table.h
+index d18740d9..bbdda848 100644
+--- a/net/batman-adv/translation-table.h
++++ b/net/batman-adv/translation-table.h
+@@ -16,8 +16,8 @@
+ #include <linux/types.h>
+ 
+ int batadv_tt_init(struct batadv_priv *bat_priv);
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark);
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark);
+ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv,
+ 			   const u8 *addr, unsigned short vid,
+ 			   const char *message, bool roaming);
+-- 
+2.52.0
+

--- a/feeds/ipq807x_v5.4/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
+++ b/feeds/ipq807x_v5.4/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
@@ -1,0 +1,248 @@
+From f142435963da7d4c32c64f3f7c59b3dfaaa962fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:13:49 +0100
+Subject: [PATCH] batman-adv: limit number of learned VLANs from bridged-in
+ clients
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently with batman-adv compatibility version 15 each added VLAN
+increases the OGM protocol overhead of this node considerably. Therefore
+adding a configurable knob to limit the number of learned, snooped VLANs
+from traffic from bridged-in clients.
+
+There are currently also still issues in the BLA code that would
+temporarily break any broadcast transmissions with every newly learned
+VLAN. Therefore setting the default limit for externally learned VLANs to
+zero for now.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ include/uapi/linux/batman_adv.h    |  6 ++++++
+ net/batman-adv/netlink.c           | 15 ++++++++++++++
+ net/batman-adv/soft-interface.c    | 33 ++++++++++++++++++++++++++----
+ net/batman-adv/soft-interface.h    |  4 ++--
+ net/batman-adv/translation-table.c |  3 ++-
+ net/batman-adv/types.h             |  6 ++++++
+ 6 files changed, 60 insertions(+), 7 deletions(-)
+
+diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+index 35dc016c..44018dd6 100644
+--- a/include/uapi/linux/batman_adv.h
++++ b/include/uapi/linux/batman_adv.h
+@@ -481,6 +481,12 @@ enum batadv_nl_attrs {
+ 	 */
+ 	BATADV_ATTR_MULTICAST_FANOUT,
+ 
++	/**
++	 * @BATADV_ATTR_VLAN_DYN_MAX: defines the maximum number of allowed
++	 * learned VLANs from bridged-in clients.
++	 */
++	BATADV_ATTR_VLAN_DYN_MAX,
++
+ 	/* add attributes above here, update the policy in netlink.c */
+ 
+ 	/**
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index 07f21cdb..afbd1446 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -131,6 +131,7 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+ 	[BATADV_ATTR_MCAST_FLAGS]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_MCAST_FLAGS_PRIV]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_VLANID]			= { .type = NLA_U16 },
++	[BATADV_ATTR_VLAN_DYN_MAX]		= { .type = NLA_U16 },
+ 	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+@@ -359,6 +360,10 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+ 			atomic_read(&bat_priv->orig_interval)))
+ 		goto nla_put_failure;
+ 
++	if (nla_put_u16(msg, BATADV_ATTR_VLAN_DYN_MAX,
++			bat_priv->softif_vlan_dyn_max))
++		goto nla_put_failure;
++
+ 	batadv_hardif_put(primary_if);
+ 
+ 	genlmsg_end(msg, hdr);
+@@ -613,6 +618,16 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+ 		atomic_set(&bat_priv->orig_interval, orig_interval);
+ 	}
+ 
++	if (info->attrs[BATADV_ATTR_VLAN_DYN_MAX]) {
++		u16 vlan_dyn_max;
++
++		attr = info->attrs[BATADV_ATTR_VLAN_DYN_MAX];
++		vlan_dyn_max = nla_get_u16(attr);
++		vlan_dyn_max = min_t(u16, vlan_dyn_max, VLAN_N_VID);
++
++		bat_priv->softif_vlan_dyn_max = vlan_dyn_max;
++	}
++
+ 	batadv_netlink_notify_mesh(bat_priv);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index 079d030e..a04b4978 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -23,6 +23,7 @@
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
++#include <linux/net.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/percpu.h>
+@@ -46,6 +47,7 @@
+ #include "distributed-arp-table.h"
+ #include "gateway_client.h"
+ #include "hard-interface.h"
++#include "log.h"
+ #include "multicast.h"
+ #include "network-coding.h"
+ #include "send.h"
+@@ -550,13 +552,16 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+  * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return: a pointer to a newly allocated softif vlan struct on success, NULL
+  * otherwise.
+  */
+ static struct batadv_softif_vlan *
+-batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid,
++			  bool own)
+ {
++	unsigned short vlan_dyn_max, vlan_dyn_count;
+ 	struct batadv_softif_vlan *vlan;
+ 
+ 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -567,6 +572,19 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 		return vlan;
+ 	}
+ 
++	vlan_dyn_max = bat_priv->softif_vlan_dyn_max;
++	vlan_dyn_count = bat_priv->softif_vlan_dyn_count;
++
++	if (vid & BATADV_VLAN_HAS_TAG && !own &&
++	    vlan_dyn_max <= vlan_dyn_count) {
++		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
++
++		net_ratelimited_function(batadv_info, bat_priv->soft_iface,
++					 "not adding VLAN %d, already learned %hu VID(s)\n",
++					 batadv_print_vid(vid), vlan_dyn_max);
++		return NULL;
++	}
++
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -582,6 +600,9 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
++	if (vid & BATADV_VLAN_HAS_TAG && !own)
++		bat_priv->softif_vlan_dyn_count++;
++
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
+@@ -591,20 +612,22 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ /**
+  * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
+  * @bat_priv: the batpriv ith all the mesh interface information
++ * @addr: the MAC address of the client to add
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return : the softif vlan struct if found or created, NULL otherwise
+  */
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid)
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own)
+ {
+ 	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 
+ 	if (vlan)
+ 		return vlan;
+ 
+-	return batadv_softif_create_vlan(bat_priv, vid);
++	return batadv_softif_create_vlan(bat_priv, vid, own);
+ }
+ 
+ /**
+@@ -805,6 +828,8 @@ static int batadv_softif_init_late(struct net_device *dev)
+ 	bat_priv->tt.last_changeset_len = 0;
+ 	bat_priv->isolation_mark = 0;
+ 	bat_priv->isolation_mark_mask = 0;
++	bat_priv->softif_vlan_dyn_max = 20;
++	bat_priv->softif_vlan_dyn_count = 0;
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 7050ccd3..6ce30fe9 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -27,8 +27,8 @@ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid);
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index a66be4f7..a88b462c 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -635,6 +635,7 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 			unsigned short vid, int ifindex, u32 mark)
+ {
++	bool own = (ifindex == BATADV_NULL_IFINDEX) ? true : false;
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+ 	struct batadv_tt_global_entry *tt_global = NULL;
+@@ -710,7 +711,7 @@ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, addr, vid, own);
+ 	if (!vlan) {
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index ca9449ec..416b4e2f 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1695,6 +1695,12 @@ struct batadv_priv {
+ 	/** @softif_vlan_list_lock: lock protecting softif_vlan_list */
+ 	spinlock_t softif_vlan_list_lock;
+ 
++	/** @softif_vlan_dyn_max: maximum number of allowed learned VLANs */
++	unsigned short softif_vlan_dyn_max;
++
++	/** @softif_vlan_dyn_count: current number of learned VLANs */
++	unsigned short softif_vlan_dyn_count;
++
+ #ifdef CONFIG_BATMAN_ADV_BLA
+ 	/** @bla: bridge loop avoidance data */
+ 	struct batadv_priv_bla bla;
+-- 
+2.52.0
+

--- a/feeds/ipq807x_v5.4/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
+++ b/feeds/ipq807x_v5.4/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
@@ -1,0 +1,191 @@
+From 6ab36677fa236fcba7875f4d4583fd4b7047bad2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:21:23 +0100
+Subject: [PATCH] batman-adv: avoid adding bridge VLAN IDs through
+ ndo_vlan_rx_add_vid()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Linux bridge by default adds the PVID of a port (default VID 1) and
+by that triggers our ndo_vlan_rx_add_vid() handler. The PVID is
+for ingress traffic from bat0 to the bridge and other bridge ports.
+However this makes no statement about what is received or send on bat0
+itself, bat0 might as well be an untagged access port, even with a PVID
+configured. Therefore ignoring here when a bridge is involved.
+
+Also, similarly a "bridge vlan add vid 42 dev bat0 untagged" would call
+this handler with VID 42. Even though we wouldn't be interested in this
+VLAN as its traffic would be untagged on our side.
+
+The issue is that any extra VLAN currently increases our own
+OGM protocol overhead quite a bit, so we want to avoid that
+by only adding VLANs that we are sure someone will be using.
+So only add VLANs through snooping of actual, VLAN tagged
+traffic, not through kernel internal network events
+if we have a bridge on top.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/multicast.c      | 29 ++-------------------
+ net/batman-adv/soft-interface.c | 46 +++++++++++++++++++++++++++++++++
+ net/batman-adv/soft-interface.h |  1 +
+ 3 files changed, 49 insertions(+), 27 deletions(-)
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 4a6079db..541c0c4d 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -72,31 +72,6 @@ static void batadv_mcast_start_timer(struct batadv_priv *bat_priv)
+ 			   msecs_to_jiffies(BATADV_MCAST_WORK_PERIOD));
+ }
+ 
+-/**
+- * batadv_mcast_get_bridge() - get the bridge on top of the softif if it exists
+- * @soft_iface: netdev struct of the mesh interface
+- *
+- * If the given soft interface has a bridge on top then the refcount
+- * of the according net device is increased.
+- *
+- * Return: NULL if no such bridge exists. Otherwise the net device of the
+- * bridge.
+- */
+-static struct net_device *batadv_mcast_get_bridge(struct net_device *soft_iface)
+-{
+-	struct net_device *upper = soft_iface;
+-
+-	rcu_read_lock();
+-	do {
+-		upper = netdev_master_upper_dev_get_rcu(upper);
+-	} while (upper && !netif_is_bridge_master(upper));
+-
+-	dev_hold(upper);
+-	rcu_read_unlock();
+-
+-	return upper;
+-}
+-
+ /**
+  * batadv_mcast_mla_rtr_flags_softif_get_ipv4() - get mcast router flags from
+  *  node for IPv4
+@@ -258,7 +233,7 @@ batadv_mcast_mla_flags_get(struct batadv_priv *bat_priv)
+ 	struct batadv_mcast_mla_flags mla_flags;
+ 	struct net_device *bridge;
+ 
+-	bridge = batadv_mcast_get_bridge(dev);
++	bridge = batadv_softif_get_bridge(dev);
+ 
+ 	memset(&mla_flags, 0, sizeof(mla_flags));
+ 	mla_flags.enabled = 1;
+@@ -499,7 +474,7 @@ batadv_mcast_mla_softif_get(struct net_device *dev,
+ 			    struct hlist_head *mcast_list,
+ 			    struct batadv_mcast_mla_flags *flags)
+ {
+-	struct net_device *bridge = batadv_mcast_get_bridge(dev);
++	struct net_device *bridge = batadv_softif_get_bridge(dev);
+ 	int ret4, ret6 = 0;
+ 
+ 	if (bridge)
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index a04b4978..90501c09 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -676,6 +676,31 @@ static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
+ 			       "vlan interface destroyed", false);
+ }
+ 
++/**
++ * batadv_softif_get_bridge() - get the bridge on top of the softif if it exists
++ * @mesh_iface: netdev struct of the mesh interface
++ *
++ * If the given mesh interface has a bridge on top then the refcount
++ * of the according net device is increased.
++ *
++ * Return: NULL if no such bridge exists. Otherwise the net device of the
++ * bridge.
++ */
++struct net_device *batadv_softif_get_bridge(struct net_device *mesh_iface)
++{
++	struct net_device *upper = mesh_iface;
++
++	rcu_read_lock();
++	do {
++		upper = netdev_master_upper_dev_get_rcu(upper);
++	} while (upper && !netif_is_bridge_master(upper));
++
++	dev_hold(upper);
++	rcu_read_unlock();
++
++	return upper;
++}
++
+ /**
+  * batadv_interface_add_vid() - ndo_add_vid API implementation
+  * @dev: the netdev of the mesh interface
+@@ -691,6 +716,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -698,6 +724,20 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	/* The Linux bridge adds the PVID of a port (default VID 1) and
++	 * triggers this handler. The PVID is for ingress traffic from
++	 * bat0 to the bridge and other bridge ports. However this makes no
++	 * statement about what is received or send on bat0 itself, bat0
++	 * might as well be an untagged access port, even with a PVID
++	 * configured. Therefore ignoring here when a bridge is involved.
++	 * Instead learn VLANs on the fly from traffic.
++	 */
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
++
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+ 	return batadv_softif_create_vlan_own(bat_priv, vid);
+@@ -719,6 +759,7 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -726,6 +767,11 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
+ 
+ 	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 6ce30fe9..b2784ecf 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -19,6 +19,7 @@ int batadv_skb_head_push(struct sk_buff *skb, unsigned int len);
+ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct sk_buff *skb, int hdr_size,
+ 			 struct batadv_orig_node *orig_node);
++struct net_device *batadv_softif_get_bridge(struct net_device *soft_iface);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+ int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
+-- 
+2.52.0
+

--- a/feeds/mediatek-sdk/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
+++ b/feeds/mediatek-sdk/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
@@ -1,0 +1,397 @@
+From 2112a502a97b3b7196faeeb8d48dcc3a1fbb0796 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 13:51:37 +0100
+Subject: [PATCH] batman-adv: add dynamic, bridged-in TT VID detection support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far, if we wanted to bridge VLAN tagged frames into the mesh one would
+need to manually create an according VLAN interface on top of bat0
+first, to trigger batman-adv to create the according structures
+for a VID.
+
+With this change the VLAN from bridged-in clients is now automatically
+detected and added to the translation table on the fly.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/hard-interface.c    |   2 +-
+ net/batman-adv/multicast.c         |   8 +-
+ net/batman-adv/soft-interface.c    | 123 ++++++++++++++++-------------
+ net/batman-adv/soft-interface.h    |   6 +-
+ net/batman-adv/translation-table.c |  19 ++---
+ net/batman-adv/translation-table.h |   4 +-
+ 6 files changed, 91 insertions(+), 71 deletions(-)
+
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 41c1ad33..f4828248 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -928,7 +928,7 @@ static int batadv_hard_if_event_softif(unsigned long event,
+ 	switch (event) {
+ 	case NETDEV_REGISTER:
+ 		bat_priv = netdev_priv(net_dev);
+-		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
++		batadv_softif_create_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 		break;
+ 	}
+ 
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 27511a06..4a6079db 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -692,6 +692,7 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ {
+ 	struct batadv_hw_addr *mcast_entry;
+ 	struct hlist_node *tmp;
++	int ret;
+ 
+ 	if (!mcast_list)
+ 		return;
+@@ -701,9 +702,10 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ 						  &bat_priv->mcast.mla_list))
+ 			continue;
+ 
+-		if (!batadv_tt_local_add(bat_priv->soft_iface,
+-					 mcast_entry->addr, BATADV_NO_FLAGS,
+-					 BATADV_NULL_IFINDEX, BATADV_NO_MARK))
++		ret = batadv_tt_local_add(bat_priv->soft_iface,
++					  mcast_entry->addr, BATADV_NO_FLAGS,
++					  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++		if (ret <= 0)
+ 			continue;
+ 
+ 		hlist_del(&mcast_entry->list);
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index d3fdf822..079d030e 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -141,6 +141,10 @@ static int batadv_interface_set_mac_addr(struct net_device *dev, void *p)
+ 
+ 	rcu_read_lock();
+ 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
++		/* we don't use this VID ourself, avoid adding us to it */
++		if (!batadv_is_my_client(bat_priv, old_addr, vlan->vid))
++			continue;
++
+ 		batadv_tt_local_remove(bat_priv, old_addr, vlan->vid,
+ 				       "mac address changed", false);
+ 		batadv_tt_local_add(dev, addr->sa_data, vlan->vid,
+@@ -543,13 +547,15 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ }
+ 
+ /**
+- * batadv_softif_create_vlan() - allocate the needed resources for a new vlan
++ * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
+  *
+- * Return: 0 on success, a negative error otherwise.
++ * Return: a pointer to a newly allocated softif vlan struct on success, NULL
++ * otherwise.
+  */
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++static struct batadv_softif_vlan *
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ {
+ 	struct batadv_softif_vlan *vlan;
+ 
+@@ -557,55 +563,94 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 	if (vlan) {
+-		batadv_softif_vlan_put(vlan);
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -EEXIST;
++		return vlan;
+ 	}
+ 
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -ENOMEM;
++		return NULL;
+ 	}
+ 
+ 	vlan->bat_priv = bat_priv;
+ 	vlan->vid = vid;
++	/* hold only one refcount, caller will store a reference to us in
++	 * tt_local->vlan without releasing any refcount
++	 */
+ 	kref_init(&vlan->refcount);
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
+-	kref_get(&vlan->refcount);
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
++	return vlan;
++}
++
++/**
++ * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
++ * @bat_priv: the batpriv ith all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Return : the softif vlan struct if found or created, NULL otherwise
++ */
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid)
++{
++	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
++
++	if (vlan)
++		return vlan;
++
++	return batadv_softif_create_vlan(bat_priv, vid);
++}
++
++/**
++ * batadv_softif_create_vlan_own() - add our own softif to the local TT
++ * @bat_priv: the bat priv with all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Adds the MAC address of our own mesh interface with the given VLAN ID as
++ * a permanent local TT entry.
++ *
++ * Return: 0 on success, a negative error otherwise.
++ */
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid)
++{
++	int ret;
++
+ 	/* add a new TT local entry. This one will be marked with the NOPURGE
+ 	 * flag
+ 	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++	ret = batadv_tt_local_add(bat_priv->soft_iface,
++				  bat_priv->soft_iface->dev_addr, vid,
++				  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+ 
+-	/* don't return reference to new softif_vlan */
+-	batadv_softif_vlan_put(vlan);
++	if (ret < 0)
++		return ret;
+ 
+ 	return 0;
+ }
+ 
+ /**
+- * batadv_softif_destroy_vlan() - remove and destroy a softif_vlan object
++ * batadv_softif_destroy_vlan_own() - remove our own softif from the local TT
+  * @bat_priv: the bat priv with all the soft interface information
+- * @vlan: the object to remove
++ * @vid: the VLAN identifier
++ *
++ * Removes the MAC address of our own soft interface with the given VLAN ID from
++ * the local TT.
+  */
+-static void batadv_softif_destroy_vlan(struct batadv_priv *bat_priv,
+-				       struct batadv_softif_vlan *vlan)
++static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
++					   unsigned short vid)
+ {
+ 	/* explicitly remove the associated TT local entry because it is marked
+ 	 * with the NOPURGE flag
+ 	 */
+-	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr,
+-			       vlan->vid, "vlan interface destroyed", false);
+-
+-	batadv_softif_vlan_put(vlan);
++	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr, vid,
++			       "vlan interface destroyed", false);
+ }
+ 
+ /**
+@@ -623,7 +668,6 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -633,25 +677,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+-	/* if a new vlan is getting created and it already exists, it means that
+-	 * it was not deleted yet. batadv_softif_vlan_get() increases the
+-	 * refcount in order to revive the object.
+-	 *
+-	 * if it does not exist then create it.
+-	 */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
+-	if (!vlan)
+-		return batadv_softif_create_vlan(bat_priv, vid);
+-
+-	/* add a new TT local entry. This one will be marked with the NOPURGE
+-	 * flag. This must be added again, even if the vlan object already
+-	 * exists, because the entry was deleted by kill_vid()
+-	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+-
+-	return 0;
++	return batadv_softif_create_vlan_own(bat_priv, vid);
+ }
+ 
+ /**
+@@ -670,7 +696,6 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -678,15 +703,8 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
+-	vlan = batadv_softif_vlan_get(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+-	if (!vlan)
+-		return -ENOENT;
+-
+-	batadv_softif_destroy_vlan(bat_priv, vlan);
+-
+-	/* finally free the vlan object */
+-	batadv_softif_vlan_put(vlan);
+ 
++	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+ }
+ 
+@@ -1080,7 +1098,6 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	list_for_each_entry(hard_iface, &batadv_hardif_list, list) {
+ 		if (hard_iface->soft_iface == soft_iface)
+@@ -1088,11 +1105,7 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ 	}
+ 
+ 	/* destroy the "untagged" VLAN */
+-	vlan = batadv_softif_vlan_get(bat_priv, BATADV_NO_FLAGS);
+-	if (vlan) {
+-		batadv_softif_destroy_vlan(bat_priv, vlan);
+-		batadv_softif_vlan_put(vlan);
+-	}
++	batadv_softif_destroy_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 
+ 	unregister_netdevice_queue(soft_iface, head);
+ }
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 9f2003f1..7050ccd3 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -21,10 +21,14 @@ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct batadv_orig_node *orig_node);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid);
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid);
+ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 36ca3125..a66be4f7 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -632,8 +632,8 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+  *
+  * Return: true if the client was successfully added, false otherwise.
+  */
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark)
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+@@ -645,10 +645,10 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	struct hlist_head *head;
+ 	struct batadv_tt_orig_list_entry *orig_entry;
+ 	int hash_added, table_size, packet_size_max;
+-	bool ret = false;
+ 	bool roamed_back = false;
+ 	u8 remote_flags;
+ 	u32 match_mark;
++	int ret = 0;
+ 
+ 	if (ifindex != BATADV_NULL_IFINDEX)
+ 		in_dev = dev_get_by_index(net, ifindex);
+@@ -699,21 +699,22 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 		net_ratelimited_function(batadv_info, soft_iface,
+ 					 "Local translation table size (%i) exceeds maximum packet size (%i); Ignoring new local tt entry: %pM\n",
+ 					 table_size, packet_size_max, addr);
++		ret = -E2BIG;
+ 		goto out;
+ 	}
+ 
+ 	tt_local = kmem_cache_alloc(batadv_tl_cache, GFP_ATOMIC);
+-	if (!tt_local)
++	if (!tt_local) {
++		ret = -ENOMEM;
+ 		goto out;
++	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
+ 	if (!vlan) {
+-		net_ratelimited_function(batadv_info, soft_iface,
+-					 "adding TT local entry %pM to non-existent VLAN %d\n",
+-					 addr, batadv_print_vid(vid));
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
++		ret = -ENOMEM;
+ 		goto out;
+ 	}
+ 
+@@ -811,7 +812,7 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	if (remote_flags ^ (tt_local->common.flags & BATADV_TT_REMOTE_MASK))
+ 		batadv_tt_local_event(bat_priv, tt_local, BATADV_NO_FLAGS);
+ 
+-	ret = true;
++	ret = 1;
+ out:
+ 	batadv_hardif_put(in_hardif);
+ 	dev_put(in_dev);
+diff --git a/net/batman-adv/translation-table.h b/net/batman-adv/translation-table.h
+index d18740d9..bbdda848 100644
+--- a/net/batman-adv/translation-table.h
++++ b/net/batman-adv/translation-table.h
+@@ -16,8 +16,8 @@
+ #include <linux/types.h>
+ 
+ int batadv_tt_init(struct batadv_priv *bat_priv);
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark);
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark);
+ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv,
+ 			   const u8 *addr, unsigned short vid,
+ 			   const char *message, bool roaming);
+-- 
+2.52.0
+

--- a/feeds/mediatek-sdk/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
+++ b/feeds/mediatek-sdk/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
@@ -1,0 +1,248 @@
+From f142435963da7d4c32c64f3f7c59b3dfaaa962fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:13:49 +0100
+Subject: [PATCH] batman-adv: limit number of learned VLANs from bridged-in
+ clients
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently with batman-adv compatibility version 15 each added VLAN
+increases the OGM protocol overhead of this node considerably. Therefore
+adding a configurable knob to limit the number of learned, snooped VLANs
+from traffic from bridged-in clients.
+
+There are currently also still issues in the BLA code that would
+temporarily break any broadcast transmissions with every newly learned
+VLAN. Therefore setting the default limit for externally learned VLANs to
+zero for now.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ include/uapi/linux/batman_adv.h    |  6 ++++++
+ net/batman-adv/netlink.c           | 15 ++++++++++++++
+ net/batman-adv/soft-interface.c    | 33 ++++++++++++++++++++++++++----
+ net/batman-adv/soft-interface.h    |  4 ++--
+ net/batman-adv/translation-table.c |  3 ++-
+ net/batman-adv/types.h             |  6 ++++++
+ 6 files changed, 60 insertions(+), 7 deletions(-)
+
+diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+index 35dc016c..44018dd6 100644
+--- a/include/uapi/linux/batman_adv.h
++++ b/include/uapi/linux/batman_adv.h
+@@ -481,6 +481,12 @@ enum batadv_nl_attrs {
+ 	 */
+ 	BATADV_ATTR_MULTICAST_FANOUT,
+ 
++	/**
++	 * @BATADV_ATTR_VLAN_DYN_MAX: defines the maximum number of allowed
++	 * learned VLANs from bridged-in clients.
++	 */
++	BATADV_ATTR_VLAN_DYN_MAX,
++
+ 	/* add attributes above here, update the policy in netlink.c */
+ 
+ 	/**
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index 07f21cdb..afbd1446 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -131,6 +131,7 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+ 	[BATADV_ATTR_MCAST_FLAGS]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_MCAST_FLAGS_PRIV]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_VLANID]			= { .type = NLA_U16 },
++	[BATADV_ATTR_VLAN_DYN_MAX]		= { .type = NLA_U16 },
+ 	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+@@ -359,6 +360,10 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+ 			atomic_read(&bat_priv->orig_interval)))
+ 		goto nla_put_failure;
+ 
++	if (nla_put_u16(msg, BATADV_ATTR_VLAN_DYN_MAX,
++			bat_priv->softif_vlan_dyn_max))
++		goto nla_put_failure;
++
+ 	batadv_hardif_put(primary_if);
+ 
+ 	genlmsg_end(msg, hdr);
+@@ -613,6 +618,16 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+ 		atomic_set(&bat_priv->orig_interval, orig_interval);
+ 	}
+ 
++	if (info->attrs[BATADV_ATTR_VLAN_DYN_MAX]) {
++		u16 vlan_dyn_max;
++
++		attr = info->attrs[BATADV_ATTR_VLAN_DYN_MAX];
++		vlan_dyn_max = nla_get_u16(attr);
++		vlan_dyn_max = min_t(u16, vlan_dyn_max, VLAN_N_VID);
++
++		bat_priv->softif_vlan_dyn_max = vlan_dyn_max;
++	}
++
+ 	batadv_netlink_notify_mesh(bat_priv);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index 079d030e..a04b4978 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -23,6 +23,7 @@
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
++#include <linux/net.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/percpu.h>
+@@ -46,6 +47,7 @@
+ #include "distributed-arp-table.h"
+ #include "gateway_client.h"
+ #include "hard-interface.h"
++#include "log.h"
+ #include "multicast.h"
+ #include "network-coding.h"
+ #include "send.h"
+@@ -550,13 +552,16 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+  * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return: a pointer to a newly allocated softif vlan struct on success, NULL
+  * otherwise.
+  */
+ static struct batadv_softif_vlan *
+-batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid,
++			  bool own)
+ {
++	unsigned short vlan_dyn_max, vlan_dyn_count;
+ 	struct batadv_softif_vlan *vlan;
+ 
+ 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -567,6 +572,19 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 		return vlan;
+ 	}
+ 
++	vlan_dyn_max = bat_priv->softif_vlan_dyn_max;
++	vlan_dyn_count = bat_priv->softif_vlan_dyn_count;
++
++	if (vid & BATADV_VLAN_HAS_TAG && !own &&
++	    vlan_dyn_max <= vlan_dyn_count) {
++		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
++
++		net_ratelimited_function(batadv_info, bat_priv->soft_iface,
++					 "not adding VLAN %d, already learned %hu VID(s)\n",
++					 batadv_print_vid(vid), vlan_dyn_max);
++		return NULL;
++	}
++
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -582,6 +600,9 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
++	if (vid & BATADV_VLAN_HAS_TAG && !own)
++		bat_priv->softif_vlan_dyn_count++;
++
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
+@@ -591,20 +612,22 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ /**
+  * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
+  * @bat_priv: the batpriv ith all the mesh interface information
++ * @addr: the MAC address of the client to add
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return : the softif vlan struct if found or created, NULL otherwise
+  */
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid)
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own)
+ {
+ 	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 
+ 	if (vlan)
+ 		return vlan;
+ 
+-	return batadv_softif_create_vlan(bat_priv, vid);
++	return batadv_softif_create_vlan(bat_priv, vid, own);
+ }
+ 
+ /**
+@@ -805,6 +828,8 @@ static int batadv_softif_init_late(struct net_device *dev)
+ 	bat_priv->tt.last_changeset_len = 0;
+ 	bat_priv->isolation_mark = 0;
+ 	bat_priv->isolation_mark_mask = 0;
++	bat_priv->softif_vlan_dyn_max = 20;
++	bat_priv->softif_vlan_dyn_count = 0;
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 7050ccd3..6ce30fe9 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -27,8 +27,8 @@ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid);
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index a66be4f7..a88b462c 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -635,6 +635,7 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 			unsigned short vid, int ifindex, u32 mark)
+ {
++	bool own = (ifindex == BATADV_NULL_IFINDEX) ? true : false;
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+ 	struct batadv_tt_global_entry *tt_global = NULL;
+@@ -710,7 +711,7 @@ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, addr, vid, own);
+ 	if (!vlan) {
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index ca9449ec..416b4e2f 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1695,6 +1695,12 @@ struct batadv_priv {
+ 	/** @softif_vlan_list_lock: lock protecting softif_vlan_list */
+ 	spinlock_t softif_vlan_list_lock;
+ 
++	/** @softif_vlan_dyn_max: maximum number of allowed learned VLANs */
++	unsigned short softif_vlan_dyn_max;
++
++	/** @softif_vlan_dyn_count: current number of learned VLANs */
++	unsigned short softif_vlan_dyn_count;
++
+ #ifdef CONFIG_BATMAN_ADV_BLA
+ 	/** @bla: bridge loop avoidance data */
+ 	struct batadv_priv_bla bla;
+-- 
+2.52.0
+

--- a/feeds/mediatek-sdk/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
+++ b/feeds/mediatek-sdk/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
@@ -1,0 +1,191 @@
+From 6ab36677fa236fcba7875f4d4583fd4b7047bad2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:21:23 +0100
+Subject: [PATCH] batman-adv: avoid adding bridge VLAN IDs through
+ ndo_vlan_rx_add_vid()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Linux bridge by default adds the PVID of a port (default VID 1) and
+by that triggers our ndo_vlan_rx_add_vid() handler. The PVID is
+for ingress traffic from bat0 to the bridge and other bridge ports.
+However this makes no statement about what is received or send on bat0
+itself, bat0 might as well be an untagged access port, even with a PVID
+configured. Therefore ignoring here when a bridge is involved.
+
+Also, similarly a "bridge vlan add vid 42 dev bat0 untagged" would call
+this handler with VID 42. Even though we wouldn't be interested in this
+VLAN as its traffic would be untagged on our side.
+
+The issue is that any extra VLAN currently increases our own
+OGM protocol overhead quite a bit, so we want to avoid that
+by only adding VLANs that we are sure someone will be using.
+So only add VLANs through snooping of actual, VLAN tagged
+traffic, not through kernel internal network events
+if we have a bridge on top.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/multicast.c      | 29 ++-------------------
+ net/batman-adv/soft-interface.c | 46 +++++++++++++++++++++++++++++++++
+ net/batman-adv/soft-interface.h |  1 +
+ 3 files changed, 49 insertions(+), 27 deletions(-)
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 4a6079db..541c0c4d 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -72,31 +72,6 @@ static void batadv_mcast_start_timer(struct batadv_priv *bat_priv)
+ 			   msecs_to_jiffies(BATADV_MCAST_WORK_PERIOD));
+ }
+ 
+-/**
+- * batadv_mcast_get_bridge() - get the bridge on top of the softif if it exists
+- * @soft_iface: netdev struct of the mesh interface
+- *
+- * If the given soft interface has a bridge on top then the refcount
+- * of the according net device is increased.
+- *
+- * Return: NULL if no such bridge exists. Otherwise the net device of the
+- * bridge.
+- */
+-static struct net_device *batadv_mcast_get_bridge(struct net_device *soft_iface)
+-{
+-	struct net_device *upper = soft_iface;
+-
+-	rcu_read_lock();
+-	do {
+-		upper = netdev_master_upper_dev_get_rcu(upper);
+-	} while (upper && !netif_is_bridge_master(upper));
+-
+-	dev_hold(upper);
+-	rcu_read_unlock();
+-
+-	return upper;
+-}
+-
+ /**
+  * batadv_mcast_mla_rtr_flags_softif_get_ipv4() - get mcast router flags from
+  *  node for IPv4
+@@ -258,7 +233,7 @@ batadv_mcast_mla_flags_get(struct batadv_priv *bat_priv)
+ 	struct batadv_mcast_mla_flags mla_flags;
+ 	struct net_device *bridge;
+ 
+-	bridge = batadv_mcast_get_bridge(dev);
++	bridge = batadv_softif_get_bridge(dev);
+ 
+ 	memset(&mla_flags, 0, sizeof(mla_flags));
+ 	mla_flags.enabled = 1;
+@@ -499,7 +474,7 @@ batadv_mcast_mla_softif_get(struct net_device *dev,
+ 			    struct hlist_head *mcast_list,
+ 			    struct batadv_mcast_mla_flags *flags)
+ {
+-	struct net_device *bridge = batadv_mcast_get_bridge(dev);
++	struct net_device *bridge = batadv_softif_get_bridge(dev);
+ 	int ret4, ret6 = 0;
+ 
+ 	if (bridge)
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index a04b4978..90501c09 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -676,6 +676,31 @@ static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
+ 			       "vlan interface destroyed", false);
+ }
+ 
++/**
++ * batadv_softif_get_bridge() - get the bridge on top of the softif if it exists
++ * @mesh_iface: netdev struct of the mesh interface
++ *
++ * If the given mesh interface has a bridge on top then the refcount
++ * of the according net device is increased.
++ *
++ * Return: NULL if no such bridge exists. Otherwise the net device of the
++ * bridge.
++ */
++struct net_device *batadv_softif_get_bridge(struct net_device *mesh_iface)
++{
++	struct net_device *upper = mesh_iface;
++
++	rcu_read_lock();
++	do {
++		upper = netdev_master_upper_dev_get_rcu(upper);
++	} while (upper && !netif_is_bridge_master(upper));
++
++	dev_hold(upper);
++	rcu_read_unlock();
++
++	return upper;
++}
++
+ /**
+  * batadv_interface_add_vid() - ndo_add_vid API implementation
+  * @dev: the netdev of the mesh interface
+@@ -691,6 +716,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -698,6 +724,20 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	/* The Linux bridge adds the PVID of a port (default VID 1) and
++	 * triggers this handler. The PVID is for ingress traffic from
++	 * bat0 to the bridge and other bridge ports. However this makes no
++	 * statement about what is received or send on bat0 itself, bat0
++	 * might as well be an untagged access port, even with a PVID
++	 * configured. Therefore ignoring here when a bridge is involved.
++	 * Instead learn VLANs on the fly from traffic.
++	 */
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
++
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+ 	return batadv_softif_create_vlan_own(bat_priv, vid);
+@@ -719,6 +759,7 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -726,6 +767,11 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
+ 
+ 	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 6ce30fe9..b2784ecf 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -19,6 +19,7 @@ int batadv_skb_head_push(struct sk_buff *skb, unsigned int len);
+ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct sk_buff *skb, int hdr_size,
+ 			 struct batadv_orig_node *orig_node);
++struct net_device *batadv_softif_get_bridge(struct net_device *soft_iface);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+ int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
+-- 
+2.52.0
+

--- a/profiles/emplus_wap588m.yml
+++ b/profiles/emplus_wap588m.yml
@@ -7,6 +7,8 @@ image: bin/targets/mediatek/filogic/openwrt-mediatek-filogic-emplus_wap588m-squa
 feeds:
   - name: mediatek
     path: ../../feeds/mediatek
+  - name: batman
+    path: ../../feeds/batman
 packages:
   - mediatek
   - iperf3

--- a/profiles/indio_um-305ax.yml
+++ b/profiles/indio_um-305ax.yml
@@ -3,6 +3,9 @@ profile: indio_um-305ax
 target: ramips
 subtarget: mt7621
 description: Build image for the Indio UM-305ax
+feeds:
+  - name: batman
+    path: ../../feeds/batman
 image: bin/targets/ramips/mt7621/openwrt-ramips-mt7621-indio_um-305ax-squashfs-sysupgrade.bin
 include:
   - ucentral-ap

--- a/profiles/senao_iap2300m.yml
+++ b/profiles/senao_iap2300m.yml
@@ -7,6 +7,8 @@ image: bin/targets/mediatek/mt7981/openwrt-mediatek-mt7981-senao_iap2300m-squash
 feeds:
   - name: mediatek
     path: ../../feeds/mediatek-sdk
+  - name: batman
+    path: ../../feeds/batman
 packages:
   - mediatek
 include:

--- a/profiles/senao_iap4300m.yml
+++ b/profiles/senao_iap4300m.yml
@@ -7,6 +7,8 @@ image: bin/targets/mediatek/mt7986/openwrt-mediatek-mt7986-senao_iap4300m-squash
 feeds:
   - name: mediatek
     path: ../../feeds/mediatek-sdk
+  - name: batman
+    path: ../../feeds/batman
 packages:
   - mediatek
 include:

--- a/profiles/senao_jeap6500.yml
+++ b/profiles/senao_jeap6500.yml
@@ -7,6 +7,8 @@ image: bin/targets/mediatek/mt7981/openwrt-mediatek-mt7981-senao_jeap6500-squash
 feeds:
   - name: mediatek
     path: ../../feeds/mediatek-sdk
+  - name: batman
+    path: ../../feeds/batman
 packages:
   - mediatek
 include:

--- a/profiles/sonicfi_rap630w-211g.yml
+++ b/profiles/sonicfi_rap630w-211g.yml
@@ -7,6 +7,8 @@ image: bin/targets/mediatek/mt7981/openwrt-mediatek-mt7981-sonicfi_rap630w_211g-
 feeds:
   - name: mediatek
     path: ../../feeds/mediatek-sdk
+  - name: batman
+    path: ../../feeds/batman
 include:
   - ucentral-ap
 packages:

--- a/profiles/sonicfi_rap63xc-211g.yml
+++ b/profiles/sonicfi_rap63xc-211g.yml
@@ -3,6 +3,9 @@ profile: sonicfi_rap63xc-211g
 target: ramips
 subtarget: mt7621
 description: Build image for the Sonicfi EAP RAP63XC-211G
+feeds:
+  - name: batman
+    path: ../../feeds/batman
 image: bin/targets/ramips/mt7621/openwrt-ramips-mt7621-sonicfi_rap63xc-211g-squashfs-sysupgrade.bin
 include:
   - ucentral-ap

--- a/profiles/yuncore_ax820.yml
+++ b/profiles/yuncore_ax820.yml
@@ -3,6 +3,9 @@ profile: yuncore_ax820
 target: ramips
 subtarget: mt7621
 description: Build image for the Yuncore AX820
+feeds:
+  - name: batman
+    path: ../../feeds/batman
 image: bin/targets/ramips/mt7621/openwrt-ramips-mt7621-yuncore_ax820-squashfs-sysupgrade.bin
 include:
   - ucentral-ap

--- a/profiles/yuncore_fap640.yml
+++ b/profiles/yuncore_fap640.yml
@@ -3,6 +3,9 @@ profile: yuncore_fap640
 target: ramips
 subtarget: mt7621
 description: Build image for the Yuncore FAP640
+feeds:
+  - name: batman
+    path: ../../feeds/batman
 image: bin/targets/ramips/mt7621/openwrt-ramips-mt7621-yuncore_fap640-squashfs-sysupgrade.bin
 include:
   - ucentral-ap


### PR DESCRIPTION
## Summary

Backports three upstream batman-adv patches that improve bridged-in VLAN
handling, and wires them into both the QCA wifi-6 (ipq807x_v5.4) and MTK
build paths on `staging-for-v4.2.0-LTS`.

### Patches

| # | Subject | Notes |
|---|---|---|
| 0060 | `batman-adv: add dynamic, bridged-in TT VID detection support` | Auto-detect VLANs from bridged-in clients instead of requiring a manual VLAN interface on top of bat0 |
| 0061 | `batman-adv: limit number of learned VLANs from bridge` | Cap how many bridge-VLAN entries land in the translation table |
| 0062 | `batman-adv: avoid adding bridge VLAN IDs through ndo_*` | Host-bridge concern, not a mesh-iface one |

Original author: **Linus Lüssing** `<linus.luessing@c0d3.blue>`
Backported to v2022.1 by: **Antonio Quartulli** `<antonio@mandelbit.com>`
Carried into wlan-ap by: **Firas Shaari** `<firas@80211networks.com>`

## Where the patches land

The repo currently ships three batman-adv copies; this PR ensures all the
relevant build paths reach the new patches.

| Path | Used for | Action |
|---|---|---|
| `feeds/ipq807x_v5.4/batman-adv/` (v2022.0) | QCA ipq50xx/60xx/807x targets that src-link the `ipq807x` feed | Patches 0060/0061/0062 appended |
| `feeds/mediatek-sdk/batman-adv/` (v2021.1) | MTK SDK builds (note: OpenWrt MTK builds skip this — gated `@!TARGET_mediatek`) | Patches appended for parity |
| `feeds/batman/batman-adv/` *(new)* — v2023.1 mirror of openwrt-routing | OpenWrt MTK targets (and any other target wanting the override) | Created in this PR, includes baseline 0001–0020 from openwrt-routing + my patches 0060/0061/0062 |

A new `feeds/batman` was created (rather than reused `feeds/mediatek-sdk/batman-adv`)
because the latter is intentionally excluded from OpenWrt MTK via
`@!TARGET_mediatek` and is at an older 2021.1 base.

## Profiles wired to the new `feeds/batman`

MTK profiles (ramips/mt7621 + mediatek/filogic/mt7981/mt7986) now src-link
`feeds/batman` so they pick up batman-adv from the wlan-ap-local mirror
instead of openwrt-routing's stock 2023.1:

- **MTK ramips/mt7621:** `yuncore_ax820`, `yuncore_fap640`, `indio_um-305ax`, `sonicfi_rap63xc-211g`
- **MTK mediatek/filogic+mt7981+mt7986:** `emplus_wap588m`, `senao_iap2300m`, `senao_iap4300m`, `senao_jeap6500`, `sonicfi_rap630w-211g`

**Deliberately NOT touched:** `edgecore_eap111`, `edgecore_eap112` — their
profiles explicitly disable `kmod-batman-adv` in `diffconfig`. Maintainer
intent left undisturbed.

**Out of scope for this PR:** QCA `ipq53xx` (WiFi-7) profiles using
`feeds/qca-wifi-7`, QCA `ipq95xx` profiles, and legacy `ipq40xx`/`ath79`
profiles. These currently fall through to openwrt-routing's batman-adv.
Each can be wired to `feeds/batman` with the same 2-line `feeds:` block in
follow-up PRs once verified.

## Build verification

All on this branch HEAD, `staging-for-v4.2.0-LTS` base, batman-adv module
built with patches 0060/0061/0062 applied:

| Target | Feed exercised | Result |
|---|---|---|
| `yuncore_fap655` (QCA ipq50xx) | `feeds/ipq807x_v5.4` v2022.0 | ✅ image built + **deployed to a live AP**, batman-adv module installed |
| `edgecore_eap101` (QCA ipq60xx) | `feeds/ipq807x_v5.4` v2022.0 | ✅ image built |
| `yuncore_ax820` (MTK ramips/mt7621) | `feeds/batman` v2023.1 | ✅ image built + **deployed to a live AP**, batman-adv module installed |
| `emplus_wap588m` (MTK mediatek/filogic) | `feeds/batman` v2023.1 | ⏳ build in progress (mechanical change is identical to the verified profiles; will update if anything unexpected surfaces) |

Live deployments retained config across the upgrade (`sysupgrade -v`) and
came back on the cloud.

## Follow-up

- Remaining MTK profiles in this PR (`yuncore_fap640`, `indio_um-305ax`,
  `sonicfi_rap63xc-211g`, `senao_iap2300m`, `senao_iap4300m`, `senao_jeap6500`,
  `sonicfi_rap630w-211g`) inherit the same `feeds:` block — not yet built but
  the change is the literal copy/paste of the verified ones.
- ipq53xx/ipq95xx/ipq40xx/ath79 fall-through profiles can adopt `feeds: batman`
  in a separate PR.
- `edgecore_eap111`/`edgecore_eap112` re-enable would be a maintainer decision.

## Test plan

- [x] `yuncore_fap655` builds cleanly with patches applied via `feeds/ipq807x_v5.4`
- [x] `edgecore_eap101` builds cleanly with patches applied via `feeds/ipq807x_v5.4`
- [x] `yuncore_ax820` builds cleanly with patches applied via the new `feeds/batman`
- [ ] `emplus_wap588m` builds cleanly (in progress)
- [x] FAP655 image deployed to live AP, returns OK with new banner `TIP-devel-aeccc46d`
- [x] AX820 image deployed to live AP, returns OK with new banner `TIP-devel-3df1e6d0`
- [ ] Functional verification of bridged-in VLAN behavior on a mesh (manual, post-merge)