### PR TITLE
ucentral-schema: add per-radio health check and self-healing support

### DIFF
--- a/feeds/ucentral/ucentral-schema/patches/006-health-metrics-to-check-radio-status.patch
+++ b/feeds/ucentral/ucentral-schema/patches/006-health-metrics-to-check-radio-status.patch
@@ -1,0 +1,252 @@
+--- ucentral-schema-2026-01-24-8491119c.orig/renderer/wifi/iface.uc	2026-06-09 13:28:03.404875054 +0800
++++ ucentral-schema-2026-01-24-8491119c/renderer/wifi/iface.uc	2026-06-09 13:42:11.536421198 +0800
+@@ -61,22 +61,20 @@ function lookup_wifs() {
+ 	for (let wif in wifs) {
+ 		if (!iftypes[wif.iftype])
+ 			continue;
+-
+-		// Allow interfaces with wiphy_freq=0 (e.g. NOHT/channel unknown state)
+ 		let w = {};
+ 		w.ssid = wif.ssid;
+ 		w.bssid = wif.mac;
+ 		w.mode = iftypes[wif.iftype];
++		w.phy = wif.wiphy;
+ 		w.channel = [];
+ 		w.frequency = [];
+ 		w.tx_power = (wif.wiphy_tx_power_level / 100) || 0;
+-		if (wif.wiphy_freq) {
+-			for (let f in [ wif.wiphy_freq, wif.center_freq1, wif.center_freq2 ])
+-				if (f) {
+-					push(w.channel, freq2channel(f));
+-					push(w.frequency, f);
+-				}
+-		}
++		w.has_channel = !!wif.wiphy_freq;
++		for (let f in [ wif.wiphy_freq, wif.center_freq1, wif.center_freq2 ])
++			if (f) {
++				push(w.channel, freq2channel(f));
++				push(w.frequency, f);
++			}
+ 		if (chwidth[wif.channel_width])
+ 			w.ch_width = chwidth[wif.channel_width];
+ 		rv[wif.ifname] = w;
+--- ucentral-schema-2026-01-24-8491119c.orig/system/health.uc	2026-06-09 13:28:34.713176181 +0800
++++ ucentral-schema-2026-01-24-8491119c/system/health.uc	2026-06-09 13:37:28.257992387 +0800
+@@ -30,6 +30,176 @@ function find_ssid(ssid) {
+ 	return 1;
+ }
+ 
++function find_ssid_on_phy(ssid, phy_idx) {
++	for (let ifname, iface in wifi_state) {
++		if (iface.ssid == ssid && iface.phy == phy_idx) {
++			if (!iface.has_channel) {
++				return -1;
++			}
++			return 0;
++		}
++	}
++	return 1;
++}
++
++function find_ssid_by_prefix(ssid, prefix) {
++	for (let ifname, iface in wifi_state) {
++		if (iface.ssid == ssid && index(ifname, prefix) == 0) {
++			if (!iface.has_channel) {
++				return -1;
++			}
++			return 0;
++		}
++	}
++	return 1;
++}
++
++function find_ssid_on_phy_band(ssid, phy_idx, band) {
++	let band_ranges = {
++		'2g': [2400, 2500],
++		'5g': [5150, 5900],
++		'6g': [5925, 7200],
++	};
++	let range = band_ranges[band];
++	if (!range)
++		return find_ssid_on_phy(ssid, phy_idx);
++
++	for (let ifname, iface in wifi_state) {
++		if (iface.ssid != ssid || iface.phy != phy_idx)
++			continue;
++
++		/* No channel assigned — can't verify band by frequency, but it's on
++		 * the right phy and SSID, so report as no_channel (more specific) */
++		if (!iface.has_channel)
++			return -1;
++
++		/* Check if any of the interface's frequencies fall within the expected band */
++		for (let f in iface.frequency) {
++			if (f >= range[0] && f <= range[1])
++				return 0;
++		}
++	}
++	return 1;
++}
++
++function find_ssid_for_radio(ssid, match_info) {
++	if (match_info.match_mode == 'prefix')
++		return find_ssid_by_prefix(ssid, match_info.ifname_prefix);
++	else if (match_info.match_mode == 'phy_band')
++		return find_ssid_on_phy_band(ssid, match_info.phy_idx, match_info.band);
++	else
++		return find_ssid_on_phy(ssid, match_info.phy_idx);
++}
++
++function get_radio_match_info(device_name) {
++	let section = wifi_config[device_name];
++	if (!section || !section.path)
++		return null;
++
++	let info = {};
++
++	/* If device has ifname_prefix, use prefix-based matching (multi-radio single-phy chips) */
++	if (section.ifname_prefix) {
++		info.match_mode = 'prefix';
++		info.ifname_prefix = section.ifname_prefix;
++		return info;
++	}
++
++	/* Parse path+N convention: e.g. "platform/soc/c000000.wifi+1"
++	 * The +N suffix indicates radio offset within a multi-radio device node */
++	let dev_path = section.path;
++	let phy_offset = 0;
++	let ofs_match = match(dev_path, /^(.+)\+([0-9]+)$/);
++	if (ofs_match) {
++		dev_path = ofs_match[1];
++		phy_offset = int(ofs_match[2]);
++	}
++
++	/* Resolve phy from sysfs path */
++	let phys = fs.glob(sprintf('/sys/devices/%s/ieee80211/phy*', dev_path));
++	if (!length(phys))
++		phys = fs.glob(sprintf('/sys/devices/platform/%s/ieee80211/phy*', dev_path));
++	if (!length(phys))
++		return null;
++
++	sort(phys);
++	if (phy_offset >= length(phys))
++		return null;
++
++	let phy_name = fs.basename(phys[phy_offset]);
++	let phy_idx;
++	let idx_str = fs.readfile(sprintf('/sys/class/ieee80211/%s/index', phy_name));
++	if (idx_str != null) {
++		phy_idx = int(trim(idx_str));
++	} else {
++		let match_res = match(phy_name, /phy([0-9]+)/);
++		if (match_res)
++			phy_idx = int(match_res[1]);
++		else
++			return null;
++	}
++
++	/* If device has a 'radio' option, multiple wifi-devices share the same
++	 * phy (reconf-capable multi-band chips). Use phy+band matching to
++	 * distinguish radios by their configured band. */
++	if (section.radio != null && section.band) {
++		info.match_mode = 'phy_band';
++		info.phy_idx = phy_idx;
++		info.band = section.band;
++		return info;
++	}
++
++	info.match_mode = 'phy';
++	info.phy_idx = phy_idx;
++	return info;
++}
++
++function check_radio_health() {
++	let radio_issues = {};
++
++	for (let k, section in wifi_config) {
++		if (section['.type'] == 'wifi-device') {
++			let dev_name = section['.name'];
++			let disabled = section.disabled;
++
++			if (disabled == '1')
++				continue;
++
++			let match_info = get_radio_match_info(dev_name);
++
++			if (match_info == null)
++				continue;
++
++			let expected_ssids = [];
++			for (let j, iface_section in wifi_config) {
++				if (iface_section['.type'] == 'wifi-iface' && iface_section.device == dev_name) {
++					push(expected_ssids, iface_section.ssid);
++				}
++			}
++
++			let failed_ssids = {};
++			for (let ssid in expected_ssids) {
++				let result = find_ssid_for_radio(ssid, match_info);
++				if (result != 0) {
++					failed_ssids[ssid] = (result == -1) ? 'no_channel' : 'missing';
++				}
++			}
++
++			if (length(failed_ssids)) {
++				radio_issues[dev_name] = {
++					failed_ssids: failed_ssids
++				};
++				if (match_info.match_mode == 'prefix')
++					radio_issues[dev_name].prefix = match_info.ifname_prefix;
++				else
++					radio_issues[dev_name].phy = match_info.phy_idx;
++			}
++		}
++	}
++
++	return radio_issues;
++}
++
+ function radius_probe(server, port, secret, user, pass)
+ {
+ 	let f = fs.open('/tmp/radius.conf', 'w');
+@@ -132,6 +302,22 @@ for (let iface in interfaces) {
+ 	}
+ }
+ 
++let radio_issues = check_radio_health();
++if (length(radio_issues)) {
++	state.radios = radio_issues;
++	for (let radio_name, issue in radio_issues) {
++		ctx.call('event', 'event', {
++			object: 'health',
++			verb: 'wifi',
++			payload: {
++				radio: radio_name,
++				error: sprintf('Radio %s has failed SSIDs', radio_name),
++				failed_ssids: issue.failed_ssids
++			}
++		});
++	}
++}
++
+ for (let l, policy in rrmd_config) {
+ 	if (policy['.type'] != 'policy' || policy.name != 'chanutil')
+ 		continue;
+@@ -166,9 +355,15 @@ let errors = length(state.interfaces);
+ if (!errors)
+ 	delete state.interfaces;
+ 
+-let sanity = 100 - (errors * 100 / count);
++let radio_errors = length(state.radios);
++if (!radio_errors)
++	delete state.radios;
++
++let total_checks = count + length(wifi_config);
++let total_errors = errors + radio_errors;
++let sanity = 100 - (total_errors * 100 / (total_checks || 1));
+ 
+-warn(printf('health check reports sanity of %d', sanity));
++warn(printf('health check reports sanity of %d (iface_errors=%d, radio_errors=%d)', sanity, errors, radio_errors));
+ ctx.call('ucentral', 'health', {sanity: sanity, data: state});
+ let f = fs.open("/tmp/ucentral.health", "w");
+ if (f) {

--- a/feeds/ucentral/ucentral-state/files/ucentral-state
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state
@@ -41,8 +41,21 @@ function self_healing() {
 				if (iface_data.ssids) {
 					// one of the VAPs have an issue: flag up!
 					heal_wifi = true;
+					ulog(LOG_INFO, 'Self-healing shall be triggered: interface %s has SSID issues\n', iface);
 					ulog(LOG_INFO, 'Time passed since last network restart = %d seconds\n', time_passed_since_nw_restart);
 					break;
+				}
+			}
+
+			/* Check for per-radio failures (SSIDs missing on specific phy/band) */
+			if (!heal_wifi && health_stat.data.radios) {
+				for (let radio_name, issue in health_stat.data.radios) {
+					if (issue.failed_ssids) {
+						heal_wifi = true;
+						ulog(LOG_INFO, 'Self-healing shall be triggered: radio %s has failed SSIDs: %J\n', radio_name, issue.failed_ssids);
+						ulog(LOG_INFO, 'Time passed since last network restart = %d seconds\n', time_passed_since_nw_restart);
+						break;
+					}
 				}
 			}
 		} else {
@@ -81,6 +94,8 @@ function self_healing() {
 
 		// restart network
 		system('/etc/init.d/network restart');
+	} else if (heal_wifi) {
+		ulog(LOG_INFO, 'Cannot trigger self-healing within 5 mins of a network restart \n');
 	}
 }
 


### PR DESCRIPTION
The global SSID lookup in health.uc could not detect a failed radio on multi-band APs because the same SSID running on a sibling radio masked the failure. This patch adds per-radio validation by matching SSIDs to their expected phy index or ifname_prefix.

Additonally, support path+N device node notation for multi-radio chips that expose multiple phys under a single sysfs path, and add phy_band matching for reconf-capable devices where multiple wifi-devices share the same phy but operate on different bands.

Changes:
- renderer/wifi/iface.uc: expose phy index and has_channel flag for each interface so dead-radio VAPs remain visible to health checks 
- system/health.uc: add check_radio_health() that validates each non-disabled radio has its expected SSIDs active with a channel assigned; failures are reported in state.radios and factored into the sanity score

Fixes: WIFI-15549