### PR TITLE
ucode: align nl80211 attributes with ATH13.1 driver and correct wireless config generation

### DIFF
--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -81,12 +81,12 @@ if [ $mlo_add_flag -eq 0 ]; then
 fi
 
 MP_CONFIG_INT="mesh_retry_timeout mesh_confirm_timeout mesh_holding_timeout mesh_max_peer_links
-	       mesh_max_retries mesh_ttl mesh_element_ttl mesh_hwmp_max_preq_retries
-	       mesh_path_refresh_time mesh_min_discovery_timeout mesh_hwmp_active_path_timeout
-	       mesh_hwmp_preq_min_interval mesh_hwmp_net_diameter_traversal_time mesh_hwmp_rootmode
-	       mesh_hwmp_rann_interval mesh_gate_announcements mesh_sync_offset_max_neighor
-	       mesh_rssi_threshold mesh_hwmp_active_path_to_root_timeout mesh_hwmp_root_interval
-	       mesh_hwmp_confirmation_interval mesh_awake_window mesh_plink_timeout"
+		mesh_max_retries mesh_ttl mesh_element_ttl mesh_hwmp_max_preq_retries
+		mesh_path_refresh_time mesh_min_discovery_timeout mesh_hwmp_active_path_timeout
+		mesh_hwmp_preq_min_interval mesh_hwmp_net_diameter_traversal_time mesh_hwmp_rootmode
+		mesh_hwmp_rann_interval mesh_gate_announcements mesh_sync_offset_max_neighor
+		mesh_rssi_threshold mesh_hwmp_active_path_to_root_timeout mesh_hwmp_root_interval
+		mesh_hwmp_confirmation_interval mesh_awake_window mesh_plink_timeout"
 MP_CONFIG_BOOL="mesh_auto_open_plinks mesh_fwding"
 MP_CONFIG_STRING="mesh_power_mode"
 
@@ -163,16 +163,16 @@ dpp_ifaces=
 #epcs params
 enable_epcs=
 epcs_params="epcs_he_mu_edca_ac_be_aifsn epcs_he_mu_edca_ac_be_aci epcs_he_mu_edca_ac_be_ecwmin
-	     epcs_he_mu_edca_ac_be_ecwmax epcs_he_mu_edca_ac_be_timer epcs_he_mu_edca_ac_bk_aifsn
-	     epcs_he_mu_edca_ac_bk_aci epcs_he_mu_edca_ac_bk_ecwmin epcs_he_mu_edca_ac_bk_ecwmax
-	     epcs_he_mu_edca_ac_bk_timer epcs_he_mu_edca_ac_vi_ecwmin epcs_he_mu_edca_ac_vi_ecwmax
-	     epcs_he_mu_edca_ac_vi_aifsn epcs_he_mu_edca_ac_vi_aci epcs_he_mu_edca_ac_vi_timer
-	     epcs_he_mu_edca_ac_vo_aifsn epcs_he_mu_edca_ac_vo_aci epcs_he_mu_edca_ac_vo_ecwmin
-	     epcs_he_mu_edca_ac_vo_ecwmax epcs_he_mu_edca_ac_vo_timer epcs_wmm_ac_be_cwmin
-	     epcs_wmm_ac_be_cwmax epcs_wmm_ac_be_aifs epcs_wmm_ac_be_txop_limit epcs_wmm_ac_bk_cwmin
-	     epcs_wmm_ac_bk_cwmax epcs_wmm_ac_bk_aifs epcs_wmm_ac_bk_txop_limit epcs_wmm_ac_vi_cwmin
-	     epcs_wmm_ac_vi_cwmax epcs_wmm_ac_vi_aifs epcs_wmm_ac_vi_txop_limit epcs_wmm_ac_vo_cwmin
-	     epcs_wmm_ac_vo_cwmax epcs_wmm_ac_vo_aifs epcs_wmm_ac_vo_txop_limit"
+		epcs_he_mu_edca_ac_be_ecwmax epcs_he_mu_edca_ac_be_timer epcs_he_mu_edca_ac_bk_aifsn
+		epcs_he_mu_edca_ac_bk_aci epcs_he_mu_edca_ac_bk_ecwmin epcs_he_mu_edca_ac_bk_ecwmax
+		epcs_he_mu_edca_ac_bk_timer epcs_he_mu_edca_ac_vi_ecwmin epcs_he_mu_edca_ac_vi_ecwmax
+		epcs_he_mu_edca_ac_vi_aifsn epcs_he_mu_edca_ac_vi_aci epcs_he_mu_edca_ac_vi_timer
+		epcs_he_mu_edca_ac_vo_aifsn epcs_he_mu_edca_ac_vo_aci epcs_he_mu_edca_ac_vo_ecwmin
+		epcs_he_mu_edca_ac_vo_ecwmax epcs_he_mu_edca_ac_vo_timer epcs_wmm_ac_be_cwmin
+		epcs_wmm_ac_be_cwmax epcs_wmm_ac_be_aifs epcs_wmm_ac_be_txop_limit epcs_wmm_ac_bk_cwmin
+		epcs_wmm_ac_bk_cwmax epcs_wmm_ac_bk_aifs epcs_wmm_ac_bk_txop_limit epcs_wmm_ac_vi_cwmin
+		epcs_wmm_ac_vi_cwmax epcs_wmm_ac_vi_aifs epcs_wmm_ac_vi_txop_limit epcs_wmm_ac_vo_cwmin
+		epcs_wmm_ac_vo_cwmax epcs_wmm_ac_vo_aifs epcs_wmm_ac_vo_txop_limit"
 ttlm_enable=
 enable_dscp_policy_capa=
 
@@ -180,40 +180,40 @@ enable_dscp_policy_capa=
 atf_offload=
 
 mac80211_freq_to_channel() {
-        local freq=$1
+	local freq=$1
 
-        if [ "$freq" -lt 1000 ]; then
+	if [ "$freq" -lt 1000 ]; then
 		echo 0
 		return
-        fi
-        if [ "$freq" -eq 2484 ]; then
+	fi
+	if [ "$freq" -eq 2484 ]; then
 		echo 14
 		return
-        fi
-        if [ "$freq" -eq 5935 ]; then
+	fi
+	if [ "$freq" -eq 5935 ]; then
 		echo 2
 		return
-        fi
-        if [ "$freq" -lt 2484 ]; then
+	fi
+	if [ "$freq" -lt 2484 ]; then
 		echo $(((freq-2407)/5))
 		return
-        fi
-        if [ "$freq" -ge 4910 ] && [ "$freq" -le 4980 ]; then
+	fi
+	if [ "$freq" -ge 4910 ] && [ "$freq" -le 4980 ]; then
 		echo $(((freq-4000)/5))
 		return
-        fi
-        if [ "$freq" -lt 5950 ]; then
+	fi
+	if [ "$freq" -lt 5950 ]; then
 		echo $(((freq-5000)/5))
 		return
-        fi
-        if [ "$freq" -le 45000 ]; then
+	fi
+	if [ "$freq" -le 45000 ]; then
 		echo $(((freq-5950)/5))
 		return
-        fi
-        if [ "$freq" -ge 58320 ] && [ "$freq" -le 70200 ]; then
+	fi
+	if [ "$freq" -ge 58320 ] && [ "$freq" -le 70200 ]; then
 		echo $(((freq-56160)/5))
 		return
-        fi
+	fi
 }
 
 wdev_tool() {
@@ -388,30 +388,30 @@ get_sta_freq_list() {
 	freq1=$1
 	freq2=$2
 
-        case "$band_name" in
-                2g) band="1:";;
-                5gl|5gh|5g) band="2:";;
-                60g) band="3:";;
-                6g|6gl|6gh) band="4:";;
-        esac
+	case "$band_name" in
+		2g) band="1:";;
+		5gl|5gh|5g) band="2:";;
+		60g) band="3:";;
+		6g|6gl|6gh) band="4:";;
+	esac
 
 	iw "$phy" info | awk -v band="$band" -v min="$freq1" -v max="$freq2" '
 
 $1 ~ /Band/ {
-        band_match = band == $2
+	band_match = band == $2
 }
 
 band_match && $3 == "MHz" {
-        freq = $2
-         if (freq >= min && freq <= max) {
-                print int($2)
-        }
+	freq = $2
+	if (freq >= min && freq <= max) {
+		print int($2)
+	}
 }
 ' | tr '\n' ' '
 }
 
 cfg_append() {
-        echo "$1" >> "$2"
+	echo "$1" >> "$2"
 }
 
 mac80211_prepare_atf_config() {
@@ -480,7 +480,7 @@ mac80211_prepare_atf_config() {
 		config_get atf_device "$1" device
 
 		if [[ "$device" != "$atf_device" ]]; then
-                        return
+			return
 		fi
 
 		config_get cmd "$1" command
@@ -923,7 +923,7 @@ mac80211_hostapd_setup_base() {
 	case "$htmode" in
 		HE*) enable_ax=1 ;;
 		EHT*) enable_ax=1; enable_be=1
-		      [ -n "$disable_eml_cap" ] && append base_cfg "disable_eml_cap=$disable_eml_cap" "$N"
+			[ -n "$disable_eml_cap" ] && append base_cfg "disable_eml_cap=$disable_eml_cap" "$N"
 		;;
 	esac
 
@@ -1185,10 +1185,10 @@ mac80211_hostapd_setup_bss() {
 
 	[ "$wds" -gt 0 ] && {
 		wds_support=$(mac80211_wds_support_check "$phy")
-                if [ "$wds_support" -ne 1 ]; then
-                        echo WDS is supported only in native wifi mode for ath11k driver. Kindly update the config > /dev/ttyMSM0
-                        return
-                fi
+		if [ "$wds_support" -ne 1 ]; then
+			echo WDS is supported only in native wifi mode for ath11k driver. Kindly update the config > /dev/ttyMSM0
+			return
+		fi
 
 		append hostapd_cfg "wds_sta=1" "$N"
 		[ -n "$wds_bridge" ] && append hostapd_cfg "wds_bridge=$wds_bridge" "$N"
@@ -1212,7 +1212,7 @@ mac80211_hostapd_setup_bss() {
 		elif [ -n "$multiple_bssid" ] && [ "$multiple_bssid" -eq 3 ] && [ $((id % mbssid_group_size)) == "0" ]; then
 			append hostapd_cfg "$fils_cfg" "$N"
 		fi
-        fi
+	fi
 
 	if [ -n "$enable_scs" ]; then
 		append hostapd_cfg "enable_scs=$enable_scs" "$N"
@@ -1279,9 +1279,9 @@ mac80211_hostapd_setup_bss() {
 			;;
 	esac
 
-        [ -n "$commitatf" ] && append hostapd_cfg "commitatf=$commitatf" "$N"
-        [ -n "$atfssidsched" ] && append hostapd_cfg "atfssidsched=$atfssidsched" "$N"
-        [ -n "$atfssidgroup" ] && append hostapd_cfg "atfssidgroup=$atfssidgroup" "$N"
+	[ -n "$commitatf" ] && append hostapd_cfg "commitatf=$commitatf" "$N"
+	[ -n "$atfssidsched" ] && append hostapd_cfg "atfssidsched=$atfssidsched" "$N"
+	[ -n "$atfssidgroup" ] && append hostapd_cfg "atfssidgroup=$atfssidgroup" "$N"
 
 	cat >> /var/run/hostapd-$phy$vif_phy_suffix.conf <<EOF
 $hostapd_cfg
@@ -1404,7 +1404,7 @@ find_phy() {
 }
 
 mac80211_check_ap() {
-        has_ap=$((has_ap+1))
+	has_ap=$((has_ap+1))
 }
 
 mac80211_get_band_name() {
@@ -1462,20 +1462,21 @@ mac80211_prepare_vif() {
 			adhoc) prefix=ibss;;
 			monitor) prefix=mon;;
 		esac
-                if [ "$is_wiphy_multi_radio" -eq 1 ]; then
-                        if [[ "$htmode" == EHT* ]] && [ -n "$mld" ]; then
+
+		if [ "$is_wiphy_multi_radio" -eq 1 ]; then
+			if [[ "$htmode" == EHT* ]] && [ -n "$mld" ]; then
 				config_get mld_ifname "$mld" ifname
 				if [ -z "$mld_ifname" ]; then
 					ifname=$phy-$mld
 				else
 					ifname="$mld_ifname"
 				fi
-                        else
+			else
 				mac80211_set_ifname "$ifname_prefix" "$prefix"
-                        fi
-                else
-                        mac80211_set_ifname "$ifname_prefix" "$prefix"
-                fi
+			fi
+		else
+			mac80211_set_ifname "$ifname_prefix" "$prefix"
+		fi
 
 	}
 
@@ -1486,12 +1487,12 @@ mac80211_prepare_vif() {
 
 	[ -z $ppe_vp ] && ppe_vp="ds"
 
-        if [ $mode == "mesh" ] && [ $ppe_vp == "ds" ]; then
-                ppe_vp="passive"
-        fi
-        if [ $mode == "monitor" ]; then
-                 append mon_ifname "$ifname"
-        fi
+	if [ $mode == "mesh" ] && [ $ppe_vp == "ds" ]; then
+		ppe_vp="passive"
+	fi
+	if [ $mode == "monitor" ]; then
+		append mon_ifname "$ifname"
+	fi
 
 	append active_ifnames "$ifname"
 	set_default wds 0
@@ -1677,93 +1678,93 @@ mac80211_setup_mesh() {
 }
 
 mac80211_get_seg0() {
-        local ht_mode="$1"
-        local seg0=0
+	local ht_mode="$1"
+	local seg0=0
 
-        case "$ht_mode" in
-                40)
-                        if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
-                                case "$(( (channel / 4) % 2 ))" in
-                                        1) seg0=$((channel - 2));;
-                                        0) seg0=$((channel + 2));;
-                                esac
-                        elif [ "$freq" -lt 2484 ]; then
-                                if [ "$channel" -lt 7 ]; then
-                                        seg0=$((channel + 2))
-                                else
-                                        seg0=$((channel - 2))
-                                fi
-                        elif [ "$freq" != 5935 ]; then
-                                case "$(( (channel / 4) % 2 ))" in
-                                        1) seg0=$((channel + 2));;
-                                        0) seg0=$((channel - 2));;
-                                esac
-                        fi
-                ;;
+	case "$ht_mode" in
+		40)
+			if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
+				case "$(( (channel / 4) % 2 ))" in
+					1) seg0=$((channel - 2));;
+					0) seg0=$((channel + 2));;
+				esac
+			elif [ "$freq" -lt 2484 ]; then
+				if [ "$channel" -lt 7 ]; then
+					seg0=$((channel + 2))
+				else
+					seg0=$((channel - 2))
+				fi
+			elif [ "$freq" != 5935 ]; then
+				case "$(( (channel / 4) % 2 ))" in
+					1) seg0=$((channel + 2));;
+					0) seg0=$((channel - 2));;
+				esac
+			fi
+		;;
 		80)
-                        if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
-                                case "$(( (channel / 4) % 4 ))" in
-                                        0) seg0=$((channel + 6));;
-                                        1) seg0=$((channel + 2));;
-                                        2) seg0=$((channel - 2));;
-                                        3) seg0=$((channel - 6));;
-                                esac
-                        elif [ "$freq" != 5935 ]; then
-                                case "$(( (channel / 4) % 4 ))" in
-                                        1) seg0=$((channel + 6));;
-                                        2) seg0=$((channel + 2));;
-                                        3) seg0=$((channel - 2));;
-                                        0) seg0=$((channel - 6));;
-                                esac
-                        fi
-                ;;
+			if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
+				case "$(( (channel / 4) % 4 ))" in
+					0) seg0=$((channel + 6));;
+					1) seg0=$((channel + 2));;
+					2) seg0=$((channel - 2));;
+					3) seg0=$((channel - 6));;
+				esac
+			elif [ "$freq" != 5935 ]; then
+				case "$(( (channel / 4) % 4 ))" in
+					1) seg0=$((channel + 6));;
+					2) seg0=$((channel + 2));;
+					3) seg0=$((channel - 2));;
+					0) seg0=$((channel - 6));;
+				esac
+			fi
+		;;
 		160)
-                        if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
-                                case "$channel" in
-                                        1|5|9|13|17|21|25|29) seg0=15;;
-                                        33|37|41|45|49|53|57|61) seg0=47;;
-                                        65|69|73|77|81|85|89|93) seg0=79;;
-                                        97|101|105|109|113|117|121|125) seg0=111;;
-                                        129|133|137|141|145|149|153|157) seg0=143;;
-                                        161|165|169|173|177|181|185|189) seg0=175;;
-                                        193|197|201|205|209|213|217|221) seg0=207;;
-                                esac
-                        elif [ "$freq" != 5935 ]; then
-                                case "$channel" in
-                                        36|40|44|48|52|56|60|64) seg0=50;;
-                                        100|104|108|112|116|120|124|128) seg0=114;;
-                                        149|153|157|161|165|169|173|177) seg0=163;;
-                                esac
-                        fi
-                ;;
+			if [ "$freq" -gt 5950 ] && [ "$freq" -le 7115 ]; then
+				case "$channel" in
+					1|5|9|13|17|21|25|29) seg0=15;;
+					33|37|41|45|49|53|57|61) seg0=47;;
+					65|69|73|77|81|85|89|93) seg0=79;;
+					97|101|105|109|113|117|121|125) seg0=111;;
+					129|133|137|141|145|149|153|157) seg0=143;;
+					161|165|169|173|177|181|185|189) seg0=175;;
+					193|197|201|205|209|213|217|221) seg0=207;;
+				esac
+			elif [ "$freq" != 5935 ]; then
+				case "$channel" in
+					36|40|44|48|52|56|60|64) seg0=50;;
+					100|104|108|112|116|120|124|128) seg0=114;;
+					149|153|157|161|165|169|173|177) seg0=163;;
+				esac
+			fi
+		;;
 		320)
-                        if [ "$freq" -ge 5955 ] && [ "$freq" -le 7115 ]; then
-                                case "$channel" in
-                                        1|5|9|13|17|21|25|29|33|37|41|45) seg0=31;;
-                                        49|53|57|61|65|69|73|77) seg0=63;;
-                                        81|85|89|93|97|101|105|109) seg0=95;;
-                                        113|117|121|125|129|133|137|141) seg0=127;;
-                                        145|149|153|157|161|165|169|173) seg0=159;;
-                                        177|181|185|189|193|197|201|205|209|213|217|221) seg0=191;;
-                                esac
-                        elif [ "$freq" -ge 5500 ] && [ "$freq" -le 5730 ]; then
-                                seg0=130
-                        fi
-                ;;
-                esac
-                printf "$seg0"
+			if [ "$freq" -ge 5955 ] && [ "$freq" -le 7115 ]; then
+				case "$channel" in
+					1|5|9|13|17|21|25|29|33|37|41|45) seg0=31;;
+					49|53|57|61|65|69|73|77) seg0=63;;
+					81|85|89|93|97|101|105|109) seg0=95;;
+					113|117|121|125|129|133|137|141) seg0=127;;
+					145|149|153|157|161|165|169|173) seg0=159;;
+					177|181|185|189|193|197|201|205|209|213|217|221) seg0=191;;
+				esac
+			elif [ "$freq" -ge 5500 ] && [ "$freq" -le 5730 ]; then
+				seg0=130
+			fi
+		;;
+	esac
+	printf "$seg0"
 }
 
 get_seg0_freq() {
-        local ctrl_freq="$1"
-        local ctrl_chan="$2"
-        local seg0_chan="$3"
+	local ctrl_freq="$1"
+	local ctrl_chan="$2"
+	local seg0_chan="$3"
 
-        if [ $((seg0_chan)) -gt $((ctrl_chan)) ]; then
-                printf $(($ctrl_freq + (($seg0_chan - $ctrl_chan) * 5)))
-        else
-                printf $(($ctrl_freq - (($ctrl_chan - $seg0_chan) * 5)))
-        fi
+	if [ $((seg0_chan)) -gt $((ctrl_chan)) ]; then
+		printf $(($ctrl_freq + (($seg0_chan - $ctrl_chan) * 5)))
+	else
+		printf $(($ctrl_freq - (($ctrl_chan - $seg0_chan) * 5)))
+	fi
 }
 
 mac80211_setup_monitor() {
@@ -1775,21 +1776,21 @@ mac80211_setup_monitor() {
 	[ -n "$freq" ] && json_add_string freq "$freq"
 	json_add_string htmode "$htmode"
 	case "$htmode" in
-                VHT20|HT20|HE20|EHT20)
-                        bw=20
-                        ;;
-                HT40*|VHT40|HE40|EHT40)
-                        bw=40
+		VHT20|HT20|HE20|EHT20)
+			bw=20
+		;;
+		HT40*|VHT40|HE40|EHT40)
+			bw=40
 			center_freq=$(get_seg0_freq "$freq" "$channel" "$(mac80211_get_seg0 40)")
-                        ;;
-                VHT80|HE80|EHT80)
-                        bw=80
-                        center_freq=$(get_seg0_freq "$freq" "$channel" "$(mac80211_get_seg0 80)")
-                        ;;
-                VHT160|HE160|EHT160)
-                        bw=160
-                        center_freq=$(get_seg0_freq "$freq" "$channel" "$(mac80211_get_seg0 160)")
-                        ;;
+		;;
+		VHT80|HE80|EHT80)
+			bw=80
+			center_freq=$(get_seg0_freq "$freq" "$channel" "$(mac80211_get_seg0 80)")
+		;;
+		VHT160|HE160|EHT160)
+			bw=160
+			center_freq=$(get_seg0_freq "$freq" "$channel" "$(mac80211_get_seg0 160)")
+		;;
 		EHT320)
 			if [ "$band" = "6g" ]; then
 				bw=320
