### PR TITLE
certificates: fix certificate partition unmounted on first install

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -160,9 +160,11 @@ MTD=$(find_mtd_index $PART_NAME)
 [ -z "$MTD" ] && return 1
 
 ubiattach -m $MTD -d 3
-[ -e /dev/ubi3 ] && mount -t ubifs ubi3:certificates /certificates
-
-check_certificates || {
-	umount /certificates
-	check_certificates
-}
+if [ -e /dev/ubi3 ] ; then
+	if mount -t ubifs ubi3:certificates /certificates; then
+		check_certificates || {
+			umount /certificates
+			check_certificates
+		}
+	fi
+fi


### PR DESCRIPTION
Problem:
certificate partition is umounted when installing the certificates for the first time on EAP104 and EAP105.

Root Cause:
In the initial state, the primary partition has already created a volume named certificates, while the backup partition has not yet created such a volume (since the backup partition has never been booted, the /lib/preinit/75_certificates script has not been executed to create the certificates volume). If an attempt is made to mount the certificates volume from the backup partition, the mount operation will fail.Because the certificate files cannot be found, the script executes umount /certificates. In effect, this unmounts the /certificates mount point from the primary partition.

Solution:
Only execute check_certificates and umount /certificates after the mount of the backup partition's certificates volume has succeeded. This prevents the script from executing umount /certificates when the mount from the backup partition fails, which would otherwise unmount the /certificates mount point from the primary partition.

Tests: Successfully verified on RAP750W-311A

Fixes: WIFI-15363