### PR TITLE
patches-25.12: fix EAP115/EAP115a Ethernet ports issues

### DIFF
--- a/feeds/mtk-app/mt798x-2p5g-phy-firmware-internal/Makefile
+++ b/feeds/mtk-app/mt798x-2p5g-phy-firmware-internal/Makefile
@@ -14,7 +14,7 @@ define KernelPackage/mt798x-2p5g-phy
   DEPENDS:=@TARGET_mediatek +mt798x-2p5g-phy-firmware-internal
   KCONFIG:=CONFIG_MEDIATEK_2P5GE_PHY=m
   FILES:=$(LINUX_DIR)/drivers/net/phy/mediatek/mtk-2p5ge.ko
-  AUTOLOAD:=$(call AutoLoad,73,mtk-2p5ge)
+  AUTOLOAD:=$(call AutoLoad,73,mtk-2p5ge,1)
 endef
 
 define KernelPackage/mt798x-2p5g-phy/description

--- a/patches-25.12/0094-mediatek-add-support-for-Edgecore-EAP115-EAP115a.patch
+++ b/patches-25.12/0094-mediatek-add-support-for-Edgecore-EAP115-EAP115a.patch
@@ -11,7 +11,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 ---
  .../uboot-envtools/files/mediatek_filogic     |   2 +
  .../mediatek/dts/mt7987a-edgecore-eap115.dts  |   9 +
- .../mediatek/dts/mt7987a-edgecore-eap115.dtsi | 230 ++++++++++++++++++
+ .../mediatek/dts/mt7987a-edgecore-eap115.dtsi | 235 ++++++++++++++++++
  .../mediatek/dts/mt7987a-edgecore-eap115a.dts |   9 +
  .../filogic/base-files/etc/board.d/01_leds    |   4 +
  .../filogic/base-files/etc/board.d/02_network |   9 +
@@ -19,7 +19,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  .../lib/preinit/05_set_edgecore_netdev        |  13 +
  .../base-files/lib/upgrade/platform.sh        |   4 +-
  target/linux/mediatek/image/filogic.mk        |  40 +++
- 10 files changed, 322 insertions(+), 2 deletions(-)
+ 10 files changed, 327 insertions(+), 2 deletions(-)
  create mode 100644 target/linux/mediatek/dts/mt7987a-edgecore-eap115.dts
  create mode 100644 target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi
  create mode 100644 target/linux/mediatek/dts/mt7987a-edgecore-eap115a.dts
@@ -58,12 +58,13 @@ new file mode 100644
 index 0000000000..9d344c7ce5
 --- /dev/null
 +++ b/target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi
-@@ -0,0 +1,230 @@
+@@ -0,0 +1,235 @@
 +// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 +
 +#include "mt7987a.dtsi"
 +#include <dt-bindings/input/input.h>
 +#include <dt-bindings/leds/common.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
 +
 +/ {
 +	aliases {
@@ -129,6 +130,7 @@ index 0000000000..9d344c7ce5
 +&gmac0 {
 +	phy-mode = "sgmii";
 +	phy-handle = <&phy2>;
++	managed = "in-band-status";
 +	nvmem-cells = <&macaddr_lan>;
 +	nvmem-cell-names = "mac-address";
 +	status = "okay";
@@ -146,6 +148,7 @@ index 0000000000..9d344c7ce5
 +	phy2: phy@2 {
 +		compatible = "ethernet-phy-id001c.c916";
 +		reg = <2>;
++		phy-mode = "sgmii";
 +		reset-gpios = <&pio 42 GPIO_ACTIVE_LOW>;
 +		reset-assert-us = <10000>;
 +		reset-deassert-us = <50000>;
@@ -156,9 +159,11 @@ index 0000000000..9d344c7ce5
 +	phy15: phy@15 {
 +		compatible = "ethernet-phy-ieee802.3-c45";
 +		reg = <15>;
-+
++		phy-mode = "internal";
 +		pinctrl-0 = <&i2p5gbe_led0_pins>;
 +		pinctrl-names = "i2p5gbe-led";
++		interrupts = <GIC_SPI 286 IRQ_TYPE_LEVEL_HIGH>;
++		interrupt-parent = <&gic>;
 +	};
 +};
 +
@@ -418,8 +423,8 @@ index 48f35a6424..7807433e22 100644
 +  IMAGES := sysupgrade.bin factory.bin
 +  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
 +  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7990-firmware \
-+	kmod-phy-realtek
++  DEVICE_PACKAGES := mt798x-2p5g-phy-firmware-internal kmod-mt798x-2p5g-phy \
++	kmod-mt7990-firmware kmod-phy-realtek
 +endef
 +TARGET_DEVICES += edgecore_eap115
 +
@@ -438,8 +443,8 @@ index 48f35a6424..7807433e22 100644
 +  IMAGES := sysupgrade.bin factory.bin
 +  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
 +  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7990-firmware \
-+	kmod-phy-realtek
++  DEVICE_PACKAGES := mt798x-2p5g-phy-firmware-internal kmod-mt798x-2p5g-phy \
++	kmod-mt7990-firmware kmod-phy-realtek
 +endef
 +TARGET_DEVICES += edgecore_eap115a
 +


### PR DESCRIPTION
Make mt798x internal 2.5GbE port driver to be loaded earlier. 
Also adjust device tree to include required entries for both ports.

Fixed: WIFI-15477