### PR TITLE
batman-adv: backport bridged-in VLAN/TT-VID fixes (wifi-6 + wifi-7)

### DIFF
--- a/feeds/qca-wifi-6/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
+++ b/feeds/qca-wifi-6/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
@@ -1,0 +1,397 @@
+From 2112a502a97b3b7196faeeb8d48dcc3a1fbb0796 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 13:51:37 +0100
+Subject: [PATCH] batman-adv: add dynamic, bridged-in TT VID detection support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far, if we wanted to bridge VLAN tagged frames into the mesh one would
+need to manually create an according VLAN interface on top of bat0
+first, to trigger batman-adv to create the according structures
+for a VID.
+
+With this change the VLAN from bridged-in clients is now automatically
+detected and added to the translation table on the fly.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/hard-interface.c    |   2 +-
+ net/batman-adv/multicast.c         |   8 +-
+ net/batman-adv/soft-interface.c    | 123 ++++++++++++++++-------------
+ net/batman-adv/soft-interface.h    |   6 +-
+ net/batman-adv/translation-table.c |  19 ++---
+ net/batman-adv/translation-table.h |   4 +-
+ 6 files changed, 91 insertions(+), 71 deletions(-)
+
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 41c1ad33..f4828248 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -928,7 +928,7 @@ static int batadv_hard_if_event_softif(unsigned long event,
+ 	switch (event) {
+ 	case NETDEV_REGISTER:
+ 		bat_priv = netdev_priv(net_dev);
+-		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
++		batadv_softif_create_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 		break;
+ 	}
+ 
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 27511a06..4a6079db 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -692,6 +692,7 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ {
+ 	struct batadv_hw_addr *mcast_entry;
+ 	struct hlist_node *tmp;
++	int ret;
+ 
+ 	if (!mcast_list)
+ 		return;
+@@ -701,9 +702,10 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ 						  &bat_priv->mcast.mla_list))
+ 			continue;
+ 
+-		if (!batadv_tt_local_add(bat_priv->soft_iface,
+-					 mcast_entry->addr, BATADV_NO_FLAGS,
+-					 BATADV_NULL_IFINDEX, BATADV_NO_MARK))
++		ret = batadv_tt_local_add(bat_priv->soft_iface,
++					  mcast_entry->addr, BATADV_NO_FLAGS,
++					  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++		if (ret <= 0)
+ 			continue;
+ 
+ 		hlist_del(&mcast_entry->list);
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index d3fdf822..079d030e 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -141,6 +141,10 @@ static int batadv_interface_set_mac_addr(struct net_device *dev, void *p)
+ 
+ 	rcu_read_lock();
+ 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
++		/* we don't use this VID ourself, avoid adding us to it */
++		if (!batadv_is_my_client(bat_priv, old_addr, vlan->vid))
++			continue;
++
+ 		batadv_tt_local_remove(bat_priv, old_addr, vlan->vid,
+ 				       "mac address changed", false);
+ 		batadv_tt_local_add(dev, addr->sa_data, vlan->vid,
+@@ -543,13 +547,15 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ }
+ 
+ /**
+- * batadv_softif_create_vlan() - allocate the needed resources for a new vlan
++ * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
+  *
+- * Return: 0 on success, a negative error otherwise.
++ * Return: a pointer to a newly allocated softif vlan struct on success, NULL
++ * otherwise.
+  */
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++static struct batadv_softif_vlan *
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ {
+ 	struct batadv_softif_vlan *vlan;
+ 
+@@ -557,55 +563,94 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 	if (vlan) {
+-		batadv_softif_vlan_put(vlan);
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -EEXIST;
++		return vlan;
+ 	}
+ 
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -ENOMEM;
++		return NULL;
+ 	}
+ 
+ 	vlan->bat_priv = bat_priv;
+ 	vlan->vid = vid;
++	/* hold only one refcount, caller will store a reference to us in
++	 * tt_local->vlan without releasing any refcount
++	 */
+ 	kref_init(&vlan->refcount);
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
+-	kref_get(&vlan->refcount);
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
++	return vlan;
++}
++
++/**
++ * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
++ * @bat_priv: the batpriv ith all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Return : the softif vlan struct if found or created, NULL otherwise
++ */
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid)
++{
++	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
++
++	if (vlan)
++		return vlan;
++
++	return batadv_softif_create_vlan(bat_priv, vid);
++}
++
++/**
++ * batadv_softif_create_vlan_own() - add our own softif to the local TT
++ * @bat_priv: the bat priv with all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Adds the MAC address of our own mesh interface with the given VLAN ID as
++ * a permanent local TT entry.
++ *
++ * Return: 0 on success, a negative error otherwise.
++ */
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid)
++{
++	int ret;
++
+ 	/* add a new TT local entry. This one will be marked with the NOPURGE
+ 	 * flag
+ 	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++	ret = batadv_tt_local_add(bat_priv->soft_iface,
++				  bat_priv->soft_iface->dev_addr, vid,
++				  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+ 
+-	/* don't return reference to new softif_vlan */
+-	batadv_softif_vlan_put(vlan);
++	if (ret < 0)
++		return ret;
+ 
+ 	return 0;
+ }
+ 
+ /**
+- * batadv_softif_destroy_vlan() - remove and destroy a softif_vlan object
++ * batadv_softif_destroy_vlan_own() - remove our own softif from the local TT
+  * @bat_priv: the bat priv with all the soft interface information
+- * @vlan: the object to remove
++ * @vid: the VLAN identifier
++ *
++ * Removes the MAC address of our own soft interface with the given VLAN ID from
++ * the local TT.
+  */
+-static void batadv_softif_destroy_vlan(struct batadv_priv *bat_priv,
+-				       struct batadv_softif_vlan *vlan)
++static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
++					   unsigned short vid)
+ {
+ 	/* explicitly remove the associated TT local entry because it is marked
+ 	 * with the NOPURGE flag
+ 	 */
+-	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr,
+-			       vlan->vid, "vlan interface destroyed", false);
+-
+-	batadv_softif_vlan_put(vlan);
++	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr, vid,
++			       "vlan interface destroyed", false);
+ }
+ 
+ /**
+@@ -623,7 +668,6 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -633,25 +677,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+-	/* if a new vlan is getting created and it already exists, it means that
+-	 * it was not deleted yet. batadv_softif_vlan_get() increases the
+-	 * refcount in order to revive the object.
+-	 *
+-	 * if it does not exist then create it.
+-	 */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
+-	if (!vlan)
+-		return batadv_softif_create_vlan(bat_priv, vid);
+-
+-	/* add a new TT local entry. This one will be marked with the NOPURGE
+-	 * flag. This must be added again, even if the vlan object already
+-	 * exists, because the entry was deleted by kill_vid()
+-	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+-
+-	return 0;
++	return batadv_softif_create_vlan_own(bat_priv, vid);
+ }
+ 
+ /**
+@@ -670,7 +696,6 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -678,15 +703,8 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
+-	vlan = batadv_softif_vlan_get(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+-	if (!vlan)
+-		return -ENOENT;
+-
+-	batadv_softif_destroy_vlan(bat_priv, vlan);
+-
+-	/* finally free the vlan object */
+-	batadv_softif_vlan_put(vlan);
+ 
++	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+ }
+ 
+@@ -1080,7 +1098,6 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	list_for_each_entry(hard_iface, &batadv_hardif_list, list) {
+ 		if (hard_iface->soft_iface == soft_iface)
+@@ -1088,11 +1105,7 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ 	}
+ 
+ 	/* destroy the "untagged" VLAN */
+-	vlan = batadv_softif_vlan_get(bat_priv, BATADV_NO_FLAGS);
+-	if (vlan) {
+-		batadv_softif_destroy_vlan(bat_priv, vlan);
+-		batadv_softif_vlan_put(vlan);
+-	}
++	batadv_softif_destroy_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 
+ 	unregister_netdevice_queue(soft_iface, head);
+ }
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 9f2003f1..7050ccd3 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -21,10 +21,14 @@ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct batadv_orig_node *orig_node);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid);
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid);
+ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 36ca3125..a66be4f7 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -632,8 +632,8 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+  *
+  * Return: true if the client was successfully added, false otherwise.
+  */
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark)
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+@@ -645,10 +645,10 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	struct hlist_head *head;
+ 	struct batadv_tt_orig_list_entry *orig_entry;
+ 	int hash_added, table_size, packet_size_max;
+-	bool ret = false;
+ 	bool roamed_back = false;
+ 	u8 remote_flags;
+ 	u32 match_mark;
++	int ret = 0;
+ 
+ 	if (ifindex != BATADV_NULL_IFINDEX)
+ 		in_dev = dev_get_by_index(net, ifindex);
+@@ -699,21 +699,22 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 		net_ratelimited_function(batadv_info, soft_iface,
+ 					 "Local translation table size (%i) exceeds maximum packet size (%i); Ignoring new local tt entry: %pM\n",
+ 					 table_size, packet_size_max, addr);
++		ret = -E2BIG;
+ 		goto out;
+ 	}
+ 
+ 	tt_local = kmem_cache_alloc(batadv_tl_cache, GFP_ATOMIC);
+-	if (!tt_local)
++	if (!tt_local) {
++		ret = -ENOMEM;
+ 		goto out;
++	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
+ 	if (!vlan) {
+-		net_ratelimited_function(batadv_info, soft_iface,
+-					 "adding TT local entry %pM to non-existent VLAN %d\n",
+-					 addr, batadv_print_vid(vid));
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
++		ret = -ENOMEM;
+ 		goto out;
+ 	}
+ 
+@@ -811,7 +812,7 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	if (remote_flags ^ (tt_local->common.flags & BATADV_TT_REMOTE_MASK))
+ 		batadv_tt_local_event(bat_priv, tt_local, BATADV_NO_FLAGS);
+ 
+-	ret = true;
++	ret = 1;
+ out:
+ 	batadv_hardif_put(in_hardif);
+ 	dev_put(in_dev);
+diff --git a/net/batman-adv/translation-table.h b/net/batman-adv/translation-table.h
+index d18740d9..bbdda848 100644
+--- a/net/batman-adv/translation-table.h
++++ b/net/batman-adv/translation-table.h
+@@ -16,8 +16,8 @@
+ #include <linux/types.h>
+ 
+ int batadv_tt_init(struct batadv_priv *bat_priv);
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark);
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark);
+ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv,
+ 			   const u8 *addr, unsigned short vid,
+ 			   const char *message, bool roaming);
+-- 
+2.52.0
+

