### PR TITLE
hostapd: fix MU-EDCA timer values not applying user settings

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/patches/zzzz-001-hostapd-fix-muedca-user-config-check.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/zzzz-001-hostapd-fix-muedca-user-config-check.patch
@@ -1,0 +1,17 @@
+--- a/src/ap/drv_callbacks.c
++++ b/src/ap/drv_callbacks.c
+@@ -1775,6 +1775,14 @@
+	int i;
+	u8 updated_count;
+
++	if (hapd->iface->conf->he_mu_edca.he_mu_ac_be_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_bk_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_vi_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_vo_param[2] != 255) {
++		wpa_printf(MSG_DEBUG, "User-configured MU-EDCA parameters detected, ignoring firmware update");
++		return;
++	}
++
+	/* Update current MU-EDCA parameters */
+	for (i = 0; i < 3; i++) {
+		hapd->iface->conf->he_mu_edca.he_mu_ac_be_param[i] =

--- a/feeds/qca-wifi-7/hostapd/patches/zzz-t04-hostapd-fix-muedca-user-config-check.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzz-t04-hostapd-fix-muedca-user-config-check.patch
@@ -1,0 +1,17 @@
+--- a/src/ap/drv_callbacks.c
++++ b/src/ap/drv_callbacks.c
+@@ -1975,6 +1975,14 @@
+ {
+	int i;
+
++	if (hapd->iface->conf->he_mu_edca.he_mu_ac_be_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_bk_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_vi_param[2] != 255 ||
++		hapd->iface->conf->he_mu_edca.he_mu_ac_vo_param[2] != 255) {
++		wpa_printf(MSG_DEBUG, "User-configured MU-EDCA parameters detected, ignoring firmware update");
++		return;
++	}
++
+	/* Update current MU-EDCA parameters */
+	for (i = 0; i < 3; i++) {
+		hapd->iface->conf->he_mu_edca.he_mu_ac_be_param[i] =


### PR DESCRIPTION
Problem: When users manually modify the following four attributes in /lib/netifd/wireless/mac80211.sh:
- he_mu_edca_ac_be_timer
- he_mu_edca_ac_bk_timer
- he_mu_edca_ac_vi_timer
- he_mu_edca_ac_vo_timer

from the default value 255 to X, the actual MU EDCA Timer field in 802.11 beacon/probe response frames remains 0xff (255) instead of the user‑set value X.

Root cause:
This happens because hostapd unconditionally overwrites these timers with the default value (255) during beacon construction, ignoring any user modifications.

Solution:
Fix this by adding a check in hostapd: if the user‑supplied value is not equal to the default (255), skip the default overwrite and preserve the user configuration.

Tests: Successfully verified on RAP710C-341X and RAP650C

Fixes: WIFI-15466