### PR TITLE
[DHCP] fix DHCP-inject mechanism to prevent DHCP-inject cannot disable

### DIFF
--- a/feeds/ucentral/udhcpinject/files/etc/init.d/dhcpinject
+++ b/feeds/ucentral/udhcpinject/files/etc/init.d/dhcpinject
@@ -26,6 +26,12 @@ start_service() {
 
 stop_service() {
     procd_kill $SERVICE_NAME
+
+    # Safety net: clean up tc filters in case the process did not clean up properly
+    for iface in $(iwinfo 2>/dev/null | awk '/^[a-z]/{print $1}'); do
+        tc filter del dev "$iface" ingress pref 32 2>/dev/null
+    done
+    ip link del ifb-inject 2>/dev/null
 }
 
 reload_service() {

--- a/feeds/ucentral/udhcpinject/src/udhcpinject.c
+++ b/feeds/ucentral/udhcpinject/src/udhcpinject.c
@@ -484,6 +484,7 @@ void signal_handler(int sig)
     case SIGTERM:
     case SIGHUP:
         cleanup();
+        exit(0);
         break;
     default:
         break;


### PR DESCRIPTION
(wlan-ap part)
Root Cause:
When dhcp-inject is removed from SSID services, the renderer template (dhcp_inject.uc) does an early return before calling services.set_enabled("dhcpinject", ...). As a result, ucentral never knows it needs to stop the dhcpinject service — the process keeps running, tc filters remain, and option 82 continues to be injected until reboot.

Solution:
1.Move services.set_enabled() before the early return — so ucentral always registers the service state (enabled or disabled), and properly calls /etc/init.d/dhcpinject stop when disabled.
2.Add exit(0) after cleanup() in signal handler — ensures the process actually terminates after cleaning up tc filters (instead of potentially hanging in pcap_loop).
3.Add tc filter cleanup in stop_service() — safety net so filters are removed even if the process crashes or exits abnormally.

Fixes: WIFI-15562