### PR TITLE
WIFI-15511-DFS-is-broken-on-WF196-APs-on-5.0.0

### DIFF
--- a/patches-25.12/0114-wifi6e-6g-default-country-code.patch
+++ b/patches-25.12/0114-wifi6e-6g-default-country-code.patch
@@ -1,0 +1,26 @@
+From fd4c07d2f6c43d27f7a4ece25a82f014f4a6f861 Mon Sep 17 00:00:00 2001
+From: ruanyaoyu <ruanyaoyu@cigtech.com>
+Date: Fri, 5 Jun 2026 10:07:53 +0800
+Subject: [PATCH] Following the previous approach, the 6G country code is not
+ configured by default, which also avoids firmware issues
+
+Signed-off-by: ruanyaoyu <ruanyaoyu@cigtech.com>
+---
+ package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+index d61786fa65..ef6ce8bca6 100644
+--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
++++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+@@ -80,7 +80,6 @@ for (let phy_name, phy in board.wlan) {
+ 
+ 		let country, encryption, defaults, num_global_macaddr;
+ 		if (band_name == '6g') {
+-			country = '00';
+ 			encryption = 'owe';
+ 		} else {
+ 			encryption = 'none';
+-- 
+2.34.1
+


### PR DESCRIPTION
Following the previous approach, the 6G country code is not
 configured by default, which also avoids firmware issues