### PR TITLE
patches-25.12: wifi-scripts: fix mbssid parameter name for WiFi 6 6 GHz LPI 

### DIFF
--- a/patches-25.12/0116-wifi-scripts-fix-mbssid-parameter-name-for-WiFi-6-6-GHz-LPI.patch
+++ b/patches-25.12/0116-wifi-scripts-fix-mbssid-parameter-name-for-WiFi-6-6-GHz-LPI.patch
@@ -1,0 +1,35 @@
+From 889bef40ece3e024c69da3b58749a964d66c3ed4 Mon Sep 17 00:00:00 2001
+From: ruanyaoyu <ruanyaoyu@cigtech.com>
+Date: Thu, 2 Jul 2026 09:54:04 +0800
+Subject: [PATCH] wifi-scripts: fix mbssid parameter name for WiFi 6 6 GHz LPI
+
+The mac80211.sh script was passing the mbssid value using the wrong
+parameter name. The hostapd configuration expects "multiple_bssid"
+rather than "mbssid", which caused the 6 GHz LPI (Low Power Indoor)
+mode to fail initialization on WiFi 6 platforms such as WF-196.
+
+- Rename the hostapd config key from "mbssid" to "multiple_bssid"
+  in the mac80211.sh wireless setup function.
+
+Fixes: WIFI-15571
+Signed-off-by: ruanyaoyu <ruanyaoyu@cigtech.com>
+---
+ .../config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh   | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+index c2d4f97ea3..930e59025f 100755
+--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
++++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+@@ -529,7 +529,7 @@ ${channel:+channel=$channel}
+ ${channel_list:+chanlist=$channel_list}
+ ${hostapd_noscan:+noscan=1}
+ ${tx_burst:+tx_queue_data2_burst=$tx_burst}
+-${multiple_bssid:+mbssid=$multiple_bssid}
++${multiple_bssid:+multiple_bssid=$multiple_bssid}
+ #num_global_macaddr=$num_global_macaddr
+ #macaddr_base=$macaddr_base
+ $base_cfg
+-- 
+2.34.1
+


### PR DESCRIPTION
patches-25.12: wifi-scripts: fix mbssid parameter name for WiFi 6 6 GHz LPI
The mac80211.sh script was passing the mbssid value using the wrong
parameter name. The hostapd configuration expects 'multiple_bssid'
rather than 'mbssid', which caused the 6 GHz LPI (Low Power Indoor)
mode to fail initialization on WiFi 6 platforms such as WF-196.

- Rename the hostapd config key from 'mbssid' to 'multiple_bssid'
  in the mac80211.sh wireless setup function.

Fixes: WIFI-15571
Signed-off-by: ruanyaoyu <ruanyaoyu@cigtech.com>