### PR TITLE
ucentral-schema: Fix HaLow SSID frequency report

### DIFF
--- a/feeds/ucentral/ucentral-schema/patches/007-fix-halow-ssid-freq-report.patch
+++ b/feeds/ucentral/ucentral-schema/patches/007-fix-halow-ssid-freq-report.patch
@@ -1,0 +1,54 @@
+--- a/system/state.uc
++++ b/system/state.uc
+@@ -820,7 +820,50 @@
+ 				ssid.ssid = wif.ssid || vap.config.mesh_id;
+ 				ssid.mode = wif.mode;
+ 				ssid.bssid = wif.bssid;
+-				ssid.frequency = uniq(wif.frequency);
++				// HaLow/S1G SSIDs tune on borrowed 5GHz channels, so
++				// wif.frequency holds 5GHz values. Remap them to real S1G
++				// frequencies (same as the radio path) so the cloud filters
++				// them into the correct band
++				if (index(ssid.band, 'S1G') != -1) {
++					let mapping_table = map5GToS1G();
++					let orig_channels = wif.channel || [];
++
++					// Pick the operating channel the same way as the radio
++					// path: prefer the second channel (center freq), fall
++					// back to the smallest mappable one.
++					let selected_channel = null;
++					if (length(orig_channels) >= 2) {
++						selected_channel = '' + orig_channels[1];
++					} else {
++						for (let i = 0; i < length(orig_channels); i++) {
++							let ch = '' + orig_channels[i];
++							if (mapping_table[ch] && (selected_channel === null || +ch < +selected_channel))
++								selected_channel = ch;
++						}
++					}
++
++					if (selected_channel !== null && mapping_table[selected_channel]) {
++						let s1g_info = mapping_table[selected_channel];
++						if (s1g_info.s1g_bw == 1) {
++							// 1MHz: driver only reports one channel, duplicate for UI
++							ssid.frequency = [s1g_info.s1g_freq, s1g_info.s1g_freq];
++						} else {
++							// 2/4/8MHz: map each orig channel to its S1G freq, keep 1:1 aligned
++							let s1g_frequencies = [];
++							for (let i = 0; i < length(orig_channels); i++) {
++								let ch = '' + orig_channels[i];
++								if (mapping_table[ch])
++									push(s1g_frequencies, mapping_table[ch].s1g_freq);
++							}
++							if (length(s1g_frequencies))
++								ssid.frequency = s1g_frequencies;
++						}
++					} else {
++						ssid.frequency = uniq(wif.frequency);
++					}
++				} else {
++					ssid.frequency = uniq(wif.frequency);
++				}
+ 				//Collect associations from both regular and WDS STA interfaces
+ 				for (let k, v in all_stations) {
+ 					let vlan = split(k, '-v');


### PR DESCRIPTION
Root Cause:
Under the morse driver, HaLow/S1G radios tune on borrowed 5GHz channels, so wif.frequency carries 5GHz values (e.g. 5560/5570). The SSID-level state reported these directly via ssid.frequency = uniq(wif.frequency). Since the cloud classifies band by frequency, it filed the HaLow SSID under 5GHz, so HaLow client/radio info did not show in Active Clients. (The radio-level state already remapped to S1G; the SSID path did not.)

Solution:
Added process_halow_ssid(), which applies the same map5GToS1G() conversion as the radio path for S1G/HaLow SSIDs: same channel-selection logic,
remapping the 5GHz frequency to real S1G frequency while keeping channel↔frequency 1:1 aligned. Non-HaLow SSIDs keep the original behaviour.

Fixes: WIFI-15593