### PR TITLE
.github/scripts, .github/workflows: refine PR guideline checks and co…

### DIFF
--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -12,6 +12,7 @@
 #   - missing Fixes: WIFI-#### trailer        (§2: "where applicable")
 #   - branch name not WIFI-<num>-<desc>       (A1; fork branches vary)
 #   - subject line longer than 72 chars
+#   - no explanatory body                     (§2; mechanical commits may skip)
 
 set -euo pipefail
 
@@ -24,6 +25,17 @@ range="${BASE_SHA}..${HEAD_SHA}"
 
 err()  { echo "::error::$*";   fail=1; }
 warn() { echo "::warning::$*"; }
+
+# Shorten a subject for display in messages so a runaway subject line doesn't
+# flood the annotations / PR comment. Reports the full length separately.
+trunc() {
+  local s="$1" max=80
+  if [ "${#s}" -gt "$max" ]; then
+    printf '%s…' "${s:0:max}"
+  else
+    printf '%s' "$s"
+  fi
+}
 
 # ---------------------------------------------------------------
 # 1. No merge commits — history must replay cleanly onto main
@@ -72,7 +84,7 @@ for sha in $(git rev-list --reverse --no-merges "$range"); do
   if echo "$subject" | grep -qE '^Revert "'; then
     : # standard revert format is fine; reason-in-body is reviewed by humans
   elif ! echo "$subject" | grep -qE "$SUBJECT_RE"; then
-    err "$short: subject '$subject' is not canonical. Use 'subsystem: imperative lower-case summary', no trailing period (e.g. 'ipq50xx: add SonicFi RAP630E')."
+    err "$short: subject '$(trunc "$subject")' is not canonical. Use 'subsystem: imperative lower-case summary', no trailing period (e.g. 'ipq50xx: add SonicFi RAP630E')."
   fi
 
   if [ "${#subject}" -gt 72 ]; then
@@ -84,9 +96,24 @@ for sha in $(git rev-list --reverse --no-merges "$range"); do
     err "$short: missing 'Signed-off-by: Name <email>' trailer (DCO, guidelines A3). Use 'git commit -s'."
   fi
 
-  # --- Fixes: trailer — expected, but 'where applicable' ---
-  if ! echo "$body" | grep -qE '^Fixes: (WIFI|WLAN)-[0-9]+'; then
+  # --- Fixes: trailer — expected 'where applicable'; must be capital-F 'Fixes:' ---
+  if echo "$body" | grep -qE '^Fixes: (WIFI|WLAN)-[0-9]+'; then
+    :  # correct: capital-F 'Fixes:' with a valid ticket
+  elif echo "$body" | grep -qiE '^fixes:' && ! echo "$body" | grep -qE '^Fixes:'; then
+    warn "$short: the trailer must be a capital-F 'Fixes: WIFI-#####' (found a different case) (guidelines A3)."
+  else
     warn "$short: no 'Fixes: WIFI-#####' trailer. Add one if this commit relates to a ticket (guidelines A3)."
+  fi
+
+  # --- Explanatory body — required by §2, but mechanical commits may skip ---
+  # "Body prose" = the message minus the subject, blank lines, and known
+  # trailers. If nothing is left, the commit has only a subject (+ trailers).
+  body_prose=$(git log -1 --format='%b' "$sha" \
+    | grep -vE '^[[:space:]]*$' \
+    | grep -viE '^(Signed-off-by|Fixes|Tested-by|Reviewed-by|Acked-by|Reported-by|Suggested-by|Co-developed-by|Co-authored-by|Cc|Link|Closes|Depends-on|Change-Id):' \
+    || true)
+  if [ -z "$body_prose" ]; then
+    warn "$short: no explanatory body — §2 expects why, then what. Mechanical commits (bumps, renames, reverts) may ignore this."
   fi
 done
 

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -1,10 +1,14 @@
 name: PR Guidelines
 
 # Enforces OPENWIFI_PR_GUIDELINES.md + OPENWIFI_CODING_GUIDELINES.md
-# on every feature/general-fix PR targeting main.
+# on every feature/general-fix PR targeting main (and the LTS staging branch).
 #
 # 'edited' is included so re-running after a PR description fix works
 # without a force-push.
+#
+# One job runs all checks, aggregates their findings into a single sticky PR
+# comment (so the author is informed directly), then fails if any hard rule was
+# violated. Check details also appear as inline Checks annotations.
 
 on:
   pull_request:
@@ -15,71 +19,136 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
+
+# Only one run per PR at a time; cancel superseded runs so rapid pushes don't
+# race to create duplicate comments or waste CI minutes.
+concurrency:
+  group: pr-guidelines-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  # ------------------------------------------------------------------
-  # 1. Commit hygiene: linear history, count, subjects, trailers (A2, A3, A7)
-  # ------------------------------------------------------------------
-  commit-hygiene:
-    name: Commit hygiene (subjects, trailers, no merges)
+  guidelines:
+    name: PR & commit guidelines
     runs-on: ubuntu-latest
+    # Only run on ready-for-review PRs from branches in this repo. Fork PRs get
+    # a read-only token, so the sticky-comment step can't post — skip them here.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full history so BASE..HEAD rev-list works, incl. fork PRs
+          # Full history so the BASE..HEAD rev-list range resolves.
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check commits against guidelines
+      - name: Run checks and post PR comment
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: bash .github/scripts/check-commits.sh
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          MARKER="<!-- pr-guidelines-check -->"
+          FAIL=0
+          : > sections.md
 