@@ -1800,14 +1801,14 @@ mac80211_setup_monitor() {
 				fi
 				center_freq=$(get_seg0_freq "$freq" "$channel" "$idx")
 			fi
-			;;
-        esac
+		;;
+	esac
 
-        if [ $is_wiphy_multi_radio -eq 1 ]; then
-                json_add_boolean is_multi_radio 1
-                [ -n "$center_freq" ] && json_add_string center_freq "$center_freq"
-                json_add_string bw "$bw"
-        fi
+	if [ $is_wiphy_multi_radio -eq 1 ]; then
+		json_add_boolean is_multi_radio 1
+		[ -n "$center_freq" ] && json_add_string center_freq "$center_freq"
+		json_add_string bw "$bw"
+	fi
 	json_close_object
 
 	json_set_namespace "$prev"
@@ -1884,20 +1885,20 @@ mac80211_set_vif_txpower() {
 }
 
 mac80211_set_fq_limit() {
-        json_select data
-        json_get_vars ifname
-        json_select ..
+	json_select data
+	json_get_vars ifname
+	json_select ..
 
-        json_select config
-        json_get_vars fq_limit
+	json_select config
+	json_get_vars fq_limit
 
-        if [ "$fq_limit" -gt 0 ]; then
-                tc qdisc add dev "$ifname" parent :1 fq_codel limit "$fq_limit"
-                tc qdisc add dev "$ifname" parent :2 fq_codel limit "$fq_limit"
-                tc qdisc add dev "$ifname" parent :3 fq_codel limit "$fq_limit"
-                tc qdisc add dev "$ifname" parent :4 fq_codel limit "$fq_limit"
-        fi
-        json_select ..
+	if [ "$fq_limit" -gt 0 ]; then
+		tc qdisc add dev "$ifname" parent :1 fq_codel limit "$fq_limit"
+		tc qdisc add dev "$ifname" parent :2 fq_codel limit "$fq_limit"
+		tc qdisc add dev "$ifname" parent :3 fq_codel limit "$fq_limit"
+		tc qdisc add dev "$ifname" parent :4 fq_codel limit "$fq_limit"
+	fi
+	json_select ..
 }
 
 wpa_supplicant_init_config() {
@@ -2166,9 +2167,9 @@ drv_mac80211_setup() {
 
 	if [ "$is_wiphy_multi_radio" -eq 1 ]; then
 		echo [debug] $device - radio as $radio > /tmp/logs
-        else
-                radio=-1
-        fi
+	else
+		radio=-1
+	fi
 
 	[ -f /tmp/mlo_support.txt ] && mlo_add_flag=$(cat /tmp/mlo_support.txt)
 	if [ $mlo_add_flag -eq 0 ]; then
@@ -2193,13 +2194,13 @@ drv_mac80211_setup() {
 	if [ $mlo_add_flag -eq 0 ]; then
 		if [ "$(cat /sys/module/ath12k/parameters/ppe_rfs_support)" == 'Y' ]; then
 			# Note: ppe_vp_accel and ppe_vp_rfs are mutually exclusive.
-			#       ppe_vp_accel enables PPE acceleration path and ppe_vp_rfs
-			#       is expected to enable only flow steering for VLAN type
-			#       interface (eg: WDS root).
+			#	ppe_vp_accel enables PPE acceleration path and ppe_vp_rfs
+			#	is expected to enable only flow steering for VLAN type
+			#	interface (eg: WDS root).
 			echo 1 >> /sys/module/mac80211/parameters/ppe_vp_rfs
 			# Note: Format is default MLO mask followed by band specific core masks
-			#       in order of 2 GHz, 5 GHz and 6GHz bands
-			#       echo <DEFAULT/ MLO MASK>,<2GHZ MASK>,<5GHZ MASK>,<6GHZ_MASK>
+			#	in order of 2 GHz, 5 GHz and 6GHz bands
+			#	echo <DEFAULT/ MLO MASK>,<2GHZ MASK>,<5GHZ MASK>,<6GHZ_MASK>
 			echo 0x7,0x7,0x7,0x7 > /sys/module/ath12k/parameters/rfs_core_mask
 
 			if [ "$(cat /sys/module/mac80211/parameters/ppe_vp_accel)" == 'Y' ]; then
@@ -2300,10 +2301,10 @@ drv_mac80211_setup() {
 	for_each_interface "sta adhoc mesh" mac80211_set_noscan
 	[ -n "$has_ap" ] && mac80211_hostapd_setup_base "$phy"
 
-        if [ "$mlo_add_flag" = 1 ]; then
+	if [ "$mlo_add_flag" = 1 ]; then
 		for_each_interface "ap" mac80211_prepare_vif
-                return;
-        fi
+		return;
+	fi
 
 	local prev
 	json_set_namespace wdev_uc prev
@@ -2403,40 +2404,40 @@ mac80211_derive_ml_info() {
 	fi
 
 	mac80211_get_wifi_ifaces() {
-	        config_get iface_mode "$1" mode
-	        if [ -n "$iface_mode" ] && [ "$iface_mode" = "sta" ]; then
-	                 append _staifaces "$1"
-	        fi
+		config_get iface_mode "$1" mode
+		if [ -n "$iface_mode" ] && [ "$iface_mode" = "sta" ]; then
+			append _staifaces "$1"
+		fi
 	}
 	config_foreach mac80211_get_wifi_ifaces wifi-iface
 
 	if [ -z "$_staifaces" ]; then
-	        return
+		return
 	fi
 
 	for _mld in $_mlds
 	do
-	        for _staifname in $_staifaces
-	        do
-	                config_get mld_name "$_staifname" mld
-	                config_get mldevice "$_staifname" device
-	                if [ ${#mldevice} -ne 12 ]; then
-	                        continue;
-	                fi
-
-	                if ! [[ "$sta_mldevices" =~ "$mldevice" ]]; then
-
-	                        if [ -n "$mld_name" ] &&  [ "$_mld" = "$mld_name" ]; then
-	                        	append sta_mldevices "$mldevice"
-	                                config_get disabled "$mldevice" disabled
-	                                if [ "$disabled" -eq 1 ]; then
-	                                        continue;
-	                                fi
-	                                config_get radio "$mldevice" radio
-	                                append _sta_radios $radio
-	                        fi
-	                fi
-	        done
+		for _staifname in $_staifaces
+		do
+			config_get mld_name "$_staifname" mld
+			config_get mldevice "$_staifname" device
+			if [ ${#mldevice} -ne 12 ]; then
+				continue;
+			fi
+			
+			if ! [[ "$sta_mldevices" =~ "$mldevice" ]]; then
+			
+				if [ -n "$mld_name" ] &&  [ "$_mld" = "$mld_name" ]; then
+					append sta_mldevices "$mldevice"
+					config_get disabled "$mldevice" disabled
+				if [ "$disabled" -eq 1 ]; then
+					continue;
+				fi
+					config_get radio "$mldevice" radio
+					append _sta_radios $radio
+				fi
+			fi
+		done
 	done
 }
 

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -230,6 +230,7 @@ drv_mac80211_init_device_config() {
 	config_add_string path phy 'macaddr:macaddr'
 	config_add_string tx_burst
 	config_add_string distance band
+	config_add_string ifname_prefix
 	config_add_string macaddr_base
 	config_add_int radio beacon_int chanbw frag rts
 	config_add_int rxantenna txantenna txpower min_tx_power antenna_gain
@@ -1454,6 +1455,13 @@ mac80211_prepare_vif() {
 	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file ppe_vp mld
 
 	[ -n "$ifname" ] || {
+		local prefix;
+
+		case "$mode" in
+			ap|sta|mesh) prefix=$mode;;
+			adhoc) prefix=ibss;;
+			monitor) prefix=mon;;
+		esac
                 if [ "$is_wiphy_multi_radio" -eq 1 ]; then
                         if [[ "$htmode" == EHT* ]] && [ -n "$mld" ]; then
 				config_get mld_ifname "$mld" ifname
@@ -1463,10 +1471,10 @@ mac80211_prepare_vif() {
 					ifname="$mld_ifname"
 				fi
                         else
-				mac80211_set_ifname "$phy$vif_phy_suffix"
+				mac80211_set_ifname "$ifname_prefix" "$prefix"
                         fi
                 else
-                        mac80211_set_ifname "$phy$vif_phy_suffix"
+                        mac80211_set_ifname "$ifname_prefix" "$prefix"
                 fi
 
 	}
@@ -2146,7 +2154,7 @@ drv_mac80211_setup() {
 		num_global_macaddr:1 multiple_bssid \
 		eht_ulmumimo_80mhz eht_ulmumimo_160mhz eht_ulmumimo_320mhz \
 		ccfs disable_csa_dfs ru_punct_bitmap \
-		macaddr_base
+		ifname_prefix macaddr_base
 	json_get_values basic_rate_list basic_rate
 	json_get_values scan_list scan_list
 	json_select ..
@@ -2178,6 +2186,8 @@ drv_mac80211_setup() {
 	}
 
 	mac80211_set_suffix
+
+	set_default ifname_prefix "$phy$vif_phy_suffix"
 
 	[ -f /tmp/mlo_support.txt ] && mlo_add_flag=$(cat /tmp/mlo_support.txt)
 	if [ $mlo_add_flag -eq 0 ]; then

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -230,6 +230,7 @@ drv_mac80211_init_device_config() {
 	config_add_string path phy 'macaddr:macaddr'
 	config_add_string tx_burst
 	config_add_string distance band
+	config_add_string ifname_prefix
 	config_add_string macaddr_base
 	config_add_int radio beacon_int chanbw frag rts
 	config_add_int rxantenna txantenna txpower min_tx_power antenna_gain
@@ -1454,6 +1455,14 @@ mac80211_prepare_vif() {
 	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file ppe_vp mld
 
 	[ -n "$ifname" ] || {
+		local prefix;
+
+		case "$mode" in
+		ap|sta|mesh) prefix=$mode;;
+		adhoc) prefix=ibss;;
+		monitor) prefix=mon;;
+		esac
+
                 if [ "$is_wiphy_multi_radio" -eq 1 ]; then
                         if [[ "$htmode" == EHT* ]] && [ -n "$mld" ]; then
 				config_get mld_ifname "$mld" ifname
@@ -1463,10 +1472,10 @@ mac80211_prepare_vif() {
 					ifname="$mld_ifname"
 				fi
                         else
-				mac80211_set_ifname "$phy$vif_phy_suffix"
+				mac80211_set_ifname "$ifname_prefix" "$prefix"
                         fi
                 else
-                        mac80211_set_ifname "$phy$vif_phy_suffix"
+			mac80211_set_ifname "$ifname_prefix" "$prefix"
                 fi
 
 	}
@@ -2146,7 +2155,7 @@ drv_mac80211_setup() {
 		num_global_macaddr:1 multiple_bssid \
 		eht_ulmumimo_80mhz eht_ulmumimo_160mhz eht_ulmumimo_320mhz \
 		ccfs disable_csa_dfs ru_punct_bitmap \
-		macaddr_base
+		ifname_prefix macaddr_base
 	json_get_values basic_rate_list basic_rate
 	json_get_values scan_list scan_list
 	json_select ..
@@ -2178,6 +2187,8 @@ drv_mac80211_setup() {
 	}
 
 	mac80211_set_suffix
+
+	set_default ifname_prefix "$phy$vif_phy_suffix"
 
 	[ -f /tmp/mlo_support.txt ] && mlo_add_flag=$(cat /tmp/mlo_support.txt)
 	if [ $mlo_add_flag -eq 0 ]; then

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -156,6 +156,7 @@ function generate_config(info, name, single_wiphy, id, radio_idx) {
 set ${s}.type='mac80211'
 set ${s}.${id}
 set ${s}.band='${lc(band_name)}'
+set ${s}.ifname_prefix='phy${lc(band_name)}'
 set ${s}.channel='${channel}'
 set ${s}.country='${country || ''}'
 set ${s}.macaddr_base='${macaddr_base || ''}'

--- a/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
+++ b/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
@@ -237,14 +237,14 @@ function wiphy_detect() {
 
 		let entry = wiphy_get_entry(name, path);
 		entry.info = info;
-		if (phy.radios) {
-			entry.multi_radio = multi_radio;
-		} else if (length(keys(band_freq_data)) > 1) {
+
+		//Fixed the missing info.radios after updating to ATH 13.1
+		let synth_multi = {};
+		let synth_radios = [];
+		if (length(keys(band_freq_data)) > 1) {
 			// Synthesize multi_radio for multi-band phy when driver does not
 			// support NL80211_ATTR_WIPHY_RADIOS (e.g., older ath12k firmware)
 			let band_order = [ '2G', '5G', '6G', '60G' ];
-			let synth_multi = {};
-			let synth_radios = [];
 			let r_idx = 0;
 			for (let bn in band_order) {
 				if (!(bn in band_freq_data))
@@ -261,10 +261,15 @@ function wiphy_detect() {
 				});
 				r_idx++;
 			}
-			if (r_idx > 1) {
-				entry.multi_radio = synth_multi;
+			if(r_idx > 1)
 				entry.info.radios = synth_radios;
-			}
+		}
+		//end		
+
+		if (phy.radios) {
+			entry.multi_radio = multi_radio;
+		} else if (length(keys(band_freq_data)) > 1) {
+			entry.multi_radio = synth_multi;
 		}
 	}
 }

--- a/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
+++ b/feeds/qca-wifi-7/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
@@ -237,14 +237,13 @@ function wiphy_detect() {
 
 		let entry = wiphy_get_entry(name, path);
 		entry.info = info;
-		if (phy.radios) {
-			entry.multi_radio = multi_radio;
-		} else if (length(keys(band_freq_data)) > 1) {
+
+		let synth_multi = {};
+		let synth_radios = [];
+		if (length(keys(band_freq_data)) > 1) {
 			// Synthesize multi_radio for multi-band phy when driver does not
 			// support NL80211_ATTR_WIPHY_RADIOS (e.g., older ath12k firmware)
 			let band_order = [ '2G', '5G', '6G', '60G' ];
-			let synth_multi = {};
-			let synth_radios = [];
 			let r_idx = 0;
 			for (let bn in band_order) {
 				if (!(bn in band_freq_data))
@@ -261,10 +260,14 @@ function wiphy_detect() {
 				});
 				r_idx++;
 			}
-			if (r_idx > 1) {
-				entry.multi_radio = synth_multi;
+			if (r_idx > 1)
 				entry.info.radios = synth_radios;
-			}
+		}
+
+		if (phy.radios) {
+			entry.multi_radio = multi_radio;
+		} else if (length(keys(band_freq_data)) > 1) {
+			entry.multi_radio = synth_multi;
 		}
 	}
 }

--- a/patches-25.12/0043-ucode-add-lib-nl80211-support-for-QCA-wifi-6-7-nl802.patch
+++ b/patches-25.12/0043-ucode-add-lib-nl80211-support-for-QCA-wifi-6-7-nl802.patch
@@ -1,19 +1,18 @@
-From c25b0e07fed49e1305a56388032c52ba02cbb19f Mon Sep 17 00:00:00 2001
+From 1eac0dfb6452b0bd104c3db9b209cf0b7feb78e0 Mon Sep 17 00:00:00 2001
 From: John Crispin <john@phrozen.org>
 Date: Fri, 1 Aug 2025 20:48:55 +0200
-Subject: [PATCH 043/115] ucode: add lib/nl80211 support for QCA wifi-6/7
- nl80211.h
+Subject: [PATCH] ucode: add lib/nl80211 support for QCA wifi-6/7 nl80211.h
 
 Integrates QCA-specific nl80211 header with extended vendor commands and attributes for WiFi 6/7 features, replacing upstream header with QSDK version.
 
 Signed-off-by: John Crispin <john@phrozen.org>
 ---
- package/utils/ucode/Makefile                  |   25 +
+ package/utils/ucode/Makefile                  |   24 +
  .../ucode/patches/000-nl80211_copy.patch      |   16 +
  package/utils/ucode/patches/0001-fixes.patch  |   62 +
  package/utils/ucode/qca-wifi-6-nl80211.h      | 7483 +++++++++++++++
- package/utils/ucode/qca-wifi-7-nl80211.h      | 8365 +++++++++++++++++
- 5 files changed, 15951 insertions(+)
+ package/utils/ucode/qca-wifi-7-nl80211.h      | 8976 +++++++++++++++++
+ 5 files changed, 16562 insertions(+)
  create mode 100644 package/utils/ucode/patches/000-nl80211_copy.patch
  create mode 100644 package/utils/ucode/patches/0001-fixes.patch
  create mode 100644 package/utils/ucode/qca-wifi-6-nl80211.h
@@ -7636,10 +7635,10 @@ index 0000000000..67c4be145e
 +#endif /* __LINUX_NL80211_H */
 diff --git a/package/utils/ucode/qca-wifi-7-nl80211.h b/package/utils/ucode/qca-wifi-7-nl80211.h
 new file mode 100644
-index 0000000000..b995313ccd
+index 0000000000..89b763ac87
 --- /dev/null
 +++ b/package/utils/ucode/qca-wifi-7-nl80211.h
-@@ -0,0 +1,8365 @@
+@@ -0,0 +1,8976 @@
 +#ifndef __LINUX_NL80211_H
 +#define __LINUX_NL80211_H
 +/*
@@ -7653,7 +7652,7 @@ index 0000000000..b995313ccd
 + * Copyright 2008 Jouni Malinen <jouni.malinen@atheros.com>
 + * Copyright 2008 Colin McCabe <colin@cozybit.com>
 + * Copyright 2015-2017	Intel Deutschland GmbH
-+ * Copyright (C) 2018-2023 Intel Corporation
++ * Copyright (C) 2018-2025 Intel Corporation
 + *
 + * Permission to use, copy, modify, and/or distribute this software for any
 + * purpose with or without fee is hereby granted, provided that the above
@@ -7715,7 +7714,7 @@ index 0000000000..b995313ccd
 + * For drivers supporting TDLS with external setup (WIPHY_FLAG_SUPPORTS_TDLS
 + * and WIPHY_FLAG_TDLS_EXTERNAL_SETUP), the station lifetime is as follows:
 + *  - a setup station entry is added, not yet authorized, without any rate
-+ *    or capability information, this just exists to avoid race conditions
++ *    or capability information; this just exists to avoid race conditions
 + *  - when the TDLS setup is done, a single NL80211_CMD_SET_STATION is valid
 + *    to add rate and capability information to the station and at the same
 + *    time mark it authorized.
@@ -7730,7 +7729,7 @@ index 0000000000..b995313ccd
 + * DOC: Frame transmission/registration support
 + *
 + * Frame transmission and registration support exists to allow userspace
-+ * management entities such as wpa_supplicant react to management frames
++ * management entities such as wpa_supplicant to react to management frames
 + * that are not being handled by the kernel. This includes, for example,
 + * certain classes of action frames that cannot be handled in the kernel
 + * for various reasons.
@@ -7756,7 +7755,7 @@ index 0000000000..b995313ccd
 + *
 + * Frame transmission allows userspace to send for example the required
 + * responses to action frames. It is subject to some sanity checking,
-+ * but many frames can be transmitted. When a frame was transmitted, its
++ * but many frames can be transmitted. When a frame is transmitted, its
 + * status is indicated to the sending socket.
 + *
 + * For more technical details, see the corresponding command descriptions
@@ -7766,7 +7765,7 @@ index 0000000000..b995313ccd
 +/**
 + * DOC: Virtual interface / concurrency capabilities
 + *
-+ * Some devices are able to operate with virtual MACs, they can have
++ * Some devices are able to operate with virtual MACs; they can have
 + * more than one virtual interface. The capability handling for this
 + * is a bit complex though, as there may be a number of restrictions
 + * on the types of concurrency that are supported.
@@ -7778,7 +7777,7 @@ index 0000000000..b995313ccd
 + * Once concurrency is desired, more attributes must be observed:
 + * To start with, since some interface types are purely managed in
 + * software, like the AP-VLAN type in mac80211 for example, there's
-+ * an additional list of these, they can be added at any time and
++ * an additional list of these; they can be added at any time and
 + * are only restricted by some semantic restrictions (e.g. AP-VLAN
 + * cannot be added without a corresponding AP interface). This list
 + * is exported in the %NL80211_ATTR_SOFTWARE_IFTYPES attribute.
@@ -7807,17 +7806,17 @@ index 0000000000..b995313ccd
 + * Packet coalesce feature helps to reduce number of received interrupts
 + * to host by buffering these packets in firmware/hardware for some
 + * predefined time. Received interrupt will be generated when one of the
-+ * following events occur.
++ * following events occurs.
 + * a) Expiration of hardware timer whose expiration time is set to maximum
 + * coalescing delay of matching coalesce rule.
-+ * b) Coalescing buffer in hardware reaches it's limit.
++ * b) Coalescing buffer in hardware reaches its limit.
 + * c) Packet doesn't match any of the configured coalesce rules.
 + *
 + * User needs to configure following parameters for creating a coalesce
 + * rule.
 + * a) Maximum coalescing delay
 + * b) List of packet patterns which needs to be matched
-+ * c) Condition for coalescence. pattern 'match' or 'no match'
++ * c) Condition for coalescence: pattern 'match' or 'no match'
 + * Multiple such rules can be created.
 + */
 +
@@ -7856,7 +7855,7 @@ index 0000000000..b995313ccd
 +/**
 + * DOC: FILS shared key authentication offload
 + *
-+ * FILS shared key authentication offload can be advertized by drivers by
++ * FILS shared key authentication offload can be advertised by drivers by
 + * setting @NL80211_EXT_FEATURE_FILS_SK_OFFLOAD flag. The drivers that support
 + * FILS shared key authentication offload should be able to construct the
 + * authentication and association frames for FILS shared key authentication and
@@ -7882,7 +7881,7 @@ index 0000000000..b995313ccd
 + * The PMKSA can be maintained in userspace persistently so that it can be used
 + * later after reboots or wifi turn off/on also.
 + *
-+ * %NL80211_ATTR_FILS_CACHE_ID is the cache identifier advertized by a FILS
++ * %NL80211_ATTR_FILS_CACHE_ID is the cache identifier advertised by a FILS
 + * capable AP supporting PMK caching. It specifies the scope within which the
 + * PMKSAs are cached in an ESS. %NL80211_CMD_SET_PMKSA and
 + * %NL80211_CMD_DEL_PMKSA are enhanced to allow support for PMKSA caching based
@@ -7933,12 +7932,12 @@ index 0000000000..b995313ccd
 + * If the configuration needs to be applied for specific peer then the MAC
 + * address of the peer needs to be passed in %NL80211_ATTR_MAC, otherwise the
 + * configuration will be applied for all the connected peers in the vif except
-+ * any peers that have peer specific configuration for the TID by default; if
-+ * the %NL80211_TID_CONFIG_ATTR_OVERRIDE flag is set, peer specific values
++ * any peers that have peer-specific configuration for the TID by default; if
++ * the %NL80211_TID_CONFIG_ATTR_OVERRIDE flag is set, peer-specific values
 + * will be overwritten.
 + *
-+ * All this configuration is valid only for STA's current connection
-+ * i.e. the configuration will be reset to default when the STA connects back
++ * All this configuration is valid only for STA's current connection,
++ * i.e., the configuration will be reset to default when the STA connects back
 + * after disconnection/roaming, and this configuration will be cleared when
 + * the interface goes down.
 + */
@@ -7969,12 +7968,30 @@ index 0000000000..b995313ccd
 +/**
 + * DOC: Multi-Link Operation
 + *
-+ * In Multi-Link Operation, a connection between to MLDs utilizes multiple
++ * In Multi-Link Operation, a connection between two MLDs utilizes multiple
 + * links. To use this in nl80211, various commands and responses now need
 + * to or will include the new %NL80211_ATTR_MLO_LINKS attribute.
 + * Additionally, various commands that need to operate on a specific link
 + * now need to be given the %NL80211_ATTR_MLO_LINK_ID attribute, e.g. to
 + * use %NL80211_CMD_START_AP or similar functions.
++ */
++
++/**
++ * DOC: OWE DH IE handling offload
++ *
++ * By setting @NL80211_EXT_FEATURE_OWE_OFFLOAD flag, drivers can indicate
++ * kernel/application space to avoid DH IE handling. When this flag is
++ * advertised, the driver/device will take care of DH IE inclusion and
++ * processing of peer DH IE to generate PMK.
++ */
++
++/**
++ * DOC: OWE DH IE handling offload
++ *
++ * By setting @NL80211_EXT_FEATURE_OWE_OFFLOAD flag, drivers can indicate
++ * kernel/application space to avoid DH IE handling. When this flag is
++ * advertised, the driver/device will take care of DH IE inclusion and
++ * processing of peer DH IE to generate PMK.
 + */
 +
 +/**
@@ -8049,8 +8066,8 @@ index 0000000000..b995313ccd
 + *	are like for %NL80211_CMD_SET_BEACON, and additionally parameters that
 + *	do not change are used, these include %NL80211_ATTR_BEACON_INTERVAL,
 + *	%NL80211_ATTR_DTIM_PERIOD, %NL80211_ATTR_SSID,
-+ *	%NL80211_ATTR_HIDDEN_SSID, %NL80211_ATTR_CIPHERS_PAIRWISE,
-+ *	%NL80211_ATTR_CIPHER_GROUP, %NL80211_ATTR_WPA_VERSIONS,
++ *	%NL80211_ATTR_HIDDEN_SSID, %NL80211_ATTR_CIPHER_SUITES_PAIRWISE,
++ *	%NL80211_ATTR_CIPHER_SUITE_GROUP, %NL80211_ATTR_WPA_VERSIONS,
 + *	%NL80211_ATTR_AKM_SUITES, %NL80211_ATTR_PRIVACY,
 + *	%NL80211_ATTR_AUTH_TYPE, %NL80211_ATTR_INACTIVITY_TIMEOUT,
 + *	%NL80211_ATTR_ACL_POLICY and %NL80211_ATTR_MAC_ADDRS.
@@ -8075,23 +8092,18 @@ index 0000000000..b995313ccd
 + *	of disconnection indication should be sent to the station
 + *	(Deauthentication or Disassociation frame and reason code for that
 + *	frame). %NL80211_ATTR_MLO_LINK_ID can be used optionally to remove
-+ *	stations connected and using at least that link.
++ *	stations connected and using at least that link as one of its links.
 + *
 + * @NL80211_CMD_GET_MPATH: Get mesh path attributes for mesh path to
-+ * 	destination %NL80211_ATTR_MAC on the interface identified by
-+ * 	%NL80211_ATTR_IFINDEX.
++ *	destination %NL80211_ATTR_MAC on the interface identified by
++ *	%NL80211_ATTR_IFINDEX.
 + * @NL80211_CMD_SET_MPATH:  Set mesh path attributes for mesh path to
-+ * 	destination %NL80211_ATTR_MAC on the interface identified by
-+ * 	%NL80211_ATTR_IFINDEX.
++ *	destination %NL80211_ATTR_MAC on the interface identified by
++ *	%NL80211_ATTR_IFINDEX.
 + * @NL80211_CMD_NEW_MPATH: Create a new mesh path for the destination given by
 + *	%NL80211_ATTR_MAC via %NL80211_ATTR_MPATH_NEXT_HOP.
 + * @NL80211_CMD_DEL_MPATH: Delete a mesh path to the destination given by
 + *	%NL80211_ATTR_MAC.
-+ * @NL80211_CMD_NEW_PATH: Add a mesh path with given attributes to the
-+ *	interface identified by %NL80211_ATTR_IFINDEX.
-+ * @NL80211_CMD_DEL_PATH: Remove a mesh path identified by %NL80211_ATTR_MAC
-+ *	or, if no MAC address given, all mesh paths, on the interface identified
-+ *	by %NL80211_ATTR_IFINDEX.
 + * @NL80211_CMD_SET_BSS: Set BSS attributes for BSS identified by
 + *	%NL80211_ATTR_IFINDEX.
 + *
@@ -8112,15 +8124,15 @@ index 0000000000..b995313ccd
 + *	after being queried by the kernel. CRDA replies by sending a regulatory
 + *	domain structure which consists of %NL80211_ATTR_REG_ALPHA set to our
 + *	current alpha2 if it found a match. It also provides
-+ * 	NL80211_ATTR_REG_RULE_FLAGS, and a set of regulatory rules. Each
-+ * 	regulatory rule is a nested set of attributes  given by
-+ * 	%NL80211_ATTR_REG_RULE_FREQ_[START|END] and
-+ * 	%NL80211_ATTR_FREQ_RANGE_MAX_BW with an attached power rule given by
-+ * 	%NL80211_ATTR_REG_RULE_POWER_MAX_ANT_GAIN and
-+ * 	%NL80211_ATTR_REG_RULE_POWER_MAX_EIRP.
++ *	NL80211_ATTR_REG_RULE_FLAGS, and a set of regulatory rules. Each
++ *	regulatory rule is a nested set of attributes  given by
++ *	%NL80211_ATTR_REG_RULE_FREQ_[START|END] and
++ *	%NL80211_ATTR_FREQ_RANGE_MAX_BW with an attached power rule given by
++ *	%NL80211_ATTR_REG_RULE_POWER_MAX_ANT_GAIN and
++ *	%NL80211_ATTR_REG_RULE_POWER_MAX_EIRP.
 + * @NL80211_CMD_REQ_SET_REG: ask the wireless core to set the regulatory domain
-+ * 	to the specified ISO/IEC 3166-1 alpha2 country code. The core will
-+ * 	store this as a valid request and then query userspace for it.
++ *	to the specified ISO/IEC 3166-1 alpha2 country code. The core will
++ *	store this as a valid request and then query userspace for it.
 + *
 + * @NL80211_CMD_GET_MESH_CONFIG: Get mesh networking properties for the
 + *	interface identified by %NL80211_ATTR_IFINDEX
@@ -8158,7 +8170,7 @@ index 0000000000..b995313ccd
 + *	%NL80211_ATTR_SCHED_SCAN_PLANS. If %NL80211_ATTR_SCHED_SCAN_PLANS is
 + *	not specified and only %NL80211_ATTR_SCHED_SCAN_INTERVAL is specified,
 + *	scheduled scan will run in an infinite loop with the specified interval.
-+ *	These attributes are mutually exculsive,
++ *	These attributes are mutually exclusive,
 + *	i.e. NL80211_ATTR_SCHED_SCAN_INTERVAL must not be passed if
 + *	NL80211_ATTR_SCHED_SCAN_PLANS is defined.
 + *	If for some reason scheduled scan is aborted by the driver, all scan
@@ -8189,7 +8201,7 @@ index 0000000000..b995313ccd
 + *	%NL80211_CMD_STOP_SCHED_SCAN command is received or when the interface
 + *	is brought down while a scheduled scan was running.
 + *
-+ * @NL80211_CMD_GET_SURVEY: get survey resuls, e.g. channel occupation
++ * @NL80211_CMD_GET_SURVEY: get survey results, e.g. channel occupation
 + *      or noise level
 + * @NL80211_CMD_NEW_SURVEY_RESULTS: survey data notification (as a reply to
 + *	NL80211_CMD_GET_SURVEY and on the "scan" multicast group)
@@ -8200,40 +8212,41 @@ index 0000000000..b995313ccd
 + *	using %NL80211_ATTR_SSID, %NL80211_ATTR_FILS_CACHE_ID,
 + *	%NL80211_ATTR_PMKID, and %NL80211_ATTR_PMK in case of FILS
 + *	authentication where %NL80211_ATTR_FILS_CACHE_ID is the identifier
-+ *	advertized by a FILS capable AP identifying the scope of PMKSA in an
++ *	advertised by a FILS capable AP identifying the scope of PMKSA in an
 + *	ESS.
 + * @NL80211_CMD_DEL_PMKSA: Delete a PMKSA cache entry, using %NL80211_ATTR_MAC
 + *	(for the BSSID) and %NL80211_ATTR_PMKID or using %NL80211_ATTR_SSID,
 + *	%NL80211_ATTR_FILS_CACHE_ID, and %NL80211_ATTR_PMKID in case of FILS
-+ *	authentication.
++ *	authentication. Additionally in case of SAE offload and OWE offloads
++ *	PMKSA entry can be deleted using %NL80211_ATTR_SSID.
 + * @NL80211_CMD_FLUSH_PMKSA: Flush all PMKSA cache entries.
 + *
 + * @NL80211_CMD_REG_CHANGE: indicates to userspace the regulatory domain
-+ * 	has been changed and provides details of the request information
-+ * 	that caused the change such as who initiated the regulatory request
-+ * 	(%NL80211_ATTR_REG_INITIATOR), the wiphy_idx
-+ * 	(%NL80211_ATTR_REG_ALPHA2) on which the request was made from if
-+ * 	the initiator was %NL80211_REGDOM_SET_BY_COUNTRY_IE or
-+ * 	%NL80211_REGDOM_SET_BY_DRIVER, the type of regulatory domain
-+ * 	set (%NL80211_ATTR_REG_TYPE), if the type of regulatory domain is
-+ * 	%NL80211_REG_TYPE_COUNTRY the alpha2 to which we have moved on
-+ * 	to (%NL80211_ATTR_REG_ALPHA2).
++ *	has been changed and provides details of the request information
++ *	that caused the change such as who initiated the regulatory request
++ *	(%NL80211_ATTR_REG_INITIATOR), the wiphy_idx
++ *	(%NL80211_ATTR_REG_ALPHA2) on which the request was made from if
++ *	the initiator was %NL80211_REGDOM_SET_BY_COUNTRY_IE or
++ *	%NL80211_REGDOM_SET_BY_DRIVER, the type of regulatory domain
++ *	set (%NL80211_ATTR_REG_TYPE), if the type of regulatory domain is
++ *	%NL80211_REG_TYPE_COUNTRY the alpha2 to which we have moved on
++ *	to (%NL80211_ATTR_REG_ALPHA2).
 + * @NL80211_CMD_REG_BEACON_HINT: indicates to userspace that an AP beacon
-+ * 	has been found while world roaming thus enabling active scan or
-+ * 	any mode of operation that initiates TX (beacons) on a channel
-+ * 	where we would not have been able to do either before. As an example
-+ * 	if you are world roaming (regulatory domain set to world or if your
-+ * 	driver is using a custom world roaming regulatory domain) and while
-+ * 	doing a passive scan on the 5 GHz band you find an AP there (if not
-+ * 	on a DFS channel) you will now be able to actively scan for that AP
-+ * 	or use AP mode on your card on that same channel. Note that this will
-+ * 	never be used for channels 1-11 on the 2 GHz band as they are always
-+ * 	enabled world wide. This beacon hint is only sent if your device had
-+ * 	either disabled active scanning or beaconing on a channel. We send to
-+ * 	userspace the wiphy on which we removed a restriction from
-+ * 	(%NL80211_ATTR_WIPHY) and the channel on which this occurred
-+ * 	before (%NL80211_ATTR_FREQ_BEFORE) and after (%NL80211_ATTR_FREQ_AFTER)
-+ * 	the beacon hint was processed.
++ *	has been found while world roaming thus enabling active scan or
++ *	any mode of operation that initiates TX (beacons) on a channel
++ *	where we would not have been able to do either before. As an example
++ *	if you are world roaming (regulatory domain set to world or if your
++ *	driver is using a custom world roaming regulatory domain) and while
++ *	doing a passive scan on the 5 GHz band you find an AP there (if not
++ *	on a DFS channel) you will now be able to actively scan for that AP
++ *	or use AP mode on your card on that same channel. Note that this will
++ *	never be used for channels 1-11 on the 2 GHz band as they are always
++ *	enabled world wide. This beacon hint is only sent if your device had
++ *	either disabled active scanning or beaconing on a channel. We send to
++ *	userspace the wiphy on which we removed a restriction from
++ *	(%NL80211_ATTR_WIPHY) and the channel on which this occurred
++ *	before (%NL80211_ATTR_FREQ_BEFORE) and after (%NL80211_ATTR_FREQ_AFTER)
++ *	the beacon hint was processed.
 + *
 + * @NL80211_CMD_AUTHENTICATE: authentication request and notification.
 + *	This command is used both as a command (request to authenticate) and
@@ -8244,7 +8257,7 @@ index 0000000000..b995313ccd
 + *	BSSID in case of station mode). %NL80211_ATTR_SSID is used to specify
 + *	the SSID (mainly for association, but is included in authentication
 + *	request, too, to help BSS selection. %NL80211_ATTR_WIPHY_FREQ +
-+ *	%NL80211_ATTR_WIPHY_FREQ_OFFSET is used to specify the frequence of the
++ *	%NL80211_ATTR_WIPHY_FREQ_OFFSET is used to specify the frequency of the
 + *	channel in MHz. %NL80211_ATTR_AUTH_TYPE is used to specify the
 + *	authentication type. %NL80211_ATTR_IE is used to define IEs
 + *	(VendorSpecificInfo, but also including RSN IE and FT IEs) to be added
@@ -8453,7 +8466,7 @@ index 0000000000..b995313ccd
 + *	reached.
 + * @NL80211_CMD_SET_CHANNEL: Set the channel (using %NL80211_ATTR_WIPHY_FREQ
 + *	and the attributes determining channel width) the given interface
-+ *	(identifed by %NL80211_ATTR_IFINDEX) shall operate on.
++ *	(identified by %NL80211_ATTR_IFINDEX) shall operate on.
 + *	In case multiple channels are supported by the device, the mechanism
 + *	with which it switches channels is implementation-defined.
 + *	When a monitor interface is given, it can only switch channel while
@@ -8525,7 +8538,7 @@ index 0000000000..b995313ccd
 + *	inform userspace of the new replay counter.
 + *
 + * @NL80211_CMD_PMKSA_CANDIDATE: This is used as an event to inform userspace
-+ *	of PMKSA caching dandidates.
++ *	of PMKSA caching candidates.
 + *
 + * @NL80211_CMD_TDLS_OPER: Perform a high-level TDLS command (e.g. link setup).
 + *	In addition, this can be used as an event to request userspace to take
@@ -8561,7 +8574,7 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_CMD_PROBE_CLIENT: Probe an associated station on an AP interface
 + *	by sending a null data frame to it and reporting when the frame is
-+ *	acknowleged. This is used to allow timing out inactive clients. Uses
++ *	acknowledged. This is used to allow timing out inactive clients. Uses
 + *	%NL80211_ATTR_IFINDEX and %NL80211_ATTR_MAC. The command returns a
 + *	direct reply with an %NL80211_ATTR_COOKIE that is later used to match
 + *	up the event with the request. The event includes the same data and
@@ -8755,7 +8768,7 @@ index 0000000000..b995313ccd
 + *	current configuration is not changed.  If it is present but
 + *	set to zero, the configuration is changed to don't-care
 + *	(i.e. the device can decide what to do).
-+ * @NL80211_CMD_NAN_FUNC_MATCH: Notification sent when a match is reported.
++ * @NL80211_CMD_NAN_MATCH: Notification sent when a match is reported.
 + *	This will contain a %NL80211_ATTR_NAN_MATCH nested attribute and
 + *	%NL80211_ATTR_COOKIE.
 + *
@@ -8772,11 +8785,15 @@ index 0000000000..b995313ccd
 + * @NL80211_CMD_DEL_PMK: For offloaded 4-Way handshake, delete the previously
 + *	configured PMK for the authenticator address identified by
 + *	%NL80211_ATTR_MAC.
-+ * @NL80211_CMD_PORT_AUTHORIZED: An event that indicates an 802.1X FT roam was
-+ *	completed successfully. Drivers that support 4 way handshake offload
-+ *	should send this event after indicating 802.1X FT assocation with
-+ *	%NL80211_CMD_ROAM. If the 4 way handshake failed %NL80211_CMD_DISCONNECT
-+ *	should be indicated instead.
++ * @NL80211_CMD_PORT_AUTHORIZED: An event that indicates port is authorized and
++ *	open for regular data traffic. For STA/P2P-client, this event is sent
++ *	with AP MAC address and for AP/P2P-GO, the event carries the STA/P2P-
++ *	client MAC address.
++ *	Drivers that support 4 way handshake offload should send this event for
++ *	STA/P2P-client after successful 4-way HS or after 802.1X FT following
++ *	NL80211_CMD_CONNECT or NL80211_CMD_ROAM. Drivers using AP/P2P-GO 4-way
++ *	handshake offload should send this event on successful completion of
++ *	4-way handshake with the peer (STA/P2P-client).
 + * @NL80211_CMD_CONTROL_PORT_FRAME: Control Port (e.g. PAE) frame TX request
 + *	and RX notification.  This command is used both as a request to transmit
 + *	a control port frame and as a notification that a control port frame
@@ -8940,6 +8957,10 @@ index 0000000000..b995313ccd
 + * @NL80211_CMD_REMOVE_LINK: Remove a link from an interface. This may come
 + *	without %NL80211_ATTR_MLO_LINK_ID as an easy way to remove all links
 + *	in preparation for e.g. roaming to a regular (non-MLO) AP.
++ *	To initiate link removal procedure, set below attributes,
++ *	%NL80211_ATTR_AP_REMOVAL_COUNT - AP removal timer count(TBTT)
++ *	%NL80211_ATTR_IE - ML reconfigure Information element
++ *	Can be extended to update multiple TBTT & element(s).
 + *
 + * @NL80211_CMD_ADD_LINK_STA: Add a link to an MLD station
 + * @NL80211_CMD_MODIFY_LINK_STA: Modify a link of an MLD station
@@ -8960,6 +8981,27 @@ index 0000000000..b995313ccd
 + *	Multi-Link reconfiguration. %NL80211_ATTR_MLO_LINKS is used to provide
 + *	information about the removed STA MLD setup links.
 + *
++ * @NL80211_CMD_SET_TID_TO_LINK_MAPPING: Set the TID to Link Mapping for a
++ *      non-AP MLD station. The %NL80211_ATTR_MLO_TTLM_DLINK and
++ *      %NL80211_ATTR_MLO_TTLM_ULINK attributes are used to specify the
++ *      TID to Link mapping for downlink/uplink traffic.
++ *
++ * @NL80211_CMD_ASSOC_MLO_RECONF: For a non-AP MLD station, request to
++ *      add/remove links to/from the association.
++ *
++ *      This command is also used by an AP MLD to process reconfiguration
++ *      requests from stations associated with the AP. The following attributes
++ *      are used in %NL80211_CMD_ASSOC_MLO_RECONF:
++ *      %NL80211_ATTR_MLD_ADDR - MLD MAC address of the station
++ *      associated with the AP,
++ *      %NL80211_ATTR_MLO_LINKS - per-link station parameters for links
++ *      to be added,
++ *      %NL80211_ATTR_MLO_RECONF_REM_LINKS - bitmap of links to be removed.
++ *
++ * @NL80211_CMD_EPCS_CFG: EPCS configuration for a station. Used by userland to
++ *	control EPCS configuration. Used to notify userland on the current state
++ *	of EPCS.
++ *
 + * @NL80211_CMD_UPDATE_HE_MUEDCA_PARAMS: Updated MU-EDCA parameters from driver.
 + *	This event is used to update dynamic MU-EDCA parameters in Beacon frame,
 + *	coming from driver and now need to be reflected in Beacon frame.
@@ -8973,6 +9015,23 @@ index 0000000000..b995313ccd
 + * @NL80211_CMD_INTERFERENCE_DETECT: Once any interference is detected on the
 + *	operating channel, userspace would be notified of it
 + *	using %NL80211_ATTR_INTERFERENCE_TYPE.
++ *
++ * @NL80211_CMD_LINK_REMOVAL_STARTED: Once first beacon with reconfiguration MLE
++ *	is sent, userspace is notified with the TBTT and TSF value to indicate
++ *	timestamp of that beacon using %NL80211_ATTR_AP_REMOVAL_COUNT and
++ *	%NL80211_ATTR_TSF respectively.
++ *
++ * @NL80211_CMD_LINK_REMOVAL_COMPLETED: Once last beacon with reconfiguration
++ *	MLE is sent, userspace is notified with completion.
++ *
++ * @NL80211_CMD_ERP: Command to enter/exit and get status regarding ErP low
++ *	power mode using %NL80211_ATTR_ERP parameters.
++ *
++ * @NL80211_CMD_QOS_MGMT: QoS management configurations for a station. Used by
++ *	userspace to send control path QoS information of QoS Management
++ *	features and also to notify userspace about the status response with
++ *	attributes defined in %NL80211_ATTR_QOS_MGMT.
++ *
 + * @NL80211_CMD_MAX: highest used command number
 + * @__NL80211_CMD_AFTER_LAST: internal use
 + */
@@ -9229,6 +9288,11 @@ index 0000000000..b995313ccd
 +
 +	NL80211_CMD_LINKS_REMOVED,
 +
++	NL80211_CMD_SET_TID_TO_LINK_MAPPING,
++
++	NL80211_CMD_ASSOC_MLO_RECONF,
++	NL80211_CMD_EPCS_CFG,
++
 +	NL80211_CMD_UPDATE_HE_MUEDCA_PARAMS,
 +
 +	/* To be Deprecated from ATH QSDK, once we upstream
@@ -9239,6 +9303,15 @@ index 0000000000..b995313ccd
 +	NL80211_CMD_STOP_BGRADAR_DETECT,
 +
 +	NL80211_CMD_INTERFERENCE_DETECT,
++
++	NL80211_CMD_LINK_REMOVAL_STARTED,
++
++	NL80211_CMD_LINK_REMOVAL_COMPLETED,
++
++	NL80211_CMD_ERP,
++
++	NL80211_CMD_QOS_MGMT,
++
 +	/* add new commands above here */
 +
 +	/* used to define NL80211_CMD_MAX below */
@@ -9363,21 +9436,21 @@ index 0000000000..b995313ccd
 + *	(see &enum nl80211_plink_action).
 + * @NL80211_ATTR_MPATH_NEXT_HOP: MAC address of the next hop for a mesh path.
 + * @NL80211_ATTR_MPATH_INFO: information about a mesh_path, part of mesh path
-+ * 	info given for %NL80211_CMD_GET_MPATH, nested attribute described at
++ *	info given for %NL80211_CMD_GET_MPATH, nested attribute described at
 + *	&enum nl80211_mpath_info.
 + *
 + * @NL80211_ATTR_MNTR_FLAGS: flags, nested element with NLA_FLAG attributes of
 + *      &enum nl80211_mntr_flags.
 + *
 + * @NL80211_ATTR_REG_ALPHA2: an ISO-3166-alpha2 country code for which the
-+ * 	current regulatory domain should be set to or is already set to.
-+ * 	For example, 'CR', for Costa Rica. This attribute is used by the kernel
-+ * 	to query the CRDA to retrieve one regulatory domain. This attribute can
-+ * 	also be used by userspace to query the kernel for the currently set
-+ * 	regulatory domain. We chose an alpha2 as that is also used by the
-+ * 	IEEE-802.11 country information element to identify a country.
-+ * 	Users can also simply ask the wireless core to set regulatory domain
-+ * 	to a specific alpha2.
++ *	current regulatory domain should be set to or is already set to.
++ *	For example, 'CR', for Costa Rica. This attribute is used by the kernel
++ *	to query the CRDA to retrieve one regulatory domain. This attribute can
++ *	also be used by userspace to query the kernel for the currently set
++ *	regulatory domain. We chose an alpha2 as that is also used by the
++ *	IEEE-802.11 country information element to identify a country.
++ *	Users can also simply ask the wireless core to set regulatory domain
++ *	to a specific alpha2.
 + * @NL80211_ATTR_REG_RULES: a nested array of regulatory domain regulatory
 + *	rules.
 + *
@@ -9420,9 +9493,9 @@ index 0000000000..b995313ccd
 + * @NL80211_ATTR_BSS: scan result BSS
 + *
 + * @NL80211_ATTR_REG_INITIATOR: indicates who requested the regulatory domain
-+ * 	currently in effect. This could be any of the %NL80211_REGDOM_SET_BY_*
++ *	currently in effect. This could be any of the %NL80211_REGDOM_SET_BY_*
 + * @NL80211_ATTR_REG_TYPE: indicates the type of the regulatory domain currently
-+ * 	set. This can be one of the nl80211_reg_type (%NL80211_REGDOM_TYPE_*)
++ *	set. This can be one of the nl80211_reg_type (%NL80211_REGDOM_TYPE_*)
 + *
 + * @NL80211_ATTR_SUPPORTED_COMMANDS: wiphy attribute that specifies
 + *	an array of command numbers (i.e. a mapping index to command number)
@@ -9441,15 +9514,15 @@ index 0000000000..b995313ccd
 + *	a u32
 + *
 + * @NL80211_ATTR_FREQ_BEFORE: A channel which has suffered a regulatory change
-+ * 	due to considerations from a beacon hint. This attribute reflects
-+ * 	the state of the channel _before_ the beacon hint processing. This
-+ * 	attributes consists of a nested attribute containing
-+ * 	NL80211_FREQUENCY_ATTR_*
++ *	due to considerations from a beacon hint. This attribute reflects
++ *	the state of the channel _before_ the beacon hint processing. This
++ *	attributes consists of a nested attribute containing
++ *	NL80211_FREQUENCY_ATTR_*
 + * @NL80211_ATTR_FREQ_AFTER: A channel which has suffered a regulatory change
-+ * 	due to considerations from a beacon hint. This attribute reflects
-+ * 	the state of the channel _after_ the beacon hint processing. This
-+ * 	attributes consists of a nested attribute containing
-+ * 	NL80211_FREQUENCY_ATTR_*
++ *	due to considerations from a beacon hint. This attribute reflects
++ *	the state of the channel _after_ the beacon hint processing. This
++ *	attributes consists of a nested attribute containing
++ *	NL80211_FREQUENCY_ATTR_*
 + *
 + * @NL80211_ATTR_CIPHER_SUITES: a set of u32 values indicating the supported
 + *	cipher suites
@@ -9496,7 +9569,7 @@ index 0000000000..b995313ccd
 + *	using %CMD_CONTROL_PORT_FRAME.  If control port routing over NL80211 is
 + *	to be used then userspace must also use the %NL80211_ATTR_SOCKET_OWNER
 + *	flag. When used with %NL80211_ATTR_CONTROL_PORT_NO_PREAUTH, pre-auth
-+ *	frames are not forwared over the control port.
++ *	frames are not forwarded over the control port.
 + *
 + * @NL80211_ATTR_TESTDATA: Testmode data blob, passed through to the driver.
 + *	We recommend using nested, driver-specific attributes within this.
@@ -9510,12 +9583,6 @@ index 0000000000..b995313ccd
 + *	that protected APs should be used. This is also used with NEW_BEACON to
 + *	indicate that the BSS is to use protection.
 + *
-+ * @NL80211_ATTR_CIPHERS_PAIRWISE: Used with CONNECT, ASSOCIATE, and NEW_BEACON
-+ *	to indicate which unicast key ciphers will be used with the connection
-+ *	(an array of u32).
-+ * @NL80211_ATTR_CIPHER_GROUP: Used with CONNECT, ASSOCIATE, and NEW_BEACON to
-+ *	indicate which group key cipher will be used with the connection (a
-+ *	u32).
 + * @NL80211_ATTR_WPA_VERSIONS: Used with CONNECT, ASSOCIATE, and NEW_BEACON to
 + *	indicate which WPA version(s) the AP we want to associate with is using
 + *	(a u32 with flags from &enum nl80211_wpa_versions).
@@ -9546,6 +9613,7 @@ index 0000000000..b995313ccd
 + *	with %NL80211_KEY_* sub-attributes
 + *
 + * @NL80211_ATTR_PID: Process ID of a network namespace.
++ * @NL80211_ATTR_NETNS_FD: File descriptor of a network namespace.
 + *
 + * @NL80211_ATTR_GENERATION: Used to indicate consistent snapshots for
 + *	dumps. This number increases whenever the object list being
@@ -9601,6 +9669,7 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_ATTR_ACK: Flag attribute indicating that the frame was
 + *	acknowledged by the recipient.
++ * @NL80211_ATTR_ACK_SIGNAL: Station's ack signal strength (s32)
 + *
 + * @NL80211_ATTR_PS_STATE: powersave state, using &enum nl80211_ps_state values.
 + *
@@ -9634,10 +9703,10 @@ index 0000000000..b995313ccd
 + *	bit. Depending on which antennas are selected in the bitmap, 802.11n
 + *	drivers can derive which chainmasks to use (if all antennas belonging to
 + *	a particular chain are disabled this chain should be disabled) and if
-+ *	a chain has diversity antennas wether diversity should be used or not.
++ *	a chain has diversity antennas whether diversity should be used or not.
 + *	HT capabilities (STBC, TX Beamforming, Antenna selection) can be
 + *	derived from the available chains after applying the antenna mask.
-+ *	Non-802.11n drivers can derive wether to use diversity or not.
++ *	Non-802.11n drivers can derive whether to use diversity or not.
 + *	Drivers may reject configurations or RX/TX mask combinations they cannot
 + *	support by returning -EINVAL.
 + *
@@ -9802,6 +9871,12 @@ index 0000000000..b995313ccd
 + * @NL80211_ATTR_DISABLE_HE: Force HE capable interfaces to disable
 + *      this feature during association. This is a flag attribute.
 + *	Currently only supported in mac80211 drivers.
++ * @NL80211_ATTR_DISABLE_EHT: Force EHT capable interfaces to disable
++ *      this feature during association. This is a flag attribute.
++ *	Currently only supported in mac80211 drivers.
++ * @NL80211_ATTR_DISABLE_EHT: Force EHT capable interfaces to disable
++ *      this feature during association. This is a flag attribute.
++ *	Currently only supported in mac80211 drivers.
 + * @NL80211_ATTR_HT_CAPABILITY_MASK: Specify which bits of the
 + *      ATTR_HT_CAPABILITY to which attention should be paid.
 + *      Currently, only mac80211 NICs support this feature.
@@ -9811,6 +9886,12 @@ index 0000000000..b995313ccd
 + *      All values are treated as suggestions and may be ignored
 + *      by the driver as required.  The actual values may be seen in
 + *      the station debugfs ht_caps file.
++ * @NL80211_ATTR_VHT_CAPABILITY_MASK: Specify which bits of the
++ *      ATTR_VHT_CAPABILITY to which attention should be paid.
++ *      Currently, only mac80211 NICs support this feature.
++ *      All values are treated as suggestions and may be ignored
++ *      by the driver as required.  The actual values may be seen in
++ *      the station debugfs vht_caps file.
 + *
 + * @NL80211_ATTR_DFS_REGION: region for regulatory rules which this country
 + *    abides to when initiating radiation on DFS channels. A country maps
@@ -10069,7 +10150,7 @@ index 0000000000..b995313ccd
 + *	scheduled scan is started.  Or the delay before a WoWLAN
 + *	net-detect scan is started, counting from the moment the
 + *	system is suspended.  This value is a u32, in seconds.
-+
++ *
 + * @NL80211_ATTR_REG_INDOOR: flag attribute, if set indicates that the device
 + *      is operating in an indoor environment.
 + *
@@ -10211,7 +10292,7 @@ index 0000000000..b995313ccd
 + *	from successful FILS authentication and is used with
 + *	%NL80211_CMD_CONNECT.
 + *
-+ * @NL80211_ATTR_FILS_CACHE_ID: A 2-octet identifier advertized by a FILS AP
++ * @NL80211_ATTR_FILS_CACHE_ID: A 2-octet identifier advertised by a FILS AP
 + *	identifying the scope of PMKSAs. This is used with
 + *	@NL80211_CMD_SET_PMKSA and @NL80211_CMD_DEL_PMKSA.
 + *
@@ -10370,11 +10451,13 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_ATTR_FILS_DISCOVERY: Optional parameter to configure FILS
 + *	discovery. It is a nested attribute, see
-+ *	&enum nl80211_fils_discovery_attributes.
++ *	&enum nl80211_fils_discovery_attributes. Userspace should pass an empty
++ *	nested attribute to disable this feature and delete the templates.
 + *
 + * @NL80211_ATTR_UNSOL_BCAST_PROBE_RESP: Optional parameter to configure
 + *	unsolicited broadcast probe response. It is a nested attribute, see
-+ *	&enum nl80211_unsol_bcast_probe_resp_attributes.
++ *	&enum nl80211_unsol_bcast_probe_resp_attributes. Userspace should pass an empty
++ *	nested attribute to disable this feature and delete the templates.
 + *
 + * @NL80211_ATTR_S1G_CAPABILITY: S1G Capability information element (from
 + *	association request when used with NL80211_CMD_NEW_STATION)
@@ -10495,6 +10578,53 @@ index 0000000000..b995313ccd
 + * @NL80211_ATTR_MLO_LINK_DISABLED: Flag attribute indicating that the link is
 + *	disabled.
 + *
++ * @NL80211_ATTR_BSS_DUMP_INCLUDE_USE_DATA: Include BSS usage data, i.e.
++ *	include BSSes that can only be used in restricted scenarios and/or
++ *	cannot be used at all.
++ *
++ * @NL80211_ATTR_MLO_TTLM_DLINK: Binary attribute specifying the downlink TID to
++ *      link mapping. The length is 8 * sizeof(u16). For each TID the link
++ *      mapping is as defined in section 9.4.2.314 (TID-To-Link Mapping element)
++ *      in Draft P802.11be_D4.0.
++ * @NL80211_ATTR_MLO_TTLM_ULINK: Binary attribute specifying the uplink TID to
++ *      link mapping. The length is 8 * sizeof(u16). For each TID the link
++ *      mapping is as defined in section 9.4.2.314 (TID-To-Link Mapping element)
++ *      in Draft P802.11be_D4.0.
++ *
++ * @NL80211_ATTR_ASSOC_SPP_AMSDU: flag attribute used with
++ *	%NL80211_CMD_ASSOCIATE indicating the SPP A-MSDUs
++ *	are used on this connection
++ *
++ * @NL80211_ATTR_WIPHY_RADIOS: Nested attribute describing physical radios
++ *	belonging to this wiphy. See &enum nl80211_wiphy_radio_attrs.
++ *
++ * @NL80211_ATTR_WIPHY_INTERFACE_COMBINATIONS: Nested attribute listing the
++ *	supported interface combinations for all radios combined. In each
++ *	nested item, it contains attributes defined in
++ *	&enum nl80211_if_combination_attrs.
++ *
++ * @NL80211_ATTR_VIF_RADIO_MASK: Bitmask of allowed radios (u32).
++ *	A value of 0 means all radios.
++ *
++ * @NL80211_ATTR_SUPPORTED_SELECTORS: supported BSS Membership Selectors, array
++ *	of supported selectors as defined by IEEE Std 802.11-2020 9.4.2.3 but
++ *	without the length restriction (at most %NL80211_MAX_SUPP_SELECTORS).
++ *	This can be used to provide a list of selectors that are implemented
++ *	by the supplicant. If not given, support for SAE_H2E is assumed.
++ *
++ * @NL80211_ATTR_MLO_RECONF_REM_LINKS: (u16) A bitmask of the links requested
++ *      to be removed from the MLO association.
++ *
++ * @NL80211_ATTR_EPCS: Flag attribute indicating that EPCS is enabled for a
++ *	station interface.
++ *
++ * @NL80211_ATTR_WIPHY_RADIO_INDEX: Integer attribute denoting the index of
++ *	the radio in interest. Internally a value of 0xff is used to indicate
++ *	this attribute is not present, and hence any associated attributes are
++ *	deemed to be applicable to all radios
++ *
++ * @NL80211_ATTR_VIF_RADIO_MASK: Bitmask of allowed radios (u32).
++ *	A value of 0 means all radios.
 + * @NL80211_ATTR_WIPHY_ANTENNA_GAIN: Configured antenna gain. Used to reduce
 + *	transmit power to stay within regulatory limits. u32, dBi.
 + *
@@ -10504,18 +10634,6 @@ index 0000000000..b995313ccd
 + *	staggered mode = 1 or burst mode = 2 in %NL80211_CMD_START_AP or
 + *	%NL80211_CMD_JOIN_MESH from user-space.
 + *
-+ * @NL80211_ATTR_RU_PUNCT_SUPP_BW: (u8) Minimum bandwidth for which
-+ *	the driver supports preamble puncturing, value should be of type
-+ *	&enum nl80211_ru_punct_supp_bw
-+ *
-+ * @NL80211_ATTR_RU_PUNCT_SUPP_HE: flag attribute, used to indicate that RU
-+ *	puncturing bitmap validation should include OFDMA bitmaps.
-+ *
-+ * @NL80211_ATTR_RU_PUNCT_BITMAP: (u16) RU puncturing bitmap where the lowest
-+ *	bit corresponds to the lowest 20 MHz channel. Each bit set to 1
-+ *	indicates that the sub-channel is punctured, set 0 indicates that the
-+ *	channel is active.
-+ *
 + * @NL80211_ATTR_MULTI_HW_MACS: nested attribute to send the hardware mac
 + *     specific channel capabilities to user space. Drivers registering
 + *     multiple physical hardware under a wiphy can use this attribute,
@@ -10524,12 +10642,6 @@ index 0000000000..b995313ccd
 + * @NL80211_ATTR_RADAR_BITMAP: (u16) RADAR bitmap where the lowest bit
 + *      corresponds to the lowest 20MHZ channel. Each bit set to 1
 + *      indicates that radar is detected in that sub-channel.
-+ *
-+ * @NL80211_ATTR_ADD_MULTI_CHAN: Add channel to the radio, this is used
-+ *  for monitor interface (u32).
-+ *
-+ * @NL80211_ATTR_DEL_MULTI_CHAN: Delete channel from the radio, this is used
-+ *  for monitor interface (u32).
 + *
 + * @NL80211_ATTR_RXMGMT_CRITICAL_UPDATE: Nested attribute listing the critical
 + *	update for each MLD. In each nested item, it contains attributes
@@ -10553,16 +10665,42 @@ index 0000000000..b995313ccd
 + *
 + * 	The above list is detailed in the enum nl80211_interference_type.
 + *
-+ * @NL80211_ATTR_WIPHY_RADIOS: Nested attribute describing physical radios
-+ *	belonging to this wiphy. See &enum nl80211_wiphy_radio_attrs.
++ * @NL80211_ATTR_AP_REMOVAL_COUNT: (u8) TBTT count up-to which reconfiguration
++ *	MLE is sent. Also, userspace will be notified with this count once the
++ *	first beacon with reconfiguration MLE is sent.
 + *
-+ * @NL80211_ATTR_WIPHY_INTERFACE_COMBINATIONS: Nested attribute listing the
-+ *	supported interface combinations for all radios combined. In each
-+ *	nested item, it contains attributes defined in
-+ *	&enum nl80211_if_combination_attrs.
++ * @NL80211_ATTR_TSF: (u64) TSF value when the first beacon with reconfiguration
++ *	MLE is sent.
 + *
-+ * @NL80211_ATTR_VIF_RADIO_MASK: Bitmask of allowed radios (u32).
-+ *	A value of 0 means all radios.
++ * @NL80211_ATTR_RXMGMT_LINK_REMOVAL_UPDATE: This is a nested attribute for driver
++ *	supporting link removal offload feature for AP MLD. When used with
++ *	%NL80211_CMD_FRAME it contains attribute defined in %NL80211_ATTR_AP_REMOVAL_COUNT,
++ *	to send link removal params for list of MLDs. Driver adds this attribute
++ *	only for probe, assoc and reassoc request frame. User-space can use these
++ *	params to update ML reconfigure element on corresponding response frame. This
++ *	attribute is needed only on ML reconfigure offload case and it is not needed on
++ *	ML reconfigure non-offload case since user space itself has these data.
++ *
++ * @NL80211_ATTR_ML_MAX_REC_LINKS: (u8) MLO Max recommended links. Max ML recommended
++ *      links are indication to non-AP MLD that how many max active links ML station can
++ *      initiate with AP MLD
++ *
++ * @NL80211_ATTR_ADVERTISED_TTLM: Nested attributes associated with advertised
++ *	TTLM. See &enum nl80211_advertised_ttlm_attrs
++ *
++ * @NL80211_ATTR_QOS_MGMT: This attribute is used with %NL80211_CMD_QOS_MGMT to
++ *	configure QoS Management (QM) features for a station. It is a nested
++ *	attribute containing various QoS-related parameters defined by the
++ *	nl80211_qm_policy.
++ *
++ * @NL80211_ATTR_ASSOC_MLD_EXT_CAPA_OPS: Extended MLD capabilities and
++ *	operations that userspace implements to use during association/ML
++ *	link reconfig, currently only "BTM MLD Recommendation For Multiple
++ *	APs Support". Drivers may set additional flags that they support
++ *	in the kernel or device.
++ *
++ * @NL80211_ATTR_6GHZ_DEVICE_DEPLOYMENT_TYPE: Attribute denoting the 6 GHz
++ *	device deployment type.
 + *
 + * @NUM_NL80211_ATTR: total number of nl80211_attrs available
 + * @NL80211_ATTR_MAX: highest attribute number currently defined
@@ -11102,6 +11240,25 @@ index 0000000000..b995313ccd
 +
 +	NL80211_ATTR_MLO_LINK_DISABLED,
 +
++	NL80211_ATTR_BSS_DUMP_INCLUDE_USE_DATA,
++
++	NL80211_ATTR_MLO_TTLM_DLINK,
++	NL80211_ATTR_MLO_TTLM_ULINK,
++
++	NL80211_ATTR_ASSOC_SPP_AMSDU,
++
++	NL80211_ATTR_WIPHY_RADIOS,
++	NL80211_ATTR_WIPHY_INTERFACE_COMBINATIONS,
++
++	NL80211_ATTR_VIF_RADIO_MASK,
++
++	NL80211_ATTR_SUPPORTED_SELECTORS,
++
++	NL80211_ATTR_MLO_RECONF_REM_LINKS,
++	NL80211_ATTR_EPCS,
++
++	NL80211_ATTR_WIPHY_RADIO_INDEX,
++
 +	NL80211_ATTR_WIPHY_ANTENNA_GAIN,
 +
 +	NL80211_ATTR_HE_MUEDCA_PARAMS,
@@ -11114,12 +11271,6 @@ index 0000000000..b995313ccd
 +
 +	NL80211_ATTR_6G_REG_POWER_MODE,
 +
-+	NL80211_ATTR_RU_PUNCT_SUPP_BW,
-+
-+	NL80211_ATTR_RU_PUNCT_SUPP_HE,
-+
-+	NL80211_ATTR_RU_PUNCT_BITMAP,
-+
 +	NL80211_ATTR_AP_PS,
 +
 +	NL80211_ATTR_MULTI_HW_MACS,
@@ -11128,18 +11279,28 @@ index 0000000000..b995313ccd
 +
 +	NL80211_ATTR_EHT_240MHZ_CAPABILITY,
 +
-+	NL80211_ATTR_ADD_MULTI_CHAN,
-+	NL80211_ATTR_DEL_MULTI_CHAN,
 +	NL80211_ATTR_RXMGMT_CRITICAL_UPDATE,
 +	NL80211_ATTR_SET_CRITICAL_UPDATE,
 +	NL80211_ATTR_CHANNEL_WIDTH_DEVICE,
 +	NL80211_ATTR_CENTER_FREQ_DEVICE,
 +	NL80211_ATTR_INTERFERENCE_TYPE,
 +
-+	NL80211_ATTR_WIPHY_RADIOS,
-+	NL80211_ATTR_WIPHY_INTERFACE_COMBINATIONS,
++	NL80211_ATTR_AP_REMOVAL_COUNT,
++	NL80211_ATTR_TSF,
++	NL80211_ATTR_RXMGMT_LINK_REMOVAL_UPDATE,
++	NL80211_ATTR_DYNAMIC_CHAIN_MASK,
++	NL80211_ATTR_ML_MAX_REC_LINKS,
 +
-+	NL80211_ATTR_VIF_RADIO_MASK,
++	NL80211_ATTR_ERP,
++
++	NL80211_ATTR_ADVERTISED_TTLM,
++	NL80211_ATTR_ADVERTISED_TTLM_EXPEC_DUR_UPDATE,
++
++	NL80211_ATTR_QOS_MGMT,
++
++	NL80211_ATTR_ASSOC_MLD_EXT_CAPA_OPS,
++
++	NL80211_ATTR_6GHZ_DEVICE_DEPLOYMENT_TYPE,
 +
 +	/* add attributes here, update the policy in nl80211.c */
 +
@@ -11183,8 +11344,10 @@ index 0000000000..b995313ccd
 +#define NL80211_ATTR_FEATURE_FLAGS NL80211_ATTR_FEATURE_FLAGS
 +
 +#define NL80211_WIPHY_NAME_MAXLEN		64
++#define NL80211_WIPHY_RADIO_ID_MAX		0xff
 +
 +#define NL80211_MAX_SUPP_RATES			32
++#define NL80211_MAX_SUPP_SELECTORS		128
 +#define NL80211_MAX_SUPP_HT_RATES		77
 +#define NL80211_MAX_SUPP_REG_RULES		128
 +#define NL80211_TKIP_DATA_OFFSET_ENCR_KEY	0
@@ -11211,6 +11374,10 @@ index 0000000000..b995313ccd
 +#define NL80211_SCAN_RSSI_THOLD_OFF		-300
 +
 +#define NL80211_CQM_TXE_MAX_INTVL		1800
++
++#define NL80211_IPADDR_MAX_LEN			16
++#define NL80211_TCLAS_TYPE10_MAX_FILTER_LEN	12
++#define NL80211_TCLAS_TYPE4_FLOW_LABEL_LEN	3
 +
 +/**
 + * enum nl80211_iftype - (virtual) interface types
@@ -11282,6 +11449,7 @@ index 0000000000..b995313ccd
 + * @NL80211_STA_FLAG_ASSOCIATED: station is associated; used with drivers
 + *	that support %NL80211_FEATURE_FULL_AP_CLIENT_STATE to transition a
 + *	previously added station into associated state
++ * @NL80211_STA_FLAG_SPP_AMSDU: station supports SPP A-MSDUs
 + * @NL80211_STA_FLAG_FT_AUTH: station uses FT authentication
 + * @NL80211_STA_FLAG_MAX: highest station flag number currently defined
 + * @__NL80211_STA_FLAG_AFTER_LAST: internal use
@@ -11295,6 +11463,7 @@ index 0000000000..b995313ccd
 +	NL80211_STA_FLAG_AUTHENTICATED,
 +	NL80211_STA_FLAG_TDLS_PEER,
 +	NL80211_STA_FLAG_ASSOCIATED,
++	NL80211_STA_FLAG_SPP_AMSDU,
 +	NL80211_STA_FLAG_FT_AUTH,
 +
 +	/* keep last */
@@ -11306,7 +11475,7 @@ index 0000000000..b995313ccd
 + * enum nl80211_sta_p2p_ps_status - station support of P2P PS
 + *
 + * @NL80211_P2P_PS_UNSUPPORTED: station doesn't support P2P PS mechanism
-+ * @@NL80211_P2P_PS_SUPPORTED: station supports P2P PS mechanism
++ * @NL80211_P2P_PS_SUPPORTED: station supports P2P PS mechanism
 + * @NUM_NL80211_P2P_PS_STATUS: number of values
 + */
 +enum nl80211_sta_p2p_ps_status {
@@ -11344,9 +11513,9 @@ index 0000000000..b995313ccd
 +
 +/**
 + * enum nl80211_he_ltf - HE long training field
-+ * @NL80211_RATE_INFO_HE_1xLTF: 3.2 usec
-+ * @NL80211_RATE_INFO_HE_2xLTF: 6.4 usec
-+ * @NL80211_RATE_INFO_HE_4xLTF: 12.8 usec
++ * @NL80211_RATE_INFO_HE_1XLTF: 3.2 usec
++ * @NL80211_RATE_INFO_HE_2XLTF: 6.4 usec
++ * @NL80211_RATE_INFO_HE_4XLTF: 12.8 usec
 + */
 +enum nl80211_he_ltf {
 +	NL80211_RATE_INFO_HE_1XLTF,
@@ -11473,7 +11642,7 @@ index 0000000000..b995313ccd
 + * @NL80211_RATE_INFO_HE_GI: HE guard interval identifier
 + *	(u8, see &enum nl80211_he_gi)
 + * @NL80211_RATE_INFO_HE_DCM: HE DCM value (u8, 0/1)
-+ * @NL80211_RATE_INFO_RU_ALLOC: HE RU allocation, if not present then
++ * @NL80211_RATE_INFO_HE_RU_ALLOC: HE RU allocation, if not present then
 + *	non-OFDMA was used (u8, see &enum nl80211_he_ru_alloc)
 + * @NL80211_RATE_INFO_320_MHZ_WIDTH: 320 MHz bitrate
 + * @NL80211_RATE_INFO_EHT_MCS: EHT MCS index (u8, 0-15)
@@ -11576,7 +11745,7 @@ index 0000000000..b995313ccd
 + *	(u64, to this station)
 + * @NL80211_STA_INFO_SIGNAL: signal strength of last received PPDU (u8, dBm)
 + * @NL80211_STA_INFO_TX_BITRATE: current unicast tx rate, nested attribute
-+ * 	containing info as possible, see &enum nl80211_rate_info
++ *	containing info as possible, see &enum nl80211_rate_info
 + * @NL80211_STA_INFO_RX_PACKETS: total received packet (MSDUs and MMPDUs)
 + *	(u32, from this station)
 + * @NL80211_STA_INFO_TX_PACKETS: total transmitted packets (MSDUs and MMPDUs)
@@ -11605,8 +11774,8 @@ index 0000000000..b995313ccd
 + *	Contains a nested array of signal strength attributes (u8, dBm)
 + * @NL80211_STA_INFO_CHAIN_SIGNAL_AVG: per-chain signal strength average
 + *	Same format as NL80211_STA_INFO_CHAIN_SIGNAL.
-+ * @NL80211_STA_EXPECTED_THROUGHPUT: expected throughput considering also the
-+ *	802.11 header (u32, kbps)
++ * @NL80211_STA_INFO_EXPECTED_THROUGHPUT: expected throughput considering also
++ *	the 802.11 header (u32, kbps)
 + * @NL80211_STA_INFO_RX_DROP_MISC: RX packets dropped for unspecified reasons
 + *	(u64)
 + * @NL80211_STA_INFO_BEACON_RX: number of beacons received from this peer (u64)
@@ -11795,7 +11964,7 @@ index 0000000000..b995313ccd
 + * @NL80211_MPATH_INFO_METRIC: metric (cost) of this mesh path
 + * @NL80211_MPATH_INFO_EXPTIME: expiration time for the path, in msec from now
 + * @NL80211_MPATH_INFO_FLAGS: mesh path flags, enumerated in
-+ * 	&enum nl80211_mpath_flags;
++ *	&enum nl80211_mpath_flags;
 + * @NL80211_MPATH_INFO_DISCOVERY_TIMEOUT: total path discovery timeout, in msec
 + * @NL80211_MPATH_INFO_DISCOVERY_RETRIES: mesh path discovery retries
 + * @NL80211_MPATH_INFO_HOP_COUNT: hop count to destination
@@ -11897,6 +12066,10 @@ index 0000000000..b995313ccd
 + *	set subfield, as in the S1G information IE, 5 bytes
 + * @NL80211_BAND_ATTR_S1G_CAPA: S1G capabilities information subfield as in the
 + *	S1G information IE, 10 bytes
++ * @NL80211_BAND_ATTR_6GHZ_POWER_MODE_FREQS: Information about the various
++ *	power modes supported by the device in the 6GHz band. This is an array
++ *	of power modes, each of which is a nested attribute containing the
++ *	frequency attributes for each power mode.
 + * @NL80211_BAND_ATTR_MAX: highest band attribute currently defined
 + * @__NL80211_BAND_ATTR_AFTER_LAST: internal use
 + */
@@ -11919,6 +12092,7 @@ index 0000000000..b995313ccd
 +
 +	NL80211_BAND_ATTR_S1G_MCS_NSS_SET,
 +	NL80211_BAND_ATTR_S1G_CAPA,
++	NL80211_BAND_ATTR_6GHZ_POWER_MODE_FREQS,
 +
 +	/* keep last */
 +	__NL80211_BAND_ATTR_AFTER_LAST,
@@ -11928,8 +12102,8 @@ index 0000000000..b995313ccd
 +#define NL80211_BAND_ATTR_HT_CAPA NL80211_BAND_ATTR_HT_CAPA
 +
 +#define NL80211_NUM_POWER_MODES_PER_IFTYPE	3
-+#define GET_POWER_MODE_FOR_NON_AP_STA(pwr_mode_usr, pwr_mode_bcn)	\
-+	(NL80211_NUM_POWER_MODES_PER_IFTYPE * (1 + pwr_mode_usr) + pwr_mode_bcn)
++#define GET_POWER_MODE_FOR_NON_AP_STA(client_type, pwr_mode_bcn)	\
++	(NL80211_NUM_POWER_MODES_PER_IFTYPE * (1 + client_type) + pwr_mode_bcn)
 +
 +enum nl80211_regulatory_power_modes {
 +	NL80211_REG_AP_LPI,
@@ -11946,6 +12120,39 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
++ * enum nl80211_reg_client_types - 6 GHz client types
++ * @NL80211_REG_REGULAR_CLIENT: Default client
++ * @NL80211_REG_SUBORDINATE_CLIENT: Subordinate Client
++ * @NL80211_REG_INVALID_CLIENT_TYPE: Invalid client type, internal use only
++ */
++enum nl80211_reg_client_types {
++	NL80211_REG_REGULAR_CLIENT,
++	NL80211_REG_SUBORDINATE_CLIENT,
++
++	NL80211_REG_INVALID_CLIENT_TYPE,
++};
++
++/**
++ * enum nl80211_reg_power_mode_attributes - power mode attributes
++ *
++ * @__NL80211_POWER_MODE_INVALID: attribute number 0 is reserved
++ * @NL80211_6GHZ_POWER_MODE_ATTR_POWER_MODE: 6GHz power mode (u8)
++ * @NL80211_6GHZ_POWER_MODE_ATTR_FREQS: Frequencies for the corresponding
++ *	power mode (nested attribute)
++ * @__NL80211_6GHZ_POWER_MODE_AFTER_LAST: internal use
++ * @NL80211_6GHZ_POWER_MODE_ATTR_MAX: highest band attribute currently defined
++ */
++enum nl80211_reg_power_mode_attributes {
++	__NL80211_POWER_MODE_INVALID,
++	NL80211_6GHZ_POWER_MODE_ATTR_POWER_MODE,
++	NL80211_6GHZ_POWER_MODE_ATTR_FREQS,
++
++	/* keep last */
++	__NL80211_6GHZ_POWER_MODE_AFTER_LAST,
++	NL80211_6GHZ_POWER_MODE_ATTR_MAX = __NL80211_6GHZ_POWER_MODE_AFTER_LAST - 1
++};
++
++/**
 + * enum nl80211_wmm_rule - regulatory wmm rule
 + *
 + * @__NL80211_WMMR_INVALID: attribute number 0 is reserved
@@ -11953,7 +12160,7 @@ index 0000000000..b995313ccd
 + * @NL80211_WMMR_CW_MAX: Maximum contention window slot.
 + * @NL80211_WMMR_AIFSN: Arbitration Inter Frame Space.
 + * @NL80211_WMMR_TXOP: Maximum allowed tx operation time.
-+ * @nl80211_WMMR_MAX: highest possible wmm rule.
++ * @NL80211_WMMR_MAX: highest possible wmm rule.
 + * @__NL80211_WMMR_LAST: Internal use.
 + */
 +enum nl80211_wmm_rule {
@@ -11975,15 +12182,16 @@ index 0000000000..b995313ccd
 + * @NL80211_FREQUENCY_ATTR_DISABLED: Channel is disabled in current
 + *	regulatory domain.
 + * @NL80211_FREQUENCY_ATTR_NO_IR: no mechanisms that initiate radiation
-+ * 	are permitted on this channel, this includes sending probe
-+ * 	requests, or modes of operation that require beaconing.
++ *	are permitted on this channel, this includes sending probe
++ *	requests, or modes of operation that require beaconing.
++ * @__NL80211_FREQUENCY_ATTR_NO_IBSS: obsolete, same as _NO_IR
 + * @NL80211_FREQUENCY_ATTR_RADAR: Radar detection is mandatory
 + *	on this channel in current regulatory domain.
 + * @NL80211_FREQUENCY_ATTR_MAX_TX_POWER: Maximum transmission power in mBm
 + *	(100 * dBm).
 + * @NL80211_FREQUENCY_ATTR_DFS_STATE: current state for DFS
 + *	(enum nl80211_dfs_state)
-+ * @NL80211_FREQUENCY_ATTR_DFS_TIME: time in miliseconds for how long
++ * @NL80211_FREQUENCY_ATTR_DFS_TIME: time in milliseconds for how long
 + *	this channel is in this DFS state.
 + * @NL80211_FREQUENCY_ATTR_NO_HT40_MINUS: HT40- isn't possible with this
 + *	channel as the control channel
@@ -12037,8 +12245,26 @@ index 0000000000..b995313ccd
 + *	as the primary or any of the secondary channels isn't possible
 + * @NL80211_FREQUENCY_ATTR_NO_EHT: EHT operation is not allowed on this channel
 + *	in current regulatory domain.
-+ * @NL80211_FREQUENCY_ATTR_PSD: power spectral density (in dBm)
++ * @NL80211_FREQUENCY_ATTR_PSD: Power spectral density (in dBm) that
 + *	is allowed on this channel in current regulatory domain.
++ * @NL80211_FREQUENCY_ATTR_DFS_CONCURRENT: Operation on this channel is
++ *	allowed for peer-to-peer or adhoc communication under the control
++ *	of a DFS master which operates on the same channel (FCC-594280 D01
++ *	Section B.3). Should be used together with %NL80211_RRF_DFS only.
++ * @NL80211_FREQUENCY_ATTR_NO_6GHZ_VLP_CLIENT: Client connection to VLP AP
++ *	not allowed using this channel
++ * @NL80211_FREQUENCY_ATTR_NO_6GHZ_AFC_CLIENT: Client connection to AFC AP
++ *	not allowed using this channel
++ * @NL80211_FREQUENCY_ATTR_CAN_MONITOR: This channel can be used in monitor
++ *	mode despite other (regulatory) restrictions, even if the channel is
++ *	otherwise completely disabled.
++ * @NL80211_FREQUENCY_ATTR_ALLOW_6GHZ_VLP_AP: This channel can be used for a
++ *	very low power (VLP) AP, despite being NO_IR.
++ * @NL80211_FREQUENCY_ATTR_ALLOW_20MHZ_ACTIVITY: This channel can be acitve in
++ *	20 MHz bandwidth, despite being NO_IR.
++ * @NL80211_FREQUENCY_ATTR_6GHZ_SUPP_PWR_MODES: 6 Ghz power modes supported by
++ *	this channel
++ * @NL80211_FREQUENCY_ATTR_6GHZ_TXPOWERS: Tx powers in each supported power mode
 + * @NL80211_FREQUENCY_ATTR_MAX: highest frequency attribute number
 + *	currently defined
 + * @__NL80211_FREQUENCY_ATTR_AFTER_LAST: internal use
@@ -12078,6 +12304,14 @@ index 0000000000..b995313ccd
 +	NL80211_FREQUENCY_ATTR_NO_320MHZ,
 +	NL80211_FREQUENCY_ATTR_NO_EHT,
 +	NL80211_FREQUENCY_ATTR_PSD,
++	NL80211_FREQUENCY_ATTR_DFS_CONCURRENT,
++	NL80211_FREQUENCY_ATTR_NO_6GHZ_VLP_CLIENT,
++	NL80211_FREQUENCY_ATTR_NO_6GHZ_AFC_CLIENT,
++	NL80211_FREQUENCY_ATTR_CAN_MONITOR,
++	NL80211_FREQUENCY_ATTR_ALLOW_6GHZ_VLP_AP,
++	NL80211_FREQUENCY_ATTR_ALLOW_20MHZ_ACTIVITY,
++	NL80211_FREQUENCY_ATTR_6GHZ_SUPP_PWR_MODES,
++	NL80211_FREQUENCY_ATTR_6GHZ_TXPOWERS,
 +
 +	/* keep last */
 +	__NL80211_FREQUENCY_ATTR_AFTER_LAST,
@@ -12090,6 +12324,10 @@ index 0000000000..b995313ccd
 +#define NL80211_FREQUENCY_ATTR_NO_IR		NL80211_FREQUENCY_ATTR_NO_IR
 +#define NL80211_FREQUENCY_ATTR_GO_CONCURRENT \
 +					NL80211_FREQUENCY_ATTR_IR_CONCURRENT
++#define NL80211_FREQUENCY_ATTR_NO_UHB_VLP_CLIENT \
++	NL80211_FREQUENCY_ATTR_NO_6GHZ_VLP_CLIENT
++#define NL80211_FREQUENCY_ATTR_NO_UHB_AFC_CLIENT \
++	NL80211_FREQUENCY_ATTR_NO_6GHZ_AFC_CLIENT
 +
 +/**
 + * enum nl80211_bitrate_attr - bitrate attributes
@@ -12112,16 +12350,16 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
-+ * enum nl80211_initiator - Indicates the initiator of a reg domain request
++ * enum nl80211_reg_initiator - Indicates the initiator of a reg domain request
 + * @NL80211_REGDOM_SET_BY_CORE: Core queried CRDA for a dynamic world
-+ * 	regulatory domain.
++ *	regulatory domain.
 + * @NL80211_REGDOM_SET_BY_USER: User asked the wireless core to set the
-+ * 	regulatory domain.
++ *	regulatory domain.
 + * @NL80211_REGDOM_SET_BY_DRIVER: a wireless drivers has hinted to the
-+ * 	wireless core it thinks its knows the regulatory domain we should be in.
++ *	wireless core it thinks its knows the regulatory domain we should be in.
 + * @NL80211_REGDOM_SET_BY_COUNTRY_IE: the wireless core has received an
-+ * 	802.11 country information element with regulatory information it
-+ * 	thinks we should consider. cfg80211 only processes the country
++ *	802.11 country information element with regulatory information it
++ *	thinks we should consider. cfg80211 only processes the country
 + *	code from the IE, and relies on the regulatory domain information
 + *	structure passed by userspace (CRDA) from our wireless-regdb.
 + *	If a channel is enabled but the country code indicates it should
@@ -12140,11 +12378,11 @@ index 0000000000..b995313ccd
 + *	to a specific country. When this is set you can count on the
 + *	ISO / IEC 3166 alpha2 country code being valid.
 + * @NL80211_REGDOM_TYPE_WORLD: the regulatory set domain is the world regulatory
-+ * 	domain.
++ *	domain.
 + * @NL80211_REGDOM_TYPE_CUSTOM_WORLD: the regulatory domain set is a custom
-+ * 	driver specific world regulatory domain. These do not apply system-wide
-+ * 	and are only applicable to the individual devices which have requested
-+ * 	them to be applied.
++ *	driver specific world regulatory domain. These do not apply system-wide
++ *	and are only applicable to the individual devices which have requested
++ *	them to be applied.
 + * @NL80211_REGDOM_TYPE_INTERSECTION: the regulatory domain set is the product
 + *	of an intersection between two regulatory domains -- the previously
 + *	set regulatory domain on the system and the last accepted regulatory
@@ -12161,21 +12399,21 @@ index 0000000000..b995313ccd
 + * enum nl80211_reg_rule_attr - regulatory rule attributes
 + * @__NL80211_REG_RULE_ATTR_INVALID: attribute number 0 is reserved
 + * @NL80211_ATTR_REG_RULE_FLAGS: a set of flags which specify additional
-+ * 	considerations for a given frequency range. These are the
-+ * 	&enum nl80211_reg_rule_flags.
++ *	considerations for a given frequency range. These are the
++ *	&enum nl80211_reg_rule_flags.
 + * @NL80211_ATTR_FREQ_RANGE_START: starting frequencry for the regulatory
-+ * 	rule in KHz. This is not a center of frequency but an actual regulatory
-+ * 	band edge.
++ *	rule in KHz. This is not a center of frequency but an actual regulatory
++ *	band edge.
 + * @NL80211_ATTR_FREQ_RANGE_END: ending frequency for the regulatory rule
-+ * 	in KHz. This is not a center a frequency but an actual regulatory
-+ * 	band edge.
++ *	in KHz. This is not a center a frequency but an actual regulatory
++ *	band edge.
 + * @NL80211_ATTR_FREQ_RANGE_MAX_BW: maximum allowed bandwidth for this
 + *	frequency range, in KHz.
 + * @NL80211_ATTR_POWER_RULE_MAX_ANT_GAIN: the maximum allowed antenna gain
-+ * 	for a given frequency range. The value is in mBi (100 * dBi).
-+ * 	If you don't have one then don't send this.
++ *	for a given frequency range. The value is in mBi (100 * dBi).
++ *	If you don't have one then don't send this.
 + * @NL80211_ATTR_POWER_RULE_MAX_EIRP: the maximum allowed EIRP for
-+ * 	a given frequency range. The value is in mBm (100 * dBm).
++ *	a given frequency range. The value is in mBm (100 * dBm).
 + * @NL80211_ATTR_DFS_CAC_TIME: DFS CAC time in milliseconds.
 + *	If not present or 0 default CAC time will be used.
 + * @NL80211_ATTR_POWER_RULE_PSD: power spectral density (in dBm).
@@ -12230,14 +12468,7 @@ index 0000000000..b995313ccd
 + *	value as specified by &struct nl80211_bss_select_rssi_adjust.
 + * @NL80211_SCHED_SCAN_MATCH_ATTR_BSSID: BSSID to be used for matching
 + *	(this cannot be used together with SSID).
-+ * @NL80211_SCHED_SCAN_MATCH_PER_BAND_RSSI: Nested attribute that carries the
-+ *	band specific minimum rssi thresholds for the bands defined in
-+ *	enum nl80211_band. The minimum rssi threshold value(s32) specific to a
-+ *	band shall be encapsulated in attribute with type value equals to one
-+ *	of the NL80211_BAND_* defined in enum nl80211_band. For example, the
-+ *	minimum rssi threshold value for 2.4GHZ band shall be encapsulated
-+ *	within an attribute of type NL80211_BAND_2GHZ. And one or more of such
-+ *	attributes will be nested within this attribute.
++ * @NL80211_SCHED_SCAN_MATCH_PER_BAND_RSSI: Obsolete
 + * @NL80211_SCHED_SCAN_MATCH_ATTR_MAX: highest scheduled scan filter
 + *	attribute number currently defined
 + * @__NL80211_SCHED_SCAN_MATCH_ATTR_AFTER_LAST: internal use
@@ -12250,7 +12481,7 @@ index 0000000000..b995313ccd
 +	NL80211_SCHED_SCAN_MATCH_ATTR_RELATIVE_RSSI,
 +	NL80211_SCHED_SCAN_MATCH_ATTR_RSSI_ADJUST,
 +	NL80211_SCHED_SCAN_MATCH_ATTR_BSSID,
-+	NL80211_SCHED_SCAN_MATCH_PER_BAND_RSSI,
++	NL80211_SCHED_SCAN_MATCH_PER_BAND_RSSI, /* obsolete */
 +
 +	/* keep last */
 +	__NL80211_SCHED_SCAN_MATCH_ATTR_AFTER_LAST,
@@ -12272,8 +12503,9 @@ index 0000000000..b995313ccd
 + * @NL80211_RRF_PTP_ONLY: this is only for Point To Point links
 + * @NL80211_RRF_PTMP_ONLY: this is only for Point To Multi Point links
 + * @NL80211_RRF_NO_IR: no mechanisms that initiate radiation are allowed,
-+ * 	this includes probe requests or modes of operation that require
-+ * 	beaconing.
++ *	this includes probe requests or modes of operation that require
++ *	beaconing.
++ * @__NL80211_RRF_NO_IBSS: obsolete, same as NO_IR
 + * @NL80211_RRF_AUTO_BW: maximum available bandwidth should be calculated
 + *	base on contiguous rules and wider channels will be allowed to cross
 + *	multiple contiguous/overlapping frequency ranges.
@@ -12285,28 +12517,43 @@ index 0000000000..b995313ccd
 + * @NL80211_RRF_NO_HE: HE operation not allowed
 + * @NL80211_RRF_NO_320MHZ: 320MHz operation not allowed
 + * @NL80211_RRF_NO_EHT: EHT operation not allowed
-+ * @NL80211_RRF_PSD: channels has power spectral density value
++ * @NL80211_RRF_PSD: Ruleset has power spectral density value
++ * @NL80211_RRF_DFS_CONCURRENT: Operation on this channel is allowed for
++ *	peer-to-peer or adhoc communication under the control of a DFS master
++ *	which operates on the same channel (FCC-594280 D01 Section B.3).
++ *	Should be used together with %NL80211_RRF_DFS only.
++ * @NL80211_RRF_NO_6GHZ_VLP_CLIENT: Client connection to VLP AP not allowed
++ * @NL80211_RRF_NO_6GHZ_AFC_CLIENT: Client connection to AFC AP not allowed
++ * @NL80211_RRF_ALLOW_6GHZ_VLP_AP: Very low power (VLP) AP can be permitted
++ *	despite NO_IR configuration.
++ * @NL80211_RRF_ALLOW_20MHZ_ACTIVITY: Allow activity in 20 MHz bandwidth,
++ *	despite NO_IR configuration.
 + */
 +enum nl80211_reg_rule_flags {
-+	NL80211_RRF_NO_OFDM		= 1<<0,
-+	NL80211_RRF_NO_CCK		= 1<<1,
-+	NL80211_RRF_NO_INDOOR		= 1<<2,
-+	NL80211_RRF_NO_OUTDOOR		= 1<<3,
-+	NL80211_RRF_DFS			= 1<<4,
-+	NL80211_RRF_PTP_ONLY		= 1<<5,
-+	NL80211_RRF_PTMP_ONLY		= 1<<6,
-+	NL80211_RRF_NO_IR		= 1<<7,
-+	__NL80211_RRF_NO_IBSS		= 1<<8,
-+	NL80211_RRF_AUTO_BW		= 1<<11,
-+	NL80211_RRF_IR_CONCURRENT	= 1<<12,
-+	NL80211_RRF_NO_HT40MINUS	= 1<<13,
-+	NL80211_RRF_NO_HT40PLUS		= 1<<14,
-+	NL80211_RRF_NO_80MHZ		= 1<<15,
-+	NL80211_RRF_NO_160MHZ		= 1<<16,
-+	NL80211_RRF_NO_HE		= 1<<17,
-+	NL80211_RRF_NO_320MHZ		= 1<<18,
-+	NL80211_RRF_NO_EHT		= 1<<19,
-+	NL80211_RRF_PSD                 = 1<<20,
++	NL80211_RRF_NO_OFDM                 = 1 << 0,
++	NL80211_RRF_NO_CCK                  = 1 << 1,
++	NL80211_RRF_NO_INDOOR               = 1 << 2,
++	NL80211_RRF_NO_OUTDOOR              = 1 << 3,
++	NL80211_RRF_DFS                     = 1 << 4,
++	NL80211_RRF_PTP_ONLY                = 1 << 5,
++	NL80211_RRF_PTMP_ONLY               = 1 << 6,
++	NL80211_RRF_NO_IR                   = 1 << 7,
++	__NL80211_RRF_NO_IBSS               = 1 << 8,
++	NL80211_RRF_AUTO_BW                 = 1 << 11,
++	NL80211_RRF_IR_CONCURRENT           = 1 << 12,
++	NL80211_RRF_NO_HT40MINUS            = 1 << 13,
++	NL80211_RRF_NO_HT40PLUS             = 1 << 14,
++	NL80211_RRF_NO_80MHZ                = 1 << 15,
++	NL80211_RRF_NO_160MHZ               = 1 << 16,
++	NL80211_RRF_NO_HE                   = 1 << 17,
++	NL80211_RRF_NO_320MHZ               = 1 << 18,
++	NL80211_RRF_NO_EHT                  = 1 << 19,
++	NL80211_RRF_PSD                     = 1 << 20,
++	NL80211_RRF_DFS_CONCURRENT          = 1 << 21,
++	NL80211_RRF_NO_6GHZ_VLP_CLIENT      = 1 << 22,
++	NL80211_RRF_NO_6GHZ_AFC_CLIENT      = 1 << 23,
++	NL80211_RRF_ALLOW_6GHZ_VLP_AP       = 1 << 24,
++	NL80211_RRF_ALLOW_20MHZ_ACTIVITY    = 1 << 25,
 +};
 +
 +#define NL80211_RRF_PASSIVE_SCAN	NL80211_RRF_NO_IR
@@ -12315,6 +12562,8 @@ index 0000000000..b995313ccd
 +#define NL80211_RRF_NO_HT40		(NL80211_RRF_NO_HT40MINUS |\
 +					 NL80211_RRF_NO_HT40PLUS)
 +#define NL80211_RRF_GO_CONCURRENT	NL80211_RRF_IR_CONCURRENT
++#define NL80211_RRF_NO_UHB_VLP_CLIENT	NL80211_RRF_NO_6GHZ_VLP_CLIENT
++#define NL80211_RRF_NO_UHB_AFC_CLIENT	NL80211_RRF_NO_6GHZ_AFC_CLIENT
 +
 +/* For backport compatibility with older userspace */
 +#define NL80211_RRF_NO_IR_ALL		(NL80211_RRF_NO_IR | __NL80211_RRF_NO_IBSS)
@@ -12429,6 +12678,7 @@ index 0000000000..b995313ccd
 + *	overrides all other flags.
 + * @NL80211_MNTR_FLAG_ACTIVE: use the configured MAC address
 + *	and ACK incoming unicast packets.
++ * @NL80211_MNTR_FLAG_SKIP_TX: do not pass local tx packets
 + *
 + * @__NL80211_MNTR_FLAG_AFTER_LAST: internal use
 + * @NL80211_MNTR_FLAG_MAX: highest possible monitor flag
@@ -12441,6 +12691,7 @@ index 0000000000..b995313ccd
 +	NL80211_MNTR_FLAG_OTHER_BSS,
 +	NL80211_MNTR_FLAG_COOK_FRAMES,
 +	NL80211_MNTR_FLAG_ACTIVE,
++	NL80211_MNTR_FLAG_SKIP_TX,
 +
 +	/* keep last */
 +	__NL80211_MNTR_FLAG_AFTER_LAST,
@@ -12461,8 +12712,8 @@ index 0000000000..b995313ccd
 + *	alternate between Active and Doze states, but may not wake up
 + *	for neighbor's beacons.
 + *
-+ * @__NL80211_MESH_POWER_AFTER_LAST - internal use
-+ * @NL80211_MESH_POWER_MAX - highest possible power save level
++ * @__NL80211_MESH_POWER_AFTER_LAST: internal use
++ * @NL80211_MESH_POWER_MAX: highest possible power save level
 + */
 +
 +enum nl80211_mesh_power_mode {
@@ -12849,6 +13100,36 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
++ * enum nl80211_bss_use_for - bitmap indicating possible BSS use
++ * @NL80211_BSS_USE_FOR_NORMAL: Use this BSS for normal "connection",
++ *	including IBSS/MBSS depending on the type.
++ * @NL80211_BSS_USE_FOR_MLD_LINK: This BSS can be used as a link in an
++ *	MLO connection. Note that for an MLO connection, all links including
++ *	the assoc link must have this flag set, and the assoc link must
++ *	additionally have %NL80211_BSS_USE_FOR_NORMAL set.
++ */
++enum nl80211_bss_use_for {
++	NL80211_BSS_USE_FOR_NORMAL = 1 << 0,
++	NL80211_BSS_USE_FOR_MLD_LINK = 1 << 1,
++};
++
++/**
++ * enum nl80211_bss_cannot_use_reasons - reason(s) connection to a
++ *	BSS isn't possible
++ * @NL80211_BSS_CANNOT_USE_NSTR_NONPRIMARY: NSTR nonprimary links aren't
++ *	supported by the device, and this BSS entry represents one.
++ * @NL80211_BSS_CANNOT_USE_6GHZ_PWR_MISMATCH: STA is not supporting
++ *	the AP power type (SP, VLP, AP) that the AP uses.
++ */
++enum nl80211_bss_cannot_use_reasons {
++	NL80211_BSS_CANNOT_USE_NSTR_NONPRIMARY	= 1 << 0,
++	NL80211_BSS_CANNOT_USE_6GHZ_PWR_MISMATCH	= 1 << 1,
++};
++
++#define NL80211_BSS_CANNOT_USE_UHB_PWR_MISMATCH \
++	NL80211_BSS_CANNOT_USE_6GHZ_PWR_MISMATCH
++
++/**
 + * enum nl80211_bss - netlink attributes for a BSS
 + *
 + * @__NL80211_BSS_INVALID: invalid
@@ -12879,7 +13160,7 @@ index 0000000000..b995313ccd
 + *	elements from a Beacon frame (bin); not present if no Beacon frame has
 + *	yet been received
 + * @NL80211_BSS_CHAN_WIDTH: channel width of the control channel
-+ *	(u32, enum nl80211_bss_scan_width)
++ *	(u32, enum nl80211_bss_scan_width) - No longer used!
 + * @NL80211_BSS_BEACON_TSF: TSF of the last received beacon (u64)
 + *	(not present if no beacon frame has been received yet)
 + * @NL80211_BSS_PRESP_DATA: the data in @NL80211_BSS_INFORMATION_ELEMENTS and
@@ -12900,6 +13181,14 @@ index 0000000000..b995313ccd
 + * @NL80211_BSS_FREQUENCY_OFFSET: frequency offset in KHz
 + * @NL80211_BSS_MLO_LINK_ID: MLO link ID of the BSS (u8).
 + * @NL80211_BSS_MLD_ADDR: MLD address of this BSS if connected to it.
++ * @NL80211_BSS_USE_FOR: u32 bitmap attribute indicating what the BSS can be
++ *	used for, see &enum nl80211_bss_use_for.
++ * @NL80211_BSS_CANNOT_USE_REASONS: Indicates the reason that this BSS cannot
++ *	be used for all or some of the possible uses by the device reporting it,
++ *	even though its presence was detected.
++ *	This is a u64 attribute containing a bitmap of values from
++ *	&enum nl80211_cannot_use_reasons, note that the attribute may be missing
++ *	if no reasons are specified.
 + * @__NL80211_BSS_AFTER_LAST: internal
 + * @NL80211_BSS_MAX: highest BSS attribute
 + */
@@ -12927,6 +13216,8 @@ index 0000000000..b995313ccd
 +	NL80211_BSS_FREQUENCY_OFFSET,
 +	NL80211_BSS_MLO_LINK_ID,
 +	NL80211_BSS_MLD_ADDR,
++	NL80211_BSS_USE_FOR,
++	NL80211_BSS_CANNOT_USE_REASONS,
 +
 +	/* keep last */
 +	__NL80211_BSS_AFTER_LAST,
@@ -13299,7 +13590,7 @@ index 0000000000..b995313ccd
 + *	(%NL80211_TID_CONFIG_ATTR_TIDS, %NL80211_TID_CONFIG_ATTR_OVERRIDE).
 + * @NL80211_TID_CONFIG_ATTR_PEER_SUPP: same as the previous per-vif one, but
 + *	per peer instead.
-+ * @NL80211_TID_CONFIG_ATTR_OVERRIDE: flag attribue, if set indicates
++ * @NL80211_TID_CONFIG_ATTR_OVERRIDE: flag attribute, if set indicates
 + *	that the new configuration overrides all previous peer
 + *	configurations, otherwise previous peer specific configurations
 + *	should be left untouched.
@@ -13473,7 +13764,7 @@ index 0000000000..b995313ccd
 + *	"TCP connection wakeup" for more details. This is a nested attribute
 + *	containing the exact information for establishing and keeping alive
 + *	the TCP connection.
-+ * @NL80211_WOWLAN_TRIG_TCP_WAKEUP_MATCH: For wakeup reporting only, the
++ * @NL80211_WOWLAN_TRIG_WAKEUP_TCP_MATCH: For wakeup reporting only, the
 + *	wakeup packet was received on the TCP connection
 + * @NL80211_WOWLAN_TRIG_WAKEUP_TCP_CONNLOST: For wakeup reporting only, the
 + *	TCP connection was lost or failed to be established
@@ -13502,6 +13793,8 @@ index 0000000000..b995313ccd
 + *	%NL80211_ATTR_SCAN_FREQUENCIES contains more than one
 + *	frequency, it means that the match occurred in more than one
 + *	channel.
++ * @NL80211_WOWLAN_TRIG_UNPROTECTED_DEAUTH_DISASSOC: For wakeup reporting only.
++ *	Wake up happened due to unprotected deauth or disassoc frame in MFP.
 + * @NUM_NL80211_WOWLAN_TRIG: number of wake on wireless triggers
 + * @MAX_NL80211_WOWLAN_TRIG: highest wowlan trigger attribute number
 + *
@@ -13529,6 +13822,7 @@ index 0000000000..b995313ccd
 +	NL80211_WOWLAN_TRIG_WAKEUP_TCP_NOMORETOKENS,
 +	NL80211_WOWLAN_TRIG_NET_DETECT,
 +	NL80211_WOWLAN_TRIG_NET_DETECT_RESULTS,
++	NL80211_WOWLAN_TRIG_UNPROTECTED_DEAUTH_DISASSOC,
 +
 +	/* keep last */
 +	NUM_NL80211_WOWLAN_TRIG,
@@ -13684,7 +13978,7 @@ index 0000000000..b995313ccd
 +
 +/**
 + * enum nl80211_coalesce_condition - coalesce rule conditions
-+ * @NL80211_COALESCE_CONDITION_MATCH: coalaesce Rx packets when patterns
++ * @NL80211_COALESCE_CONDITION_MATCH: coalesce Rx packets when patterns
 + *	in a rule are matched.
 + * @NL80211_COALESCE_CONDITION_NO_MATCH: coalesce Rx packets when patterns
 + *	in a rule are not matched.
@@ -13823,14 +14117,14 @@ index 0000000000..b995313ccd
 +	/* keep last */
 +	NUM_NL80211_IFACE_COMB_PER_HW_COMB,
 +	MAX_NL80211_IFACE_COMB_PER_HW_COMB =
-+			NUM_NL80211_IFACE_COMB_PER_HW_COMB - 1
++		NUM_NL80211_IFACE_COMB_PER_HW_COMB - 1
 +};
 +
 +/**
 + * enum nl80211_plink_state - state of a mesh peer link finite state machine
 + *
 + * @NL80211_PLINK_LISTEN: initial state, considered the implicit
-+ *	state of non existent mesh peer links
++ *	state of non-existent mesh peer links
 + * @NL80211_PLINK_OPN_SNT: mesh plink open frame has been sent to
 + *	this mesh peer
 + * @NL80211_PLINK_OPN_RCVD: mesh plink open frame has been received
@@ -13866,7 +14160,7 @@ index 0000000000..b995313ccd
 + * @NL80211_PLINK_ACTION_BLOCK: block traffic from this mesh peer
 + * @NUM_NL80211_PLINK_ACTIONS: number of possible actions
 + */
-+enum plink_actions {
++enum nl80211_plink_action {
 +	NL80211_PLINK_ACTION_NO_ACTION,
 +	NL80211_PLINK_ACTION_OPEN,
 +	NL80211_PLINK_ACTION_BLOCK,
@@ -14123,7 +14417,7 @@ index 0000000000..b995313ccd
 + *	request to use RRM (see %NL80211_ATTR_USE_RRM) with
 + *	%NL80211_CMD_ASSOCIATE and %NL80211_CMD_CONNECT requests, which will set
 + *	the ASSOC_REQ_USE_RRM flag in the association request even if
-+ *	NL80211_FEATURE_QUIET is not advertized.
++ *	NL80211_FEATURE_QUIET is not advertised.
 + * @NL80211_EXT_FEATURE_MU_MIMO_AIR_SNIFFER: This device supports MU-MIMO air
 + *	sniffer which means that it can be configured to hear packets from
 + *	certain groups which can be configured by the
@@ -14135,13 +14429,15 @@ index 0000000000..b995313ccd
 + *	the BSS that the interface that requested the scan is connected to
 + *	(if available).
 + * @NL80211_EXT_FEATURE_BSS_PARENT_TSF: Per BSS, this driver reports the
-+ *	time the last beacon/probe was received. The time is the TSF of the
-+ *	BSS that the interface that requested the scan is connected to
-+ *	(if available).
++ *	time the last beacon/probe was received. For a non-MLO connection, the
++ *	time is the TSF of the BSS that the interface that requested the scan is
++ *	connected to (if available). For an MLO connection, the time is the TSF
++ *	of the BSS corresponding with link ID specified in the scan request (if
++ *	specified).
 + * @NL80211_EXT_FEATURE_SET_SCAN_DWELL: This driver supports configuration of
 + *	channel dwell time.
 + * @NL80211_EXT_FEATURE_BEACON_RATE_LEGACY: Driver supports beacon rate
-+ *	configuration (AP/mesh), supporting a legacy (non HT/VHT) rate.
++ *	configuration (AP/mesh), supporting a legacy (non-HT/VHT) rate.
 + * @NL80211_EXT_FEATURE_BEACON_RATE_HT: Driver supports beacon rate
 + *	configuration (AP/mesh) with HT rates.
 + * @NL80211_EXT_FEATURE_BEACON_RATE_VHT: Driver supports beacon rate
@@ -14191,6 +14487,7 @@ index 0000000000..b995313ccd
 + *	receiving control port frames over nl80211 instead of the netdevice.
 + * @NL80211_EXT_FEATURE_ACK_SIGNAL_SUPPORT: This driver/device supports
 + *	(average) ACK signal strength reporting.
++ * @NL80211_EXT_FEATURE_DATA_ACK_SIGNAL_SUPPORT: Backward-compatible ID
 + * @NL80211_EXT_FEATURE_TXQS: Driver supports FQ-CoDel-enabled intermediate
 + *      TXQs.
 + * @NL80211_EXT_FEATURE_SCAN_RANDOM_SN: Driver/device supports randomizing the
@@ -14215,8 +14512,7 @@ index 0000000000..b995313ccd
 + * @NL80211_EXT_FEATURE_AP_PMKSA_CACHING: Driver/device supports PMKSA caching
 + *	(set/del PMKSA operations) in AP mode.
 + *
-+ * @NL80211_EXT_FEATURE_SCHED_SCAN_BAND_SPECIFIC_RSSI_THOLD: Driver supports
-+ *	filtering of sched scan results using band specific RSSI thresholds.
++ * @NL80211_EXT_FEATURE_SCHED_SCAN_BAND_SPECIFIC_RSSI_THOLD: Obsolete
 + *
 + * @NL80211_EXT_FEATURE_STA_TX_PWR: This driver supports controlling tx power
 + *	to a station.
@@ -14314,6 +14610,22 @@ index 0000000000..b995313ccd
 + *	in authentication and deauthentication frames sent to unassociated peer
 + *	using @NL80211_CMD_FRAME.
 + *
++ * @NL80211_EXT_FEATURE_OWE_OFFLOAD: Driver/Device wants to do OWE DH IE
++ *	handling in station mode.
++ *
++ * @NL80211_EXT_FEATURE_OWE_OFFLOAD_AP: Driver/Device wants to do OWE DH IE
++ *	handling in AP mode.
++ *
++ * @NL80211_EXT_FEATURE_DFS_CONCURRENT: The device supports peer-to-peer or
++ *	ad hoc operation on DFS channels under the control of a concurrent
++ *	DFS master on the same channel as described in FCC-594280 D01
++ *	(Section B.3). This, for example, allows P2P GO and P2P clients to
++ *	operate on DFS channels as long as there's a concurrent BSS connection.
++ *
++ * @NL80211_EXT_FEATURE_SPP_AMSDU_SUPPORT: The driver has support for SPP
++ *	(signaling and payload protected) A-MSDUs and this shall be advertised
++ *	in the RSNXE.
++ *
 + * @NL80211_EXT_FEATURE_WIDE_BAND_SCAN: Driver/device supports wide band scan
 + *	 on a frequency along with its corresponding phymode (40Mhz, 80Mhz)
 + *
@@ -14322,6 +14634,21 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_EXT_FEATURE_DEVICE_BW: Driver/device supports different parameters
 + *	for device bandwidth compared to the operating bandwidth.
++ *
++ * @NL80211_EXT_FEATURE_MLD_LINK_REMOVAL_OFFLOAD: Driver/device which supports
++ *	ML reconfig link removal offload.
++ *
++ * @NL80211_EXT_FEATURE_ERP: Driver supports ErP low power mode.
++ *
++ * @NL80211_EXT_FEATURE_TARGET_AND_HOST_AFC_SUPPORT: Both the host and the
++ *       target supports AFC (Automatic Frequency Control) feature.
++ *
++ * @NL80211_EXT_FEATURE_RETAIL_AFC_SUPPORT: The device supports retail AFC
++ *       mode where channel selection after AFC response will be done
++ *       by the application layers.
++ *
++ * @NL80211_EXT_FEATURE_BEACON_ADVERTISED_TTLM_OFFLOAD: Driver supports offload
++ *	of advertisement of TTLM in beacon
 + *
 + * @NUM_NL80211_EXT_FEATURES: number of extended features.
 + * @MAX_NL80211_EXT_FEATURES: highest extended feature index.
@@ -14364,7 +14691,7 @@ index 0000000000..b995313ccd
 +	NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER,
 +	NL80211_EXT_FEATURE_AIRTIME_FAIRNESS,
 +	NL80211_EXT_FEATURE_AP_PMKSA_CACHING,
-+	NL80211_EXT_FEATURE_SCHED_SCAN_BAND_SPECIFIC_RSSI_THOLD,
++	NL80211_EXT_FEATURE_SCHED_SCAN_BAND_SPECIFIC_RSSI_THOLD, /* obsolete */
 +	NL80211_EXT_FEATURE_EXT_KEY_ID,
 +	NL80211_EXT_FEATURE_STA_TX_PWR,
 +	NL80211_EXT_FEATURE_SAE_OFFLOAD,
@@ -14395,9 +14722,18 @@ index 0000000000..b995313ccd
 +	NL80211_EXT_FEATURE_PUNCT,
 +	NL80211_EXT_FEATURE_SECURE_NAN,
 +	NL80211_EXT_FEATURE_AUTH_AND_DEAUTH_RANDOM_TA,
++	NL80211_EXT_FEATURE_OWE_OFFLOAD,
++	NL80211_EXT_FEATURE_OWE_OFFLOAD_AP,
++	NL80211_EXT_FEATURE_DFS_CONCURRENT,
++	NL80211_EXT_FEATURE_SPP_AMSDU_SUPPORT,
 +	NL80211_EXT_FEATURE_STA_MGMT_RTS_CTS,
 +	NL80211_EXT_FEATURE_BEACON_RATE_EHT,
 +	NL80211_EXT_FEATURE_DEVICE_BW,
++	NL80211_EXT_FEATURE_MLD_LINK_REMOVAL_OFFLOAD,
++	NL80211_EXT_FEATURE_ERP,
++	NL80211_EXT_FEATURE_TARGET_AND_HOST_AFC_SUPPORT,
++	NL80211_EXT_FEATURE_RETAIL_AFC_SUPPORT,
++	NL80211_EXT_FEATURE_BEACON_ADVERTISED_TTLM_OFFLOAD,
 +
 +	/* add new features before the definition below */
 +	NUM_NL80211_EXT_FEATURES,
@@ -14482,7 +14818,7 @@ index 0000000000..b995313ccd
 + *	request parameters IE in the probe request
 + * @NL80211_SCAN_FLAG_ACCEPT_BCAST_PROBE_RESP: accept broadcast probe responses
 + * @NL80211_SCAN_FLAG_OCE_PROBE_REQ_HIGH_TX_RATE: send probe request frames at
-+ *	rate of at least 5.5M. In case non OCE AP is discovered in the channel,
++ *	rate of at least 5.5M. In case non-OCE AP is discovered in the channel,
 + *	only the first probe req in the channel will be sent in high rate.
 + * @NL80211_SCAN_FLAG_OCE_PROBE_REQ_DEFERRAL_SUPPRESSION: allow probe request
 + *	tx deferral (dot11FILSProbeDelay shall be set to 15ms)
@@ -14518,12 +14854,12 @@ index 0000000000..b995313ccd
 + *	received on the 2.4/5 GHz channels to actively scan only the 6GHz
 + *	channels on which APs are expected to be found. Note that when not set,
 + *	the scan logic would scan all 6GHz channels, but since transmission of
-+ *	probe requests on non PSC channels is limited, it is highly likely that
++ *	probe requests on non-PSC channels is limited, it is highly likely that
 + *	these channels would passively be scanned. Also note that when the flag
 + *	is set, in addition to the colocated APs, PSC channels would also be
 + *	scanned if the user space has asked for it.
 + * @NL80211_SCAN_FLAG_WIDE_BAND_SCAN: This flag intends the driver to perform
-+ *	wide band scan only if the driver supports it.
++ * 	wide band scan only if the driver supports it.
 + */
 +enum nl80211_scan_flags {
 +	NL80211_SCAN_FLAG_LOW_PRIORITY				= 1<<0,
@@ -14571,6 +14907,8 @@ index 0000000000..b995313ccd
 + * @NL80211_SMPS_STATIC: static SMPS (use a single antenna)
 + * @NL80211_SMPS_DYNAMIC: dynamic smps (start with a single antenna and
 + *	turn on other antennas after CTS/RTS).
++ * @__NL80211_SMPS_AFTER_LAST: internal
++ * @NL80211_SMPS_MAX: highest used enumeration
 + */
 +enum nl80211_smps_mode {
 +	NL80211_SMPS_OFF,
@@ -14792,6 +15130,8 @@ index 0000000000..b995313ccd
 + * @NL80211_NAN_FUNC_PUBLISH: function is publish
 + * @NL80211_NAN_FUNC_SUBSCRIBE: function is subscribe
 + * @NL80211_NAN_FUNC_FOLLOW_UP: function is follow-up
++ * @__NL80211_NAN_FUNC_TYPE_AFTER_LAST: internal use
++ * @NL80211_NAN_FUNC_MAX_TYPE: internal use
 + */
 +enum nl80211_nan_function_type {
 +	NL80211_NAN_FUNC_PUBLISH,
@@ -14853,7 +15193,7 @@ index 0000000000..b995313ccd
 + *	The instance ID for the follow up Service Discovery Frame. This is u8.
 + * @NL80211_NAN_FUNC_FOLLOW_UP_REQ_ID: relevant if the function's type
 + *	is follow up. This is a u8.
-+ *	The requestor instance ID for the follow up Service Discovery Frame.
++ *	The requester instance ID for the follow up Service Discovery Frame.
 + * @NL80211_NAN_FUNC_FOLLOW_UP_DEST: the MAC address of the recipient of the
 + *	follow up Service Discovery Frame. This is a binary attribute.
 + * @NL80211_NAN_FUNC_CLOSE_RANGE: is this function limited for devices in a
@@ -14952,7 +15292,7 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
-+ * nl80211_external_auth_action - Action to perform with external
++ * enum nl80211_external_auth_action - Action to perform with external
 + *     authentication request. Used by NL80211_ATTR_EXTERNAL_AUTH_ACTION.
 + * @NL80211_EXTERNAL_AUTH_START: Start the authentication.
 + * @NL80211_EXTERNAL_AUTH_ABORT: Abort the ongoing authentication.
@@ -14970,7 +15310,7 @@ index 0000000000..b995313ccd
 + * @NL80211_FTM_RESP_ATTR_LCI: The content of Measurement Report Element
 + *	(9.4.2.22 in 802.11-2016) with type 8 - LCI (9.4.2.22.10),
 + *	i.e. starting with the measurement token
-+ * @NL80211_FTM_RESP_ATTR_CIVIC: The content of Measurement Report Element
++ * @NL80211_FTM_RESP_ATTR_CIVICLOC: The content of Measurement Report Element
 + *	(9.4.2.22 in 802.11-2016) with type 11 - Civic (Section 9.4.2.22.13),
 + *	i.e. starting with the measurement token
 + * @__NL80211_FTM_RESP_ATTR_LAST: Internal
@@ -15243,7 +15583,7 @@ index 0000000000..b995313ccd
 + * @NL80211_PMSR_FTM_CAPA_ATTR_TRIGGER_BASED: flag attribute indicating if
 + *	trigger based ranging measurement is supported
 + * @NL80211_PMSR_FTM_CAPA_ATTR_NON_TRIGGER_BASED: flag attribute indicating
-+ *	if non trigger based ranging measurement is supported
++ *	if non-trigger-based ranging measurement is supported
 + *
 + * @NUM_NL80211_PMSR_FTM_CAPA_ATTR: internal
 + * @NL80211_PMSR_FTM_CAPA_ATTR_MAX: highest attribute number
@@ -15297,7 +15637,7 @@ index 0000000000..b995313ccd
 + *      if neither %NL80211_PMSR_FTM_REQ_ATTR_TRIGGER_BASED nor
 + *	%NL80211_PMSR_FTM_REQ_ATTR_NON_TRIGGER_BASED is set, EDCA based
 + *	ranging will be used.
-+ * @NL80211_PMSR_FTM_REQ_ATTR_NON_TRIGGER_BASED: request non trigger based
++ * @NL80211_PMSR_FTM_REQ_ATTR_NON_TRIGGER_BASED: request non-trigger-based
 + *	ranging measurement (flag)
 + *	This attribute and %NL80211_PMSR_FTM_REQ_ATTR_TRIGGER_BASED are
 + *	mutually exclusive.
@@ -15375,7 +15715,7 @@ index 0000000000..b995313ccd
 + * @NL80211_PMSR_FTM_RESP_ATTR_NUM_FTMR_ATTEMPTS: number of FTM Request frames
 + *	transmitted (u32, optional)
 + * @NL80211_PMSR_FTM_RESP_ATTR_NUM_FTMR_SUCCESSES: number of FTM Request frames
-+ *	that were acknowleged (u32, optional)
++ *	that were acknowledged (u32, optional)
 + * @NL80211_PMSR_FTM_RESP_ATTR_BUSY_RETRY_TIME: retry time received from the
 + *	busy peer (u32, seconds)
 + * @NL80211_PMSR_FTM_RESP_ATTR_NUM_BURSTS_EXP: actual number of bursts exponent
@@ -15539,7 +15879,7 @@ index 0000000000..b995313ccd
 + * @NL80211_FILS_DISCOVERY_ATTR_INT_MIN: Minimum packet interval (u32, TU).
 + *	Allowed range: 0..10000 (TU = Time Unit)
 + * @NL80211_FILS_DISCOVERY_ATTR_INT_MAX: Maximum packet interval (u32, TU).
-+ *	Allowed range: 0..10000 (TU = Time Unit)
++ *	Allowed range: 0..10000 (TU = Time Unit). If set to 0, the feature is disabled.
 + * @NL80211_FILS_DISCOVERY_ATTR_TMPL: Template data for FILS discovery action
 + *	frame including the headers.
 + *
@@ -15572,7 +15912,8 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_UNSOL_BCAST_PROBE_RESP_ATTR_INT: Maximum packet interval (u32, TU).
 + *	Allowed range: 0..20 (TU = Time Unit). IEEE P802.11ax/D6.0
-+ *	26.17.2.3.2 (AP behavior for fast passive scanning).
++ *	26.17.2.3.2 (AP behavior for fast passive scanning). If set to 0, the feature is
++ *	disabled.
 + * @NL80211_UNSOL_BCAST_PROBE_RESP_ATTR_TMPL: Unsolicited broadcast probe response
 + *	frame template (binary).
 + *
@@ -15615,6 +15956,7 @@ index 0000000000..b995313ccd
 + *
 + * @NL80211_SAR_TYPE_POWER: power limitation specified in 0.25dBm unit
 + *
++ * @NUM_NL80211_SAR_TYPE: internal
 + */
 +enum nl80211_sar_type {
 +	NL80211_SAR_TYPE_POWER,
@@ -15627,6 +15969,10 @@ index 0000000000..b995313ccd
 +
 +/**
 + * enum nl80211_sar_attrs - Attributes for SAR spec
++ *
++ * @__NL80211_SAR_ATTR_INVALID: Invalid
++ *
++ * @__NL80211_SAR_ATTR_INVALID: Invalid
 + *
 + * @NL80211_SAR_ATTR_TYPE: the SAR type as defined in &enum nl80211_sar_type.
 + *
@@ -15658,6 +16004,10 @@ index 0000000000..b995313ccd
 +
 +/**
 + * enum nl80211_sar_specs_attrs - Attributes for SAR power limit specs
++ *
++ * @__NL80211_SAR_ATTR_SPECS_INVALID: Invalid
++ *
++ * @__NL80211_SAR_ATTR_SPECS_INVALID: Invalid
 + *
 + * @NL80211_SAR_ATTR_SPECS_POWER: Required (s32)value to specify the actual
 + *	power limit value in units of 0.25 dBm if type is
@@ -15740,10 +16090,25 @@ index 0000000000..b995313ccd
 + *	Setting this flag is permitted only if the driver advertises EMA support
 + *	by setting wiphy->ema_max_profile_periodicity to non-zero.
 + *
++ * @NL80211_MBSSID_CONFIG_ATTR_TX_LINK_ID: Link ID of the transmitted profile.
++ *	This parameter is mandatory if the transmitted profile is part of an MLD
++ *	and the interface getting configured is a non-transmitted profile. For all
++ *	other cases it will be ignored.
++ *
 + * @NL80211_MBSSID_CONFIG_ATTR_TX_LINK_ID: Mandatory parameter for a non-transmitted profile
 + *	which provides the interface index (u32) of the transmitted profile which
 + * 	is an MLD. The link id must be valid in the wdev of given Transmitting interface
 + * 	index.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_MAX_MBSSID_GROUPS: Used by the kernel
++ *	to advertise the maximum mbssid groups (u8) supported by the driver.
++ *	Driver should indicate this to the userspace
++ *	by setting wiphy->mbssid_max_ngroups to a non-zero value.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_MAX_BEACON_SIZE: Used by the kernel
++ *	to advertise the maximum beacon size (u16) supported by the driver.
++ *	Driver should indicate this to the userspace
++ *	by setting wiphy->max_beacon_size to a non-zero value.
 + *
 + * @__NL80211_MBSSID_CONFIG_ATTR_LAST: Internal
 + * @NL80211_MBSSID_CONFIG_ATTR_MAX: highest attribute
@@ -15757,6 +16122,8 @@ index 0000000000..b995313ccd
 +	NL80211_MBSSID_CONFIG_ATTR_TX_IFINDEX,
 +	NL80211_MBSSID_CONFIG_ATTR_EMA,
 +	NL80211_MBSSID_CONFIG_ATTR_TX_LINK_ID,
++	NL80211_MBSSID_CONFIG_ATTR_MAX_MBSSID_GROUPS,
++	NL80211_MBSSID_CONFIG_ATTR_MAX_BEACON_SIZE,
 +
 +	/* keep last */
 +	__NL80211_MBSSID_CONFIG_ATTR_LAST,
@@ -15780,20 +16147,86 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
-+ * enum nl80211_ru_punct_supp_bw - Bandwidths supporting preamble puncturing
++ * enum nl80211_wiphy_radio_attrs - wiphy radio attributes
 + *
-+ * @NL80211_RU_PUNCT_NOT_SUPP: preamble puncturing is not supported
-+ * @NL80211_RU_PUNCT_SUPP_BW_80: puncturing supported within channels of at
-+ *	least 80 MHz bandwidth
-+ * @NL80211_RU_PUNCT_SUPP_BW_160: puncturing supported within channels of at
-+ *	least 160 MHz bandwidth
-+ * @NL80211_RU_PUNCT_SUPP_BW_320: puncturing supported within 320 MHz.
++ * @__NL80211_WIPHY_RADIO_ATTR_INVALID: Invalid
++ *
++ * @NL80211_WIPHY_RADIO_ATTR_INDEX: Index of this radio (u32)
++ * @NL80211_WIPHY_RADIO_ATTR_FREQ_RANGE: Frequency range supported by this
++ *	radio. Attribute may be present multiple times.
++ * @NL80211_WIPHY_RADIO_ATTR_INTERFACE_COMBINATION: Supported interface
++ *	combination for this radio. Attribute may be present multiple times
++ *	and contains attributes defined in &enum nl80211_if_combination_attrs.
++ * @NL80211_WIPHY_RADIO_ATTR_ANTENNA_MASK: bitmask (u32) of antennas
++ *	connected to this radio.
++ * @NL80211_WIPHY_RADIO_ATTR_RTS_THRESHOLD: RTS threshold (u32) of this radio.
++ * @NL80211_WIPHY_RADIO_ATTR_ANTENNA_TX: Bitmap of allowed antennas for transmitting.
++ *	This can be used to mask out antennas which are not attached or should
++ *	not be used for transmitting. If an antenna is not selected in this
++ *	bitmap the hardware is not allowed to transmit on this antenna.
++ *
++ *	Each bit represents one antenna, starting with antenna 1 at the first
++ *	bit. Depending on which antennas are selected in the bitmap, 802.11n
++ *	drivers can derive which chainmasks to use (if all antennas belonging to
++ *	a particular chain are disabled this chain should be disabled) and if
++ *	a chain has diversity antennas whether diversity should be used or not.
++ *	HT capabilities (STBC, TX Beamforming, Antenna selection) can be
++ *	derived from the available chains after applying the antenna mask.
++ *	Non-802.11n drivers can derive whether to use diversity or not.
++ *	Drivers may reject configurations or RX/TX mask combinations they cannot
++ *	support by returning -EINVAL.
++ * @NL80211_WIPHY_RADIO_ATTR_ANTENNA_RX: Bitmap of allowed antennas for receiving.
++ *	This can be used to mask out antennas which are not attached or should
++ *	not be used for receiving. If an antenna is not selected in this bitmap
++ *	the hardware should not be configured to receive on this antenna.
++ *	For a more detailed description see @NL80211_ATTR_WIPHY_ANTENNA_TX.
++ * @NL80211_WIPHY_RADIO_ATTR_ANTENNA_AVAIL_TX: Bitmap of antennas which are available
++ *	for configuration as TX antennas via the above parameters.
++ * @NL80211_WIPHY_RADIO_ATTR_ANTENNA_AVAIL_RX: Bitmap of antennas which are available
++ *	for configuration as RX antennas via the above parameters.
++ *
++ * @__NL80211_WIPHY_RADIO_ATTR_LAST: Internal
++ * @NL80211_WIPHY_RADIO_ATTR_MAX: Highest attribute
 + */
-+enum nl80211_ru_punct_supp_bw {
-+	NL80211_RU_PUNCT_NOT_SUPP,
-+	NL80211_RU_PUNCT_SUPP_BW_80,
-+	NL80211_RU_PUNCT_SUPP_BW_160,
-+	NL80211_RU_PUNCT_SUPP_BW_320,
++enum nl80211_wiphy_radio_attrs {
++	__NL80211_WIPHY_RADIO_ATTR_INVALID,
++
++	NL80211_WIPHY_RADIO_ATTR_INDEX,
++	NL80211_WIPHY_RADIO_ATTR_FREQ_RANGE,
++	NL80211_WIPHY_RADIO_ATTR_INTERFACE_COMBINATION,
++	NL80211_WIPHY_RADIO_ATTR_ANTENNA_MASK,
++	NL80211_WIPHY_RADIO_ATTR_RTS_THRESHOLD,
++	NL80211_WIPHY_RADIO_ATTR_ANTENNA_TX,
++	NL80211_WIPHY_RADIO_ATTR_ANTENNA_RX,
++	NL80211_WIPHY_RADIO_ATTR_ANTENNA_AVAIL_TX,
++	NL80211_WIPHY_RADIO_ATTR_ANTENNA_AVAIL_RX,
++
++	/* keep last */
++	__NL80211_WIPHY_RADIO_ATTR_LAST,
++	NL80211_WIPHY_RADIO_ATTR_MAX = __NL80211_WIPHY_RADIO_ATTR_LAST - 1,
++};
++
++/**
++ * enum nl80211_wiphy_radio_freq_range - wiphy radio frequency range
++ *
++ * @__NL80211_WIPHY_RADIO_FREQ_ATTR_INVALID: Invalid
++ *
++ * @NL80211_WIPHY_RADIO_FREQ_ATTR_START: Frequency range start (u32).
++ *	The unit is kHz.
++ * @NL80211_WIPHY_RADIO_FREQ_ATTR_END: Frequency range end (u32).
++ *	The unit is kHz.
++ *
++ * @__NL80211_WIPHY_RADIO_FREQ_ATTR_LAST: Internal
++ * @NL80211_WIPHY_RADIO_FREQ_ATTR_MAX: Highest attribute
++ */
++enum nl80211_wiphy_radio_freq_range {
++	__NL80211_WIPHY_RADIO_FREQ_ATTR_INVALID,
++
++	NL80211_WIPHY_RADIO_FREQ_ATTR_START,
++	NL80211_WIPHY_RADIO_FREQ_ATTR_END,
++
++	__NL80211_WIPHY_RADIO_FREQ_ATTR_LAST,
++	NL80211_WIPHY_RADIO_FREQ_ATTR_MAX = __NL80211_WIPHY_RADIO_FREQ_ATTR_LAST - 1,
 +};
 +
 +/**
@@ -15896,6 +16329,7 @@ index 0000000000..b995313ccd
 + * @NL80211_CU_MLD_LINK_ATTR_CRITICAL_FLAG: critical flag value
 + * @NL80211_CU_MLD_LINK_ATTR_BPCC: BSS parameter change count value
 + * @NL80211_CU_MLD_LINK_ATTR_SWITCH_COUNT: CSA/CCA switch count
++ * @NL80211_CU_ATTR_TTLM_EXPEC_DUR: Current expected duration
 + * @__NL80211_CU_MLD_LINK_ATTR_LAST: internal use
 + * @NL80211_CU_MLD_LINK ATTR_MAX: maximum per link critical update attribute
 + */
@@ -15906,6 +16340,8 @@ index 0000000000..b995313ccd
 +	NL80211_CU_MLD_LINK_ATTR_CRITICAL_FLAG,
 +	NL80211_CU_MLD_LINK_ATTR_BPCC,
 +	NL80211_CU_MLD_LINK_ATTR_SWITCH_COUNT,
++	NL80211_CU_ATTR_AP_REMOVAL_COUNT,
++	NL80211_CU_ATTR_TTLM_EXPEC_DUR,
 +
 +	/* keep last */
 +	__NL80211_CU_MLD_LINK_ATTR_LAST,
@@ -15955,53 +16391,227 @@ index 0000000000..b995313ccd
 +};
 +
 +/**
-+ * enum nl80211_wiphy_radio_attrs - wiphy radio attributes
++ * enum nl80211_erp_attrs - set ErP attributes during entry/exit
 + *
-+ * @__NL80211_WIPHY_RADIO_ATTR_INVALID: Invalid
++ * @NL80211_ERP_ATTR_ENTER: (flag) enter into ErP mode.
++ * @NL80211_ERP_ATTR_EXIT: (flag) exit from ErP mode.
++ * @NL80211_ERP_ATTR_STATUS: (u8) get/send ErP status from driver.
++ * @NL80211_ERP_ATTR_TRIGGER: (u32) trigger to initiate automatic exit from ErP
++ *     low power mode.
 + *
-+ * @NL80211_WIPHY_RADIO_ATTR_INDEX: Index of this radio (u32)
-+ * @NL80211_WIPHY_RADIO_ATTR_FREQ_RANGE: Frequency range supported by this
-+ *	radio. Attribute may be present multiple times.
-+ * @NL80211_WIPHY_RADIO_ATTR_INTERFACE_COMBINATION: Supported interface
-+ *	combination for this radio. Attribute may be present multiple times
-+ *	and contains attributes defined in &enum nl80211_if_combination_attrs.
++ * @__NL80211_ERP_ATTR_LAST : internal use
++ * @NL80211_ERP_ATTR_MAX : maximum ErP attributes
 + *
-+ * @__NL80211_WIPHY_RADIO_ATTR_LAST: Internal
-+ * @NL80211_WIPHY_RADIO_ATTR_MAX: Highest attribute
 + */
-+enum nl80211_wiphy_radio_attrs {
-+	__NL80211_WIPHY_RADIO_ATTR_INVALID,
++enum nl80211_erp_attrs {
++	__NL80211_ERP_ATTR_INVALID,
 +
-+	NL80211_WIPHY_RADIO_ATTR_INDEX,
-+	NL80211_WIPHY_RADIO_ATTR_FREQ_RANGE,
-+	NL80211_WIPHY_RADIO_ATTR_INTERFACE_COMBINATION,
++	NL80211_ERP_ATTR_ENTER,
++	NL80211_ERP_ATTR_EXIT,
++	NL80211_ERP_ATTR_STATUS,
++	NL80211_ERP_ATTR_TRIGGER,
 +
 +	/* keep last */
-+	__NL80211_WIPHY_RADIO_ATTR_LAST,
-+	NL80211_WIPHY_RADIO_ATTR_MAX = __NL80211_WIPHY_RADIO_ATTR_LAST - 1,
++	__NL80211_ERP_ATTR_LAST,
++	NL80211_ERP_ATTR_MAX = __NL80211_ERP_ATTR_LAST - 1
 +};
 +
 +/**
-+ * enum nl80211_wiphy_radio_freq_range - wiphy radio frequency range
++ * enum nl80211_advertised_ttlm_attrs - Advertised TTLM attributes
 + *
-+ * @__NL80211_WIPHY_RADIO_FREQ_ATTR_INVALID: Invalid
++ * @__NL80211_ADVERTISED_TTLM_ATTR_INVALID: Invalid
 + *
-+ * @NL80211_WIPHY_RADIO_FREQ_ATTR_START: Frequency range start (u32).
-+ *	The unit is kHz.
-+ * @NL80211_WIPHY_RADIO_FREQ_ATTR_END: Frequency range end (u32).
-+ *	The unit is kHz.
++ * @NL80211_ADVERTISED_TTLM_ATTR_IE_COUNT: Indicates the number of TTLM IEs to
++ *	be included by target in beacon.
++ * @NL80211_ADVERTISED_TTLM_ATTR_LINK_MAP_SIZE: Indicates the link mapping size
++ *	to be used while forming TTLM IE as defined in section 9.4.2.314
++ *	(TID-To-Link Mapping element) in Draft P802.11be_D4.0. A value of 1
++ *	indicates that the length of the link mapping is 1 octet and a value of
++ *	0 indicates that it is of 2 octets.
++ * @NL80211_ADVERTISED_TTLM_ATTR_IEEE_LINK_MAP: indicates bitmap of the links
++ *	that will be enabled and advertised in TTLM IE of beacon. The same
++ *	bitmap will be copied to all TIDs map value of the IE with directection
++ *	bit set to 0x3 indicating BiDi direction as defined in section
++ *	35.3.7.2.4 (Advertised TTLM in Beacon and Probe Response frames) in
++ *	Draft P802.11be_D4.0.
++ * @NL80211_ADVERTISED_TTLM_ATTR_SWITCH_TIME: Indicates the mapping switch time
++ *	of each TTLM IE as defined in section 9.4.2.314 (TID-To-Link Mapping
++ *	element) in Draft P802.11be_D4.0.
++ * @NL80211_ADVERTISED_TTLM_ATTR_DURATION: Indicates the expected duration of
++ *	each TTLM IE as defined in section 9.4.2.314 (TID-To-Link Mapping
++ *	element) in Draft P802.11be_D4.0.
++ * @NL80211_ADVERTISED_TTLM_ATTR_STATUS: Indicates the status update indication
++ *	from lower layers in driver-offloaded enabled TTLM advertisement.
++ *	See &enum advertised_ttlm_status_type for details
++ * @NL80211_ADVERTISED_TTLM_ATTR_MST_TSF_UPDATE: Indicates the MST value in TSF
++ *	format converted from TU by lower layers. This attribute carried the MST
++ *	in TSF for each link of the MLD.
++ * @NL80211_ADVERTISED_TTLM_ATTR_ED_UPDATE: Indicates the current ED value to be
++ *	used in Probe Response frame. This attribute carries the ED values for
++ *	each link of the AP MLD.
 + *
-+ * @__NL80211_WIPHY_RADIO_FREQ_ATTR_LAST: Internal
-+ * @NL80211_WIPHY_RADIO_FREQ_ATTR_MAX: Highest attribute
++ * @__NL80211_ADVERTISED_TTLM_ATTR_LAST: Internal use
++ * @NL80211_ADVERTISED_TTLM_ATTR_MAX: Highest attribute
 + */
-+enum nl80211_wiphy_radio_freq_range {
-+	__NL80211_WIPHY_RADIO_FREQ_ATTR_INVALID,
++enum nl80211_advertised_ttlm_attrs {
++	__NL80211_ADVERTISED_TTLM_ATTR_INVALID,
 +
-+	NL80211_WIPHY_RADIO_FREQ_ATTR_START,
-+	NL80211_WIPHY_RADIO_FREQ_ATTR_END,
++	NL80211_ADVERTISED_TTLM_ATTR_IE_COUNT,
++	NL80211_ADVERTISED_TTLM_ATTR_LINK_MAP_SIZE,
++	NL80211_ADVERTISED_TTLM_ATTR_IEEE_LINK_MAP,
++	NL80211_ADVERTISED_TTLM_ATTR_SWITCH_TIME,
++	NL80211_ADVERTISED_TTLM_ATTR_DURATION,
++	NL80211_ADVERTISED_TTLM_ATTR_STATUS,
++	NL80211_ADVERTISED_TTLM_ATTR_MST_TSF_UPDATE,
++	NL80211_ADVERTISED_TTLM_ATTR_ED_UPDATE,
 +
-+	__NL80211_WIPHY_RADIO_FREQ_ATTR_LAST,
-+	NL80211_WIPHY_RADIO_FREQ_ATTR_MAX = __NL80211_WIPHY_RADIO_FREQ_ATTR_LAST - 1,
++	/* keep last */
++	__NL80211_ADVERTISED_TTLM_ATTR_LAST,
++	NL80211_ADVERTISED_TTLM_ATTR_MAX =
++		__NL80211_ADVERTISED_TTLM_ATTR_LAST - 1,
++};
++
++enum nl80211_tclas_type4_attrs {
++	NL80211_TCLAS_TYPE4_ATTR_INVALID,
++	NL80211_TCLAS_TYPE4_ATTR_CLASSIFIER_MASK,
++	NL80211_TCLAS_TYPE4_ATTR_IP_VERSION,
++	NL80211_TCLAS_TYPE4_ATTR_SRC_IP,
++	NL80211_TCLAS_TYPE4_ATTR_DST_IP,
++	NL80211_TCLAS_TYPE4_ATTR_SRC_PORT,
++	NL80211_TCLAS_TYPE4_ATTR_DST_PORT,
++	NL80211_TCLAS_TYPE4_ATTR_DSCP,
++	NL80211_TCLAS_TYPE4_ATTR_PROTOCOL,
++	NL80211_TCLAS_TYPE4_ATTR_NEXT_HEADER,
++	NL80211_TCLAS_TYPE4_ATTR_FLOW_LABEL,
++
++	/* keep last */
++	__NL80211_TCLAS_TYPE4_ATTR_AFTER_LAST,
++	NL80211_TCLAS_TYPE4_ATTR_MAX =
++		__NL80211_TCLAS_TYPE4_ATTR_AFTER_LAST - 1
++};
++
++enum nl80211_tclas_type10_attrs {
++	NL80211_TCLAS_TYPE10_ATTR_INVALID,
++	NL80211_TCLAS_TYPE10_ATTR_PROT_INSTANCE,
++	NL80211_TCLAS_TYPE10_ATTR_PROT_NUMBER,
++	NL80211_TCLAS_TYPE10_ATTR_FILTER_VALUE,
++	NL80211_TCLAS_TYPE10_ATTR_FILTER_MASK,
++
++	/* keep last */
++	__NL80211_TCLAS_TYPE10_ATTR_AFTER_LAST,
++	NL80211_TCLAS_TYPE10_ATTR_MAX =
++	__NL80211_TCLAS_TYPE10_ATTR_AFTER_LAST - 1
++};
++
++enum nl80211_tclas_attrs {
++	NL80211_TCLAS_ATTR_INVALID,
++	NL80211_TCLAS_ATTR_USER_PRIORITY,
++	NL80211_TCLAS_ATTR_CLASSIFIER_TYPE,
++	NL80211_TCLAS_ATTR_TYPE4_PARAMS,
++	NL80211_TCLAS_ATTR_TYPE10_PARAMS,
++
++	/* keep last */
++	__NL80211_TCLAS_ATTR_AFTER_LAST,
++	NL80211_TCLAS_ATTR_MAX = __NL80211_TCLAS_ATTR_AFTER_LAST - 1
++};
++
++enum nl80211_qm_qos_attrs {
++	NL80211_QM_QOS_ATTR_INVALID,
++	NL80211_QM_QOS_ATTR_CONTROL_INFO,
++	NL80211_QM_QOS_ATTR_MIN_SVC_INTERVAL,
++	NL80211_QM_QOS_ATTR_MAX_SVC_INTERVAL,
++	NL80211_QM_QOS_ATTR_MIN_DATA_RATE,
++	NL80211_QM_QOS_ATTR_DELAY_BOUND,
++	NL80211_QM_QOS_ATTR_MAX_MSDU_SIZE,
++	NL80211_QM_QOS_ATTR_SVC_START_TIME,
++	NL80211_QM_QOS_ATTR_SVC_START_TIME_LINK_ID,
++	NL80211_QM_QOS_ATTR_MEAN_DATA_RATE,
++	NL80211_QM_QOS_ATTR_BURST_SIZE,
++	NL80211_QM_QOS_ATTR_MSDU_LIFETIME,
++	NL80211_QM_QOS_ATTR_MSDU_DELIVERY_INFO,
++	NL80211_QM_QOS_ATTR_MEDIUM_TIME,
++
++	/* keep last */
++	__NL80211_QM_QOS_ATTR_AFTER_LAST,
++	NL80211_QM_QOS_ATTR_MAX = __NL80211_QM_QOS_ATTR_AFTER_LAST - 1
++};
++
++/**
++ * enum nl80211_qm_desc_attrs - QoS Management descriptor attributes
++ *
++ * @NL80211_QM_DESC_ATTR_INVALID: Invalid
++ *
++ * @NL80211_QM_DESC_ATTR_USER_PRIORITY_BITMAP - User priority bitmap
++ * of tid values sent by non-AP STA in an MSCS request
++ *
++ * @NL80211_QM_DESC_ATTR_USER_PRIORITY_LIMIT - User priority limit
++ * sent by non-AP STA in an MSCS request
++ *
++ * @NL80211_QM_DESC_ATTR_TCLAS_MASK - Traffic Classifier Mask with bitmap
++ * of parameters to be matched in an UL flow for DL prioritization
++ */
++enum nl80211_qm_desc_attrs {
++	NL80211_QM_DESC_ATTR_INVALID,
++	NL80211_QM_DESC_ATTR_QM_ID,
++	NL80211_QM_DESC_ATTR_REQUEST_TYPE,
++	NL80211_QM_DESC_ATTR_PRIORITY,
++	NL80211_QM_DESC_ATTR_TCLAS_ELEMENTS,
++	NL80211_QM_DESC_ATTR_TCLAS_PROCESSING,
++	NL80211_QM_DESC_ATTR_QOS_ATTRIBUTES,
++	NL80211_QM_DESC_ATTR_STATUS,
++	NL80211_QM_DESC_ATTR_USER_PRIORITY_BITMAP,
++	NL80211_QM_DESC_ATTR_USER_PRIORITY_LIMIT,
++	NL80211_QM_DESC_ATTR_TCLAS_MASK,
++
++	/* keep last */
++	__NL80211_QM_DESC_ATTR_LAST,
++	NL80211_QM_DESC_ATTR_MAX = __NL80211_QM_DESC_ATTR_LAST - 1
++};
++
++enum nl80211_qm_attrs {
++	__NL80211_QM_ATTR_INVALID,
++	NL80211_QM_ATTR_MAC_ADDR,
++	NL80211_QM_ATTR_QM_TYPE,
++	NL80211_QM_ATTR_DIALOG_TOKEN,
++	NL80211_QM_ATTR_DESCRIPTOR_PARAMS,
++
++	/* keep last */
++	__NL80211_QM_ATTR_LAST,
++	NL80211_QM_ATTR_MAX = __NL80211_QM_ATTR_LAST - 1
++};
++
++/**
++ * enum nl80211_6g_txpower_attr - Tx powers in each power mode
++ * @__NL80211_6GHZ_TXPOWER_ATTR_INVALID: attribute number 0 is reserved
++ * @NL80211_6GHZ_TXPOWER_ATTR_LPI: Tx power in LPI power mode
++ * @NL80211_6GHZ_TXPOWER_ATTR_SP: Tx power in SP power mode
++ * @NL80211_6GHZ_TXPOWER_ATTR_VLP: Tx power in VLP power mode
++ * @NL80211_6GHZ_TXPOWER_ATTR_MAX: Maximum power mode attribute number
++ *     currently defined
++ */
++enum nl80211_6ghz_txpower_attr {
++	__NL80211_6GHZ_TXPOWER_ATTR_INVALID,
++	NL80211_6GHZ_TXPOWER_ATTR_LPI,
++	NL80211_6GHZ_TXPOWER_ATTR_SP,
++	NL80211_6GHZ_TXPOWER_ATTR_VLP,
++
++	/* keep last */
++	__NL80211_6GHZ_TXPOWER_ATTR_AFTER_LAST,
++	NL80211_6GHZ_TXPOWER_ATTR_MAX =
++		__NL80211_6GHZ_TXPOWER_ATTR_AFTER_LAST - 1
++};
++
++/**
++ * enum nl80211_6ghz_dev_deployment_type - 6 GHz device deployment types
++ *
++ * @NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_UNKNOWN: Unknown deployment type.
++ * @NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_INDOOR: Indoor deployment type.
++ * @NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_OUTDOOR: Outdoor deployment type.
++ */
++enum nl80211_6ghz_dev_deployment_type {
++	NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_UNKNOWN,
++	NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_INDOOR,
++	NL80211_6GHZ_DEV_DEPLOYMENT_TYPE_OUTDOOR,
 +};
 +
 +#endif /* __LINUX_NL80211_H */


### PR DESCRIPTION
Problem
After the system was upgraded to ATH13.1, the nl80211.h (and related nl80211.sh) attributes in the ucode were not in sync with the driver. The alignment was initially performed in the WIFI‑15425 branch, but this change caused /etc/config/wireless to fail to generate properly. The underlying cause was that the updated nl80211.h led to ucentral missing the phy.info.radios structure, which in turn broke the configuration parsing logic.

Fix
To resolve this, we modified the code in wifi-detect.uc – the script responsible for generating /etc/board.json. We added a specific patch that supplements the radios information for ATH13.1 devices, ensuring that the required fields are present before ucentral processes the data. This fix guarantees that /etc/config/wireless can be correctly produced even with the new nl80211 attribute set.

Verification
After applying the above changes, we validated the system by testing the OWE transition mode. The feature now works flawlessly, confirming that both the attribute alignment and the configuration generation are functioning as expected.