### PR TITLE
 mediatek: mt7981b-emplus-wap588m: set in-band-status on LAN GMAC

### DIFF
--- a/feeds/mediatek/mediatek/dts/mt7981b-emplus-wap588m.dts
+++ b/feeds/mediatek/mediatek/dts/mt7981b-emplus-wap588m.dts
@@ -187,47 +187,41 @@
 	};
 };
 
-&eth {
-        status = "okay";
+&mdio_bus {
+	phy1: ethernet-phy@1 {
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <1>;
+		phy-mode = "sgmii";
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <120000>;
+		reset-deassert-us = <120000>;
+	};
+};
 
-        gmac0: mac@0 {
-                compatible = "mediatek,eth-mac";
-                reg = <0>;
-                phy-mode = "sgmii";
-                phy-handle = <&phy1>;
-        };
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "sgmii";
+		phy-handle = <&phy1>;
+		nvmem-cells = <&macaddr_lan>;
+		nvmem-cell-names = "mac-address";
+		managed = "in-band-status";
+	};
 
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
 		phy-mode = "gmii";
-		phy-handle = <&phy0>;
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_wan>;
+		nvmem-cell-names = "mac-address";
 	};
 
-        mdio: mdio-bus {
-                #address-cells = <1>;
-                #size-cells = <0>;
-
-		// MT7981 internal PHY
-		phy0: ethernet-phy@0 {
-			compatible = "ethernet-phy-id03a2.9461";
-			reg = <0>;
-			phy-mode = "gmii";
-			nvmem-cells = <&phy_calibration>;
-			nvmem-cell-names = "phy-cal-data";
-		};
-
-
-		// RTL8211FS PHY
-		phy1: ethernet-phy@1 {
-			compatible = "ethernet-phy-id001c.c916";
-			reg = <1>;
-			reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-			reset-assert-us = <120000>;
-			reset-deassert-us = <120000>;
-			phy-mode = "sgmii";
-		};
-    };
 };
 
 &wifi {


### PR DESCRIPTION
 The LAN port (gmac0, SGMII via phy1) had no managed link mode, so
 phylink never took link state from the SGMII PCS and the port could
 not transmit. Set managed = "in-band-status" so link/speed/duplex come
 from SGMII in-band signalling, bringing the LAN port up.

 Tested on WAP588M: LAN links up and passes traffic.

 Fixes: WIFI-15572