--- a/feeds/qca-wifi-6/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
+++ b/feeds/qca-wifi-6/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
@@ -1,0 +1,248 @@
+From f142435963da7d4c32c64f3f7c59b3dfaaa962fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:13:49 +0100
+Subject: [PATCH] batman-adv: limit number of learned VLANs from bridged-in
+ clients
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently with batman-adv compatibility version 15 each added VLAN
+increases the OGM protocol overhead of this node considerably. Therefore
+adding a configurable knob to limit the number of learned, snooped VLANs
+from traffic from bridged-in clients.
+
+There are currently also still issues in the BLA code that would
+temporarily break any broadcast transmissions with every newly learned
+VLAN. Therefore setting the default limit for externally learned VLANs to
+zero for now.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ include/uapi/linux/batman_adv.h    |  6 ++++++
+ net/batman-adv/netlink.c           | 15 ++++++++++++++
+ net/batman-adv/soft-interface.c    | 33 ++++++++++++++++++++++++++----
+ net/batman-adv/soft-interface.h    |  4 ++--
+ net/batman-adv/translation-table.c |  3 ++-
+ net/batman-adv/types.h             |  6 ++++++
+ 6 files changed, 60 insertions(+), 7 deletions(-)
+
+diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+index 35dc016c..44018dd6 100644
+--- a/include/uapi/linux/batman_adv.h
++++ b/include/uapi/linux/batman_adv.h
+@@ -481,6 +481,12 @@ enum batadv_nl_attrs {
+ 	 */
+ 	BATADV_ATTR_MULTICAST_FANOUT,
+ 
++	/**
++	 * @BATADV_ATTR_VLAN_DYN_MAX: defines the maximum number of allowed
++	 * learned VLANs from bridged-in clients.
++	 */
++	BATADV_ATTR_VLAN_DYN_MAX,
++
+ 	/* add attributes above here, update the policy in netlink.c */
+ 
+ 	/**
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index 07f21cdb..afbd1446 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -131,6 +131,7 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+ 	[BATADV_ATTR_MCAST_FLAGS]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_MCAST_FLAGS_PRIV]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_VLANID]			= { .type = NLA_U16 },
++	[BATADV_ATTR_VLAN_DYN_MAX]		= { .type = NLA_U16 },
+ 	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+@@ -359,6 +360,10 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+ 			atomic_read(&bat_priv->orig_interval)))
+ 		goto nla_put_failure;
+ 
++	if (nla_put_u16(msg, BATADV_ATTR_VLAN_DYN_MAX,
++			bat_priv->softif_vlan_dyn_max))
++		goto nla_put_failure;
++
+ 	batadv_hardif_put(primary_if);
+ 
+ 	genlmsg_end(msg, hdr);
+@@ -613,6 +618,16 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+ 		atomic_set(&bat_priv->orig_interval, orig_interval);
+ 	}
+ 
++	if (info->attrs[BATADV_ATTR_VLAN_DYN_MAX]) {
++		u16 vlan_dyn_max;
++
++		attr = info->attrs[BATADV_ATTR_VLAN_DYN_MAX];
++		vlan_dyn_max = nla_get_u16(attr);
++		vlan_dyn_max = min_t(u16, vlan_dyn_max, VLAN_N_VID);
++
++		bat_priv->softif_vlan_dyn_max = vlan_dyn_max;
++	}
++
+ 	batadv_netlink_notify_mesh(bat_priv);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index 079d030e..a04b4978 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -23,6 +23,7 @@
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
++#include <linux/net.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/percpu.h>
+@@ -46,6 +47,7 @@
+ #include "distributed-arp-table.h"
+ #include "gateway_client.h"
+ #include "hard-interface.h"
++#include "log.h"
+ #include "multicast.h"
+ #include "network-coding.h"
+ #include "send.h"
+@@ -550,13 +552,16 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+  * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return: a pointer to a newly allocated softif vlan struct on success, NULL
+  * otherwise.
+  */
+ static struct batadv_softif_vlan *
+-batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid,
++			  bool own)
+ {
++	unsigned short vlan_dyn_max, vlan_dyn_count;
+ 	struct batadv_softif_vlan *vlan;
+ 
+ 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -567,6 +572,19 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 		return vlan;
+ 	}
+ 
++	vlan_dyn_max = bat_priv->softif_vlan_dyn_max;
++	vlan_dyn_count = bat_priv->softif_vlan_dyn_count;
++
++	if (vid & BATADV_VLAN_HAS_TAG && !own &&
++	    vlan_dyn_max <= vlan_dyn_count) {
++		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
++
++		net_ratelimited_function(batadv_info, bat_priv->soft_iface,
++					 "not adding VLAN %d, already learned %hu VID(s)\n",
++					 batadv_print_vid(vid), vlan_dyn_max);
++		return NULL;
++	}
++
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -582,6 +600,9 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
++	if (vid & BATADV_VLAN_HAS_TAG && !own)
++		bat_priv->softif_vlan_dyn_count++;
++
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
+@@ -591,20 +612,22 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ /**
+  * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
+  * @bat_priv: the batpriv ith all the mesh interface information
++ * @addr: the MAC address of the client to add
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return : the softif vlan struct if found or created, NULL otherwise
+  */
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid)
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own)
+ {
+ 	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 
+ 	if (vlan)
+ 		return vlan;
+ 
+-	return batadv_softif_create_vlan(bat_priv, vid);
++	return batadv_softif_create_vlan(bat_priv, vid, own);
+ }
+ 
+ /**
+@@ -805,6 +828,8 @@ static int batadv_softif_init_late(struct net_device *dev)
+ 	bat_priv->tt.last_changeset_len = 0;
+ 	bat_priv->isolation_mark = 0;
+ 	bat_priv->isolation_mark_mask = 0;
++	bat_priv->softif_vlan_dyn_max = 20;
++	bat_priv->softif_vlan_dyn_count = 0;
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 7050ccd3..6ce30fe9 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -27,8 +27,8 @@ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid);
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index a66be4f7..a88b462c 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -635,6 +635,7 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 			unsigned short vid, int ifindex, u32 mark)
+ {
++	bool own = (ifindex == BATADV_NULL_IFINDEX) ? true : false;
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+ 	struct batadv_tt_global_entry *tt_global = NULL;
+@@ -710,7 +711,7 @@ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, addr, vid, own);
+ 	if (!vlan) {
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index ca9449ec..416b4e2f 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1695,6 +1695,12 @@ struct batadv_priv {
+ 	/** @softif_vlan_list_lock: lock protecting softif_vlan_list */
+ 	spinlock_t softif_vlan_list_lock;
+ 
++	/** @softif_vlan_dyn_max: maximum number of allowed learned VLANs */
++	unsigned short softif_vlan_dyn_max;
++
++	/** @softif_vlan_dyn_count: current number of learned VLANs */
++	unsigned short softif_vlan_dyn_count;
++
+ #ifdef CONFIG_BATMAN_ADV_BLA
+ 	/** @bla: bridge loop avoidance data */
+ 	struct batadv_priv_bla bla;
+-- 
+2.52.0
+

