### PR TITLE
 Mediatek: Add EMPLUS WAP7636M  device , WiFi 7 tri-band

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -138,6 +138,7 @@ senao,iap4300m|\
 senao,jeap6500)
 	PART_NAME=ubi
 	;;
+emplus,wap7636m|\
 emplus,wap588m)
 	tmp_active_fw=$(fw_printenv | grep active_fw | awk -F= {'print $2'})
 	if [ $tmp_active_fw == "0" ]; then

--- a/patches-25.12/0112-mediatek-Add-Emplus-WAP7636M-device.patch
+++ b/patches-25.12/0112-mediatek-Add-Emplus-WAP7636M-device.patch
@@ -1,0 +1,781 @@
+From c184b2b88951a1bae79ac88a98d83450fc088433 Mon Sep 17 00:00:00 2001
+From: "800246@emplustech.com" <cp.chang@emplustech.com>
+Date: Fri, 22 May 2026 17:53:58 +0800
+Subject: [PATCH 1/1] mediatek: Add Emplus WAP7636M device
+
+Specifications: WiFi 7 AP
+SoC: MediaTek MT7988d
+RF Chipset: MT7995AV + MT7976CN + MT7977IAN
+2.4ghz 2X2
+5ghz 3x3
+6ghz 3x3
+RAM: 1GB DDR4 RAM
+Flash: SPI-NAND 256 MiB
+Ethernet: 1 x 2.5GGbE (internal)
+Reset Button: 1
+Power Source: Standard PoE 802.3af/at and DC 12V input
+LED Indicator: 5x Single-color LED indicator (SPI-GPIO Control)
+
+Signed-off-by: 800246@emplustech.com <cp.chang@emplustech.com>
+---
+ .../uboot-envtools/files/mediatek_filogic     |   1 +
+ package/firmware/wireless-regdb/Makefile      |  10 +
+ ...s-regdb-emplus-wap7636m-US-regd-6GHz.patch |  13 +
+ ...7996-emplus-wap7636m-thermal-protect.patch |  13 +
+ .../mediatek/dts/mt7988d-emplus-wap7636m.dts  | 567 ++++++++++++++++++
+ .../filogic/base-files/etc/board.d/01_leds    |   7 +
+ .../filogic/base-files/etc/board.d/02_network |   9 +
+ .../base-files/lib/upgrade/platform.sh        |  18 +
+ target/linux/mediatek/image/filogic.mk        |  18 +
+ 9 files changed, 656 insertions(+)
+ create mode 100644 package/firmware/wireless-regdb/patches-emplus_wap7636m/501-wireless-regdb-emplus-wap7636m-US-regd-6GHz.patch
+ create mode 100644 package/kernel/mt76/patches-emplus_wap7636m/3000-wifi-mt76-mt7996-emplus-wap7636m-thermal-protect.patch
+ create mode 100644 target/linux/mediatek/dts/mt7988d-emplus-wap7636m.dts
+
+diff --git a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+index 34abdc6744..70f731720a 100644
+--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
++++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+@@ -75,6 +75,7 @@ edgecore,eap111|\
+ edgecore,eap115|\
+ edgecore,eap115a|\
+ emplus,wap588m|\
++emplus,wap7636m|\
+ netgear,wax220|\
+ zbtlink,zbt-z8102ax|\
+ zbtlink,zbt-z8103ax)
+diff --git a/package/firmware/wireless-regdb/Makefile b/package/firmware/wireless-regdb/Makefile
+index d9fab19964..fe192bbcbd 100644
+--- a/package/firmware/wireless-regdb/Makefile
++++ b/package/firmware/wireless-regdb/Makefile
+@@ -22,6 +22,16 @@ define Package/wireless-regdb
+   TITLE:=Wireless Regulatory Database
+ endef
+ 
++ifdef CONFIG_TARGET_PROFILE
++TARGET_PROFILE=$(subst ",,$(CONFIG_TARGET_PROFILE))
++PATCH_PROFILE_NAME=patches-$(subst DEVICE_,,$(TARGET_PROFILE))
++endif
++
++define Build/Patch
++	$(Build/Patch/Default)
++	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_PROFILE_NAME)/,profile/)
++endef
++
+ define Build/Compile
+ 	$(STAGING_DIR_HOST)/bin/$(PYTHON) $(PKG_BUILD_DIR)/db2fw.py $(PKG_BUILD_DIR)/regulatory.db $(PKG_BUILD_DIR)/db.txt
+ endef
+diff --git a/package/firmware/wireless-regdb/patches-emplus_wap7636m/501-wireless-regdb-emplus-wap7636m-US-regd-6GHz.patch b/package/firmware/wireless-regdb/patches-emplus_wap7636m/501-wireless-regdb-emplus-wap7636m-US-regd-6GHz.patch
+new file mode 100644
+index 0000000000..d3de535dfb
+--- /dev/null
++++ b/package/firmware/wireless-regdb/patches-emplus_wap7636m/501-wireless-regdb-emplus-wap7636m-US-regd-6GHz.patch
+@@ -0,0 +1,13 @@
++Index: wireless-regdb-2026.03.18/db.txt
++===================================================================
++--- wireless-regdb-2026.03.18.orig/db.txt
+++++ wireless-regdb-2026.03.18/db.txt
++@@ -2053,7 +2053,7 @@ country US: DFS-FCC
++ 	(5850 - 5895 @ 40), (27), NO-OUTDOOR, AUTO-BW, NO-IR
++ 	# 6g band
++ 	# https://www.federalregister.gov/documents/2020/05/26/2020-11236/unlicensed-use-of-the-6ghz-band
++-	(5925 - 7125 @ 320), (12), NO-OUTDOOR, NO-IR
+++	(5925 - 7125 @ 320), (12), NO-OUTDOOR
++ 	# 60g band
++ 	# reference: section IV-D https://docs.fcc.gov/public/attachments/FCC-16-89A1.pdf
++ 	# channels 1-6 EIRP=40dBm(43dBm peak)
+diff --git a/package/kernel/mt76/patches-emplus_wap7636m/3000-wifi-mt76-mt7996-emplus-wap7636m-thermal-protect.patch b/package/kernel/mt76/patches-emplus_wap7636m/3000-wifi-mt76-mt7996-emplus-wap7636m-thermal-protect.patch
+new file mode 100644
+index 0000000000..b8e155ce52
+--- /dev/null
++++ b/package/kernel/mt76/patches-emplus_wap7636m/3000-wifi-mt76-mt7996-emplus-wap7636m-thermal-protect.patch
+@@ -0,0 +1,13 @@
++Index: mt76-2026.03.19~39c960c3/mt7996/mt7996.h
++===================================================================
++--- mt76-2026.03.19~39c960c3.orig/mt7996/mt7996.h
+++++ mt76-2026.03.19~39c960c3/mt7996/mt7996.h
++@@ -120,7 +120,7 @@
++ #define MT7996_CDEV_THROTTLE_MAX	99
++ #define MT7996_CRIT_TEMP_IDX		0
++ #define MT7996_MAX_TEMP_IDX		1
++-#define MT7996_CRIT_TEMP		110
+++#define MT7996_CRIT_TEMP		114
++ #define MT7996_MAX_TEMP			120
++ 
++ #define MT7996_MAX_HIF_RXD_IN_PG	5
+diff --git a/target/linux/mediatek/dts/mt7988d-emplus-wap7636m.dts b/target/linux/mediatek/dts/mt7988d-emplus-wap7636m.dts
+new file mode 100644
+index 0000000000..1bda707712
+--- /dev/null
++++ b/target/linux/mediatek/dts/mt7988d-emplus-wap7636m.dts
+@@ -0,0 +1,567 @@
++// SPDX-License-Identifier: (GPL-2.0 OR MIT)
++/*
++ * Copyright (C) 2021 MediaTek Inc.
++ * Author: Sam.Shih <sam.shih@mediatek.com>
++ */
++
++/dts-v1/;
++
++#include "mt7988a.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++//#include "mt7987a.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
++
++/ {
++	model = "Emplus WAP7636M";
++	compatible = "emplus,wap7636m", "mediatek,mt7988", "mediatek,mt7988d";
++
++	chosen {
++		bootargs = "console=ttyS0,115200n1 loglevel=8  \
++			    earlycon=uart8250,mmio32,0x11000000 \
++			    pci=pcie_bus_perf";
++	};
++
++	aliases {
++		serial0 = &serial0;
++		label-mac-device = &gmac1;
++	};
++	cpus {
++		/delete-node/ cpu@3;
++	};
++	memory {
++		reg = <0x0 0x40000000 0x0 0x40000000>;
++		device_type = "memory";
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
++		};
++
++		wps {
++			label = "wps";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	led-spi {
++		compatible = "spi-gpio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		sck-gpio = <&pio 17 GPIO_ACTIVE_HIGH>;
++		mosi-gpio = <&pio 18 GPIO_ACTIVE_HIGH>;
++		num-chipselects = <0>;
++		//pinctrl-0 = <&spi_gpio_pins>;
++		
++		ssr: ssr@0 {
++			compatible = "fairchild,74hc595";
++			reg = <0>;
++			gpio-controller;
++			#gpio-cells = <2>;
++			registers-number = <1>;
++			spi-max-frequency = <1000000>;
++			enable-gpio = <&pio 4 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	spi-leds {
++		compatible = "gpio-leds";
++		led_pwr: led_pwr {
++			label = "power";
++			gpios = <&ssr 0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "none";
++			default-state = "on";
++		};
++		led_lan2p5: led_lan2p5 {
++			label = "wan";
++			gpios = <&ssr 1 GPIO_ACTIVE_HIGH>;
++		};
++		led_wifi2p4: led_wifi2p4 {
++			label = "wifi2g";
++			gpios = <&ssr 2 GPIO_ACTIVE_HIGH>;
++		};
++		led_wifi5: led_wifi5 {
++			label = "wifi5g";
++			gpios = <&ssr 3 GPIO_ACTIVE_HIGH>;
++		};
++		led_wifi6: led_wifi6 {
++			label = "wifi6g";
++			gpios = <&ssr 4 GPIO_ACTIVE_HIGH>;
++		};
++	}; 
++
++};
++
++&cpu0 {
++	proc-supply = <&rt5190_buck3>;
++};
++
++&cpu1 {
++	proc-supply = <&rt5190_buck3>;
++};
++
++&cpu2 {
++	proc-supply = <&rt5190_buck3>;
++};
++
++//&cci {
++//	proc-supply = <&rt5190_buck3>;
++//};
++&eth {
++	status = "okay";
++	pinctrl-0 = <&mdio0_pins>;
++    status = "okay";	
++};
++
++&gmac0 {
++	/*
++	 * gmac0 in mt7988a.dtsi is connected to internal 4-port GSW CPU port.
++	 * Your board has no 1G switch RJ45 ports, so disable it.
++	 */
++	status = "disabled";
++};
++
++&gmac1 {
++	/*
++	 * MT7988D internal 2.5G PHY.
++	 * This is the only RJ45 port on your board.
++	 */
++	phy-mode = "internal";
++	phy-connection-type = "internal";
++
++	/* Important: use phy-handle, not phy */
++	phy-handle = <&int_2p5g_phy>;
++
++	/delete-property/ pcs-handle;
++	status = "okay";
++};
++
++&gmac2 {
++	/*
++	 * gmac2 is normally for external SGMII/USXGMII PHY.
++	 * No external RJ45/PHY on your design, disable it.
++	 */
++	status = "disabled";
++	/delete-property/ pcs-handle;
++};
++
++&switch {
++	/*
++	 * Disable MT7988 internal 4-port 1G switch,
++	 * because your board does not route those 4 GPHY ports to RJ45.
++	 */
++	status = "disabled";
++};
++
++&gsw_port0 {
++	status = "disabled";
++};
++
++&gsw_port1 {
++	status = "disabled";
++};
++
++&gsw_port2 {
++	status = "disabled";
++};
++
++&gsw_port3 {
++	status = "disabled";
++};
++
++&int_2p5g_phy {
++	status = "okay";
++	compatible = "mediatek,mt7988-2p5ge-phy", "ethernet-phy-ieee802.3-c45";
++    pinctrl-names = "i2p5gbe-led";
++	pinctrl-0 = <&i2p5gbe_led0_pins>;	
++	async-probe; 
++};
++
++&i2p5gbe_led0 {
++	status = "disabled";
++};
++
++//&i2p5gbe_led1 {
++//	status = "disabled";
++//};
++
++/*&gsw_port0 {
++	label = "lan0";
++};
++
++
++&gsw_port1 {
++	label = "lan1";
++};
++
++&gsw_port2 {
++	label = "lan2";
++};
++
++&gsw_port3 {
++	label = "lan3";
++};*/
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0_pins>;
++	status = "okay";
++
++	rt5190a_64: rt5190a@64 {
++		compatible = "richtek,rt5190a";
++		reg = <0x64>;
++		/*interrupts-extended = <&gpio26 0 IRQ_TYPE_LEVEL_LOW>;*/
++		vin2-supply = <&rt5190_buck1>;
++		vin3-supply = <&rt5190_buck1>;
++		vin4-supply = <&rt5190_buck1>;
++
++		regulators {
++			rt5190_buck1: buck1 {
++				regulator-name = "rt5190a-buck1";
++				regulator-min-microvolt = <5090000>;
++				regulator-max-microvolt = <5090000>;
++				regulator-allowed-modes =
++				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++			buck2 {
++				regulator-name = "vcore";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <1400000>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++
++			rt5190_buck3: buck3 {
++				regulator-name = "vproc";
++				regulator-min-microvolt = <600000>;
++				regulator-max-microvolt = <1400000>;
++				regulator-boot-on;
++			};
++			buck4 {
++				regulator-name = "rt5190a-buck4";
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-allowed-modes =
++				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
++				regulator-boot-on;
++				regulator-always-on;
++			};
++			ldo {
++				regulator-name = "rt5190a-ldo";
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-boot-on;
++				regulator-always-on;				
++			};
++		};
++	};
++};	
++
++&i2c1 {
++	status = "disabled";
++};
++
++&pwm {
++	status = "disabled";
++};
++
++&serial0 {
++	status = "okay";
++}; 
++
++&spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_flash_pins>;
++	status = "okay";
++
++	spi_nand: spi_nand@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "spi-nand";
++		spi-cal-enable;
++		spi-cal-mode = "read-data";
++		spi-cal-datalen = <7>;
++		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
++		spi-cal-addrlen = <5>;
++		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
++		mediatek,nmbm;
++		mediatek,bmt-max-ratio = <1>;
++		mediatek,bmt-max-reserved-blocks = <64>;
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2"; //1024KB
++				reg = <0x00000 0x0100000>;
++				read-only;
++			};
++			partition@100000 {
++				label = "u-boot-env"; //512KB
++				reg = <0x0100000 0x0080000>;
++			};
++			factory: partition@180000 {
++				label = "Factory"; //4096KB
++				reg = <0x180000 0x0400000>;
++				compatible = "nvmem-cells";
++				nvmem-layout {
++					compatible = "fixed-layout";
++					#address-cells = <1>;
++					#size-cells = <1>;
++					
++					eeprom: eeprom@0 {
++						reg = <0x0 0x100000>;
++					};
++
++					macaddr_factory_4: macaddr@4 {
++						reg = <0x4 0x6>;
++					};
++					
++					macaddr_factory_a: macaddr@a {
++						reg = <0xa 0x6>;
++					};
++					
++					macaddr_factory_fffee: macaddr@fffee {
++						reg = <0xfffee 0x6>;
++					};
++					
++					macaddr_factory_ffff4: macaddr@ffff4 {
++						reg = <0xffff4 0x6>;		\
++					};
++					
++					macaddr_factory_ffffa: macaddr@ffffa {
++						reg = <0xffffa 0x6>;
++					};
++				};
++			};
++			partition@580000 {
++				label = "FIP"; //2048KB
++				reg = <0x580000 0x0200000>;
++			};
++			partition@780000 {
++				label = "ubi"; //109MB
++				reg = <0x780000 0x6D00000>;
++			};
++			partition@7480000 {
++				label = "ubi_1"; //109MB
++				reg = <0x7480000 0x6D00000>;
++			};
++			partition@E180000 {
++				label = "cert"; //384KB
++				reg = <0xE180000 0x0060000>;
++			};
++			partition@E1E0000 {
++				label = "userconfig"; //640KB
++				reg = <0xE1E0000 0x00a0000>;
++			};
++			partition@E280000 {
++				label = "crashdump"; //384KB
++				reg = <0xE280000 0x0060000>;
++			};
++		};
++	};
++};
++
++&spi1 {
++	pinctrl-names = "default";
++	/* pin shared with snfi */
++	pinctrl-0 = <&spic_pins>;
++	status = "disabled";
++};
++
++&pcie0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie0_pins>;
++	reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
++	status = "okay";
++    pcie@0,0 {
++		reg = <0x0000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		mt7996@0,0 {
++			compatible = "mediatek,mt76";
++			reg = <0x0000 0 0 0 0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			nvmem-cells = <&eeprom>;
++			nvmem-cell-names = "eeprom";
++
++			band@0 {
++				/* 2.4 GHz */
++				reg = <0>;
++				nvmem-cell-names = "mac-address";
++			};
++
++			band@1 {
++				/* 5 GHz */
++				reg = <1>;
++				nvmem-cell-names = "mac-address";
++			};
++			band@2 {
++				/* 6 GHz */
++				reg = <2>;
++				nvmem-cell-names = "mac-address";
++			};			
++		};
++    };
++};
++
++&pcie1 {
++	pinctrl-names = "default";
++    pinctrl-0 = <&pcie1_pins>;
++    status = "disabled";
++};
++
++
++&pcie2 {
++	pinctrl-names = "default";
++    pinctrl-0 = <&pcie2_pins>;
++    status = "disabled";
++};
++
++&pcie3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie3_pins>;
++	status = "okay";
++	
++};
++
++&pio {
++
++	i2c0_pins: i2c0-pins-g0 {
++		mux {
++			function = "i2c";
++			groups = "i2c0_1";
++		};
++	};
++
++	mdio0_pins: mdio0-pins {
++		mux {
++			function = "eth";
++			groups = "mdc_mdio0";
++		};
++
++		conf {
++			groups = "mdc_mdio0";
++			drive-strength = <MTK_DRIVE_8mA>;
++		};
++	};
++
++	/* i2c1_pins: i2c1-pins-g0 {
++		mux {
++			function = "i2c";
++			groups = "i2c1_0";
++		};
++	}; */
++
++	pcie0_pins: pcie0-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie_2l_0_pereset", "pcie_clk_req_n0_0";
++		};
++	};
++
++	pcie1_pins: pcie1-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie_2l_1_pereset", "pcie_clk_req_n1",
++				 "pcie_wake_n1_0";
++		};
++	}; 
++
++	pcie2_pins: pcie2-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie_1l_0_pereset", "pcie_clk_req_n2_0",
++				 "pcie_wake_n2_0";
++		};
++	};
++
++	pcie3_pins: pcie3-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie_1l_1_pereset", "pcie_clk_req_n3",
++				 "pcie_wake_n3_0";
++		};
++	};
++	
++
++	spi0_flash_pins: spi0-pins {
++		mux {
++			function = "spi";
++			groups = "spi0", "spi0_wp_hold";
++		};
++	};
++	
++	spic_pins: spi1-pins {
++		mux {
++			function = "spi";
++			groups = "spi1";
++		};
++	};
++	i2p5gbe_led0_pins: 2p5gbe-led0-pins {
++    	mux {
++        	function = "led";
++	        groups = "2p5gbe_led0";
++    	};
++	};
++
++	i2p5gbe_led1_pins: 2p5gbe-led1-pins {
++    	mux {
++        	function = "led";
++	        groups = "2p5gbe_led1";
++    	};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
++
++&xfi_tphy0 {
++	status = "disabled";
++};
++
++&xfi_tphy1 {
++	status = "disabled";
++};
++
++&sgmiipcs0 {
++	status = "disabled";
++};
++
++&sgmiipcs1 {
++	status = "disabled";
++};
++
++&usxgmiisys0 {
++	status = "disabled";
++};
++
++&usxgmiisys1 {
++	status = "disabled";
++};
++
++//&hnat {
++//	mtketh-wan = "eth1";
++//	mtketh-lan = "lan";
++//	mtketh-lan2 = "eth2";
++//	mtketh-max-gmac = <3>;
++//	status = "okay";
++//};
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+index 5578ad110d..6c2e3a5ca6 100644
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+@@ -107,6 +107,13 @@ emplus,wap588m)
+ 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+ 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+ 	;;
++emplus,wap7636m)
++	ucidef_set_led_default "power" "POWER" "power" "1"
++	ucidef_set_led_netdev "wan" "WAN" "wan" "eth0" "link tx rx"
++	ucidef_set_led_netdev "wifi2g" "WIFI2G" "wifi2g" "phy0.0-ap0" "link tx rx"
++	ucidef_set_led_netdev "wifi5g" "WIFI5G" "wifi5g" "phy0.1-ap0" "link tx rx"
++	ucidef_set_led_netdev "wifi6g" "WIFI6G" "wifi6g" "phy0.2-ap0" "link tx rx"
++	;;	
+ elecom,wrc-x3000gs3)
+ 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
+ 	;;
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+index ece799761b..c782425067 100644
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+@@ -222,6 +222,9 @@ mediatek_setup_interfaces()
+ 	sonicfi,rap630w-211g)
+ 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
+ 		;;
++	emplus,wap7636m)
++		ucidef_set_interfaces_lan_wan lan eth0
++		;;		
+ 	*)
+ 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
+ 		;;
+@@ -333,6 +336,12 @@ mediatek_setup_macs()
+ 		[ -d "${sysfs}/phy0" ] && macaddr_add "$wan_mac" 2 > "${sysfs}/phy0/macaddress"
+ 		[ -d "${sysfs}/phy1" ] && macaddr_add "$wan_mac" 3 > "${sysfs}/phy1/macaddress"
+ 		;;
++	emplus,wap7636m)
++		part_name="Factory"		
++	 	wan_mac_offset=0xFFFFA
++		wan_mac=$(mtd_get_mac_binary $part_name $wan_mac_offset)
++		label_mac=$wan_mac
++		;;		
+ 	esac
+ 
+ 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+diff --git a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+index e0c7d5b663..0ae48badb5 100644
+--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+@@ -332,6 +332,24 @@ platform_do_upgrade() {
+ 		CI_FWSETENV="-s /tmp/fw_setenv.txt"
+ 		nand_do_upgrade "$1"
+ 		;;
++	emplus,wap7636m)
++		local active_fw
++		CI_UBIPART="ubi_1"
++		active_fw="$(fw_printenv -n active_fw 2>/dev/null)"
++		if [ "$active_fw" = "1" ]; then
++			{
++				echo "active_fw 0"
++				echo "mtdparts nmbm0:1024k(bl2),512k(u-boot-env),4096k(factory),2048k(fip),111616k(ubi),111616k(ubi_1),384k(cert),640k(userconfig),384k(crashdump)"
++			} > /tmp/fw_setenv.txt
++		else
++			{
++				echo "active_fw 1"
++				echo "mtdparts nmbm0:1024k(bl2),512k(u-boot-env),4096k(factory),2048k(fip),111616k(ubi_1),111616k(ubi),384k(cert),640k(userconfig),384k(crashdump)"
++			} > /tmp/fw_setenv.txt
++		fi
++		CI_FWSETENV="-s /tmp/fw_setenv.txt"
++		nand_do_upgrade "$1"
++		;;		
+ 	*)
+ 		nand_do_upgrade "$1"
+ 		;;
+diff --git a/target/linux/mediatek/image/filogic.mk b/target/linux/mediatek/image/filogic.mk
+index 767cb45481..768d91c0b9 100644
+--- a/target/linux/mediatek/image/filogic.mk
++++ b/target/linux/mediatek/image/filogic.mk
+@@ -3515,3 +3515,21 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+ endif
+ endef
+ TARGET_DEVICES += zyxel_wx5600-t0-ubootmod
++
++define Device/emplus_wap7636m
++  DEVICE_VENDOR := EMPLUS
++  DEVICE_MODEL := WAP7636M
++  DEVICE_DTS := mt7988d-emplus-wap7636m
++  DEVICE_DTS_DIR := ../dts
++  SUPPORTED_DEVICES := emplus,wap7636m
++  DEVICE_PACKAGES :=  mt7988-2p5g-phy-firmware kmod-mt7996-233-firmware  mt7988-wo-firmware kmod-usb3 kmod-mt7992-firmware
++  UBINIZE_OPTS := -E 5
++  BLOCKSIZE := 128k
++  PAGESIZE := 2048
++  IMAGE_SIZE := 65536k
++  KERNEL_IN_UBI := 1
++  IMAGES += factory.bin
++  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
++  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
++endef
++TARGET_DEVICES += emplus_wap7636m
+-- 
+2.34.1
+

