### PR TITLE
portal.uc: use null instead of NULL on handle_request error paths

### DIFF
--- a/feeds/ucentral/uspot/files/usr/share/uspot/portal.uc
+++ b/feeds/ucentral/uspot/files/usr/share/uspot/portal.uc
@@ -254,7 +254,7 @@ return {
 		if (!ctx.mac) {
 			this.syslog(ctx, 'failed to look up mac');
 			include('error.uc', ctx);
-			return NULL;
+			return null;
 		}
 		ctx.spotfilter = lookup_station(ctx.mac);
 		ctx.config = config[ctx.spotfilter] || {};
@@ -272,7 +272,7 @@ return {
 		if (!connected) {
 			this.syslog(ctx, 'spotfilter error');
 			include('error.uc', ctx);
-			return NULL;
+			return null;
 		}
 		ctx.connected = connected;
 		if (!uam && connected?.state) {


### PR DESCRIPTION
Bare NULL at portal.uc:257 and :275 throws at runtime in uspot's
strict-mode uhttpd handler ("access to undeclared variable NULL"),
though it silently resolves in non-strict shells like plain `ucode`.
Lowercase null is the language literal and works in both; matches
line 115's `return null;` and line 117's `let reply = null;`.

Fixes: WIFI-15592
Signed-off-by: Venkat Chimata <venkat@nearhop.com>