--- a/feeds/qca-wifi-6/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
+++ b/feeds/qca-wifi-6/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
@@ -1,0 +1,191 @@
+From 6ab36677fa236fcba7875f4d4583fd4b7047bad2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:21:23 +0100
+Subject: [PATCH] batman-adv: avoid adding bridge VLAN IDs through
+ ndo_vlan_rx_add_vid()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Linux bridge by default adds the PVID of a port (default VID 1) and
+by that triggers our ndo_vlan_rx_add_vid() handler. The PVID is
+for ingress traffic from bat0 to the bridge and other bridge ports.
+However this makes no statement about what is received or send on bat0
+itself, bat0 might as well be an untagged access port, even with a PVID
+configured. Therefore ignoring here when a bridge is involved.
+
+Also, similarly a "bridge vlan add vid 42 dev bat0 untagged" would call
+this handler with VID 42. Even though we wouldn't be interested in this
+VLAN as its traffic would be untagged on our side.
+
+The issue is that any extra VLAN currently increases our own
+OGM protocol overhead quite a bit, so we want to avoid that
+by only adding VLANs that we are sure someone will be using.
+So only add VLANs through snooping of actual, VLAN tagged
+traffic, not through kernel internal network events
+if we have a bridge on top.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/multicast.c      | 29 ++-------------------
+ net/batman-adv/soft-interface.c | 46 +++++++++++++++++++++++++++++++++
+ net/batman-adv/soft-interface.h |  1 +
+ 3 files changed, 49 insertions(+), 27 deletions(-)
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 4a6079db..541c0c4d 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -72,31 +72,6 @@ static void batadv_mcast_start_timer(struct batadv_priv *bat_priv)
+ 			   msecs_to_jiffies(BATADV_MCAST_WORK_PERIOD));
+ }
+ 
+-/**
+- * batadv_mcast_get_bridge() - get the bridge on top of the softif if it exists
+- * @soft_iface: netdev struct of the mesh interface
+- *
+- * If the given soft interface has a bridge on top then the refcount
+- * of the according net device is increased.
+- *
+- * Return: NULL if no such bridge exists. Otherwise the net device of the
+- * bridge.
+- */
+-static struct net_device *batadv_mcast_get_bridge(struct net_device *soft_iface)
+-{
+-	struct net_device *upper = soft_iface;
+-
+-	rcu_read_lock();
+-	do {
+-		upper = netdev_master_upper_dev_get_rcu(upper);
+-	} while (upper && !netif_is_bridge_master(upper));
+-
+-	dev_hold(upper);
+-	rcu_read_unlock();
+-
+-	return upper;
+-}
+-
+ /**
+  * batadv_mcast_mla_rtr_flags_softif_get_ipv4() - get mcast router flags from
+  *  node for IPv4
+@@ -258,7 +233,7 @@ batadv_mcast_mla_flags_get(struct batadv_priv *bat_priv)
+ 	struct batadv_mcast_mla_flags mla_flags;
+ 	struct net_device *bridge;
+ 
+-	bridge = batadv_mcast_get_bridge(dev);
++	bridge = batadv_softif_get_bridge(dev);
+ 
+ 	memset(&mla_flags, 0, sizeof(mla_flags));
+ 	mla_flags.enabled = 1;
+@@ -499,7 +474,7 @@ batadv_mcast_mla_softif_get(struct net_device *dev,
+ 			    struct hlist_head *mcast_list,
+ 			    struct batadv_mcast_mla_flags *flags)
+ {
+-	struct net_device *bridge = batadv_mcast_get_bridge(dev);
++	struct net_device *bridge = batadv_softif_get_bridge(dev);
+ 	int ret4, ret6 = 0;
+ 
+ 	if (bridge)
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index a04b4978..90501c09 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -676,6 +676,31 @@ static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
+ 			       "vlan interface destroyed", false);
+ }
+ 
++/**
++ * batadv_softif_get_bridge() - get the bridge on top of the softif if it exists
++ * @mesh_iface: netdev struct of the mesh interface
++ *
++ * If the given mesh interface has a bridge on top then the refcount
++ * of the according net device is increased.
++ *
++ * Return: NULL if no such bridge exists. Otherwise the net device of the
++ * bridge.
++ */
++struct net_device *batadv_softif_get_bridge(struct net_device *mesh_iface)
++{
++	struct net_device *upper = mesh_iface;
++
++	rcu_read_lock();
++	do {
++		upper = netdev_master_upper_dev_get_rcu(upper);
++	} while (upper && !netif_is_bridge_master(upper));
++
++	dev_hold(upper);
++	rcu_read_unlock();
++
++	return upper;
++}
++
+ /**
+  * batadv_interface_add_vid() - ndo_add_vid API implementation
+  * @dev: the netdev of the mesh interface
+@@ -691,6 +716,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -698,6 +724,20 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	/* The Linux bridge adds the PVID of a port (default VID 1) and
++	 * triggers this handler. The PVID is for ingress traffic from
++	 * bat0 to the bridge and other bridge ports. However this makes no
++	 * statement about what is received or send on bat0 itself, bat0
++	 * might as well be an untagged access port, even with a PVID
++	 * configured. Therefore ignoring here when a bridge is involved.
++	 * Instead learn VLANs on the fly from traffic.
++	 */
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
++
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+ 	return batadv_softif_create_vlan_own(bat_priv, vid);
+@@ -719,6 +759,7 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -726,6 +767,11 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
+ 
+ 	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 6ce30fe9..b2784ecf 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -19,6 +19,7 @@ int batadv_skb_head_push(struct sk_buff *skb, unsigned int len);
+ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct sk_buff *skb, int hdr_size,
+ 			 struct batadv_orig_node *orig_node);
++struct net_device *batadv_softif_get_bridge(struct net_device *soft_iface);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+ int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
+-- 
+2.52.0
+

