### PR TITLE
WIFI-15508-CIG-WF-189-The-OpenWiFi-version-based-on-ATH13.1CSU1-current-latest-version-has-a-low-TP-testing-rate-NEW

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/etc/uci-defaults/35-packet-steering
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/etc/uci-defaults/35-packet-steering
@@ -1,0 +1,21 @@
+#!/bin/sh
+# QCA IPQ platforms: default packet_steering to disabled.
+# Hardware acceleration (PPE/NSS/SFE) handles packet distribution;
+# software RPS provides no benefit and may cause uneven CPU load.
+# Only set defaults if not already configured (preserves user settings).
+
+changed=0
+
+if [ -z "$(uci -q get network.globals.packet_steering)" ]; then
+    uci set network.globals.packet_steering='0'
+    changed=1
+fi
+
+if [ -z "$(uci -q get network.globals.steering_flows)" ]; then
+    uci set network.globals.steering_flows='0'
+    changed=1
+fi
+
+[ "$changed" = "1" ] && uci commit network
+
+exit 0

--- a/feeds/qca-wifi-7/ipq54xx/base-files/etc/uci-defaults/35-packet-steering
+++ b/feeds/qca-wifi-7/ipq54xx/base-files/etc/uci-defaults/35-packet-steering
@@ -1,0 +1,21 @@
+#!/bin/sh
+# QCA IPQ platforms: default packet_steering to disabled.
+# Hardware acceleration (PPE/NSS/SFE) handles packet distribution;
+# software RPS provides no benefit and may cause uneven CPU load.
+# Only set defaults if not already configured (preserves user settings).
+
+changed=0
+
+if [ -z "$(uci -q get network.globals.packet_steering)" ]; then
+    uci set network.globals.packet_steering='0'
+    changed=1
+fi
+
+if [ -z "$(uci -q get network.globals.steering_flows)" ]; then
+    uci set network.globals.steering_flows='0'
+    changed=1
+fi
+
+[ "$changed" = "1" ] && uci commit network
+
+exit 0


### PR DESCRIPTION
…rrent latest version) has a low TP testing rate

	Set the default value of network.globals.packet_steering to '0'
for QCA-based products. Previously, packet_steering was enabled by default, which caused uneven CPU load distribution across cores during throughput testing.

	This change is limited to QCA platform targets only, as the
packet steering behavior and its impact are specific to QCA chipset architecture (e.g., IPQ5332, IPQ5425).