### PR TITLE
WIFI-15508-CIG-WF-189-The-OpenWiFi-version-based-on-ATH13.1CSU1-current-latest-version-has-a-low-TP-testing-rate

### DIFF
--- a/patches-25.12/0113-base-files-disable-packet-steering-by-default.patch
+++ b/patches-25.12/0113-base-files-disable-packet-steering-by-default.patch
@@ -1,0 +1,35 @@
+From 601c2ff0f71e4563f91ff11a780f530d0523e5c6 Mon Sep 17 00:00:00 2001
+From: ruanyaoyu <ruanyaoyu@actiontec.com>
+Date: Tue, 26 May 2026 10:00:00 +0800
+Subject: [PATCH] base-files: disable packet-steering by default
+
+Align with upstream QSDK behavior: explicitly set packet_steering='0'
+and steering_flows='0' in config_generate. On IPQ platforms with
+hardware acceleration (PPE/NSS/SFE), software packet-steering via RPS
+provides no benefit and may interfere with hardware queue scheduling.
+
+Without this patch, upstream OpenWrt leaves packet_steering unset,
+which causes the packet-steering.uc script to enable RPS by default
+on multi-core systems.
+
+Signed-off-by: ruanyaoyu <ruanyaoyu@actiontec.com>
+---
+ package/base-files/files/bin/config_generate | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/package/base-files/files/bin/config_generate b/package/base-files/files/bin/config_generate
+index d6ef2a02cd..358f955ae7 100755
+--- a/package/base-files/files/bin/config_generate
++++ b/package/base-files/files/bin/config_generate
+@@ -47,6 +47,8 @@ generate_static_network() {
+ 		delete network.globals
+ 		set network.globals='globals'
+ 		set network.globals.dhcp_default_duid='auto'
++		set network.globals.packet_steering='0'
++		set network.globals.steering_flows='0'
+ 	EOF
+ 	[ -e /proc/sys/net/ipv6 ] && {
+ 		uci -q batch <<-EOF
+-- 
+2.34.1
+


### PR DESCRIPTION
…rrent latest version) has a low TP testing rate

Set the default configuration in config_generate to '0' for network.globals.packet_steering. Previously, packet_steering was enabled by default, which resulted in uneven CPU load during TP testing