### PR TITLE
portal.uc: use null instead of NULL on handle_request error paths

### DIFF
--- a/feeds/ucentral/uspot/files/usr/share/uspot/portal.uc
+++ b/feeds/ucentral/uspot/files/usr/share/uspot/portal.uc
@@ -254,7 +254,7 @@ return {
 		if (!ctx.mac) {
 			this.syslog(ctx, 'failed to look up mac');
 			include('error.uc', ctx);
-			return NULL;
+			return null;
 		}
 		ctx.spotfilter = lookup_station(ctx.mac);
 		ctx.config = config[ctx.spotfilter] || {};
@@ -272,7 +272,7 @@ return {
 		if (!connected) {
 			this.syslog(ctx, 'spotfilter error');
 			include('error.uc', ctx);
-			return NULL;
+			return null;
 		}
 		ctx.connected = connected;
 		if (!uam && connected?.state) {


### PR DESCRIPTION
The two return NULL; statements at portal.uc:257 and portal.uc:275 throw at runtime inside uhttpd's ucode handler:

  Reference error: access to undeclared variable NULL

uspot's uhttpd loads handler.uc under strict-declarations, so bare NULL is treated as a reference to an undeclared variable and errors out instead of being coerced to null.  In non-strict mode (e.g. standalone `ucode` on the shell) the same code silently resolves, which is likely why the bug slipped in.

Lowercase null is the language literal and works in both modes. Matches the rest of the file - line 115 already uses return null; and line 117 uses let reply = null;.

Both affected sites are error paths: MAC lookup failed, or spotfilter did not reply.  Each already calls include('error.uc', ctx) before returning, so the return value only exists to bail out of the function.  Any valid literal works; null matches convention.

Reproduced:
  $ echo "'use strict'; if (a == NULL) {}" > /tmp/t.uc
  $ ucode /tmp/t.uc
  Reference error: access to undeclared variable NULL

Fixed by s/return NULL;/return null;/g at portal.uc:257 and :275.