### PR TITLE
rrmd: main fix captive portal client removal and re-authentication flow

### DIFF
--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/station.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/station.uc
@@ -221,7 +221,7 @@ return {
 	},
 
 	kick: function(msg) {
-		if (!msg.addr || !msg.ban_time || !msg.reason)
+		if (!msg.addr || msg.ban_time == null || !msg.reason)
 			return false;
 
 		if (!exists(stations, msg.addr))

--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/station.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/station.uc
@@ -238,6 +238,35 @@ return {
 		/* tell hostapd to kick a station via ubus */
 		global.ubus.conn.call(`hostapd.${stations[msg.addr].device}`, 'del_client', payload);
 
+		/* clear captive portal auth state so client must re-authenticate after reconnect */
+		let uci = require('uci').cursor();
+		uci.foreach('uspot', 'uspot', function(s) {
+			if (s['.anonymous'])
+				return;
+			let ifnames = type(s.ifname) == 'array' ? s.ifname : [s.ifname];
+			for (let ifname in ifnames) {
+				if (ifname == stations[msg.addr].device) {
+					/*
+					 * go through uspot first so it can close out RADIUS
+					 * accounting (Acct-Stop) and its own bookkeeping, but
+					 * uspot only acts if the client is in *its* in-memory
+					 * cache. Also call spotfilter directly so the BPF
+					 * authorization entry is guaranteed to be cleared even
+					 * if that cache is stale (e.g. after a uspot restart).
+					 */
+					global.ubus.conn.call('uspot', 'client_remove', {
+						interface: s['.name'],
+						address: msg.addr
+					});
+					global.ubus.conn.call('spotfilter', 'client_remove', {
+						interface: s['.name'],
+						address: msg.addr
+					});
+					break;
+				}
+			}
+		});
+
 		return true;
 	},
 


### PR DESCRIPTION
rrmd: main fix captive portal client removal and re-authentication flow
  
Two issues in kick() prevented proper client removal and re-auth:
 
1. !msg.ban_time treated ban_time=0 (immediate deauth, no roaming ban)
as falsy, silently aborting the kick. Fix: guard on
msg.ban_time == null instead, so 0 is accepted and passed through
to hostapd as-is. hostapd already bans on every radio itself via
hapd->iface->interfaces->for_each_interface() when global_ban is
set, so no extra per-interface looping is needed on the rrmd side.
 
2. spotfilter authorization was left intact after kick, so the client
got internet access on reconnect without re-authenticating through
the captive portal. Fix: call uspot.client_remove (to close RADIUS
accounting/bookkeeping) and spotfilter.client_remove directly, so
the BPF auth entry is cleared even if uspot's in-memory cache is
stale.
 
Fixes: WIFI-15563

Signed-off-by: Sujeet Kumar sujeet.kumar@inventum.net