### PR TITLE
netifd, hostapd: bridge RADIUS dynamic VLAN clients on ath12k

### DIFF
--- a/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t99-ubus-vlan-add-qca-dynamic-vlan.patch
+++ b/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t99-ubus-vlan-add-qca-dynamic-vlan.patch
@@ -1,0 +1,27 @@
+From: Marek Kwaczynski <marek@shasta.cloud>
+Subject: [PATCH] hostapd: emit ubus vlan_add for QCA driver-created dynamic AP_VLAN
+
+The QCA nl80211 path creates and binds the dynamic AP_VLAN netdev via
+set_sta_vlan, bypassing vlan_if_add() where hostapd_ubus_add_vlan() is
+normally called. Emit the event from ap_sta_bind_vlan() so userspace can
+bridge the dynamically created VLAN interface.
+
+Signed-off-by: Marek Kwaczynski <marek@shasta.cloud>
+
+--- a/src/ap/sta_info.c
++++ b/src/ap/sta_info.c
+@@ -1832,6 +1832,14 @@ skip_counting:
+ 	/* During 1x reauth, if the vlan id changes, then remove the old id. */
+ 	if (old_vlanid > 0 && old_vlanid != sta->vlan_id)
+ 		vlan_remove_dynamic(vlan_bss, old_vlanid);
++
++	/* The QCA driver creates and binds the dynamic AP_VLAN netdev via
++	 * set_sta_vlan, bypassing vlan_if_add() where the ubus vlan_add event
++	 * is normally emitted. Emit it here so userspace can bridge the
++	 * dynamic VLAN interface. */
++	if (ret == 0 && vlan && vlan->dynamic_vlan > 0 &&
++	    sta->vlan_id > 0 && sta->vlan_id != old_vlanid)
++		hostapd_ubus_add_vlan(vlan_bss, vlan);
+ done:
+ 
+ 	return ret;

--- a/patches-25.12/0117-netifd-do-not-vlan-parse-dotted-device-names.patch
+++ b/patches-25.12/0117-netifd-do-not-vlan-parse-dotted-device-names.patch
@@ -1,0 +1,49 @@
+From 3b490a54df6e61c5086d01b3947ee0c7b1ecc6c8 Mon Sep 17 00:00:00 2001
+From: Marek Kwaczynski <marek@shasta.cloud>
+Date: Tue, 30 Jun 2026 17:49:36 +0000
+Subject: [PATCH] netifd: do not VLAN-parse added device names containing dots
+
+A device name containing '.' is resolved as a VLAN device chain. A
+dynamically created netdev can legitimately contain '.' in its name
+(e.g. a QCA AP_VLAN interface phyX.Y-Z-vNNN), which the VLAN parser
+splits at the first '.' and fails to resolve, so add_device returns
+"Not found" and the dynamic VLAN interface cannot be bridged. When such
+an external device is explicitly added and the netdev already exists,
+use it directly.
+
+Fixes: WIFI-15505
+Signed-off-by: Marek Kwaczynski <marek@shasta.cloud>
+---
+ .../400-ap-vlan-dotted-device-name.patch      | 20 +++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/400-ap-vlan-dotted-device-name.patch
+
+diff --git a/package/network/config/netifd/patches/400-ap-vlan-dotted-device-name.patch b/package/network/config/netifd/patches/400-ap-vlan-dotted-device-name.patch
+new file mode 100644
+index 0000000000..e104be8631
+--- /dev/null
++++ b/package/network/config/netifd/patches/400-ap-vlan-dotted-device-name.patch
+@@ -0,0 +1,20 @@
++Index: b/device.c
++===================================================================
++--- a/device.c
+++++ b/device.c
++@@ -865,8 +865,14 @@ __device_get(const char *name, int creat
++ 
++ 	dev = avl_find_element(&devices, name, dev, avl);
++ 
++-	if (!dev && check_vlan && strchr(name, '.'))
+++	if (!dev && check_vlan && strchr(name, '.')) {
+++		/* A dynamically added external device whose name contains '.'
+++		 * (e.g. a QCA AP_VLAN netdev) must not be parsed as a VLAN. */
+++		if (create > 1 && if_nametoindex(name))
+++			return device_create_default(name, true);
+++
++ 		return get_vlan_device_chain(name, create);
+++	}
++ 
++ 	if (name[0] == '@')
++ 		return device_alias_get(name + 1);
+-- 
+2.43.0
+


### PR DESCRIPTION
## What
Fix RADIUS-assigned dynamic VLAN (DVLAN) clients on ath12k getting no DHCP: the dynamically created AP_VLAN interface was never bridged.

## Why
- hostapd: the QCA nl80211 path creates and binds the AP_VLAN via `set_sta_vlan`, bypassing `vlan_if_add()` where the ubus `vlan_add` event is emitted, so userspace was never notified.
- netifd: `add_device` parses the AP_VLAN name (`phyX.Y-Z-vNNN`) as a VLAN chain, splitting at the first dot and failing to resolve it ("Not found").

## How
- hostapd: emit `vlan_add` from `ap_sta_bind_vlan()`.
- netifd: when an external device whose name contains a dot already exists as a netdev, use it directly instead of VLAN-parsing.
