### PR TITLE
mediatek: mt7981b-emplus-wap588m: exchange lan port and wan port

### DIFF
--- a/feeds/mediatek/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/feeds/mediatek/mediatek/filogic/base-files/etc/board.d/02_network
@@ -139,7 +139,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" wan
 		;;
 	emplus,wap588m)
-		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;		
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan

--- a/feeds/mediatek/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev
+++ b/feeds/mediatek/mediatek/filogic/base-files/lib/preinit/06_set_emplus_netdev
@@ -1,0 +1,11 @@
+emplus_swap_ethdev() {
+	case "$(cat /tmp/sysinfo/board_name)" in
+	emplus,wap588m)
+		ip link set eth0 name lan
+		ip link set eth1 name eth0
+		ip link set lan name eth1
+		;;
+	esac
+}
+
+boot_hook_add preinit_main emplus_swap_ethdev

--- a/feeds/mediatek/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/feeds/mediatek/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -32,6 +32,19 @@ preinit_set_mac_address() {
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		;;
+	emplus,wap588m)
+		lan_mac_offset="0x2A"
+		wan_mac_offset="0x24"
+		part_name="Factory"
+		lan_mac=$(mtd_get_mac_binary $part_name $lan_mac_offset)
+		wan_mac=$(mtd_get_mac_binary $part_name $wan_mac_offset)
+		ip link set eth0 down
+		ip link set eth1 down
+		ip link set dev eth0 address "$wan_mac"
+		ip link set dev eth1 address "$lan_mac"
+		ip link set eth0 up
+		ip link set eth1 up
+		;;
 	*)
 		;;
 	esac


### PR DESCRIPTION
Per the customer requirement, LAN port need to be eth1 , WAN port need to be eth0

Tested on WAP588M: eth0 and eth1 have been inter-exchanged

Fixes: WIFI-15573