### PR TITLE
mtk/hostapd: fix the issue 11r is not enabling for proto: psk2-radius

### DIFF
--- a/profiles/sonicfi_rap630w-211g.yml
+++ b/profiles/sonicfi_rap630w-211g.yml
@@ -11,6 +11,7 @@ feeds:
     path: ../../feeds/batman
 include:
   - ucentral-ap
+  - hostapd
 packages:
   - mediatek
 diffconfig: |


### PR DESCRIPTION
This patch is used to fix the issues in v4.2.x : WIFI-15348 & WIFI-15349 & WIFI-15364

the main branch does not need this patch, but for firmware v4.2.X,  we still need merge it into the branch 'staging-for-v4'.2.0-LTS' to fix these issues.

root cause: The hostapd used in the RAP630W-211g is the original hostapd package from OpenWrt,
but the MTK project should use feeds/hostapd, which already contains all the hostapd patches.

