### PR TITLE
.github/scripts: fix branch-name check to require staging- prefix

### DIFF
--- a/.github/scripts/check-commits.sh
+++ b/.github/scripts/check-commits.sh
@@ -10,7 +10,7 @@
 # WARNINGS (annotate, don't fail — "typically"/"where applicable" rules):
 #   - more than 3 commits                     (A1: "typically 1-3")
 #   - missing Fixes: WIFI-#### trailer        (§2: "where applicable")
-#   - branch name not WIFI-<num>-<desc>       (A1; fork branches vary)
+#   - branch name not staging-WIFI-<num>-<desc> (A1; fork branches vary)
 #   - subject line longer than 72 chars
 #   - no explanatory body                     (§2; mechanical commits may skip)
 
@@ -58,10 +58,10 @@ elif [ "$count" -gt 3 ]; then
 fi
 
 # ---------------------------------------------------------------
-# 3. Branch naming — WIFI-<number>-<short-kebab-description>
+# 3. Branch naming — staging-WIFI-<number>-<short-hyphenated-description>
 # ---------------------------------------------------------------
-if [ -n "$HEAD_REF" ] && ! echo "$HEAD_REF" | grep -qE '^(WIFI|WLAN)-[0-9]+-[a-zA-Z0-9-]+$'; then
-  warn "Branch '$HEAD_REF' does not match WIFI-<number>-<short-kebab-description> (guidelines A1)."
+if [ -n "$HEAD_REF" ] && ! echo "$HEAD_REF" | grep -qE '^staging-(WIFI|WLAN)-[0-9]+-[a-zA-Z0-9.-]+$'; then
+  warn "Branch '$HEAD_REF' does not match staging-WIFI-<number>-<short-hyphenated-description> (guidelines A1)."
 fi
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
The commit checker's branch-name rule matched WIFI-<num>-<desc> but OPENWIFI_PR_GUIDELINES.md (A1) requires all PR branches to carry the staging- prefix, so valid branches like staging-WIFI-15609-update-eap105-led were flagged. The pattern also rejected dots, tripping release-backport branches such as staging-WIFI-15388-pmf-value-fix-for-4.2.3.

Anchor the regex on staging-(WIFI|WLAN)-<number>- and allow dots in the description, and update the warning text and comments to match.