### PR TITLE
docs: clarify guidelines (subject casing, Fixes scope, SPDX, tests)

### DIFF
--- a/OPENWIFI_CODING_GUIDELINES.md
+++ b/OPENWIFI_CODING_GUIDELINES.md
@@ -34,10 +34,11 @@ The history is **linear**. Keep it that way:
 Every commit follows the OpenWrt/kernel trailer style:
 
 ```
-<subsystem>: <imperative, lower-case summary, no trailing period>
+<subsystem>: <imperative summary — first word lower-case; proper nouns, board names, and identifiers keep their case; no trailing period>
 
-<body: why the change is needed and what it does, wrapped at ~72 cols.
-Use "-" bullet lists for multi-part fixes.>
+<Required body, wrapped at ~72 cols: explain why the change is needed, then what
+it does. Use "-" bullets for multi-part fixes. Record test evidence as plain text
+("Tested on EAP105 ...") for functional/board/driver changes.>
 
 Fixes: WIFI-15468
 Signed-off-by: Your Name <email>
@@ -49,8 +50,9 @@ Signed-off-by: Your Name <email>
   **mandatory**. Examples in use: `ucentral-schema:`, `ipq807x:`, `ucentral:`, `hostapd:`,
   `patches-25.12:`, `ucentral-client:`, `uspot:`, `netifd:`, `mac80211:`, `profiles:`,
   `qca-wifi-7:`, `config.yml:`.
-- **Lower-case after the colon**, imperative mood (`fix`, `add`, `remove`, `update`,
-  `disable`), **no trailing period**.
+- **First word after the colon is lower-case and imperative** (`fix`, `add`, `remove`,
+  `update`, `disable`); **preserve the case of proper nouns, board names, and identifiers**
+  (e.g. `SonicFi RAP630E`, `OpenWrt`, `RTGS`); **no trailing period**.
 - **Patch commits carry the OpenWrt version** in the prefix: `patches-25.12: …`. Bump the
   number when you renumber/rebase patches.
 - Target/driver prefixes can stack: `qca-wifi-7: wifi-scripts: fix …`,
@@ -66,9 +68,21 @@ config.yml: update OpenWrt baseline to v25.12.3
 
 ### Body
 
-- Explain **why**, then **what**. For multi-part fixes, lead with a one-line problem
-  statement, then a `-` bullet per root cause.
-- **`Fixes: <TICKET>`** references the tracker (`WIFI-#####`, `WLAN-####`).
+A body is **required** on every commit. Write it as plain text, not labelled
+sections:
+
+- **Explain why, then what.** Lead with the reason the change is needed (the bug, gap, or
+  motivation the diff can't show), then what the commit does. Imperative mood, wrapped at
+  ~72 columns; use `-` bullets for multi-part fixes.
+- **Record test evidence as plain text** for functional, board, or driver changes — e.g.
+  "Tested on EAP105 and EAP014, verified FT roam with no DHCP drop." This is required for
+  the changes B1 (Hardware risk) calls out; mechanical commits (bumps, renames, reverts)
+  need none. Optionally use a `Tested-by:` trailer when someone else verified the change.
+
+Trailers follow the body:
+
+- **`Fixes: <TICKET>`** (`WIFI-#####`, `WLAN-####`) **where the commit addresses a tracked
+  issue.** Bug fixes reference a ticket; refactors, additions, and bumps often have none.
 - **`Signed-off-by:` is required on every commit** (DCO). Preserve upstream sign-offs when
   forwarding a patch; add your own.
 
@@ -95,12 +109,30 @@ config.yml: update OpenWrt baseline to v25.12.3
 
 ---
 
-## 3. C code style (`wlan-ucentral-client`, packages)
+## 3. File headers (SPDX)
+
+Every **new** source file begins with an SPDX license identifier, written in that file's own
+comment syntax; for files with a shebang, the identifier goes **immediately after the
+shebang line**. Use the **same license as the rest of the package** — C sources in these
+repos use `BSD-3-Clause`. When editing an existing file, match its current header; don't
+change a file's license identifier as a drive-by.
+
+Comment syntax per language:
+
+- C / headers: `/* SPDX-License-Identifier: BSD-3-Clause */`
+- ucode (`.uc`): `// SPDX-License-Identifier: <package license>` — above `"use strict";`
+- Shell / procd init scripts: shebang first, then `# SPDX-License-Identifier: <package license>`
+- YAML / UCI config: `# SPDX-License-Identifier: <package license>`
+
+---
+
+## 4. C code style (`wlan-ucentral-client`, packages)
 
 Follow the **OpenWrt / libubox / Linux-kernel** idiom — be consistent with it, not with
 generic C conventions.
 
-- **`/* SPDX-License-Identifier: BSD-3-Clause */`** as the first line of every file.
+- **`/* SPDX-License-Identifier: BSD-3-Clause */`** as the first line of every C source and
+  header file (see §3 for the cross-language rule).
 - **Tabs for indentation.** Never spaces.
 - **K&R braces.** For function *definitions*, the return type and name go on the same line,
   but the opening brace is on its own line:
@@ -125,7 +157,7 @@ generic C conventions.
 
 ---
 
-## 4. ucode (`.uc`) style (`wlan-ucentral-schema` renderer & state)
+## 5. ucode (`.uc`) style (`wlan-ucentral-schema` renderer & state)
 
 - **`"use strict";`** at the top of every module.
 - **Tabs for indentation.**
@@ -148,7 +180,7 @@ generic C conventions.
 
 ---
 
-## 5. Schema authoring (`wlan-ucentral-schema`)
+## 6. Schema authoring (`wlan-ucentral-schema`)
 
 - **Author in YAML, never hand-edit generated JSON.** The source of truth is the
   `schema/*.yml` files (2-space indent); `ucentral.schema.json`, `*.pretty.json`, and the
@@ -162,13 +194,16 @@ generic C conventions.
 
 ---
 
-## 6. Quick checklist
+## 7. Quick checklist
 
 - [ ] One logical change per commit; tree builds at every commit.
-- [ ] Subject is `subsystem: imperative lower-case summary` with no trailing period.
-- [ ] Body explains *why*; multi-part fixes use `-` bullets; `Fixes: <TICKET>` where applicable.
+- [ ] Subject `subsystem: imperative summary`: first word lower-case, proper nouns/board
+      names keep their case, no trailing period.
+- [ ] Body present (why, then what); test evidence in plain text for functional/board/driver
+      changes; `Fixes: <TICKET>` where applicable.
 - [ ] `Signed-off-by:` present on every commit (yours preserved + upstream preserved).
-- [ ] C: tabs, SPDX header, `static`, blobmsg policy + `__MAX` sentinel, `ULOG_*` logging.
+- [ ] New source files carry an SPDX identifier (first line, or immediately after a shebang).
+- [ ] C: tabs, `static`, blobmsg policy + `__MAX` sentinel, `ULOG_*` logging.
 - [ ] ucode: `"use strict"`, tabs, `let`, helpers imported from `libs/`, null-guards + `assert()`.
 - [ ] Schema: edited the `.yml`, regenerated JSON via `generate.sh`, didn't hand-edit JSON.
 - [ ] Patch packages prefixed with the OpenWrt version (`patches-25.12: …`).

--- a/OPENWIFI_PR_GUIDELINES.md
+++ b/OPENWIFI_PR_GUIDELINES.md
@@ -18,7 +18,7 @@ Code formatting and commit-message rules live in
 ## The core principle: PRs are rebased, not merged
 
 These repositories keep a **linear history**. A PR lands by **replaying its commits onto
-`main`** (cherry-pick / rebase / `git am`), not by creating a merge commit. As a result:
+`main`** (GitHub's "Rebase and merge" button), not by creating a merge commit. As a result:
 
 - The **author field stays the contributor**; the integrator becomes the *committer*.
 - The contributor's **`Signed-off-by`** is preserved.
@@ -37,22 +37,26 @@ your branch without rewriting it.
 
 > **Which base branch?** This guide covers **feature / general-fix PRs, which target
 > `main`.** A fix for an already-shipped release (4.2.x / 2.11.x) is a **backport PR that
-> targets `release/vX.Y.0`** and is cut from that release branch — see
+> targets that release's `staging-for-vX.Y.0-LTS` branch** — nothing lands on
+> `release/vX.Y.0` directly (see B7) — see
 > [OPENWIFI_RELEASE_PROCEDURE.md](OPENWIFI_RELEASE_PROCEDURE.md).
 
 ## A1. Branch off the latest `main`, named after the ticket
 
 `main` is the integration branch for feature work — branch feature/general-fix PRs off
-`main` (release backports branch off `release/vX.Y.0` instead; see the release procedure).
+`main` (release backports branch off `staging-for-vX.Y.0-LTS` instead; see the release
+procedure).
 
 ```bash
 git checkout main
 git pull origin main
-git checkout -b WIFI-14728-ipq50xx-add-sonicfi-rap630e
+git checkout -b staging-WIFI-14728-ipq50xx-add-sonicfi-rap630e
 ```
 
-Branch name = **`WIFI-<number>-<short-kebab-description>`**, e.g.
-`WIFI-14817-6G-CBP-fail-on-20M-BW`, `WIFI-14896-support-HaLow-Mesh`.
+Branch name = **`staging-WIFI-<number>-<short-hyphenated-description>`** — all PR branches
+carry the `staging-` prefix. Words are separated by hyphens, with acronyms, band names, and
+board identifiers kept in their conventional case (mirroring the subject-line rule) — e.g.
+`staging-WIFI-14817-6G-CBP-fail-on-20M-BW`, `staging-WIFI-14896-support-HaLow-Mesh`.
 **One ticket → one branch → one focused PR.** Keep PRs small — typically **1–3 commits**.
 
 ## A2. Stay current with `rebase`, never `merge`
@@ -74,20 +78,27 @@ git rebase -i origin/main
 `squash`/`fixup` the "fix typo", "address review", and duplicate commits into their parent.
 Target state: **1–3 commits, each builds on its own**, each with:
 
-- Subject `subsystem: imperative lower-case summary` (no trailing period) —
+- Subject `subsystem: imperative summary` — first word after the colon lower-case, proper
+  nouns / board names / identifiers keep their case, no trailing period —
   e.g. `ipq50xx: add SonicFi RAP630E`, not `WIFI-14728 ipq50xx : add sonicfi rap630e`.
 - Patch-package commits prefixed with the OpenWrt version: `patches-25.12: …`.
-- Body explaining **why**, with `-` bullets for multi-part changes.
-- **`Fixes: WIFI-<number>`** and **`Signed-off-by: Your Name <email>`** on *every* commit (DCO).
+- Required body (see the coding guide, §2 → *Body*): explain why, then what, as plain text.
+  Include test evidence ("Tested on EAP105 ...") for functional/board/driver changes.
+- **`Signed-off-by: Your Name <email>`** on *every* commit (DCO).
+- **`Fixes: WIFI-<number>`** where the commit addresses a tracked issue (bug fixes reference
+  a ticket; refactors, additions, and bumps often have none).
 - **`main` builds at every commit** — they may be applied individually.
 
 ## A4. Open the PR with a self-justifying description
 
-- **What & why** (mirror the commit body for single-commit PRs).
+- **What & why** — mirror the commit body. For a single-commit PR, restate why the change
+  is needed and what it does; for a multi-commit PR, give a short per-commit summary plus
+  the overall test evidence.
 - **Ticket:** link `WIFI-<number>`.
 - **Affected targets / boards / drivers:** be explicit (`ipq50xx`, `WF189`, `qca-wifi-7`).
-- **Test evidence:** what you ran, on which hardware, and the result. Board regressions are
-  reverted, so show you tested on the affected hardware.
+- **Test evidence:** what you ran, on which hardware, and the result — the PR-level view of
+  the test evidence in each commit body. Board regressions are reverted, so show you tested
+  on the affected hardware.
 - **Schema changes (`wlan-ucentral-schema`):** confirm you edited the `.yml` source and
   regenerated JSON via `generate.sh` (never hand-edit generated JSON); note any device⇄cloud
   compatibility impact.
@@ -100,7 +111,8 @@ git push --force-with-lease     # update the same PR; --force-with-lease, not --
 ```
 
 Fold review fixes into the relevant commit rather than stacking "address review" commits.
-Expect your commit to be **reworded or split** by the integrator for consistency — that is
+Commits land on `main` exactly as pushed — nothing is rewritten on apply — so expect
+reviewers to ask you to **reword or split** commits before the PR is merged; that is
 normal, not a rejection.
 
 ## A6. Submodule & cross-repo changes
@@ -112,66 +124,61 @@ it in `wlan-ucentral-schema` first, then bump the submodule in `wlan-ap` as its 
 
 ## A7. Contributor checklist
 
-- [ ] Branch `WIFI-<ticket>-<desc>`, cut from latest `main`.
+- [ ] Branch `staging-WIFI-<ticket>-<desc>`, cut from latest `main`.
 - [ ] Rebased on `main` — **no `Merge branch 'main'` commits**.
 - [ ] 1–3 focused commits; no duplicate/fixup/"address review" commits.
-- [ ] Each commit: `subsystem: imperative summary`, body says *why*, `Fixes: WIFI-#####`,
-      `Signed-off-by:`.
+- [ ] Each commit: `subsystem: imperative summary`; required body (why, then what) with
+      test evidence for functional/board changes; `Signed-off-by:` present; `Fixes: WIFI-#####`
+      where applicable.
 - [ ] `main` builds at every commit.
 - [ ] PR description: what/why, ticket, affected targets/boards, **test evidence**.
 - [ ] Schema edited in `.yml` + regenerated; submodule bump is its own PR/commit.
-- [ ] Feature/general-fix PR targets `main`; a release backport targets `release/vX.Y.0`
-      (see [OPENWIFI_RELEASE_PROCEDURE.md](OPENWIFI_RELEASE_PROCEDURE.md)).
+- [ ] No trunk-applicable fix targets an LTS branch directly — landed on `main` first and
+      cherry-picked (release-only fixes excepted, with a note saying why).
+- [ ] Feature/general-fix PR targets `main`; a release backport targets
+      `staging-for-vX.Y.0-LTS` (see [OPENWIFI_RELEASE_PROCEDURE.md](OPENWIFI_RELEASE_PROCEDURE.md)).
 - [ ] `git log origin/main..HEAD` shows only your real commits, no merge lines.
 
 ---
 
 # Part B — Reviewer / Merger Guide
 
-Integrate by **replaying commits onto `main`**. Do **not** use GitHub's "Merge pull request"
-button for feature PRs — it creates a merge commit.
+Integrate with GitHub's **"Rebase and merge"** button — it replays the PR's commits onto
+`main` with no merge commit. Do **not** use "Create a merge commit" or "Squash and merge"
+for feature PRs.
 
 ## B1. Review before integrating
 
 - **Scope:** one ticket, focused, 1–3 commits. Push back on bundled/unrelated changes.
 - **Commit hygiene:** each commit standalone, canonical `subsystem: summary` subject,
-  `Fixes:` + `Signed-off-by:` present. Reword non-canonical subjects on apply.
+  a required body (why, then what), `Signed-off-by:` present (and `Fixes:` where the commit
+  fixes a tracked issue). Reword non-canonical subjects on apply.
 - **Per-commit build:** since commits are applied individually, every commit must leave
   `main` buildable.
-- **Hardware risk:** for board/driver changes, require test evidence on the named target.
-  When a regression slips through, revert it with a reason (see B6).
+- **Hardware risk:** for board/driver changes, require test evidence on the named target,
+  recorded in the commit body ("Tested on ..."). When a regression slips through, revert it
+  with a reason (see B6).
 - **Schema (`wlan-ucentral-schema`):** confirm `.yml` edited and JSON regenerated via
   `generate.sh`, not hand-edited; check device⇄cloud compatibility.
 
-## B2. Integrate by replaying onto `main`
+## B2. Integrate with Rebase and merge
 
-```bash
-git fetch origin WIFI-14728-ipq50xx-add-sonicfi-rap630e
-git checkout main
-git pull --ff-only origin main
+Confirm the PR branch is rebased on the current `main` and every commit is in its final
+shape — canonical subject, required body, `Signed-off-by` present — then press GitHub's
+**"Rebase and merge"** button. Nothing is rewritten on apply.
 
-# Option A — cherry-pick specific commits (take some, drop others):
-git cherry-pick <sha1> <sha2>
+This keeps the contributor as **author** and you as **committer**, preserves their
+`Signed-off-by`, and adds no merge commit. If only some commits should land, ask the
+contributor to drop or split them and re-push, rather than cherry-picking around the PR.
 
-# Option B — rebase the branch onto main, then fast-forward:
-git rebase main WIFI-14728-ipq50xx-add-sonicfi-rap630e
-git checkout main
-git merge --ff-only WIFI-14728-ipq50xx-add-sonicfi-rap630e
+## B3. Clean up before merge
 
-# Option C — apply as mailed patches (preserves authorship + S-o-b):
-git am < patches.mbox
-```
-
-All three keep the contributor as **author** and you as **committer**, preserve their
-`Signed-off-by`, and add no merge commit.
-
-## B3. Clean up on apply
+Rebase and merge applies commits verbatim, so fix-ups happen on the PR branch before the
+button is pressed — request them from the contributor, or push to the PR branch:
 
 - **Reword** non-canonical subjects (`WIFI-14728 ipq50xx : add sonicfi rap630e` →
   `ipq50xx: add SonicFi RAP630E`).
 - **Drop** any `Merge branch 'main'` commits that leaked into the branch — rebase past them.
-- **Add your own `Signed-off-by`** below the contributor's when you take responsibility for
-  the patch; keep theirs intact.
 - **Split or squash** if a commit mixes concerns or a fixup should fold into its parent.
 
 ## B4. Push and confirm linear history
@@ -179,7 +186,6 @@ All three keep the contributor as **author** and you as **committer**, preserve 
 ```bash
 git log --pretty='%h %an (committer %cn) %s' -5    # authorship preserved?
 git log --merges -1                                 # not your feature apply?
-git push origin main
 ```
 
 The contributor's PR auto-closes as "merged" once the commits are on `main`.
@@ -215,25 +221,37 @@ Signed-off-by: ...
 
 ## B7. Releases
 
-- `main` is the integration branch — **feature PRs land there first**. Fixes for a shipped
-  release go onto its **`release/vX.Y.0`** branch (4.2.x, 2.11.x), not onto `main`.
-- Releases are **semver tags with RC candidates** (`v4.2.x`, `v2.11.x`, `…-rcN`), and every
-  `vX.Y.Z` tag lives **on the release branch**. Release branches are **merge-based** (the
-  opposite of `main`): fixes arrive as GitHub-merged PRs from `staging-*` (or vendor)
-  branches, e.g. `Merge pull request #1046 from .../staging-WIFI-15388-pmf-value-fix-for-4.2.3`.
-- Fixes that apply to the trunk are landed on `main` first and **cherry-picked** into the
-  release branch; **release-only** fixes are authored directly on the release-branch staging
-  branch. The full workflow — branching, backport PRs, version bump, tagging — is in
+- `main` is the trunk — **feature/general-fix PRs land there first**. Changes for an LTS
+  release go onto its **`staging-for-v<X.Y.0>-LTS`** branch (e.g. `staging-for-v4.2.0-LTS`),
+  where they are validated, and the staging branch is then **merged into `release/v<X.Y.0>`**
+  (e.g. `release/v4.2.0`) only once everything has been checked. `release/v<X.Y.0>` is not
+  touched until then, so it is never affected by unverified changes.
+- Releases are **semver tags with RC candidates** (`v4.2.x`, `…-rcN`), cut **on the release
+  branch only** (`release/v<X.Y.0>`) — never on `main` or the staging branch. The LTS branch
+  is **merge-based**: backport PRs from `staging-WIFI-…-for-vX.Y.Z` branches are merged in,
+  e.g. `Merge pull request #1046 from .../staging-WIFI-15388-pmf-value-fix-for-4.2.3`.
+- **Trunk-first (required):** a fix that also applies to the trunk **lands on `main` first**,
+  then is **cherry-picked** into the LTS branch (`staging-for-v<X.Y.0>-LTS`). Do **not** open
+  a fix PR directly against the LTS branch when it also applies to `main`. **Release-only**
+  fixes (version bumps, RC-specific or release-branch-only changes) are authored directly on
+  the LTS branch, with a note in the PR saying why they don't apply to `main`. Reviewers
+  reject direct-to-LTS PRs that aren't genuinely release-only. The full workflow — branching,
+  backport PRs, version bump, tagging — is in
   [OPENWIFI_RELEASE_PROCEDURE.md](OPENWIFI_RELEASE_PROCEDURE.md).
 
 ## B8. Reviewer / merger checklist
 
 - [ ] PR is scoped to one ticket, 1–3 standalone commits.
-- [ ] Each commit canonical subject + `Fixes:` + `Signed-off-by:`; subjects reworded if needed.
+- [ ] Each commit: canonical subject; required body (why, then what) with test evidence for
+      functional/board changes; `Signed-off-by:` present; `Fixes:` where applicable; subjects
+      reworded if needed.
 - [ ] `main` builds at every commit.
-- [ ] Hardware/board change has test evidence on the named target.
-- [ ] Applied via cherry-pick / rebase+ff / `git am` — **no merge commit**.
-- [ ] Authorship preserved, contributor `Signed-off-by` kept, your `Signed-off-by` added.
+- [ ] Hardware/board change has test evidence on the named target (commit body or
+      optional `Tested-by:` trailer).
+- [ ] QA has signed off on the ticket's staging branch, where QA coverage exists
+      (non-blocking; note in the PR when a change ships without QA validation).
+- [ ] Integrated via **Rebase and merge** — **no merge commit**.
+- [ ] Authorship preserved, contributor `Signed-off-by` kept.
 - [ ] History still linear (`git log --merges` unchanged for feature work).
 - [ ] Submodule bump lists included upstream commits; reverts state a reason.
 - [ ] Release work merged only on release/version branches.


### PR DESCRIPTION
Problem: a few areas of the coding and PR guidelines could be made clearer and more consistent based on how we've been using them:
- the subject-line casing note read as fully lower-case, while the examples (add SonicFi RAP630E, config.yml: ...) keep proper-noun case.
- Fixes: was described slightly differently across the two guides.
- branch naming referred to "kebab-case", while the examples keep acronym case (6G-CBP, HaLow).
- the SPDX note lived in the C section, so its scope for ucode/shell/ YAML was open to interpretation.
- test evidence was captured at PR level; per-commit would help.

Solution:
- state the subject rule as "first word lower-case imperative; proper nouns, board names, and identifiers keep their case".
- align Fixes: to "where the commit addresses a tracked issue" in both guides, and keep it separate from the Signed-off-by/DCO requirement.
- reword branch naming to "short-hyphenated-description", noting that acronyms and board names keep their case.
- add a cross-language "File headers (SPDX)" section and scope the C rule to C sources/headers.
- add an optional Problem/Solution/Tests commit body, with the PR description mirroring it.

Tests: N/A - documentation only, no functional change.