### PR TITLE
qca-wifi-7: hostapd: restore global ban and seconds ban_time in del_c…

### DIFF
--- a/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t05-hostapd-ubus-global-ban-and-seconds.patch
+++ b/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t05-hostapd-ubus-global-ban-and-seconds.patch
@@ -1,0 +1,85 @@
+diff --git a/src/ap/ubus.c b/src/ap/ubus.c
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -137,7 +137,7 @@
+ 		}
+ 	}
+ 
+-	eloop_register_timeout(0, time * 1000, hostapd_bss_del_ban, ban, hapd);
++	eloop_register_timeout(time, 0, hostapd_bss_del_ban, ban, hapd);
+ }
+ 
+ static int
+@@ -440,6 +440,7 @@
+ 	DEL_CLIENT_REASON,
+ 	DEL_CLIENT_DEAUTH,
+ 	DEL_CLIENT_BAN_TIME,
++	DEL_CLIENT_GLOBAL_BAN,
+ 	__DEL_CLIENT_MAX
+ };
+ 
+@@ -448,9 +449,27 @@
+ 	[DEL_CLIENT_REASON] = { "reason", BLOBMSG_TYPE_INT32 },
+ 	[DEL_CLIENT_DEAUTH] = { "deauth", BLOBMSG_TYPE_INT8 },
+ 	[DEL_CLIENT_BAN_TIME] = { "ban_time", BLOBMSG_TYPE_INT32 },
++	[DEL_CLIENT_GLOBAL_BAN] = { "global_ban", BLOBMSG_TYPE_INT8 },
+ };
+ 
+ static int
++hostapd_bss_del_client_cb(struct hostapd_iface *iface, void *ctx)
++{
++	struct blob_attr **tb = ctx;
++	u8 addr[ETH_ALEN];
++	int i;
++
++	hwaddr_aton(blobmsg_data(tb[DEL_CLIENT_ADDR]), addr);
++
++	for (i = 0; i < iface->num_bss; i++) {
++		struct hostapd_data *bss = iface->bss[i];
++
++		hostapd_bss_ban_client(bss, addr, blobmsg_get_u32(tb[DEL_CLIENT_BAN_TIME]));
++	}
++	return 0;
++}
++
++static int
+ hostapd_bss_del_client(struct ubus_context *ctx, struct ubus_object *obj,
+ 			struct ubus_request_data *req, const char *method,
+ 			struct blob_attr *msg)
+@@ -458,8 +477,8 @@
+ 	struct blob_attr *tb[__DEL_CLIENT_MAX];
+ 	struct hostapd_data *hapd = container_of(obj, struct hostapd_data, ubus.obj);
+ 	struct sta_info *sta;
+-	bool deauth = false;
+-	int reason;
++	bool deauth = false, global = false;
++	int reason, ban_time = 0;
+ 	u8 addr[ETH_ALEN];
+ 
+ 	blobmsg_parse(del_policy, __DEL_CLIENT_MAX, tb, blob_data(msg), blob_len(msg));
+@@ -476,6 +495,9 @@
+ 	if (tb[DEL_CLIENT_DEAUTH])
+ 		deauth = blobmsg_get_bool(tb[DEL_CLIENT_DEAUTH]);
+ 
++	if (tb[DEL_CLIENT_GLOBAL_BAN])
++		global = blobmsg_get_bool(tb[DEL_CLIENT_GLOBAL_BAN]);
++
+ 	sta = ap_get_sta(hapd, addr);
+ 	if (sta) {
+ 		if (deauth) {
+@@ -487,8 +509,13 @@
+ 		}
+ 	}
+ 
+-	if (tb[DEL_CLIENT_BAN_TIME])
+-		hostapd_bss_ban_client(hapd, addr, blobmsg_get_u32(tb[DEL_CLIENT_BAN_TIME]));
++	if (tb[DEL_CLIENT_BAN_TIME]) {
++		ban_time = blobmsg_get_u32(tb[DEL_CLIENT_BAN_TIME]);
++		if (global)
++			hapd->iface->interfaces->for_each_interface(hapd->iface->interfaces, hostapd_bss_del_client_cb, tb);
++		else
++			hostapd_bss_ban_client(hapd, addr, ban_time);
++	}
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
…lient

The ath13.1.5 SDK update overwrote the hostapd ubus overlay src/ap/ubus.c with the vendor version and dropped two ban features:

- ban_time was armed with eloop_register_timeout(0, time * 1000, ...), so the value was treated as microseconds and an N second ban expired after N ms.
- global_ban (DEL_CLIENT_GLOBAL_BAN) and the per-interface fan-out were removed, so a kick only banned the single BSS and the station immediately reassociated on the other band.

Restore the seconds based timeout and the global_ban handling, reinstating the behaviour originally added in 56e0b3b50cf4 ("hostapd: globally ban clients when they are kicked"), so a kicked station is banned across all BSSes for the requested duration.

Fixes: 45d2d0b129c3 ("qca-wifi-7: update feed to ath13.1.5 SDK")
Fixes: WIFI-15434