### PR TITLE
rrmd: accept per-BSS hostapd ubus objects with dotted ifnames

### DIFF
--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/local.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/local.uc
@@ -118,11 +118,10 @@ stations_stats = {
 
 function interfaces_subunsub(path, sub) {
 	/* check if this is a hostapd instance */
-	let name = split(path, '.');
-
-	if (length(name) != 2 || name[0] != 'hostapd')
+	let prefix = 'hostapd.';
+	if (substr(path, 0, length(prefix)) != prefix)
 		return;
-	name = name[1];
+	let name = substr(path, length(prefix));
 
 	ulog_info(sprintf('%s %s\n', sub ? 'add' : 'remove', path));
 


### PR DESCRIPTION
On ath13.1 multi-BSS, hostapd publishes one ubus object per BSS as hostapd.<phy>.<radio>-<bss>, e.g. hostapd.phy00.1-0. The split(.) based parser in interfaces_subunsub required exactly two dot-separated components and rejected those names, so the interfaces[] table stayed empty and every BSS-targeted RRM action (channel_switch, tx_power, kick by addr->bssid) returned "failed to trigger" or "station unknown".

Replace the 2-part split with a "hostapd." prefix strip so dotted ifnames are preserved while remaining backward compatible with hostapd.wlan0 style names on older platforms.

Fixes: WIFI-15434