### PR TITLE
hostapd/ucentral-state: fix reload crash on dead radio and add radio …

### DIFF
--- a/feeds/qca-wifi-6/hostapd/files/hostapd.uc
+++ b/feeds/qca-wifi-6/hostapd/files/hostapd.uc
@@ -538,7 +538,7 @@ function iface_reload_config(name, phydev, config, old_config)
 		return false;
 	}
 
-	if (iface.state() != "ENABLED") {
+	if (type(iface.state) != "function" || iface.state() != "ENABLED") {
 		hostapd.printf(`Interface ${iface_name} is not fully configured`);
 		return false;
 	}

--- a/feeds/ucentral/ucentral-state/files/ucentral-state
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state
@@ -41,8 +41,21 @@ function self_healing() {
 				if (iface_data.ssids) {
 					// one of the VAPs have an issue: flag up!
 					heal_wifi = true;
+					ulog(LOG_INFO, 'Self-healing shall be triggered: interface %s has SSID issues\n', iface);
 					ulog(LOG_INFO, 'Time passed since last network restart = %d seconds\n', time_passed_since_nw_restart);
 					break;
+				}
+			}
+
+			/* Check for per-radio failures (SSIDs missing on specific phy/band) */
+			if (!heal_wifi && health_stat.data.radios) {
+				for (let radio_name, issue in health_stat.data.radios) {
+					if (issue.failed_ssids) {
+						heal_wifi = true;
+						ulog(LOG_INFO, 'Self-healing shall be triggered: radio %s has failed SSIDs: %J\n', radio_name, issue.failed_ssids);
+						ulog(LOG_INFO, 'Time passed since last network restart = %d seconds\n', time_passed_since_nw_restart);
+						break;
+					}
 				}
 			}
 		} else {
@@ -81,6 +94,8 @@ function self_healing() {
 
 		// restart network
 		system('/etc/init.d/network restart');
+	} else if (heal_wifi) {
+		ulog(LOG_INFO, 'Cannot trigger self-healing within 5 mins of a network restart \n');
 	}
 }
 


### PR DESCRIPTION
…self-healing

hostapd: guard iface.state() call with type check in iface_reload_config(). When a radio disappears (ENODEV), the native interface object may remain in hostapd.interfaces but with an invalid .state property. This caused "left-hand side is not a function" errors on every config reload attempt. The function already returns false for non-ENABLED interfaces, so the type guard simply takes the same path without throwing.

ucentral-state: extend self_healing() to check health_stat.data.radios for per-radio SSID failures. When any radio reports failed_ssids, trigger a network restart (subject to the existing 5-minute cooldown). Added diagnostic logging for both interface and radio triggered restarts.

Fixes: WIFI-15549