--- a/patches-25.12/0113-mediatek-Fix-2p5ge-rcu_stall.patch
+++ b/patches-25.12/0113-mediatek-Fix-2p5ge-rcu_stall.patch
@@ -1,0 +1,33 @@
+From 3cdd4b7b03ed3b9fac4993fa695f699fc3d80a8f Mon Sep 17 00:00:00 2001
+From: "800246@emplustech.com" <cp.chang@emplustech.com>
+Date: Fri, 22 May 2026 17:58:56 +0800
+Subject: [PATCH 1/1] mediatek: Fix 2p5ge rcu_stall
+
+Signed-off-by: 800246@emplustech.com <cp.chang@emplustech.com>
+---
+ .../patches-6.12/999-mtk-2p5ge_fix_rcu_stall.patch  | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ create mode 100755 target/linux/mediatek/patches-6.12/999-mtk-2p5ge_fix_rcu_stall.patch
+
+diff --git a/target/linux/mediatek/patches-6.12/999-mtk-2p5ge_fix_rcu_stall.patch b/target/linux/mediatek/patches-6.12/999-mtk-2p5ge_fix_rcu_stall.patch
+new file mode 100755
+index 0000000000..ba7ddd517d
+--- /dev/null
++++ b/target/linux/mediatek/patches-6.12/999-mtk-2p5ge_fix_rcu_stall.patch
+@@ -0,0 +1,13 @@
++Index: linux-6.12.74/drivers/net/phy/mediatek/mtk-2p5ge.c
++===================================================================
++--- linux-6.12.74.orig/drivers/net/phy/mediatek/mtk-2p5ge.c
+++++ linux-6.12.74/drivers/net/phy/mediatek/mtk-2p5ge.c
++@@ -404,7 +404,7 @@ static int mt7988_2p5ge_phy_load_fw(stru
++ 		phy_set_bits(phydev, MII_BMCR, BMCR_RESET);
++ 		usleep_range(10000, 11000);
++ 	}
++-	phy_set_bits(phydev, MII_BMCR, BMCR_PDOWN);
+++	//phy_set_bits(phydev, MII_BMCR, BMCR_PDOWN);
++ 
++ 	/* Write magic number to safely stall MCU */
++ 	phy_write_mmd(phydev, MDIO_MMD_VEND1, MTK_PHY_HOST_CMD1, 0x1100);
+-- 
+2.34.1
+