--- a/feeds/qca-wifi-7/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
+++ b/feeds/qca-wifi-7/batman-adv/patches/0060-batman-adv-add-dynamic-bridged-in-TT-VID-detection-s.patch
@@ -1,0 +1,397 @@
+From 2112a502a97b3b7196faeeb8d48dcc3a1fbb0796 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 13:51:37 +0100
+Subject: [PATCH] batman-adv: add dynamic, bridged-in TT VID detection support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far, if we wanted to bridge VLAN tagged frames into the mesh one would
+need to manually create an according VLAN interface on top of bat0
+first, to trigger batman-adv to create the according structures
+for a VID.
+
+With this change the VLAN from bridged-in clients is now automatically
+detected and added to the translation table on the fly.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/hard-interface.c    |   2 +-
+ net/batman-adv/multicast.c         |   8 +-
+ net/batman-adv/soft-interface.c    | 123 ++++++++++++++++-------------
+ net/batman-adv/soft-interface.h    |   6 +-
+ net/batman-adv/translation-table.c |  19 ++---
+ net/batman-adv/translation-table.h |   4 +-
+ 6 files changed, 91 insertions(+), 71 deletions(-)
+
+diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+index 41c1ad33..f4828248 100644
+--- a/net/batman-adv/hard-interface.c
++++ b/net/batman-adv/hard-interface.c
+@@ -928,7 +928,7 @@ static int batadv_hard_if_event_softif(unsigned long event,
+ 	switch (event) {
+ 	case NETDEV_REGISTER:
+ 		bat_priv = netdev_priv(net_dev);
+-		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
++		batadv_softif_create_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 		break;
+ 	}
+ 
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 27511a06..4a6079db 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -692,6 +692,7 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ {
+ 	struct batadv_hw_addr *mcast_entry;
+ 	struct hlist_node *tmp;
++	int ret;
+ 
+ 	if (!mcast_list)
+ 		return;
+@@ -701,9 +702,10 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+ 						  &bat_priv->mcast.mla_list))
+ 			continue;
+ 
+-		if (!batadv_tt_local_add(bat_priv->soft_iface,
+-					 mcast_entry->addr, BATADV_NO_FLAGS,
+-					 BATADV_NULL_IFINDEX, BATADV_NO_MARK))
++		ret = batadv_tt_local_add(bat_priv->soft_iface,
++					  mcast_entry->addr, BATADV_NO_FLAGS,
++					  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++		if (ret <= 0)
+ 			continue;
+ 
+ 		hlist_del(&mcast_entry->list);
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index d3fdf822..079d030e 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -141,6 +141,10 @@ static int batadv_interface_set_mac_addr(struct net_device *dev, void *p)
+ 
+ 	rcu_read_lock();
+ 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
++		/* we don't use this VID ourself, avoid adding us to it */
++		if (!batadv_is_my_client(bat_priv, old_addr, vlan->vid))
++			continue;
++
+ 		batadv_tt_local_remove(bat_priv, old_addr, vlan->vid,
+ 				       "mac address changed", false);
+ 		batadv_tt_local_add(dev, addr->sa_data, vlan->vid,
+@@ -543,13 +547,15 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ }
+ 
+ /**
+- * batadv_softif_create_vlan() - allocate the needed resources for a new vlan
++ * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
+  *
+- * Return: 0 on success, a negative error otherwise.
++ * Return: a pointer to a newly allocated softif vlan struct on success, NULL
++ * otherwise.
+  */
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++static struct batadv_softif_vlan *
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ {
+ 	struct batadv_softif_vlan *vlan;
+ 
+@@ -557,55 +563,94 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 	if (vlan) {
+-		batadv_softif_vlan_put(vlan);
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -EEXIST;
++		return vlan;
+ 	}
+ 
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+-		return -ENOMEM;
++		return NULL;
+ 	}
+ 
+ 	vlan->bat_priv = bat_priv;
+ 	vlan->vid = vid;
++	/* hold only one refcount, caller will store a reference to us in
++	 * tt_local->vlan without releasing any refcount
++	 */
+ 	kref_init(&vlan->refcount);
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
+-	kref_get(&vlan->refcount);
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
++	return vlan;
++}
++
++/**
++ * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
++ * @bat_priv: the batpriv ith all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Return : the softif vlan struct if found or created, NULL otherwise
++ */
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid)
++{
++	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
++
++	if (vlan)
++		return vlan;
++
++	return batadv_softif_create_vlan(bat_priv, vid);
++}
++
++/**
++ * batadv_softif_create_vlan_own() - add our own softif to the local TT
++ * @bat_priv: the bat priv with all the mesh interface information
++ * @vid: the VLAN identifier
++ *
++ * Adds the MAC address of our own mesh interface with the given VLAN ID as
++ * a permanent local TT entry.
++ *
++ * Return: 0 on success, a negative error otherwise.
++ */
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid)
++{
++	int ret;
++
+ 	/* add a new TT local entry. This one will be marked with the NOPURGE
+ 	 * flag
+ 	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
++	ret = batadv_tt_local_add(bat_priv->soft_iface,
++				  bat_priv->soft_iface->dev_addr, vid,
++				  BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+ 
+-	/* don't return reference to new softif_vlan */
+-	batadv_softif_vlan_put(vlan);
++	if (ret < 0)
++		return ret;
+ 
+ 	return 0;
+ }
+ 
+ /**
+- * batadv_softif_destroy_vlan() - remove and destroy a softif_vlan object
++ * batadv_softif_destroy_vlan_own() - remove our own softif from the local TT
+  * @bat_priv: the bat priv with all the soft interface information
+- * @vlan: the object to remove
++ * @vid: the VLAN identifier
++ *
++ * Removes the MAC address of our own soft interface with the given VLAN ID from
++ * the local TT.
+  */
+-static void batadv_softif_destroy_vlan(struct batadv_priv *bat_priv,
+-				       struct batadv_softif_vlan *vlan)
++static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
++					   unsigned short vid)
+ {
+ 	/* explicitly remove the associated TT local entry because it is marked
+ 	 * with the NOPURGE flag
+ 	 */
+-	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr,
+-			       vlan->vid, "vlan interface destroyed", false);
+-
+-	batadv_softif_vlan_put(vlan);
++	batadv_tt_local_remove(bat_priv, bat_priv->soft_iface->dev_addr, vid,
++			       "vlan interface destroyed", false);
+ }
+ 
+ /**
+@@ -623,7 +668,6 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -633,25 +677,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+-	/* if a new vlan is getting created and it already exists, it means that
+-	 * it was not deleted yet. batadv_softif_vlan_get() increases the
+-	 * refcount in order to revive the object.
+-	 *
+-	 * if it does not exist then create it.
+-	 */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
+-	if (!vlan)
+-		return batadv_softif_create_vlan(bat_priv, vid);
+-
+-	/* add a new TT local entry. This one will be marked with the NOPURGE
+-	 * flag. This must be added again, even if the vlan object already
+-	 * exists, because the entry was deleted by kill_vid()
+-	 */
+-	batadv_tt_local_add(bat_priv->soft_iface,
+-			    bat_priv->soft_iface->dev_addr, vid,
+-			    BATADV_NULL_IFINDEX, BATADV_NO_MARK);
+-
+-	return 0;
++	return batadv_softif_create_vlan_own(bat_priv, vid);
+ }
+ 
+ /**
+@@ -670,7 +696,6 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -678,15 +703,8 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
+-	vlan = batadv_softif_vlan_get(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+-	if (!vlan)
+-		return -ENOENT;
+-
+-	batadv_softif_destroy_vlan(bat_priv, vlan);
+-
+-	/* finally free the vlan object */
+-	batadv_softif_vlan_put(vlan);
+ 
++	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+ }
+ 
+@@ -1080,7 +1098,6 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_hard_iface *hard_iface;
+-	struct batadv_softif_vlan *vlan;
+ 
+ 	list_for_each_entry(hard_iface, &batadv_hardif_list, list) {
+ 		if (hard_iface->soft_iface == soft_iface)
+@@ -1088,11 +1105,7 @@ static void batadv_softif_destroy_netlink(struct net_device *soft_iface,
+ 	}
+ 
+ 	/* destroy the "untagged" VLAN */
+-	vlan = batadv_softif_vlan_get(bat_priv, BATADV_NO_FLAGS);
+-	if (vlan) {
+-		batadv_softif_destroy_vlan(bat_priv, vlan);
+-		batadv_softif_vlan_put(vlan);
+-	}
++	batadv_softif_destroy_vlan_own(bat_priv, BATADV_NO_FLAGS);
+ 
+ 	unregister_netdevice_queue(soft_iface, head);
+ }
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 9f2003f1..7050ccd3 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -21,10 +21,14 @@ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct batadv_orig_node *orig_node);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+-int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid);
++int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
++				  unsigned short vid);
+ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
++struct batadv_softif_vlan *
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
++				 unsigned short vid);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index 36ca3125..a66be4f7 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -632,8 +632,8 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+  *
+  * Return: true if the client was successfully added, false otherwise.
+  */
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark)
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+@@ -645,10 +645,10 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	struct hlist_head *head;
+ 	struct batadv_tt_orig_list_entry *orig_entry;
+ 	int hash_added, table_size, packet_size_max;
+-	bool ret = false;
+ 	bool roamed_back = false;
+ 	u8 remote_flags;
+ 	u32 match_mark;
++	int ret = 0;
+ 
+ 	if (ifindex != BATADV_NULL_IFINDEX)
+ 		in_dev = dev_get_by_index(net, ifindex);
+@@ -699,21 +699,22 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 		net_ratelimited_function(batadv_info, soft_iface,
+ 					 "Local translation table size (%i) exceeds maximum packet size (%i); Ignoring new local tt entry: %pM\n",
+ 					 table_size, packet_size_max, addr);
++		ret = -E2BIG;
+ 		goto out;
+ 	}
+ 
+ 	tt_local = kmem_cache_alloc(batadv_tl_cache, GFP_ATOMIC);
+-	if (!tt_local)
++	if (!tt_local) {
++		ret = -ENOMEM;
+ 		goto out;
++	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
+ 	if (!vlan) {
+-		net_ratelimited_function(batadv_info, soft_iface,
+-					 "adding TT local entry %pM to non-existent VLAN %d\n",
+-					 addr, batadv_print_vid(vid));
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
++		ret = -ENOMEM;
+ 		goto out;
+ 	}
+ 
+@@ -811,7 +812,7 @@ bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	if (remote_flags ^ (tt_local->common.flags & BATADV_TT_REMOTE_MASK))
+ 		batadv_tt_local_event(bat_priv, tt_local, BATADV_NO_FLAGS);
+ 
+-	ret = true;
++	ret = 1;
+ out:
+ 	batadv_hardif_put(in_hardif);
+ 	dev_put(in_dev);
+diff --git a/net/batman-adv/translation-table.h b/net/batman-adv/translation-table.h
+index d18740d9..bbdda848 100644
+--- a/net/batman-adv/translation-table.h
++++ b/net/batman-adv/translation-table.h
+@@ -16,8 +16,8 @@
+ #include <linux/types.h>
+ 
+ int batadv_tt_init(struct batadv_priv *bat_priv);
+-bool batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+-			 unsigned short vid, int ifindex, u32 mark);
++int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
++			unsigned short vid, int ifindex, u32 mark);
+ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv,
+ 			   const u8 *addr, unsigned short vid,
+ 			   const char *message, bool roaming);
+-- 
+2.52.0
+

