### PR TITLE
ipq807x_v5.4, qca-wifi-7: implement auto recovery feature on Cybertan sonicfi devices for v4.2.x

### DIFF
--- a/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq50xx/base-files/etc/init.d/bootcount
@@ -9,7 +9,11 @@ boot() {
 		;;
 	edgecore,oap101|\
 	edgecore,oap101e|\
-	edgecore,eap104)
+	edgecore,eap104|\
+	sonicfi,rap630w-311g|\
+	sonicfi,rap630c-311g|\
+	sonicfi,rap630w-312g|\
+	cybertan,rap630w-312g)
 		avail=$(fw_printenv -n upgrade_available)
 		[ "${avail}" -eq 0 ] && fw_setenv upgrade_available 1
 		fw_setenv bootcount 0

--- a/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
+++ b/feeds/ipq807x_v5.4/ipq60xx/base-files/etc/init.d/bootcount
@@ -12,7 +12,8 @@ boot() {
 	edgecore,eap102|\
 	edgecore,oap102|\
 	edgecore,oap103|\
-	edgecore,eap104)
+	edgecore,eap104|\
+	sonicfi,rap650c)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1
 		fw_setenv bootcount 0

--- a/feeds/qca-wifi-7/ipq53xx/base-files/etc/init.d/bootcount
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/etc/init.d/bootcount
@@ -4,7 +4,11 @@ START=99
 
 boot() {
 	case "$(board_name)" in
-	edgecore,eap105)
+	edgecore,eap105|\
+	sonicfi,rap7110c-341x|\
+	sonicfi,rap750e-h|\
+	sonicfi,rap750e-s|\
+	sonicfi,rap750w-311a)
 		avail=$(fw_printenv -n upgrade_available)
 		[ ${avail} -eq 0 ] && fw_setenv upgrade_available 1
 		fw_setenv bootcount 0

--- a/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
@@ -37,7 +37,7 @@ do_flash_emmc() {
 
 sonicfi_dualimage_check() {
 	local boot_part=""
-	boot_part=$(fw_printenv | grep bootfrom | awk -F'=' '{printf $2}')
+	boot_part=$(fw_printenv -n bootfrom)
 	[ -n "$boot_part" ] || boot_part="0"
 	echo "boot_part=$boot_part" > /dev/console
 


### PR DESCRIPTION
we need to implement auto recovery feature on Cybertan sonicfi devices for v4.2.x

Implement the auto-recovery feature on CyberTan SonicFi devices for v4.2.x, per the TIP design doc: https://telecominfraproject.atlassian.net/wiki/spaces/WIFI/pages/1918009348/Dual+Boot+Support+with+Automatic+Failure+Recovery
Target devices:

sonicfi_rap750w-311a
sonicfi_rap750e-s
sonicfi_rap750e-h
sonicfi_rap7110c-341x
sonicfi_rap630w-311g
sonicfi_rap630w-312g
sonicfi_rap630c-311g