### PR TITLE
mediatek: mt7981b-emplus-wap588m: exchange lan port and wan port 

### DIFF
--- a/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
+++ b/patches-25.12/0116-WAP588M-Fix-LAN-port-can-not-transmit-data.patch
@@ -1,0 +1,50 @@
+From e10752f0276830410b3fe2fba50f030257f9abaf Mon Sep 17 00:00:00 2001
+From: "800246@emplustech.com" <cp.chang@emplustech.com>
+Date: Mon, 29 Jun 2026 09:48:28 +0800
+Subject: [PATCH 1/1] WAP588M:Fix LAN port can not transmit data
+
+Signed-off-by: 800246@emplustech.com <cp.chang@emplustech.com>
+---
+ .../mediatek/dts/mt7981b-emplus-wap588m.dts   | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+index e3dfc2e3d5..b143608497 100644
+--- a/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
++++ b/target/linux/mediatek/dts/mt7981b-emplus-wap588m.dts
+@@ -204,14 +204,6 @@
+ 	pinctrl-0 = <&mdio_pins>;
+ 	status = "okay";
+ 
+-	gmac0: mac@0 {
+-		compatible = "mediatek,eth-mac";
+-		reg = <0>;
+-		phy-mode = "sgmii";
+-		phy-handle = <&phy1>;
+-		nvmem-cells = <&macaddr_lan>;
+-		nvmem-cell-names = "mac-address";
+-	};
+ 
+ 	gmac1: mac@1 {
+ 		compatible = "mediatek,eth-mac";
+@@ -221,6 +213,17 @@
+ 		nvmem-cells = <&macaddr_wan>;
+ 		nvmem-cell-names = "mac-address";
+ 	};
++
++	gmac0: mac@0 {
++		compatible = "mediatek,eth-mac";
++		reg = <0>;
++		phy-mode = "sgmii";
++		phy-handle = <&phy1>;
++		nvmem-cells = <&macaddr_lan>;
++		nvmem-cell-names = "mac-address";
++		managed = "in-band-status";
++	};
++
+ };
+ 
+ &wifi {
+-- 
+2.34.1
+

--- a/patches-25.12/0117-WAP588M-Switch-LAN-port-and-WAN-port.patch
+++ b/patches-25.12/0117-WAP588M-Switch-LAN-port-and-WAN-port.patch
@@ -1,0 +1,124 @@
+From 79cd0914b1f08e3f99b2a7e981c405b262b19e9a Mon Sep 17 00:00:00 2001
+From: "800246@emplustech.com" <cp.chang@emplustech.com>
+Date: Mon, 29 Jun 2026 10:02:03 +0800
+Subject: [PATCH 1/1] WAP588M:Switch LAN port and WAN port
+
+Signed-off-by: 800246@emplustech.com <cp.chang@emplustech.com>
+---
+ .../filogic/base-files/etc/board.d/01_leds       |  7 +++++--
+ .../filogic/base-files/etc/board.d/02_network    | 16 +++++++++++++---
+ .../base-files/lib/preinit/06_set_emplus_netdev  | 11 +++++++++++
+ .../base-files/lib/preinit/10_fix_eth_mac.sh     | 13 +++++++++++++
+ 4 files changed, 42 insertions(+), 5 deletions(-)
+ create mode 100644 target/linux/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev
+
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+index 6c2e3a5ca6..5273f1263e 100644
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+@@ -104,8 +104,11 @@ edgecore,eap115a)
+ 	ucidef_set_led_netdev "wan" "wan" "orange:indicator" "eth0"
+ 	;;
+ emplus,wap588m)
+-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
++	ucidef_set_led_default "power" "POWER" "blue:power" "1"
++	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0" "link tx rx"
++	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1" "link tx rx"
++	ucidef_set_led_netdev "wifi2g" "WIFI2G" "green:wlan-2ghz" "wlan0" "link tx rx"
++	ucidef_set_led_netdev "wifi5g" "WIFI5G" "green:wlan-5ghz" "wlan1" "link tx rx"
+ 	;;
+ emplus,wap7636m)
+ 	ucidef_set_led_default "power" "POWER" "power" "1"
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+index c782425067..d5baf8c65d 100644
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+@@ -126,7 +126,6 @@ mediatek_setup_interfaces()
+ 		;;
+ 	airpi,ap3000m|\
+ 	bananapi,bpi-r3-mini|\
+-	emplus,wap588m|\
+ 	huasifei,wh3000|\
+ 	huasifei,wh3000-pro-emmc|\
+ 	huasifei,wh3000-pro-nand)
+@@ -222,9 +221,12 @@ mediatek_setup_interfaces()
+ 	sonicfi,rap630w-211g)
+ 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
+ 		;;
++	emplus,wap588m)
++		ucidef_set_interfaces_lan_wan "eth1" "eth0"
++		;;
+ 	emplus,wap7636m)
+ 		ucidef_set_interfaces_lan_wan lan eth0
+-		;;		
++		;;
+ 	*)
+ 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
+ 		;;
+@@ -336,12 +338,20 @@ mediatek_setup_macs()
+ 		[ -d "${sysfs}/phy0" ] && macaddr_add "$wan_mac" 2 > "${sysfs}/phy0/macaddress"
+ 		[ -d "${sysfs}/phy1" ] && macaddr_add "$wan_mac" 3 > "${sysfs}/phy1/macaddress"
+ 		;;
++	emplus,wap588m)
++		lan_mac_offset="0x2A"
++		wan_mac_offset="0x24"
++		part_name="Factory"
++		lan_mac=$(mtd_get_mac_binary $part_name $lan_mac_offset)
++		wan_mac=$(mtd_get_mac_binary $part_name $wan_mac_offset)
++		label_mac=$wan_mac
++		;;
+ 	emplus,wap7636m)
+ 		part_name="Factory"		
+ 	 	wan_mac_offset=0xFFFFA
+ 		wan_mac=$(mtd_get_mac_binary $part_name $wan_mac_offset)
+ 		label_mac=$wan_mac
+-		;;		
++		;;
+ 	esac
+ 
+ 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+diff --git a/target/linux/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev b/target/linux/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev
+new file mode 100644
+index 0000000000..dacabc9fe7
+--- /dev/null
++++ b/target/linux/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev
+@@ -0,0 +1,11 @@
++emplus_swap_ethdev() {
++	case "$(cat /tmp/sysinfo/board_name)" in
++	emplus,wap588m)
++		ip link set eth0 name lan
++		ip link set eth1 name eth0
++		ip link set lan name eth1
++		;;
++	esac
++}
++
++boot_hook_add preinit_main emplus_swap_ethdev
+diff --git a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+index 0d4c165e48..53ca9de974 100644
+--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
++++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+@@ -60,6 +60,19 @@ preinit_set_mac_address() {
+ 		ip link set dev port5 address "$lan_mac"
+ 		ip link set dev port6 address "$lan_mac"
+ 		;;
++	emplus,wap588m)
++		lan_mac_offset="0x2A"
++		wan_mac_offset="0x24"
++		part_name="Factory"
++		lan_mac=$(mtd_get_mac_binary $part_name $lan_mac_offset)
++		wan_mac=$(mtd_get_mac_binary $part_name $wan_mac_offset)
++		ip link set eth0 down
++		ip link set eth1 down
++		ip link set dev eth0 address "$wan_mac"
++		ip link set dev eth1 address "$lan_mac"
++		ip link set eth0 up
++		ip link set eth1 up
++		;;
+ 	*)
+ 		;;
+ 	esac
+-- 
+2.34.1
+


### PR DESCRIPTION
Per the customer requirement, LAN port need to be eth1 , WAN port need to be eth0

Tested on WAP588M: eth0 and eth1 have been inter-exchanged

Fixes: WIFI-15578
