### PR TITLE
mac80211: scan: fix ms/jiffies mismatch in passive scan overhead

### DIFF
--- a/feeds/mediatek/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
+++ b/feeds/mediatek/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
@@ -1,0 +1,28 @@
+Index: backports-6.12.6/net/mac80211/scan.c
+===================================================================
+--- backports-6.12.6.orig/net/mac80211/scan.c
++++ backports-6.12.6/net/mac80211/scan.c
+@@ -29,6 +29,9 @@
+ #define IEEE80211_CHANNEL_TIME (HZ / 33)
+ #define IEEE80211_PASSIVE_CHANNEL_TIME (HZ / 9)
+ 
++/*  Overhead compensation for FW channel switch and wiphy_delayed_work scheduling */
++#define IEEE80211_PASSIVE_MIN_CHANNEL_TIME (HZ / 20)
++
+ void ieee80211_rx_bss_put(struct ieee80211_local *local,
+ 			  struct ieee80211_bss *bss)
+ {
+@@ -1015,8 +1018,11 @@
+ 	 */
+ 	if ((chan->flags & (IEEE80211_CHAN_NO_IR | IEEE80211_CHAN_RADAR)) ||
+ 	    !scan_req->n_ssids) {
+-		*next_delay = max(msecs_to_jiffies(scan_req->duration),
+-				  IEEE80211_PASSIVE_CHANNEL_TIME);
++		unsigned long duration = msecs_to_jiffies(scan_req->duration);
++
++		*next_delay = duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME ?
++		duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME : 0;
++
+ 		local->next_scan_state = SCAN_DECISION;
+ 		if (scan_req->n_ssids)
+ 			set_bit(SCAN_BEACON_WAIT, &local->scanning);


### PR DESCRIPTION
On mediatek/filogic (mac80211 backports 6.12.6) set the passive
channel dwell to scan_req->duration minus a fixed overhead
(IEEE80211_PASSIVE_MIN_CHANNEL_TIME, HZ/20 = 50ms at CONFIG_HZ=100)
to compensate for FW channel switch and wiphy_delayed_work scheduling.
Measured channel active time then tracks the requested duration to
within ~5ms for durations >= 100ms.

Fixes: WIFI-14822