### PR TITLE
mediatek: mt7981b-emplus-wap588m: set in-band-status on LAN GMAC

### DIFF
--- a/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
+++ b/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
@@ -1,0 +1,50 @@
+From e10752f0276830410b3fe2fba50f030257f9abaf Mon Sep 17 00:00:00 2001
+From: "800246@emplustech.com" <cp.chang@emplustech.com>
+Date: Mon, 29 Jun 2026 09:48:28 +0800
+Subject: [PATCH 1/1] WAP588M:Fix LAN port can not transmit data
+
+Signed-off-by: 800246@emplustech.com <cp.chang@emplustech.com>
+---
+ .../mediatek/dts/mt7981b-emplus-wap588m.dts   | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+index e3dfc2e3d5..b143608497 100644
+--- a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
++++ b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+@@ -204,14 +204,6 @@
+ 	pinctrl-0 = <&mdio_pins>;
+ 	status = "okay";
+ 
+-	gmac0: mac@0 {
+-		compatible = "mediatek,eth-mac";
+-		reg = <0>;
+-		phy-mode = "sgmii";
+-		phy-handle = <&phy1>;
+-		nvmem-cells = <&macaddr_lan>;
+-		nvmem-cell-names = "mac-address";
+-	};
+ 
+ 	gmac1: mac@1 {
+ 		compatible = "mediatek,eth-mac";
+@@ -221,6 +213,17 @@
+ 		nvmem-cells = <&macaddr_wan>;
+ 		nvmem-cell-names = "mac-address";
+ 	};
++
++	gmac0: mac@0 {
++		compatible = "mediatek,eth-mac";
++		reg = <0>;
++		phy-mode = "sgmii";
++		phy-handle = <&phy1>;
++		nvmem-cells = <&macaddr_lan>;
++		nvmem-cell-names = "mac-address";
++		managed = "in-band-status";
++	};
++
+ };
+ 
+ &wifi {
+-- 
+2.34.1
+

--- a/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
+++ b/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
@@ -1,0 +1,25 @@
+From e10752f0276830410b3fe2fba50f030257f9abaf Mon Sep 17 00:00:00 2001
+From: CP Chang <cp.chang@emplustech.com>
+Date: Mon, 29 Jun 2026 09:48:28 +0800
+Subject: [PATCH 1/1] WAP588M:Fix LAN port can not transmit data
+
+Signed-off-by: CP Chang <cp.chang@emplustech.com>
+---
+ .../mediatek/dts/mt7981b-emplus-wap588m.dts   | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+index e3dfc2e3d5..b143608497 100644
+--- a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
++++ b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+@@ -211,6 +211,7 @@
+ 		phy-handle = <&phy1>;
+ 		nvmem-cells = <&macaddr_lan>;
+ 		nvmem-cell-names = "mac-address";
++		managed = "in-band-status";
+ 	};
+ 
+ 	gmac1: mac@1 {
+-- 
+2.34.1
+


### PR DESCRIPTION
The LAN port (gmac0, SGMII via phy1) had no managed link mode, so
phylink never took link state from the SGMII PCS and the port could
not transmit. Set managed = "in-band-status" so link/speed/duplex come
from SGMII in-band signalling, bringing the LAN port up.

Tested on WAP588M: LAN links up and passes traffic.

Fixes: WIFI-15572