### PR TITLE
qca-wifi-6/hostapd: fix incorrect psk_idx value

### DIFF
--- a/feeds/qca-wifi-6/hostapd/patches/601-ucode_support.patch
+++ b/feeds/qca-wifi-6/hostapd/patches/601-ucode_support.patch
@@ -696,7 +696,7 @@
  #ifdef CONFIG_OWE
  	if ((hapd->conf->wpa_key_mgmt & WPA_KEY_MGMT_OWE) &&
  	    sta && sta->owe_pmk) {
-@@ -381,12 +382,17 @@ static const u8 * hostapd_wpa_auth_get_p
+@@ -381,13 +382,18 @@ static const u8 * hostapd_wpa_auth_get_p
  	 * returned psk which should not be returned again.
  	 * logic list (all hostapd_get_psk; all sta->psk)
  	 */
@@ -709,11 +709,13 @@
  		if (vlan_id)
  			*vlan_id = 0;
  		psk = sta->psk->psk;
+-		for (pos = sta->psk; pos; pos = pos->next) {
 +		if (vlan_id)
 +			sta->psk_idx = psk_idx;
- 		for (pos = sta->psk; pos; pos = pos->next) {
++		for (pos = sta->psk; pos; pos = pos->next, psk_idx++) {
  			if (pos->is_passphrase) {
  				pbkdf2_sha1(pos->passphrase,
+ 						hapd->conf->ssid.ssid,
 @@ -397,9 +403,13 @@ static const u8 * hostapd_wpa_auth_get_p
  			}
  			if (pos->psk == prev_psk) {


### PR DESCRIPTION
hostapd_wpa_auth_get_psk()  walks the per-STA sta->psk list to find the PSK matching the 4-way-handshake MIC and records the matched position in sta->psk_idx, which mpskd maps back to the configured key/VLAN. The local psk_idx counter is initialised to 1 but never incremented while walking the list, so every match beyond the first entry is reported as index 1. A station whose key sits at list position >= 2 therefore receives the 2nd key's VLAN instead of its own.

Advance psk_idx as the list is walked so sta->psk_idx reflects the true position of the matching PSK.

This is the same fix of this PR
https://github.com/Telecominfraproject/wlan-ap/pull/1163

Fixes: WIFI-15354