### PR TITLE
mac80211:circular dependency between feeds/mediatek/mac80211 and ucode

### DIFF
--- a/feeds/mediatek/mac80211/Makefile
+++ b/feeds/mediatek/mac80211/Makefile
@@ -129,7 +129,7 @@ define KernelPackage/mac80211
   $(call KernelPackage/mac80211/Default)
   TITLE:=Linux 802.11 Wireless Networking Stack
   # +kmod-crypto-cmac is a runtime only dependency of net/mac80211/aes_cmac.c
-  DEPENDS+= +kmod-cfg80211 +kmod-crypto-cmac +kmod-crypto-ccm +kmod-crypto-gcm +hostapd-common
+  DEPENDS+= +kmod-cfg80211 +kmod-crypto-cmac +kmod-crypto-ccm +kmod-crypto-gcm
   KCONFIG:=\
 	CONFIG_AVERAGE=y
   FILES:= $(PKG_BUILD_DIR)/net/mac80211/mac80211.ko


### PR DESCRIPTION
The root cause is a circular dependency between feeds/mediatek/mac80211 and ucode: mac80211->hostapd->ucode, while ucode also depends on mac80211. As a result, the build system drops this dependency and chooses to compile ucode first, which leads to a missing nl80211.h.
To fix it, remove the hostapd dependency part from the Makefile in feeds/mediatek/mac80211

Fixes: WIFI-15599