### PR TITLE
mediatek: mac80211: keep passive dwell floor when scan duration is unset

### DIFF
--- a/feeds/mediatek/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
+++ b/feeds/mediatek/mac80211/patches/subsys/mtk-9905-mac80211-decrease-passive-scan-chan-time.patch
@@ -12,7 +12,7 @@ Index: backports-6.12.6/net/mac80211/scan.c
  void ieee80211_rx_bss_put(struct ieee80211_local *local,
  			  struct ieee80211_bss *bss)
  {
-@@ -1015,8 +1018,11 @@
+@@ -1015,8 +1018,15 @@
  	 */
  	if ((chan->flags & (IEEE80211_CHAN_NO_IR | IEEE80211_CHAN_RADAR)) ||
  	    !scan_req->n_ssids) {
@@ -20,8 +20,12 @@ Index: backports-6.12.6/net/mac80211/scan.c
 -				  IEEE80211_PASSIVE_CHANNEL_TIME);
 +		unsigned long duration = msecs_to_jiffies(scan_req->duration);
 +
-+		*next_delay = duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME ?
-+		duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME : 0;
++		if (!scan_req->duration)
++			*next_delay = IEEE80211_PASSIVE_CHANNEL_TIME;
++		else if (duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME)
++			*next_delay = duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME;
++		else
++			*next_delay = 0;
 +
  		local->next_scan_state = SCAN_DECISION;
  		if (scan_req->n_ssids)


### PR DESCRIPTION
When scan_req->duration is 0 (the default for all normal and roaming scans, nothing sets it), the two-way expression collapsed next_delay to 0, cutting passive channel dwell to roughly the FW/scheduling overhead (~40ms) and missing most beacons on passive and DFS channels. Restore the PASSIVE_CHANNEL_TIME floor for the duration==0 case while keeping the HZ/20 overhead compensation for explicit non-zero durations.

Fixes: WIFI-14822