### PR TITLE
.github/workflows: add per-ref concurrency to cancel superseded builds

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -13,6 +13,12 @@ on:
     branches: [ main, next, staging-* ]
     tags: [ v* ]
 
+# Only one run per ref at a time; cancel superseded runs so rapid pushes to the
+# same branch don't stack up parallel full-matrix builds and waste CI minutes.
+concurrency:
+  group: build-dev-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   set-matrix:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pushes to build-dev.yml had no concurrency control, so every push spawned a fresh full-matrix build and rapid successive pushes to the same branch stacked up in parallel instead of superseding each other, wasting CI minutes.

Add a concurrency group keyed on github.ref with cancel-in-progress, mirroring the pattern already used in pr-guidelines.yml. Grouping per ref keeps branches independent (a push to next won't cancel a main build); only a newer push to the same ref cancels its in-flight run.