### PR TITLE
WIFI-15478:Openwrt-25.12 AP selects non PSC channel after ACS even with acs-exclude-6ghz-non-psc parameter enabled

### DIFF
--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -99,6 +99,9 @@ enable_color=
 #ACS DFS
 acs_exclude_dfs=
 
+#ACS PSC
+acs_exclude_6ghz_non_psc=
+
 updated_chanlist=
 min_tx_power=
 noscan=
@@ -231,7 +234,7 @@ drv_mac80211_init_device_config() {
 	config_add_int radio beacon_int chanbw frag rts
 	config_add_int rxantenna txantenna txpower min_tx_power antenna_gain
 	config_add_int num_global_macaddr multiple_bssid
-	config_add_boolean noscan ht_coex acs_exclude_dfs background_radar
+	config_add_boolean noscan ht_coex acs_exclude_dfs background_radar acs_exclude_6ghz_non_psc
 	config_add_array ht_capab
 	config_add_array channels
 	config_add_array scan_list
@@ -570,6 +573,10 @@ mac80211_hostapd_setup_base() {
 	[ "$auto_channel" -gt 0 ] && json_get_vars acs_exclude_dfs
 	[ -n "$acs_exclude_dfs" ] && [ "$acs_exclude_dfs" -gt 0 ] &&
 		append base_cfg "acs_exclude_dfs=1" "$N"
+
+	[ "$auto_channel" -gt 0 ] && json_get_vars acs_exclude_6ghz_non_psc
+	[ -n "$acs_exclude_6ghz_non_psc" ] && [ "$acs_exclude_6ghz_non_psc" -gt 0 ] &&
+		append base_cfg "acs_exclude_6ghz_non_psc=1" "$N"
 
 	json_get_vars noscan ht_coex min_tx_power:0 tx_burst disable_csa_dfs use_ru_puncture_dfs
 	json_get_values ht_capab_list ht_capab


### PR DESCRIPTION
fixed WIFI-15478:Openwrt-25.12 AP selects non PSC channel after ACS even with acs-exclude-6ghz-non-psc parameter enabled