### PR TITLE
WIFI-15451:fix 5GHz radio fails to initialize with EHT config allow-dfs false instead of falling back to HE

### DIFF
--- a/feeds/ucentral/ucentral-schema/patches/001-fix-5-GHz-radio-fails-to-initialize-with-EHT-config-allow-dfs-false-instead-of-falling-back-to-HE.patch
+++ b/feeds/ucentral/ucentral-schema/patches/001-fix-5-GHz-radio-fails-to-initialize-with-EHT-config-allow-dfs-false-instead-of-falling-back-to-HE.patch
@@ -1,0 +1,16 @@
+diff -Nur ucentral-schema-2026.05.11~6fe9800e/renderer/templates/radio.uc ucentral-schema-2026.05.11~6fe9800e_new/renderer/templates/radio.uc
+--- ucentral-schema-2026.05.11~6fe9800e/renderer/templates/radio.uc	2026-06-05 20:50:15.915396459 +0800
++++ ucentral-schema-2026.05.11~6fe9800e_new/renderer/templates/radio.uc	2026-06-05 20:52:52.262823108 +0800
+@@ -25,6 +25,12 @@
+ 
+ 		for (let supported_mode in supported_phy_modes) {
+ 			if (match(supported_mode, fallback_modes[channel_mode])) {
++				if(!radio.allow_dfs)
++				{
++					let suffix = substr(supported_mode, length(supported_mode) - 3, 3);
++					if(suffix == "160")
++						continue;
++				}
+ 				warn("Selected radio does not support requested HT mode %s, falling back to %s",
+ 					wanted_mode, supported_mode);
+ 				delete radio.channel;


### PR DESCRIPTION
fixed WIFI-15451:fix 5GHz radio fails to initialize with EHT config allow-dfs false instead of falling back to HE