### PR TITLE
certificates: restore insta operational certs across factory reset

### DIFF
--- a/feeds/tip/certificates/files/etc/init.d/early_boot
+++ b/feeds/tip/certificates/files/etc/init.d/early_boot
@@ -30,7 +30,11 @@ boot() {
 		touch /tmp/squashfs
 	;;
 	esac
-	[ -f /etc/ucentral/key.pem ] && return
+	# Skip the restore only when fully provisioned. Checking key.pem alone was
+	# not enough: an app factory reset with keep_redirector (cmd_factory.uc)
+	# preserves key.pem but not operational.pem, which made this return early
+	# and never restore the operational cert stored in the insta partition.
+	[ -f /etc/ucentral/key.pem -a -f /etc/ucentral/operational.pem ] && return
 	/usr/bin/mount_certs
 	copy_certificates
 }

--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -8,16 +8,26 @@ check_certificates() {
 
 check_certificates 1
 
+# Read the currently-active cert partition. store_certs writes to the
+# alternate partition and then advances cert_part to point at it, so the
+# reader must return that same partition and must NOT flip cert_part
+# (flipping here made a factory-reset boot read the stale/empty slot).
+# fw_printenv needs /etc/fw_env.config, but the uboot-envtools uci-default
+# only generates it at S95done - long after this runs at S09early_boot. On
+# a factory-reset boot the config is gone, so cert_part reads empty and we
+# would pick the wrong (stale/empty) partition. Generate it now if missing.
 tar_part_lookup() {
+	[ -s /etc/fw_env.config ] || {
+		for _ube in /etc/uci-defaults/30_uboot-envtools /rom/etc/uci-defaults/30_uboot-envtools; do
+			[ -f "$_ube" ] && { (. "$_ube") >/dev/null 2>&1; break; }
+		done
+	}
 	part="$(fw_printenv -n cert_part)"
-	if [ "$part" -eq 0 ]; then
+	if [ "$part" = "1" ]; then
 		echo "$2"
-		part=1
 	else
 		echo "$1"
-		part=0
 	fi
-	fw_setenv cert_part $part
 }
 
 . /lib/functions.sh
@@ -56,7 +66,7 @@ yuncore,ax820)
 		umount /mnt
 	fi
 	part=$(tar_part_lookup "insta1" "insta2")
-	if [ -n "insta" ]; then
+	if [ -n "$part" ]; then
 		mtd=$(find_mtd_index $part)
 		[ -n "$mtd" ] && tar xf /dev/mtdblock$mtd -C /certificates
 	fi


### PR DESCRIPTION
certificates: restore insta operational certs across factory reset

Boards that store the EST-enrolled operational cert/CA in the insta1/insta2 A/B flash partitions could lose them after a factory reset. Three problems in the early-boot restore path, all fixed here:

- mount_certs and store_certs shared a tar_part_lookup() that both read AND flipped the cert_part u-boot env, so the reader selected the opposite partition from where store_certs wrote. Make mount_certs map cert_part to the active partition without flipping (store_certs keeps flipping).
- mount_certs runs from early_boot at S09, before uboot-envtools generates /etc/fw_env.config (S95). A factory reset wipes that config, so fw_printenv returned empty and the wrong (empty) partition was picked. Generate the config first when it is missing. Also fix the always-true [ -n "insta" ] guard to [ -n "$part" ].
- early_boot skipped the restore whenever /etc/ucentral/key.pem existed. An app factory reset (keep_redirector) preserves the birth key.pem but not the operational cert, so mount_certs never ran. Return early only when fully provisioned (key.pem AND operational.pem present).

Fixes: WIFI-15591
Signed-off-by: abhishek vyas <abhishek.vyas@inventum.net>