--- a/feeds/qca-wifi-7/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
+++ b/feeds/qca-wifi-7/batman-adv/patches/0061-batman-adv-limit-number-of-learned-VLANs-from-bridge.patch
@@ -1,0 +1,248 @@
+From f142435963da7d4c32c64f3f7c59b3dfaaa962fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:13:49 +0100
+Subject: [PATCH] batman-adv: limit number of learned VLANs from bridged-in
+ clients
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently with batman-adv compatibility version 15 each added VLAN
+increases the OGM protocol overhead of this node considerably. Therefore
+adding a configurable knob to limit the number of learned, snooped VLANs
+from traffic from bridged-in clients.
+
+There are currently also still issues in the BLA code that would
+temporarily break any broadcast transmissions with every newly learned
+VLAN. Therefore setting the default limit for externally learned VLANs to
+zero for now.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ include/uapi/linux/batman_adv.h    |  6 ++++++
+ net/batman-adv/netlink.c           | 15 ++++++++++++++
+ net/batman-adv/soft-interface.c    | 33 ++++++++++++++++++++++++++----
+ net/batman-adv/soft-interface.h    |  4 ++--
+ net/batman-adv/translation-table.c |  3 ++-
+ net/batman-adv/types.h             |  6 ++++++
+ 6 files changed, 60 insertions(+), 7 deletions(-)
+
+diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+index 35dc016c..44018dd6 100644
+--- a/include/uapi/linux/batman_adv.h
++++ b/include/uapi/linux/batman_adv.h
+@@ -481,6 +481,12 @@ enum batadv_nl_attrs {
+ 	 */
+ 	BATADV_ATTR_MULTICAST_FANOUT,
+ 
++	/**
++	 * @BATADV_ATTR_VLAN_DYN_MAX: defines the maximum number of allowed
++	 * learned VLANs from bridged-in clients.
++	 */
++	BATADV_ATTR_VLAN_DYN_MAX,
++
+ 	/* add attributes above here, update the policy in netlink.c */
+ 
+ 	/**
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index 07f21cdb..afbd1446 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -131,6 +131,7 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+ 	[BATADV_ATTR_MCAST_FLAGS]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_MCAST_FLAGS_PRIV]		= { .type = NLA_U32 },
+ 	[BATADV_ATTR_VLANID]			= { .type = NLA_U16 },
++	[BATADV_ATTR_VLAN_DYN_MAX]		= { .type = NLA_U16 },
+ 	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+@@ -359,6 +360,10 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+ 			atomic_read(&bat_priv->orig_interval)))
+ 		goto nla_put_failure;
+ 
++	if (nla_put_u16(msg, BATADV_ATTR_VLAN_DYN_MAX,
++			bat_priv->softif_vlan_dyn_max))
++		goto nla_put_failure;
++
+ 	batadv_hardif_put(primary_if);
+ 
+ 	genlmsg_end(msg, hdr);
+@@ -613,6 +618,16 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+ 		atomic_set(&bat_priv->orig_interval, orig_interval);
+ 	}
+ 
++	if (info->attrs[BATADV_ATTR_VLAN_DYN_MAX]) {
++		u16 vlan_dyn_max;
++
++		attr = info->attrs[BATADV_ATTR_VLAN_DYN_MAX];
++		vlan_dyn_max = nla_get_u16(attr);
++		vlan_dyn_max = min_t(u16, vlan_dyn_max, VLAN_N_VID);
++
++		bat_priv->softif_vlan_dyn_max = vlan_dyn_max;
++	}
++
+ 	batadv_netlink_notify_mesh(bat_priv);
+ 
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index 079d030e..a04b4978 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -23,6 +23,7 @@
+ #include <linux/kref.h>
+ #include <linux/list.h>
+ #include <linux/lockdep.h>
++#include <linux/net.h>
+ #include <linux/netdevice.h>
+ #include <linux/netlink.h>
+ #include <linux/percpu.h>
+@@ -46,6 +47,7 @@
+ #include "distributed-arp-table.h"
+ #include "gateway_client.h"
+ #include "hard-interface.h"
++#include "log.h"
+ #include "multicast.h"
+ #include "network-coding.h"
+ #include "send.h"
+@@ -550,13 +552,16 @@ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+  * batadv_softif_create_vlan() - create a softif vlan struct
+  * @bat_priv: the bat priv with all the soft interface information
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return: a pointer to a newly allocated softif vlan struct on success, NULL
+  * otherwise.
+  */
+ static struct batadv_softif_vlan *
+-batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
++batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid,
++			  bool own)
+ {
++	unsigned short vlan_dyn_max, vlan_dyn_count;
+ 	struct batadv_softif_vlan *vlan;
+ 
+ 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -567,6 +572,19 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 		return vlan;
+ 	}
+ 
++	vlan_dyn_max = bat_priv->softif_vlan_dyn_max;
++	vlan_dyn_count = bat_priv->softif_vlan_dyn_count;
++
++	if (vid & BATADV_VLAN_HAS_TAG && !own &&
++	    vlan_dyn_max <= vlan_dyn_count) {
++		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
++
++		net_ratelimited_function(batadv_info, bat_priv->soft_iface,
++					 "not adding VLAN %d, already learned %hu VID(s)\n",
++					 batadv_print_vid(vid), vlan_dyn_max);
++		return NULL;
++	}
++
+ 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+ 	if (!vlan) {
+ 		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+@@ -582,6 +600,9 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ 
+ 	atomic_set(&vlan->ap_isolation, 0);
+ 
++	if (vid & BATADV_VLAN_HAS_TAG && !own)
++		bat_priv->softif_vlan_dyn_count++;
++
+ 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+ 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+ 
+@@ -591,20 +612,22 @@ batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+ /**
+  * batadv_softif_vlan_get_or_create() - retrieve or create a softif vlan struct
+  * @bat_priv: the batpriv ith all the mesh interface information
++ * @addr: the MAC address of the client to add
+  * @vid: the VLAN identifier
++ * @own: VLAN was not detected via bridged in traffic
+  *
+  * Return : the softif vlan struct if found or created, NULL otherwise
+  */
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid)
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own)
+ {
+ 	struct batadv_softif_vlan *vlan = batadv_softif_vlan_get(bat_priv, vid);
+ 
+ 	if (vlan)
+ 		return vlan;
+ 
+-	return batadv_softif_create_vlan(bat_priv, vid);
++	return batadv_softif_create_vlan(bat_priv, vid, own);
+ }
+ 
+ /**
+@@ -805,6 +828,8 @@ static int batadv_softif_init_late(struct net_device *dev)
+ 	bat_priv->tt.last_changeset_len = 0;
+ 	bat_priv->isolation_mark = 0;
+ 	bat_priv->isolation_mark_mask = 0;
++	bat_priv->softif_vlan_dyn_max = 20;
++	bat_priv->softif_vlan_dyn_count = 0;
+ 
+ 	/* randomize initial seqno to avoid collision */
+ 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 7050ccd3..6ce30fe9 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -27,8 +27,8 @@ void batadv_softif_vlan_release(struct kref *ref);
+ struct batadv_softif_vlan *batadv_softif_vlan_get(struct batadv_priv *bat_priv,
+ 						  unsigned short vid);
+ struct batadv_softif_vlan *
+-batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv,
+-				 unsigned short vid);
++batadv_softif_vlan_get_or_create(struct batadv_priv *bat_priv, const u8* addr,
++				 unsigned short vid, bool own);
+ 
+ /**
+  * batadv_softif_vlan_put() - decrease the vlan object refcounter and
+diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+index a66be4f7..a88b462c 100644
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -635,6 +635,7 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 			unsigned short vid, int ifindex, u32 mark)
+ {
++	bool own = (ifindex == BATADV_NULL_IFINDEX) ? true : false;
+ 	struct batadv_priv *bat_priv = netdev_priv(soft_iface);
+ 	struct batadv_tt_local_entry *tt_local;
+ 	struct batadv_tt_global_entry *tt_global = NULL;
+@@ -710,7 +711,7 @@ int batadv_tt_local_add(struct net_device *soft_iface, const u8 *addr,
+ 	}
+ 
+ 	/* increase the refcounter of the related vlan */
+-	vlan = batadv_softif_vlan_get_or_create(bat_priv, vid);
++	vlan = batadv_softif_vlan_get_or_create(bat_priv, addr, vid, own);
+ 	if (!vlan) {
+ 		kmem_cache_free(batadv_tl_cache, tt_local);
+ 		tt_local = NULL;
+diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+index ca9449ec..416b4e2f 100644
+--- a/net/batman-adv/types.h
++++ b/net/batman-adv/types.h
+@@ -1695,6 +1695,12 @@ struct batadv_priv {
+ 	/** @softif_vlan_list_lock: lock protecting softif_vlan_list */
+ 	spinlock_t softif_vlan_list_lock;
+ 
++	/** @softif_vlan_dyn_max: maximum number of allowed learned VLANs */
++	unsigned short softif_vlan_dyn_max;
++
++	/** @softif_vlan_dyn_count: current number of learned VLANs */
++	unsigned short softif_vlan_dyn_count;
++
+ #ifdef CONFIG_BATMAN_ADV_BLA
+ 	/** @bla: bridge loop avoidance data */
+ 	struct batadv_priv_bla bla;
+-- 
+2.52.0
+

--- a/feeds/qca-wifi-7/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
+++ b/feeds/qca-wifi-7/batman-adv/patches/0062-batman-adv-avoid-adding-bridge-VLAN-IDs-through-ndo_.patch
@@ -1,0 +1,191 @@
+From 6ab36677fa236fcba7875f4d4583fd4b7047bad2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Thu, 15 Jan 2026 14:21:23 +0100
+Subject: [PATCH] batman-adv: avoid adding bridge VLAN IDs through
+ ndo_vlan_rx_add_vid()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Linux bridge by default adds the PVID of a port (default VID 1) and
+by that triggers our ndo_vlan_rx_add_vid() handler. The PVID is
+for ingress traffic from bat0 to the bridge and other bridge ports.
+However this makes no statement about what is received or send on bat0
+itself, bat0 might as well be an untagged access port, even with a PVID
+configured. Therefore ignoring here when a bridge is involved.
+
+Also, similarly a "bridge vlan add vid 42 dev bat0 untagged" would call
+this handler with VID 42. Even though we wouldn't be interested in this
+VLAN as its traffic would be untagged on our side.
+
+The issue is that any extra VLAN currently increases our own
+OGM protocol overhead quite a bit, so we want to avoid that
+by only adding VLANs that we are sure someone will be using.
+So only add VLANs through snooping of actual, VLAN tagged
+traffic, not through kernel internal network events
+if we have a bridge on top.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+[antonio@mandelbit.com: backported to v2022.1]
+Signed-off-by: Antonio Quartulli <antonio@mandelbit.com>
+Signed-off-by: Firas Shaari <firas@80211networks.com>
+---
+ net/batman-adv/multicast.c      | 29 ++-------------------
+ net/batman-adv/soft-interface.c | 46 +++++++++++++++++++++++++++++++++
+ net/batman-adv/soft-interface.h |  1 +
+ 3 files changed, 49 insertions(+), 27 deletions(-)
+
+diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+index 4a6079db..541c0c4d 100644
+--- a/net/batman-adv/multicast.c
++++ b/net/batman-adv/multicast.c
+@@ -72,31 +72,6 @@ static void batadv_mcast_start_timer(struct batadv_priv *bat_priv)
+ 			   msecs_to_jiffies(BATADV_MCAST_WORK_PERIOD));
+ }
+ 
+-/**
+- * batadv_mcast_get_bridge() - get the bridge on top of the softif if it exists
+- * @soft_iface: netdev struct of the mesh interface
+- *
+- * If the given soft interface has a bridge on top then the refcount
+- * of the according net device is increased.
+- *
+- * Return: NULL if no such bridge exists. Otherwise the net device of the
+- * bridge.
+- */
+-static struct net_device *batadv_mcast_get_bridge(struct net_device *soft_iface)
+-{
+-	struct net_device *upper = soft_iface;
+-
+-	rcu_read_lock();
+-	do {
+-		upper = netdev_master_upper_dev_get_rcu(upper);
+-	} while (upper && !netif_is_bridge_master(upper));
+-
+-	dev_hold(upper);
+-	rcu_read_unlock();
+-
+-	return upper;
+-}
+-
+ /**
+  * batadv_mcast_mla_rtr_flags_softif_get_ipv4() - get mcast router flags from
+  *  node for IPv4
+@@ -258,7 +233,7 @@ batadv_mcast_mla_flags_get(struct batadv_priv *bat_priv)
+ 	struct batadv_mcast_mla_flags mla_flags;
+ 	struct net_device *bridge;
+ 
+-	bridge = batadv_mcast_get_bridge(dev);
++	bridge = batadv_softif_get_bridge(dev);
+ 
+ 	memset(&mla_flags, 0, sizeof(mla_flags));
+ 	mla_flags.enabled = 1;
+@@ -499,7 +474,7 @@ batadv_mcast_mla_softif_get(struct net_device *dev,
+ 			    struct hlist_head *mcast_list,
+ 			    struct batadv_mcast_mla_flags *flags)
+ {
+-	struct net_device *bridge = batadv_mcast_get_bridge(dev);
++	struct net_device *bridge = batadv_softif_get_bridge(dev);
+ 	int ret4, ret6 = 0;
+ 
+ 	if (bridge)
+diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+index a04b4978..90501c09 100644
+--- a/net/batman-adv/soft-interface.c
++++ b/net/batman-adv/soft-interface.c
+@@ -676,6 +676,31 @@ static void batadv_softif_destroy_vlan_own(struct batadv_priv *bat_priv,
+ 			       "vlan interface destroyed", false);
+ }
+ 
++/**
++ * batadv_softif_get_bridge() - get the bridge on top of the softif if it exists
++ * @mesh_iface: netdev struct of the mesh interface
++ *
++ * If the given mesh interface has a bridge on top then the refcount
++ * of the according net device is increased.
++ *
++ * Return: NULL if no such bridge exists. Otherwise the net device of the
++ * bridge.
++ */
++struct net_device *batadv_softif_get_bridge(struct net_device *mesh_iface)
++{
++	struct net_device *upper = mesh_iface;
++
++	rcu_read_lock();
++	do {
++		upper = netdev_master_upper_dev_get_rcu(upper);
++	} while (upper && !netif_is_bridge_master(upper));
++
++	dev_hold(upper);
++	rcu_read_unlock();
++
++	return upper;
++}
++
+ /**
+  * batadv_interface_add_vid() - ndo_add_vid API implementation
+  * @dev: the netdev of the mesh interface
+@@ -691,6 +716,7 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 				    unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported.
+ 	 * batman-adv does not know how to handle other types
+@@ -698,6 +724,20 @@ static int batadv_interface_add_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	/* The Linux bridge adds the PVID of a port (default VID 1) and
++	 * triggers this handler. The PVID is for ingress traffic from
++	 * bat0 to the bridge and other bridge ports. However this makes no
++	 * statement about what is received or send on bat0 itself, bat0
++	 * might as well be an untagged access port, even with a PVID
++	 * configured. Therefore ignoring here when a bridge is involved.
++	 * Instead learn VLANs on the fly from traffic.
++	 */
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
++
+ 	vid |= BATADV_VLAN_HAS_TAG;
+ 
+ 	return batadv_softif_create_vlan_own(bat_priv, vid);
+@@ -719,6 +759,7 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 				     unsigned short vid)
+ {
+ 	struct batadv_priv *bat_priv = netdev_priv(dev);
++	struct net_device *bridge;
+ 
+ 	/* only 802.1Q vlans are supported. batman-adv does not know how to
+ 	 * handle other types
+@@ -726,6 +767,11 @@ static int batadv_interface_kill_vid(struct net_device *dev, __be16 proto,
+ 	if (proto != htons(ETH_P_8021Q))
+ 		return -EINVAL;
+ 
++	bridge = batadv_softif_get_bridge(dev);
++	if (bridge) {
++		dev_put(bridge);
++		return 0;
++	}
+ 
+ 	batadv_softif_destroy_vlan_own(bat_priv, vid | BATADV_VLAN_HAS_TAG);
+ 	return 0;
+diff --git a/net/batman-adv/soft-interface.h b/net/batman-adv/soft-interface.h
+index 6ce30fe9..b2784ecf 100644
+--- a/net/batman-adv/soft-interface.h
++++ b/net/batman-adv/soft-interface.h
+@@ -19,6 +19,7 @@ int batadv_skb_head_push(struct sk_buff *skb, unsigned int len);
+ void batadv_interface_rx(struct net_device *soft_iface,
+ 			 struct sk_buff *skb, int hdr_size,
+ 			 struct batadv_orig_node *orig_node);
++struct net_device *batadv_softif_get_bridge(struct net_device *soft_iface);
+ bool batadv_softif_is_valid(const struct net_device *net_dev);
+ extern struct rtnl_link_ops batadv_link_ops;
+ int batadv_softif_create_vlan_own(struct batadv_priv *bat_priv,
+-- 
+2.52.0
+


### PR DESCRIPTION
## Summary

Backports three upstream batman-adv patches to **both** `feeds/qca-wifi-6` and `feeds/qca-wifi-7` batman-adv packages, fixing bridged-in VLAN handling for QCA targets on main:

- **0060** — batman-adv: add dynamic, bridged-in TT VID detection support
- **0061** — batman-adv: limit number of learned VLANs from bridge
- **0062** — batman-adv: avoid adding bridge VLAN IDs through ndo_*

Original author: Linus Luessing <linus.luessing@c0d3.blue>
Backported to v2022.1 by: Antonio Quartulli <antonio@mandelbit.com>

Equivalent of #1100 (staging-for-v4.2.0-LTS) but targeting main with coverage for both wifi-6 and wifi-7 feeds.

## Feeds affected

| Feed | batman-adv version | Patches |
|---|---|---|
| `feeds/qca-wifi-6` | v2022.0 | 0060, 0061, 0062 |
| `feeds/qca-wifi-7` | v2023.1 | 0060, 0061, 0062 |

**Note:** MTK targets (e.g. AX820) use batman-adv from the `openwrt-routing` feed, which already carries v2024.3 — these patches are not needed there and are not included.

## Build verification

- ✅ yuncore_ax820 (MTK ramips/mt7621) — confirms no breakage on MTK path
- ✅ yuncore_fap655 (QCA wifi-6 / ipq50xx) — patches 0060/0061/0062 applied cleanly
- ✅ yuncore_eap105 (QCA wifi-7 / ipq53xx) — patches 0060/0061/0062 applied cleanly

Signed-off-by: Firas Shaari <firas@80211networks.com>