### PR TITLE
ath11k: tolerate non-PASS regulatory status from QSDK firmware

### DIFF
--- a/feeds/qca-wifi-6/mac80211/patches/pending/a-106-ath11k-tolerate-non-PASS-regulatory-status-from-QSDK-FW.patch
+++ b/feeds/qca-wifi-6/mac80211/patches/pending/a-106-ath11k-tolerate-non-PASS-regulatory-status-from-QSDK-FW.patch
@@ -1,0 +1,21 @@
+--- a/drivers/net/wireless/ath/ath11k/wmi.c	2026-05-26 14:17:01.872100388 -0400
++++ b/drivers/net/wireless/ath/ath11k/wmi.c	2026-05-26 15:07:49.474044951 -0400
+@@ -7527,12 +7527,13 @@
+ 	enum wmi_vdev_type vdev_type;
+ 
+ 	if (reg_info->status_code != REG_SET_CC_STATUS_PASS) {
+-		/* In case of failure to set the requested ctry,
+-		 * fw retains the current regd. We print a failure info
+-		 * and return from here.
++		/* QSDK firmware may send a non-PASS status but still
++		 * include usable regulatory rules. Log and continue
++		 * rather than aborting -- matches pre-6.18 behaviour.
+ 		 */
+-		ath11k_warn(ab, "Failed to set the requested Country regulatory setting\n");
+-		return -EINVAL;
++		ath11k_dbg(ab, ATH11K_DBG_REG,
++			   "regulatory status %d, continuing with available rules\n",
++			   reg_info->status_code);
+ 	}
+ 
+ 	pdev_idx = reg_info->phy_id;


### PR DESCRIPTION
## Problem

CIG WF196 (IPQ8074 + QCN9074) running ApNos v5.0.0 (OpenWrt 25.12.3) fails to start 5 GHz on any DFS channel:

```
ath11k c000000.wifi1: Failed to set the requested Country regulatory setting
ath11k c000000.wifi1: failed to process regulatory info from received event
ath11k c000000.wifi1: vdev start resp error status 4 (invalid regdomain)
```

Non-DFS channels (36, 149) work. DFS channels (52, 64, 100, 116) all fail. Regression from ApNos 4.2.4 on the same hardware + firmware.

## Root cause

QSDK firmware (WLAN.HK.2.7.0.1-01744) sends `WMI_REG_CHAN_LIST_CC_EVENT` with `status_code != REG_SET_CC_STATUS_PASS` (typically `REG_CURRENT_ALPHA2_NOT_FOUND`).

In backports-6.1.24 (ApNos 4.2.4): the regulatory event handler had **no status_code check** -- it processed whatever rules the firmware sent regardless of status.

The current QSDK backports added a check at `wmi.c` that rejects the event entirely with `-EINVAL` when status is non-PASS. This leaves the firmware DFS regulatory context broken -- firmware then refuses DFS vdev_start because it never received a valid channel list for DFS bands.

## Fix

Downgrade the fatal check to a debug log and continue processing the regulatory rules the firmware provided:

```diff
 if (reg_info->status_code != REG_SET_CC_STATUS_PASS) {
-    ath11k_warn(ab, "Failed to set the requested Country regulatory setting\n");
-    return -EINVAL;
+    ath11k_dbg(ab, ATH11K_DBG_REG,
+               "regulatory status %d, continuing with available rules\n",
+               reg_info->status_code);
 }
```

Patch location: `feeds/qca-wifi-6/mac80211/patches/pending/a-106-ath11k-tolerate-non-PASS-regulatory-status-from-QSDK-FW.patch`

## Verification

Tested on CIG WF196 (IPQ8074 + QCN9074) with firmware WLAN.HK.2.7.0.1-01744:

| Channel | Before | After |
|---|---|---|
| 36 (non-DFS) | Works | Works |
| 52 (DFS UNII-2) | Fails status 4 | **Works** |
| 64 (DFS UNII-2) | Fails status 4 | **Works** |
| 116 (DFS UNII-2C) | Fails status 4 | **Works** |
| dmesg "Failed to set Country" | Every boot | **Gone** |
| dmesg "status 4 invalid regdomain" | Every DFS attempt | **Gone** |

## Scope

Affects all QCA wifi-6 APs using QSDK-era firmware (WLAN.HK.2.x) with the current QSDK backports. Does not affect QCA wifi-7 or MediaTek targets.

**Note:** This PR is based on `main~1` (`3f602f67`) to avoid `ef629637` which introduced a broken ucentral-schema Makefile (missing `PKG_SOURCE_VERSION`). That commit should be reverted separately.