### PR TITLE
qca-wifi-7/wifi-scripts: fix wpa_supplicant fails to start up sometimes

### DIFF
--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -1990,7 +1990,7 @@ wpa_supplicant_start() {
 	[ -n "$wpa_supp_init" ] || return 0
 	[ -n "$mld" ] && is_mld="true"
 
-	ubus_call wpa_supplicant config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "num_global_macaddr": '"$num_global_macaddr"', "is_ml": '"$is_mld"', "macaddr_base" : '"$macaddr_base"' }' > /dev/null
+	ubus_call wpa_supplicant config_set '{ "phy": "'"$phy"'", "radio": '"$radio"', "num_global_macaddr": '"$num_global_macaddr"', "is_ml": '"$is_mld"', "macaddr_base" : "'"$macaddr_base"'" }' > /dev/null
 	if [ "${dpp}" -eq 1 ]; then
 		/usr/sbin/wpa_cli -i $ifname -p /var/run/wpa_supplicant -a /lib/netifd/dpp-supplicant-event-update -B
 	fi


### PR DESCRIPTION
Enclosing macaddr_base in double quotes can resolve the parsing issue.

fixes: WIFI-15524