--- a/profiles/emplus_wap7636m.yml
+++ b/profiles/emplus_wap7636m.yml
@@ -1,0 +1,30 @@
+---
+profile: emplus_wap7636m
+target: mediatek
+subtarget: filogic
+description: Build image for the EMPLUS WAP7636M
+image: bin/targets/mediatek/filogic/openwrt-mediatek-filogic-emplus_wap7636m-squashfs-sysupgrade.bin
+packages:
+  - iperf3
+  - lscpu
+  - tree  
+include:
+  - ucentral-ap
+diffconfig: |
+  CONFIG_PACKAGE_mt7988-2p5g-phy-firmware=y
+  CONFIG_PACKAGE_mt7988-wo-firmware=y
+  CONFIG_PACKAGE_kmod-gpio-nxp-74hc164=y
+  CONFIG_PACKAGE_kmod-spi-bitbang=y
+  CONFIG_PACKAGE_kmod-spi-gpio=y
+  CONFIG_PACKAGE_kmod-mt7996-233-firmware=y
+  CONFIG_PACKAGE_kmod-mt7996-firmware-common=y
+  CONFIG_PACKAGE_kmod-mt7996e=y
+  CONFIG_BUSYBOX_CUSTOM=y
+  CONFIG_BUSYBOX_CONFIG_TFTP=y
+  CONFIG_BUSYBOX_CONFIG_FEATURE_TFTP_GET=y
+  CONFIG_BUSYBOX_CONFIG_FEATURE_TFTP_PUT=y
+  CONFIG_BUSYBOX_CONFIG_FEATURE_TFTP_BLOCKSIZE=y
+  CONFIG_BUSYBOX_CONFIG_FEATURE_TFTP_PROGRESS_BAR=y
+  CONFIG_BUSYBOX_CONFIG_MPSTAT=y
+  CONFIG_BUSYBOX_CONFIG_PSTREE=y
+  CONFIG_BUSYBOX_CONFIG_LSPCI=y


### PR DESCRIPTION
 Specifications: WiFi 7 AP
 SoC: MediaTek MT7988d
 RF Chipset: MT7995AV + MT7976CN + MT7977IAN
 2.4ghz 2X2
 5ghz 3x3
 6ghz 3x3
 RAM: 1GB DDR4 RAM
 Flash: SPI-NAND 256 MiB
 Ethernet: 1 x 2.5GGbE (internal)
 Reset Button: 1
 Power Source: Standard PoE 802.3af/at and DC 12V input
 LED Indicator: 5x Single-color LED indicator (SPI-GPIO Control)