-  # ------------------------------------------------------------------
-  # 2. PR description: ticket link + test evidence sections (A4)
-  # ------------------------------------------------------------------
-  pr-description:
-    name: PR description (ticket + test evidence)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate PR body
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.pull_request.body || '';
-            const errors = [];
+          # Run a check command, re-emit its output (so ::error::/::warning::
+          # annotations still render), and fold its findings into the comment.
+          run_check() {
+            local title="$1"; shift
+            local out rc
+            out="$("$@" 2>&1)"; rc=$?
+            echo "$out"
 
-            if (!/\b(WIFI|WLAN)-\d+\b/.test(body))
-              errors.push('PR description must reference the ticket (WIFI-##### / WLAN-####).');
+            {
+              echo "### $title"
+              echo ""
+              local lines
+              lines="$(echo "$out" | grep -E '^::(error|warning)::' || true)"
+              if [ -n "$lines" ]; then
+                echo "$lines" | sed -E 's/^::error::/- ❌ /; s/^::warning::/- ⚠️ /'
+              elif [ "$rc" -ne 0 ]; then
+                # Non-zero exit but no annotation — the check crashed rather than
+                # reporting a specific violation. Don't claim "no issues".
+                echo "- ❌ Check failed unexpectedly — see the Actions log for details."
+              else
+                echo "No issues found."
+              fi
+              echo ""
+            } >> sections.md
 
-            if (!/test/i.test(body))
-              errors.push('PR description must include test evidence: what you ran, on which hardware, and the result.');
+            [ "$rc" -ne 0 ] && FAIL=1
+            return 0
+          }
 
-            if (errors.length) {
-              errors.forEach(e => core.error(e));
-              core.setFailed('PR description does not meet OPENWIFI_PR_GUIDELINES.md A4. See errors above.');
-            } else {
-              core.info('PR description OK.');
-            }
+          # ------------------------------------------------------------------
+          # 1. Commit hygiene: linear history, count, subjects, trailers (A2, A3, A7)
+          # ------------------------------------------------------------------
+          run_check "Commit hygiene" bash .github/scripts/check-commits.sh
 
-  # ------------------------------------------------------------------
-  # 3. C style: tabs, SPDX header on new files (coding guidelines §3)
-  #    Runs only on changed .c/.h files, so it never blocks doc PRs.
-  # ------------------------------------------------------------------
-  c-style:
-    name: C style (tabs, SPDX)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          # ------------------------------------------------------------------
+          # 2. C style: tabs, SPDX header on new files (coding guidelines §3)
+          #    Runs only on changed .c/.h files, so it never blocks doc PRs.
+          # ------------------------------------------------------------------
+          run_check "C style" bash .github/scripts/check-c-style.sh
 
-      - name: Check changed C files
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: bash .github/scripts/check-c-style.sh
+          # ------------------------------------------------------------------
+          # 3. PR description: ticket link (A4)
+          #    Test evidence is NOT enforced here — it lives in the Jira ticket
+          #    when a reviewer requests it, not in the PR description.
+          # ------------------------------------------------------------------
+          # Routed through run_check so the ::error:: reaches stdout (inline
+          # annotation) and only the bullet lands in the sticky comment.
+          check_pr_desc() {
+            echo "$PR_BODY" | grep -qE '\b(WIFI|WLAN)-[0-9]+\b' && return 0
+            echo "::error::PR description must reference the ticket (WIFI-##### / WLAN-####)."
+            return 1
+          }
+          run_check "PR description (ticket link)" check_pr_desc
+
+          # ------------------------------------------------------------------
+          # 4. Report: aggregate all findings into one sticky PR comment,
+          #    then fail last so the comment is always posted first.
+          # ------------------------------------------------------------------
+          {
+            echo "$MARKER"
+            if [ "$FAIL" -ne 0 ]; then
+              echo "## ❌ PR & Commit Guidelines — action needed"
+              echo ""
+              echo "This PR doesn't yet follow the OpenWiFi contribution guidelines. Fix the ❌ items below, then re-push (\`git push --force-with-lease\`) or edit the PR description to re-run."
+            else
+              echo "## ✅ PR & Commit Guidelines — all checks passed"
+              echo ""
+              echo "Commits, PR description, and C style all look good. Thanks!"
+            fi
+            echo ""
+            cat sections.md
+            echo "See [OPENWIFI_PR_GUIDELINES.md](OPENWIFI_PR_GUIDELINES.md) and [OPENWIFI_CODING_GUIDELINES.md](OPENWIFI_CODING_GUIDELINES.md). Items marked ⚠️ are advisory and do not fail the check."
+          } > comment.md
+
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Post or update the sticky comment (found via the hidden marker).
+          EXISTING="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -n1 || true)"
+
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" -F body=@comment.md >/dev/null
+            echo "Updated existing comment $EXISTING."
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@comment.md >/dev/null
+            echo "Created new comment."
+          fi
+
+          # Fail the check last, so the comment is always posted first.
+          if [ "$FAIL" -ne 0 ]; then
+            echo "PR/commit guidelines not satisfied. See the PR comment for details."
+            exit 1
+          fi
+          echo "All PR & commit guideline checks passed."


### PR DESCRIPTION
…mment output

The PR-guidelines workflow flagged some cases and missed a couple of rules from the contribution guides. Tighten it up:

- skip draft PRs so work-in-progress isn't nagged until ready
- report "check failed unexpectedly" when a check exits non-zero without emitting an annotation, instead of claiming no issues were found
- truncate overly long commit subjects in messages so a runaway subject line doesn't flood the annotations and PR comment
- make the Fixes: trailer check case-aware, nudging toward the canonical capital-F "Fixes: WIFI-#####" (still advisory)
- warn when a commit has no explanatory body (§2), ignoring blank lines and known trailers so mechanical commits and reverts don't false-warn
- route the PR-description ticket check through run_check so its error reaches stdout as an inline annotation, not only the sticky comment
- skip fork PRs, whose read-only token can't post the sticky comment