### PR TITLE
WIFI-15543: Update anti-rollback function on Sonicfi RAP750W-311A/RAP750E-S/RAP750E-H

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
@@ -225,8 +225,8 @@ platform_check_image() {
 		local info_output=$(get_firmware_info "$1")
 		FW_VER="${info_output%%|*}"
 		FW_BUILD_DATE="${info_output#*|}"
-		local LIMIT_VER="4.2.3"
-		local LIMIT_BUILD_DATE="20260402"
+		local LIMIT_VER="5.0.0"
+		local LIMIT_BUILD_DATE="20260603"
 
 		echo "Checking version for $board..."
 		echo "Current: v$CURRENT_VER, Firmware: v$FW_VER, Limit: <= v$LIMIT_VER"


### PR DESCRIPTION
We have resolved issue [[WIFI-15306] certificates partition fails to mount on rap750w-311a - Jira](https://telecominfraproject.atlassian.net/browse/WIFI-15306) via PR[#1027](https://github.com/Telecominfraproject/wlan-ap/pull/1027), which was merged into release “Tip 5.0”. Therefore, rollback shall be restricted starting from version 5.0. However, the previous rollback restriction version set for [[WIFI-15401] RAP7110C-341X/RAP750W-311A/RAP750E-S/RAP750E-H anti-rollback funciton - Jira](https://telecominfraproject.atlassian.net/browse/WIFI-15401) was version4.2.3 at that time. Now the downgrade restriction version needs to be updated as "5.0.0"

[WIFI-15306]: https://telecominfraproject.atlassian.net/browse/WIFI-15306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WIFI-15401]: https://telecominfraproject.atlassian.net/browse/WIFI-15401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