### PR TITLE
hostapd: fix unrecognized osen and operator_icon

### DIFF
--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1305,14 +1305,14 @@ hostapd_set_bss_options() {
 
 	set_default hs20 0
 	set_default disable_dgaf "$hs20"
-	set_default osen 0
+	#set_default osen 0
 	set_default anqp_domain_id 0
 	set_default hs20_deauth_req_timeout 60
 	if [ "$hs20" = "1" ]; then
 		append bss_conf "hs20=1" "$N"
 		append_hs20_icons
 		append bss_conf "disable_dgaf=$disable_dgaf" "$N"
-		append bss_conf "osen=$osen" "$N"
+		[ -n "$osen" ] && append bss_conf "osen=$osen" "$N"
 		append bss_conf "anqp_domain_id=$anqp_domain_id" "$N"
 		append bss_conf "hs20_deauth_req_timeout=$hs20_deauth_req_timeout" "$N"
 		[ -n "$osu_ssid" ] && append bss_conf "osu_ssid=$osu_ssid" "$N"
@@ -1324,7 +1324,7 @@ hostapd_set_bss_options() {
 		json_for_each_item append_hs20_oper_friendly_name hs20_oper_friendly_name
 		json_for_each_item append_hs20_conn_capab hs20_conn_capab
 		json_for_each_item append_osu_provider osu_provider
-		json_for_each_item append_operator_icon operator_icon
+		[ -n "$operator_icon" ] && json_for_each_item append_operator_icon operator_icon
 	fi
 
 	if [ "$eap_server" = "1" ]; then

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -387,12 +387,11 @@ hostapd_common_add_bss_config() {
 	config_add_array iw_roaming_consortium iw_domain_name iw_anqp_3gpp_cell_net iw_nai_realm
 	config_add_array iw_anqp_elem iw_venue_name iw_venue_url
 
-	config_add_boolean hs20 disable_dgaf osen
+	config_add_boolean hs20 disable_dgaf
 	config_add_int anqp_domain_id
 	config_add_int hs20_deauth_req_timeout
 	config_add_array hs20_oper_friendly_name
 	config_add_array osu_provider
-	config_add_array operator_icon
 	config_add_array hs20_conn_capab
 	config_add_string osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
 
@@ -533,10 +532,6 @@ append_hs20_icon() {
 append_hs20_icons() {
 	config_load wireless
 	config_foreach append_hs20_icon hs20-icon
-}
-
-append_operator_icon() {
-	append bss_conf "operator_icon=$1" "$N"
 }
 
 append_osu_icon() {
@@ -1296,23 +1291,21 @@ hostapd_set_bss_options() {
 	esac
 	[ -n "$iw_qos_map_set" ] && append bss_conf "qos_map_set=$iw_qos_map_set" "$N"
 
-	local hs20 disable_dgaf osen anqp_domain_id hs20_deauth_req_timeout \
+	local hs20 disable_dgaf anqp_domain_id hs20_deauth_req_timeout \
 		osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
 		hs20_t_c_server_url
-	json_get_vars hs20 disable_dgaf osen anqp_domain_id hs20_deauth_req_timeout \
+	json_get_vars hs20 disable_dgaf anqp_domain_id hs20_deauth_req_timeout \
 		osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
 		hs20_t_c_server_url
 
 	set_default hs20 0
 	set_default disable_dgaf "$hs20"
-	set_default osen 0
 	set_default anqp_domain_id 0
 	set_default hs20_deauth_req_timeout 60
 	if [ "$hs20" = "1" ]; then
 		append bss_conf "hs20=1" "$N"
 		append_hs20_icons
 		append bss_conf "disable_dgaf=$disable_dgaf" "$N"
-		append bss_conf "osen=$osen" "$N"
 		append bss_conf "anqp_domain_id=$anqp_domain_id" "$N"
 		append bss_conf "hs20_deauth_req_timeout=$hs20_deauth_req_timeout" "$N"
 		[ -n "$osu_ssid" ] && append bss_conf "osu_ssid=$osu_ssid" "$N"
@@ -1324,7 +1317,6 @@ hostapd_set_bss_options() {
 		json_for_each_item append_hs20_oper_friendly_name hs20_oper_friendly_name
 		json_for_each_item append_hs20_conn_capab hs20_conn_capab
 		json_for_each_item append_osu_provider osu_provider
-		json_for_each_item append_operator_icon operator_icon
 	fi
 
 	if [ "$eap_server" = "1" ]; then


### PR DESCRIPTION
Problem
In the config delivered under this test case, the radius host and anqp_3gpp_cell_net formats are incorrect. In addition, osen and operator_icon are not recognized in the hostapd updated to ATH13.1.

Fix
Modify the radius host and anqp_3gpp_cell_net in the config to correct values. Additionally, since hostapd does not support osen and operator_icon, these two configuration items should be removed from hostapd.sh.

Verification
With these modifications, iwinfo can correctly display wireless information, and wireless functionality operates normally.