### PR TITLE
WIFI-15442: Fix Clients fail to obtain IP in NAT mode at TIP-devel-168e840 on Cybertan_rap630c-311g

### DIFF
--- a/patches-25.12/0114-netifd-remove-all-members-and-re-add-member-the-bridge-wake-up-issue.patch
+++ b/patches-25.12/0114-netifd-remove-all-members-and-re-add-member-the-bridge-wake-up-issue.patch
@@ -1,0 +1,50 @@
+From 3ed83ad575cdfe9d19cab9a341ac3b8e3a4ab6fb Mon Sep 17 00:00:00 2001
+From: "Yingwei.Huang" <Yingwei.Huang@cybertan.com.tw>
+Date: Tue, 9 Jun 2026 09:46:10 +0800
+Subject: [PATCH] netifd: remove all members and re-add member the bridge fails
+ to wake up
+
+Fix the issue :After the bridge clears all members when handling DEV_EVENT_REMOVE,
+the bridge fails to wake up again when a new member is added later.
+
+Fixes: WIFI-15442
+
+Signed-off-by: Yingwei.Huang <Yingwei.Huang@cybertan.com.tw>
+---
+ ...and_re-add_member_bride_wakeup_issue.patch | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/201_remove_all_members_and_re-add_member_bride_wakeup_issue.patch
+
+diff --git a/package/network/config/netifd/patches/201_remove_all_members_and_re-add_member_bride_wakeup_issue.patch b/package/network/config/netifd/patches/201_remove_all_members_and_re-add_member_bride_wakeup_issue.patch
+new file mode 100644
+index 0000000000..43a38e4fca
+--- /dev/null
++++ b/package/network/config/netifd/patches/201_remove_all_members_and_re-add_member_bride_wakeup_issue.patch
+@@ -0,0 +1,24 @@
++--- a/bridge.c	2026-02-26 20:08:34.000000000 +0800
+++++ b/bridge.c	2026-06-08 09:56:14.677686765 +0800
++@@ -827,6 +827,8 @@
++ 		bridge_disable_member(bm, false);
++ 
++ 	bridge_disable_interface(bst);
+++
+++	device_broadcast_event(&bst->dev, DEV_EVENT_REMOVE);
++ 
++ 	return 0;
++ }
++
++--- a/device.c	2026-02-26 20:08:34.000000000 +0800
+++++ b/device.c	2026-06-08 09:57:34.413834815 +0800
++@@ -979,6 +979,9 @@
++ 		device_refresh_present(dev);
++ 	if (!state)
++ 		safe_list_for_each(&dev->users, device_release_cb, NULL);
+++
+++	dev->sys_present = state;
+++	dev->present = state;
++ }
++ 
++ void device_set_link(struct device *dev, bool state)
+-- 
+2.34.1
+


### PR DESCRIPTION
Fixes a netifd module issue:
After the bridge clears all members when handling DEV_EVENT_REMOVE, the bridge fails to wake up again when a new member is added later.It usually occurs inside a bridge consisting entirely of Wi-Fi interfaces, because in this case it triggers a condition where all bridge members are cleared and then added again.
https://telecominfraproject.atlassian.net/browse/WIFI-15442
