### PR TITLE
mediatek: mac80211: keep passive dwell floor and set overhead to HZ/20

### DIFF
--- a/patches-25.12/0110-mediatek-mac80211-decrease-passive-scan-channel-time.patch
+++ b/patches-25.12/0110-mediatek-mac80211-decrease-passive-scan-channel-time.patch
@@ -1,5 +1,5 @@
 From 0d945a89f275f1377a8e6f0f0dc975d95c320e13 Mon Sep 17 00:00:00 2001
-From: Mateusz Bajorski <mbajorski@shasta.cloud>
+From: Marek Kwaczynski <marek@shasta.cloud>
 Date: Mon, 15 Dec 2025 13:11:26 +0100
 Subject: [PATCH 110/115] mediatek: mac80211: decrease passive scan channel
  time
@@ -13,8 +13,8 @@ Fixes: SW-4949, SW-5898
 Signed-off-by: Mateusz Bajorski <mbajorski@shasta.cloud>
 Signed-off-by: Marek Kwaczynski <marek@shasta.cloud>
 ---
- ...0211-decrease-passive-scan-chan-time.patch | 28 +++++++++++++++++++
- 1 file changed, 28 insertions(+)
+ ...0211-decrease-passive-scan-chan-time.patch | 32 +++++++++++++++++++
+ 1 file changed, 32 insertions(+)
  create mode 100644 package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
 
 diff --git a/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch b/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
@@ -22,7 +22,7 @@ new file mode 100644
 index 0000000000..01834ad4a4
 --- /dev/null
 +++ b/package/kernel/mac80211/patches/subsys/x-mtk-0001-mac80211-decrease-passive-scan-chan-time.patch
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,32 @@
 +Index: backports-6.12.6/net/mac80211/scan.c
 +===================================================================
 +--- backports-6.12.6.orig/net/mac80211/scan.c
@@ -32,12 +32,12 @@ index 0000000000..01834ad4a4
 + #define IEEE80211_PASSIVE_CHANNEL_TIME (HZ / 9)
 +
 ++/*  Overhead compensation for FW channel switch and wiphy_delayed_work scheduling */
-++#define IEEE80211_PASSIVE_MIN_CHANNEL_TIME (HZ / 25)
+++#define IEEE80211_PASSIVE_MIN_CHANNEL_TIME (HZ / 20)
 ++
 + void ieee80211_rx_bss_put(struct ieee80211_local *local,
 + 			  struct ieee80211_bss *bss)
 + {
-+@@ -1015,8 +1018,11 @@ set_channel:
++@@ -1015,8 +1018,15 @@ set_channel:
 + 	 */
 + 	if ((chan->flags & (IEEE80211_CHAN_NO_IR | IEEE80211_CHAN_RADAR)) ||
 + 	    !scan_req->n_ssids) {
@@ -45,8 +45,12 @@ index 0000000000..01834ad4a4
 +-				  IEEE80211_PASSIVE_CHANNEL_TIME);
 ++		unsigned long duration = msecs_to_jiffies(scan_req->duration);
 ++
-++		*next_delay = duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME ?
-++		duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME : 0;
+++		if (!scan_req->duration)
+++			*next_delay = IEEE80211_PASSIVE_CHANNEL_TIME;
+++		else if (duration > IEEE80211_PASSIVE_MIN_CHANNEL_TIME)
+++			*next_delay = duration - IEEE80211_PASSIVE_MIN_CHANNEL_TIME;
+++		else
+++			*next_delay = 0;
 ++
 + 		local->next_scan_state = SCAN_DECISION;
 + 		if (scan_req->n_ssids)


### PR DESCRIPTION
The 25.12 passive-scan overhead-compensation patch collapsed next_delay to 0 when scan_req->duration is 0 (the default for all normal and roaming scans, nothing sets it), cutting passive channel dwell to roughly the FW/scheduling overhead and missing most beacons on passive and DFS channels. Restore the PASSIVE_CHANNEL_TIME floor for the duration==0 case while keeping the overhead compensation for explicit non-zero durations.

Set the overhead constant to HZ/20 (50ms), which on EAP-111 makes the measured channel active time track the requested duration within ~5ms (100->~100ms, 200->~200ms); the previous HZ/25 overshot by ~10ms.

Fixes: WIFI-14822