### PR TITLE
mediatek: hostapd: wifi-scripts: Ported hostapd patches and wifi-scripts from v4.2.x LTS

### DIFF
--- a/feeds/mediatek/hostapd/patches/0264-owf-hostapd-add-uci_section-bss-config-option.patch
+++ b/feeds/mediatek/hostapd/patches/0264-owf-hostapd-add-uci_section-bss-config-option.patch
@@ -1,0 +1,31 @@
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -2467,6 +2467,8 @@ static int hostapd_config_fill(struct ho
+ 			return 1;
+ 		}
+ 		conf->driver = driver;
++	} else if (os_strcmp(buf, "uci_section") == 0) {
++		bss->uci_section = os_strdup(pos);
+ 	} else if (os_strcmp(buf, "driver_params") == 0) {
+ 		os_free(conf->driver_params);
+ 		conf->driver_params = os_strdup(pos);
+--- a/src/ap/ap_config.c
++++ b/src/ap/ap_config.c
+@@ -891,6 +891,7 @@ void hostapd_config_free_bss(struct host
+ 	os_free(conf->radius_req_attr_sqlite);
+ 	os_free(conf->rsn_preauth_interfaces);
+ 	os_free(conf->ctrl_interface);
++	os_free(conf->uci_section);
+ 	os_free(conf->config_id);
+ 	os_free(conf->ca_cert);
+ 	os_free(conf->server_cert);
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -289,6 +289,7 @@ struct hostapd_bss_config {
+ 	char snoop_iface[IFNAMSIZ + 1];
+ 	char vlan_bridge[IFNAMSIZ + 1];
+ 	char wds_bridge[IFNAMSIZ + 1];
++	char *uci_section;
+ 	int bridge_hairpin; /* hairpin_mode on bridge members */
+ 
+ 	enum hostapd_logger_level logger_syslog_level, logger_stdout_level;

--- a/feeds/mediatek/hostapd/patches/0265-owf-hostapd-add-dynamic_probe_resp-config-option.patch
+++ b/feeds/mediatek/hostapd/patches/0265-owf-hostapd-add-dynamic_probe_resp-config-option.patch
@@ -1,0 +1,43 @@
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -3621,6 +3621,8 @@ static int hostapd_config_fill(struct ho
+ 		bss->ignore_broadcast_ssid = atoi(pos);
+ 	} else if (os_strcmp(buf, "no_probe_resp_if_max_sta") == 0) {
+ 		bss->no_probe_resp_if_max_sta = atoi(pos);
++	} else if (os_strcmp(buf, "dynamic_probe_resp") == 0) {
++		bss->dynamic_probe_resp = atoi(pos);
+ #ifdef CONFIG_WEP
+ 	} else if (os_strcmp(buf, "wep_default_key") == 0) {
+ 		bss->ssid.wep.idx = atoi(pos);
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -492,6 +492,7 @@ struct hostapd_bss_config {
+ 	bool no_disconnect_on_group_keyerror;
+ 	int ignore_broadcast_ssid;
+ 	int no_probe_resp_if_max_sta;
++	int dynamic_probe_resp;
+ 
+ 	int wmm_enabled;
+ 	int wmm_uapsd;
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -1601,7 +1601,8 @@ void handle_probe_req(struct hostapd_dat
+ 	}
+ #endif /* CONFIG_P2P */
+ 
+-	if (hapd->conf->ignore_broadcast_ssid && elems.ssid_len == 0 &&
++	if (!hapd->conf->dynamic_probe_resp &&
++	    hapd->conf->ignore_broadcast_ssid && elems.ssid_len == 0 &&
+ 	    elems.ssid_list_len == 0 && elems.short_ssid_list_len == 0) {
+ 		wpa_printf(MSG_MSGDUMP, "Probe Request from " MACSTR " for "
+ 			   "broadcast SSID ignored", MAC2STR(mgmt->sa));
+@@ -1669,7 +1670,8 @@ void handle_probe_req(struct hostapd_dat
+ 		return;
+ 	}
+ 
+-	if (hapd->conf->ignore_broadcast_ssid && res == WILDCARD_SSID_MATCH) {
++	if (!hapd->conf->dynamic_probe_resp &&
++	    hapd->conf->ignore_broadcast_ssid && res == WILDCARD_SSID_MATCH) {
+ 		wpa_printf(MSG_MSGDUMP, "Probe Request from " MACSTR " for "
+ 			   "broadcast SSID ignored", MAC2STR(mgmt->sa));
+ 		return;

--- a/feeds/mediatek/hostapd/patches/0266-owf-hostapd-fix-ap-sta-channel-setup-failed.patch
+++ b/feeds/mediatek/hostapd/patches/0266-owf-hostapd-fix-ap-sta-channel-setup-failed.patch
@@ -1,0 +1,27 @@
+--- a/src/common/hw_features_common.c
++++ b/src/common/hw_features_common.c
+@@ -756,9 +756,21 @@ int hostapd_set_freq_params(struct hosta
+ 			    center_segment0 == channel - 6)
+ 				data->center_freq1 = 5000 + center_segment0 * 5;
+ 			else {
+-				wpa_printf(MSG_ERROR,
+-					   "Wrong coupling between HT and VHT/HE channel setting");
+-				return -1;
++				if (channel <= 48)
++					center_segment0 = 42;
++				else if (channel <= 64)
++					center_segment0 = 58;
++				else if (channel <= 112)
++					center_segment0 = 106;
++				else if (channel <= 128)
++					center_segment0 = 122;
++				else if (channel <= 144)
++					center_segment0 = 138;
++				else if (channel <= 161)
++					center_segment0 = 155;
++				else if (channel <= 177)
++					center_segment0 = 171;
++				data->center_freq1 = 5000 + center_segment0 * 5;
+ 			}
+ 		}
+ 		break;

--- a/feeds/mediatek/hostapd/patches/0267-owf-hostapd-RADIUS-DAS-CoA-and-Proxy-State-suppo.patch
+++ b/feeds/mediatek/hostapd/patches/0267-owf-hostapd-RADIUS-DAS-CoA-and-Proxy-State-suppo.patch
@@ -1,0 +1,93 @@
+--- a/src/radius/radius_das.h
++++ b/src/radius/radius_das.h
+@@ -37,6 +37,8 @@ struct radius_das_attrs {
+ 	const u8 *cui;
+ 	size_t cui_len;
+ 
++	const u8 *proxy;
++	size_t proxy_len;
+ 	/* Authorization changes */
+ 	const u8 *hs20_t_c_filtering;
+ };
+--- a/src/radius/radius_das.c
++++ b/src/radius/radius_das.c
+@@ -61,6 +61,9 @@ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ 		RADIUS_ATTR_EVENT_TIMESTAMP,
+ 		RADIUS_ATTR_MESSAGE_AUTHENTICATOR,
+ 		RADIUS_ATTR_CHARGEABLE_USER_IDENTITY,
++		RADIUS_ATTR_VENDOR_SPECIFIC,
++		RADIUS_ATTR_CALLED_STATION_ID,
++		RADIUS_ATTR_PROXY_STATE,
+ #ifdef CONFIG_IPV6
+ 		RADIUS_ATTR_NAS_IPV6_ADDRESS,
+ #endif /* CONFIG_IPV6 */
+@@ -157,6 +160,12 @@ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ 		attrs.cui_len = len;
+ 	}
+ 
++	if (radius_msg_get_attr_ptr(msg, RADIUS_ATTR_PROXY_STATE,
++				    &buf, &len, NULL) == 0) {
++		attrs.proxy = buf;
++		attrs.proxy_len = len;
++	}
++
+ 	res = das->disconnect(das->ctx, &attrs);
+ 	switch (res) {
+ 	case RADIUS_DAS_NAS_MISMATCH:
+@@ -165,10 +174,7 @@ static struct radius_msg * radius_das_disconnect(struct radius_das_data *das,
+ 		error = 403;
+ 		break;
+ 	case RADIUS_DAS_SESSION_NOT_FOUND:
+-		wpa_printf(MSG_INFO, "DAS: Session not found for request from "
+-			   "%s:%d", abuf, from_port);
+-		error = 503;
+-		break;
++		return NULL;
+ 	case RADIUS_DAS_MULTI_SESSION_MATCH:
+ 		wpa_printf(MSG_INFO,
+ 			   "DAS: Multiple sessions match for request from %s:%d",
+@@ -195,6 +201,9 @@ fail:
+ 		return NULL;
+ 	}
+ 
++	if (attrs.proxy)
++		radius_msg_add_attr(reply, RADIUS_ATTR_PROXY_STATE, attrs.proxy, attrs.proxy_len);
++
+ 	if (error) {
+ 		if (!radius_msg_add_attr_int32(reply, RADIUS_ATTR_ERROR_CAUSE,
+ 					       error)) {
+@@ -223,9 +232,9 @@ static struct radius_msg * radius_das_coa(struct radius_das_data *das,
+ 		RADIUS_ATTR_EVENT_TIMESTAMP,
+ 		RADIUS_ATTR_MESSAGE_AUTHENTICATOR,
+ 		RADIUS_ATTR_CHARGEABLE_USER_IDENTITY,
+-#ifdef CONFIG_HS20
+ 		RADIUS_ATTR_VENDOR_SPECIFIC,
+-#endif /* CONFIG_HS20 */
++		RADIUS_ATTR_CALLED_STATION_ID,
++		RADIUS_ATTR_PROXY_STATE,
+ #ifdef CONFIG_IPV6
+ 		RADIUS_ATTR_NAS_IPV6_ADDRESS,
+ #endif /* CONFIG_IPV6 */
+@@ -351,6 +360,12 @@ static struct radius_msg * radius_das_coa(struct radius_das_data *das,
+ 	}
+ #endif /* CONFIG_HS20 */
+ 
++	if (radius_msg_get_attr_ptr(msg, RADIUS_ATTR_PROXY_STATE,
++				    &buf, &len, NULL) == 0) {
++		attrs.proxy = buf;
++		attrs.proxy_len = len;
++	}
++
+ 	res = das->coa(das->ctx, &attrs);
+ 	switch (res) {
+ 	case RADIUS_DAS_NAS_MISMATCH:
+@@ -391,6 +406,9 @@ fail:
+ 		return NULL;
+ 	}
+ 
++	if (attrs.proxy)
++		radius_msg_add_attr(reply, RADIUS_ATTR_PROXY_STATE, attrs.proxy, attrs.proxy_len);
++
+ 	if (error &&
+ 	    !radius_msg_add_attr_int32(reply, RADIUS_ATTR_ERROR_CAUSE, error)) {
+ 		radius_msg_free(reply);

--- a/feeds/mediatek/hostapd/patches/0268-owf-hostapd-add-ft_l2_refresh-support.patch
+++ b/feeds/mediatek/hostapd/patches/0268-owf-hostapd-add-ft_l2_refresh-support.patch
@@ -1,0 +1,69 @@
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -3336,6 +3336,8 @@ static int hostapd_config_fill(struct ho
+ 		bss->ft_over_ds = atoi(pos);
+ 	} else if (os_strcmp(buf, "ft_psk_generate_local") == 0) {
+ 		bss->ft_psk_generate_local = atoi(pos);
++	} else if (os_strcmp(buf, "ft_l2_refresh") == 0) {
++		bss->ft_l2_refresh = atoi(pos);
+ #endif /* CONFIG_IEEE80211R_AP */
+ #ifndef CONFIG_NO_CTRL_IFACE
+ 	} else if (os_strcmp(buf, "ctrl_interface") == 0) {
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -426,6 +426,7 @@ struct hostapd_bss_config {
+ 	int pmk_r1_push;
+ 	int ft_over_ds;
+ 	int ft_psk_generate_local;
++	int ft_l2_refresh;
+ 	int r1_max_key_lifetime;
+ 	char *rxkh_file;
+ #endif /* CONFIG_IEEE80211R_AP */
+--- a/src/ap/wpa_auth_glue.c
++++ b/src/ap/wpa_auth_glue.c
+@@ -1866,6 +1866,27 @@ static int hostapd_wpa_auth_remove_pmkid
+ 	return hostapd_remove_pmkid(hapd, sta_addr, pmkid);
+ }
+ 
++static void wpa_ft_refresh(void *eloop_data, void *user_data)
++{
++	struct hostapd_data *hapd = eloop_data;
++	struct ft_rrb_frame *frame;
++	struct l2_ethhdr *buf;
++	size_t len;
++
++	len = sizeof(*buf) + sizeof(*frame);
++	buf = os_zalloc(len);
++	frame = (struct ft_rrb_frame *)(buf + 1);
++	frame->frame_type = RSN_REMOTE_FRAME_TYPE_FT_RRB;
++	frame->packet_type = FT_PACKET_REQUEST;
++	memset(buf->h_dest, 0xff, ETH_ALEN);
++	os_memcpy(buf->h_source, hapd->own_addr, ETH_ALEN);
++	buf->h_proto = host_to_be16(ETH_P_RRB);
++	l2_packet_send(hapd->l2, buf->h_dest, ETH_P_RRB, (u8 *) buf, len);
++	os_free(buf);
++
++	eloop_register_timeout(hapd->conf->ft_l2_refresh, 0, wpa_ft_refresh,
++			       hapd, NULL);
++}
+ 
+ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ {
+@@ -1987,6 +2008,9 @@ int hostapd_setup_wpa(struct hostapd_dat
+ 				   "Failed to open ETH_P_OUI interface");
+ 			return -1;
+ 		}
++
++		if (hapd->conf->ft_l2_refresh)
++			wpa_ft_refresh(hapd, NULL);
+ 	}
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+@@ -2037,6 +2061,7 @@ void hostapd_deinit_wpa(struct hostapd_d
+ 	hostapd_wpa_ft_rrb_rx_later(hapd, NULL); /* flush without delivering */
+ 	eloop_cancel_timeout(hostapd_oui_deliver_later, hapd, ELOOP_ALL_CTX);
+ 	hostapd_oui_deliver_later(hapd, NULL); /* flush without delivering */
++	eloop_cancel_timeout(wpa_ft_refresh, hapd, ELOOP_ALL_CTX);
+ 	l2_packet_deinit(hapd->l2);
+ 	hapd->l2 = NULL;
+ 	hostapd_wpa_unregister_ft_oui(hapd);

--- a/feeds/mediatek/hostapd/patches/0269-owf-hostapd-support-dynamic-VLAN-on-wired-driver.patch
+++ b/feeds/mediatek/hostapd/patches/0269-owf-hostapd-support-dynamic-VLAN-on-wired-driver.patch
@@ -1,0 +1,27 @@
+--- a/src/ap/vlan_init.c
++++ b/src/ap/vlan_init.c
+@@ -23,7 +23,8 @@ static int vlan_if_add(struct hostapd_da
+ 		       int existsok)
+ {
+ 	bool vlan_exists = iface_exists(vlan->ifname);
+-	int ret;
++	int ret = 0;
++
+ #ifdef CONFIG_WEP
+ 	int i;
+ 
+@@ -37,7 +38,13 @@ static int vlan_if_add(struct hostapd_da
+ 	}
+ #endif /* CONFIG_WEP */
+ 
+-	if (!vlan_exists)
++	if (!hapd->driver || !hapd->driver->if_add) {
++		char *dot = strrchr(vlan->ifname, '.');
++		if (dot)
++			*dot = '\0';
++		ret = 0;
++	}
++	else if (!vlan_exists)
+ 		ret = hostapd_vlan_if_add(hapd, vlan->ifname);
+ 	else if (!existsok)
+ 		return -1;

--- a/feeds/mediatek/hostapd/patches/0270-owf-hostapd-notify-ubus-on-rssi-ignored-probe.patch
+++ b/feeds/mediatek/hostapd/patches/0270-owf-hostapd-notify-ubus-on-rssi-ignored-probe.patch
@@ -1,0 +1,59 @@
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -1510,8 +1510,10 @@ void handle_probe_req(struct hostapd_dat
+ 	};
+ 
+ 	if (hapd->iconf->rssi_ignore_probe_request && ssi_signal &&
+-	    ssi_signal < hapd->iconf->rssi_ignore_probe_request)
++	    ssi_signal < hapd->iconf->rssi_ignore_probe_request) {
++		hostapd_ubus_notify_rssi(hapd, "rssi-ignore-probe", mgmt->sa, ssi_signal);
+ 		return;
++	}
+ 
+ 	if (len < IEEE80211_HDRLEN)
+ 		return;
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -1951,6 +1951,23 @@ void hostapd_ubus_notify(struct hostapd_
+ 	ubus_notify(ctx, &hapd->ubus.obj, type, b.head, -1);
+ }
+ 
++void hostapd_ubus_notify_rssi(struct hostapd_data *hapd, const char *type,
++			      const u8 *addr, int rssi)
++{
++	if (!hapd->ubus.obj.has_subscribers)
++		return;
++
++	if (!addr)
++		return;
++
++	blob_buf_init(&b, 0);
++	blobmsg_add_macaddr(&b, "address", addr);
++	blobmsg_add_string(&b, "ifname", hapd->conf->iface);
++	blobmsg_add_u32(&b, "rssi", rssi);
++
++	ubus_notify(ctx, &hapd->ubus.obj, type, b.head, -1);
++}
++
+ void hostapd_ubus_notify_authorized(struct hostapd_data *hapd, struct sta_info *sta,
+ 				    const char *auth_alg)
+ {
+--- a/src/ap/ubus.h
++++ b/src/ap/ubus.h
+@@ -52,4 +52,5 @@ void hostapd_ubus_notify(struct hostapd_
+ void hostapd_ubus_notify(struct hostapd_data *hapd, const char *type, const u8 *mac);
++void hostapd_ubus_notify_rssi(struct hostapd_data *hapd, const char *type, const u8 *addr, int rssi);
+ void hostapd_ubus_notify_beacon_report(struct hostapd_data *hapd,
+ 				       const u8 *addr, u8 token, u8 rep_mode,
+ 				       struct rrm_measurement_beacon_report *rep,
+@@ -116,6 +117,10 @@ static inline void hostapd_ubus_notify(s
+ {
+ }
+ 
++static inline void hostapd_ubus_notify_rssi(struct hostapd_data *hapd, const char *type, const u8 *addr, int rssi)
++{
++}
++
+ static inline void hostapd_ubus_notify_beacon_report(struct hostapd_data *hapd,
+ 						     const u8 *addr, u8 token,
+ 						     u8 rep_mode,

--- a/feeds/mediatek/hostapd/patches/0271-owf-hostapd-allow-CoA-Disconnect-approval-via-ub.patch
+++ b/feeds/mediatek/hostapd/patches/0271-owf-hostapd-allow-CoA-Disconnect-approval-via-ub.patch
@@ -1,0 +1,35 @@
+--- a/src/ap/ubus.h
++++ b/src/ap/ubus.h
+@@ -12,6 +12,7 @@ enum hostapd_ubus_event_type {
+ 	HOSTAPD_UBUS_PROBE_REQ,
+ 	HOSTAPD_UBUS_AUTH_REQ,
+ 	HOSTAPD_UBUS_ASSOC_REQ,
++	HOSTAPD_UBUS_COA,
+ 	HOSTAPD_UBUS_TYPE_MAX
+ };
+ 
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -1344,6 +1344,22 @@ hostapd_das_disconnect(void *ctx, struct
+ 	struct hostapd_data *hapd = ctx;
+ 	struct sta_info *sta;
+ 	int multi;
++	struct hostapd_ubus_request req = {
++		.type = HOSTAPD_UBUS_COA,
++		.mgmt_frame = 0,
++		.ssi_signal = 0,
++		.addr = attr->sta_addr,
++	};
++
++	if (hostapd_ubus_handle_event(hapd, &req)) {
++		wpa_printf(MSG_INFO, "DAS: disconnect approved via ubus");
++		sta = ap_get_sta(hapd, attr->sta_addr);
++		if (sta) {
++			hostapd_drv_sta_deauth(hapd, attr->sta_addr, 2);
++			ap_sta_deauthenticate(hapd, sta, 2);
++		}
++		return RADIUS_DAS_SUCCESS;
++	}
+ 
+ 	if (hostapd_das_nas_mismatch(hapd, attr))
+ 		return RADIUS_DAS_NAS_MISMATCH;

--- a/feeds/mediatek/hostapd/patches/0272-owf-hostapd-track-EWMA-management-frame-signal.patch
+++ b/feeds/mediatek/hostapd/patches/0272-owf-hostapd-track-EWMA-management-frame-signal.patch
@@ -1,0 +1,70 @@
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -7107,9 +7107,20 @@ static int robust_action_frame(u8 category)
+ }
+ 
+ 
++static int
++ewma(int new, int old)
++{
++	#define ALPHA	10
++	if (!old)
++		return new;
++	if (new >= 0)
++		return old;
++	return ((ALPHA * new) + ((100 - ALPHA) * old)) / 100;
++}
++
+ static int handle_action(struct hostapd_data *hapd,
+ 			 const struct ieee80211_mgmt *mgmt, size_t len,
+-			 unsigned int freq)
++			 unsigned int freq, int ssi_signal)
+ {
+ 	struct sta_info *sta;
+ 	u8 *action __maybe_unused;
+@@ -7166,6 +7177,7 @@ static int handle_action(struct hostapd_data *hapd,
+ 
+ 		sta->last_seq_ctrl = seq_ctrl;
+ 		sta->last_subtype = WLAN_FC_STYPE_ACTION;
++		sta->signal_mgmt = ewma(ssi_signal, sta->signal_mgmt);
+ 	}
+ 
+ 	switch (mgmt->u.action.category) {
+@@ -7352,6 +7364,8 @@ int ieee802_11_mgmt(struct hostapd_data *hapd, const u8 *buf, size_t len,
+ 	int ret = 0;
+ 	unsigned int freq;
+ 	int ssi_signal = fi ? fi->ssi_signal : 0;
++
++	hapd->signal_mgmt = ewma(ssi_signal, hapd->signal_mgmt);
+ #ifdef CONFIG_NAN_USD
+ 	static const u8 nan_network_id[ETH_ALEN] =
+ 		{ 0x51, 0x6f, 0x9a, 0x01, 0x00, 0x00 };
+@@ -7493,7 +7507,7 @@ int ieee802_11_mgmt(struct hostapd_data *hapd, const u8 *buf, size_t len,
+ 		break;
+ 	case WLAN_FC_STYPE_ACTION:
+ 		wpa_printf(MSG_DEBUG, "mgmt::action");
+-		ret = handle_action(hapd, mgmt, len, freq);
++		ret = handle_action(hapd, mgmt, len, freq, ssi_signal);
+ 		break;
+ 	default:
+ 		hostapd_logger(hapd, mgmt->sa, HOSTAPD_MODULE_IEEE80211,
+--- a/src/ap/sta_info.h
++++ b/src/ap/sta_info.h
+@@ -327,6 +327,7 @@ struct sta_info {
+ #ifdef CONFIG_PASN
+ 	struct pasn_data *pasn;
+ #endif /* CONFIG_PASN */
++	int signal_mgmt;
+ 
+ #ifdef CONFIG_IEEE80211BE
+ 	struct mld_info mld_info;
+--- a/src/ap/hostapd.h
++++ b/src/ap/hostapd.h
+@@ -549,6 +549,7 @@ struct hostapd_data {
+ #ifdef CONFIG_CTRL_IFACE_UDP
+        unsigned char ctrl_iface_cookie[CTRL_IFACE_COOKIE_LEN];
+ #endif /* CONFIG_CTRL_IFACE_UDP */
++       int signal_mgmt;
+ 
+ #ifdef CONFIG_IEEE80211BE
+ 	u8 eht_mld_bss_param_change;

--- a/feeds/mediatek/hostapd/patches/0273-owf-hostapd-reuse-FT-ANonce-during-roaming.patch
+++ b/feeds/mediatek/hostapd/patches/0273-owf-hostapd-reuse-FT-ANonce-during-roaming.patch
@@ -1,0 +1,43 @@
+--- a/src/ap/wpa_auth_ft.c
++++ b/src/ap/wpa_auth_ft.c
+@@ -3421,6 +3421,7 @@ static int wpa_ft_process_auth_req(struct wpa_state_machine *sm,
+ 	size_t identity_len = 0, radius_cui_len = 0;
+ 	size_t pmk_r1_len, kdk_len, len;
+ 	int retval = WLAN_STATUS_UNSPECIFIED_FAILURE;
++	struct os_reltime now;
+ 
+ 	*resp_ies = NULL;
+ 	*resp_ies_len = 0;
+@@ -3557,10 +3558,18 @@ pmk_r1_derived:
+ 	os_memcpy(sm->pmk_r1, pmk_r1, pmk_r1_len);
+ 	sm->pmk_r1_len = pmk_r1_len;
+ 
+-	if (random_get_bytes(sm->ANonce, WPA_NONCE_LEN)) {
+-		wpa_printf(MSG_DEBUG, "FT: Failed to get random data for "
+-			   "ANonce");
+-		goto out;
++	if (os_get_reltime(&now) < 0 ||
++	    os_reltime_expired(&now, &sm->ANonce_time, 1)) {
++		if (random_get_bytes(sm->ANonce, WPA_NONCE_LEN)) {
++			wpa_printf(MSG_DEBUG, "FT: Failed to get random data for "
++				   "ANonce");
++			goto out;
++		}
++		sm->ANonce_time.sec = now.sec;
++		sm->ANonce_time.usec = now.usec;
++		wpa_printf(MSG_INFO, "FT: ANonce was randomized");
++	} else {
++		wpa_printf(MSG_INFO, "FT: ANonce has not expired");
+ 	}
+ 
+ 	/* Now that we know the correct PMK-R1 length and as such, the length
+--- a/src/ap/wpa_auth_i.h
++++ b/src/ap/wpa_auth_i.h
+@@ -54,6 +54,7 @@ struct wpa_state_machine {
+ 	bool MICVerified;
+ 	bool GUpdateStationKeys;
+ 	u8 ANonce[WPA_NONCE_LEN];
++	struct os_reltime ANonce_time;
+ 	u8 SNonce[WPA_NONCE_LEN];
+ 	u8 alt_SNonce[WPA_NONCE_LEN];
+ 	u8 alt_replay_counter[WPA_REPLAY_COUNTER_LEN];

--- a/feeds/mediatek/hostapd/patches/0274-owf-hostapd-report-roaming-origin-target-over-ubus.patch
+++ b/feeds/mediatek/hostapd/patches/0274-owf-hostapd-report-roaming-origin-target-over-ubus.patch
@@ -1,0 +1,50 @@
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -519,6 +519,7 @@ static void handle_auth_ft_finish(void *ctx, const u8 *dst,
+ 
+ 	hostapd_logger(hapd, dst, HOSTAPD_MODULE_IEEE80211,
+ 		       HOSTAPD_LEVEL_DEBUG, "authentication OK (FT)");
++	hostapd_ubus_notify(hapd, "ft-finish", sta->addr);
+ 	sta->flags |= WLAN_STA_AUTH;
+ 	mlme_authenticate_indication(hapd, sta);
+ }
+@@ -6311,6 +6312,9 @@ static void handle_assoc(struct hostapd_data *hapd,
+ 	}
+ 
+ 	sta = ap_get_sta(hapd, mgmt->sa);
++	if (sta && reassoc)
++		os_memcpy(sta->origin_ap, mgmt->u.reassoc_req.current_ap,
++			  ETH_ALEN);
+ 
+ #ifdef CONFIG_IEEE80211BE
+ 	/*
+--- a/src/ap/sta_info.h
++++ b/src/ap/sta_info.h
+@@ -93,6 +93,7 @@ struct sta_info {
+ 	struct sta_info *next; /* next entry in sta list */
+ 	struct sta_info *hnext; /* next entry in hash table list */
+ 	u8 addr[6];
++	u8 origin_ap[6];
+ 	u8 setup_link_addr[6];
+ 	be32 ipaddr;
+ 	struct dl_list ip6addr; /* list head for struct ip6addr */
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -1947,6 +1947,7 @@ void hostapd_ubus_notify(struct hostapd_data *hapd, const char *type, const u8 *
+ 	blob_buf_init(&b, 0);
+ 	blobmsg_add_macaddr(&b, "address", addr);
+ 	blobmsg_add_string(&b, "ifname", hapd->conf->iface);
++	blobmsg_add_macaddr(&b, "target", hapd->conf->bssid);
+ 
+ 	ubus_notify(ctx, &hapd->ubus.obj, type, b.head, -1);
+ }
+@@ -1988,6 +1989,9 @@ void hostapd_ubus_notify_authorized(struct hostapd_data *hapd, struct sta_info *
+ 		blobmsg_add_u32(&b, "", sta->bandwidth[1]);
+ 		blobmsg_close_array(&b, r);
+ 	}
++	if (!is_zero_ether_addr(sta->origin_ap))
++		blobmsg_add_macaddr(&b, "origin", sta->origin_ap);
++	blobmsg_add_macaddr(&b, "target", hapd->conf->bssid);
+ 
+ 	ubus_notify(ctx, &hapd->ubus.obj, "sta-authorized", b.head, -1);
+ }

--- a/feeds/mediatek/hostapd/patches/0275-owf-hostapd-carry-WISPr-rate-limit-across-FT-roaming.patch
+++ b/feeds/mediatek/hostapd/patches/0275-owf-hostapd-carry-WISPr-rate-limit-across-FT-roaming.patch
@@ -1,0 +1,538 @@
+--- a/src/ap/wpa_auth.h
++++ b/src/ap/wpa_auth.h
+@@ -16,6 +16,10 @@
+ 
+ struct vlan_description;
+ struct mld_info;
++struct rate_description {
++	u32 rx;
++	u32 tx;
++};
+ 
+ #define MAX_OWN_IE_OVERRIDE 257
+ 
+@@ -93,6 +97,7 @@ struct ft_rrb_frame {
+ 
+ #define FT_RRB_NOTIFIER_R1KH_ID	18 /* FT_R1KH_ID_LEN */
+ #define FT_RRB_STA_ADDR 	19 /* ETH_ALEN */
++#define FT_RRB_RATE_LIMIT	20 /* 2 * le32 */
+ 
+ struct ft_rrb_tlv {
+ 	le16 type;
+@@ -424,6 +429,10 @@ struct wpa_auth_callbacks {
+ 			struct vlan_description *vlan);
+ 	int (*get_vlan)(void *ctx, const u8 *sta_addr,
+ 			struct vlan_description *vlan);
++	int (*set_rate_limit)(void *ctx, const u8 *sta_addr,
++			      struct rate_description *rate);
++	int (*get_rate_limit)(void *ctx, const u8 *sta_addr,
++			      struct rate_description *rate);
+ 	int (*set_identity)(void *ctx, const u8 *sta_addr,
+ 			    const u8 *identity, size_t identity_len);
+ 	size_t (*get_identity)(void *ctx, const u8 *sta_addr, const u8 **buf);
+@@ -604,7 +613,7 @@ int wpa_ft_fetch_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 			struct vlan_description *vlan,
+ 			const u8 **identity, size_t *identity_len,
+ 			const u8 **radius_cui, size_t *radius_cui_len,
+-			int *session_timeout);
++			int *session_timeout, struct rate_description *rate);
+ 
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+--- a/src/ap/wpa_auth_glue.c
++++ b/src/ap/wpa_auth_glue.c
+@@ -1433,6 +1433,41 @@ static int hostapd_wpa_auth_get_vlan(void *ctx, const u8 *sta_addr,
+ }
+ 
+ 
++static int hostapd_wpa_auth_set_rate_limit(void *ctx, const u8 *sta_addr,
++					   struct rate_description *rate)
++{
++	struct hostapd_data *hapd = ctx;
++	struct sta_info *sta;
++
++	sta = ap_get_sta(hapd, sta_addr);
++	if (!sta || !sta->wpa_sm)
++		return -1;
++
++	os_memcpy(sta->bandwidth, rate, sizeof(*rate));
++	hostapd_logger(hapd, sta->addr, HOSTAPD_MODULE_IEEE80211,
++		       HOSTAPD_LEVEL_INFO, "rate-limit %d %d",
++		       sta->bandwidth[0], sta->bandwidth[1]);
++
++	return 0;
++}
++
++
++static int hostapd_wpa_auth_get_rate_limit(void *ctx, const u8 *sta_addr,
++					   struct rate_description *rate)
++{
++	struct hostapd_data *hapd = ctx;
++	struct sta_info *sta;
++
++	sta = ap_get_sta(hapd, sta_addr);
++	if (!sta)
++		return -1;
++
++	os_memcpy(rate, sta->bandwidth, sizeof(*rate));
++
++	return 0;
++}
++
++
+ static int
+ hostapd_wpa_auth_set_identity(void *ctx, const u8 *sta_addr,
+ 			      const u8 *identity, size_t identity_len)
+@@ -1924,6 +1959,8 @@ int hostapd_setup_wpa(struct hostapd_data *hapd)
+ 		.add_sta_ft = hostapd_wpa_auth_add_sta_ft,
+ 		.set_vlan = hostapd_wpa_auth_set_vlan,
+ 		.get_vlan = hostapd_wpa_auth_get_vlan,
++		.set_rate_limit = hostapd_wpa_auth_set_rate_limit,
++		.get_rate_limit = hostapd_wpa_auth_get_rate_limit,
+ 		.set_identity = hostapd_wpa_auth_set_identity,
+ 		.get_identity = hostapd_wpa_auth_get_identity,
+ 		.set_radius_cui = hostapd_wpa_auth_set_radius_cui,
+--- a/src/ap/wpa_auth_ft.c
++++ b/src/ap/wpa_auth_ft.c
+@@ -443,10 +443,54 @@ static size_t wpa_ft_vlan_lin(const struct vlan_description *vlan,
+ }
+ 
+ 
++static size_t wpa_ft_rate_limit_len(const struct rate_description *rate)
++{
++	if (!rate || (!rate->rx && !rate->tx))
++		return 0;
++
++	return (sizeof(struct ft_rrb_tlv) + 2 * sizeof(le32));
++}
++
++
++static size_t wpa_ft_rate_limit_lin(const struct rate_description *rate,
++				    u8 *start, u8 *endpos)
++{
++	size_t tlv_len;
++	struct ft_rrb_tlv *hdr;
++	u8 *pos = start;
++
++	if (!rate || (!rate->rx && !rate->tx))
++		return 0;
++
++	tlv_len = sizeof(*hdr);
++	if (start + tlv_len > endpos)
++		return tlv_len;
++	hdr = (struct ft_rrb_tlv *) pos;
++	hdr->type = host_to_le16(FT_RRB_RATE_LIMIT);
++	hdr->len = host_to_le16(2 * sizeof(le32));
++	pos = start + tlv_len;
++
++	tlv_len += sizeof(le32);
++	if (start + tlv_len > endpos)
++		return tlv_len;
++	WPA_PUT_LE32(pos, rate->rx);
++	pos = start + tlv_len;
++
++	tlv_len += sizeof(le32);
++	if (start + tlv_len > endpos)
++		return tlv_len;
++	WPA_PUT_LE32(pos, rate->tx);
++	pos = start + tlv_len;
++
++	return tlv_len;
++}
++
++
+ static int wpa_ft_rrb_lin(const struct tlv_list *tlvs1,
+ 			  const struct tlv_list *tlvs2,
+ 			  const struct vlan_description *vlan,
+-			  u8 **plain, size_t *plain_len)
++			  u8 **plain, size_t *plain_len,
++			  const struct rate_description *rate)
+ {
+ 	u8 *pos, *endpos;
+ 	size_t tlv_len;
+@@ -454,6 +498,7 @@ static int wpa_ft_rrb_lin(const struct tlv_list *tlvs1,
+ 	tlv_len = wpa_ft_tlv_len(tlvs1);
+ 	tlv_len += wpa_ft_tlv_len(tlvs2);
+ 	tlv_len += wpa_ft_vlan_len(vlan);
++	tlv_len += wpa_ft_rate_limit_len(rate);
+ 
+ 	*plain_len = tlv_len;
+ 	*plain = os_zalloc(tlv_len);
+@@ -467,6 +512,7 @@ static int wpa_ft_rrb_lin(const struct tlv_list *tlvs1,
+ 	pos += wpa_ft_tlv_lin(tlvs1, pos, endpos);
+ 	pos += wpa_ft_tlv_lin(tlvs2, pos, endpos);
+ 	pos += wpa_ft_vlan_lin(vlan, pos, endpos);
++	pos += wpa_ft_rate_limit_lin(rate, pos, endpos);
+ 
+ 	/* validity check */
+ 	if (pos != endpos) {
+@@ -535,7 +581,8 @@ static int wpa_ft_rrb_build(const u8 *key, const size_t key_len,
+ 			    const struct tlv_list *tlvs_auth,
+ 			    const struct vlan_description *vlan,
+ 			    const u8 *src_addr, u8 type,
+-			    u8 **packet, size_t *packet_len)
++			    u8 **packet, size_t *packet_len,
++			    const struct rate_description *rate)
+ {
+ 	u8 *plain = NULL, *auth = NULL, *pos, *tmp;
+ 	size_t plain_len = 0, auth_len = 0;
+@@ -543,10 +590,11 @@ static int wpa_ft_rrb_build(const u8 *key, const size_t key_len,
+ 	size_t pad_len = 0;
+ 
+ 	*packet = NULL;
+-	if (wpa_ft_rrb_lin(tlvs_enc0, tlvs_enc1, vlan, &plain, &plain_len) < 0)
++	if (wpa_ft_rrb_lin(tlvs_enc0, tlvs_enc1, vlan, &plain, &plain_len,
++			   rate) < 0)
+ 		goto out;
+ 
+-	if (wpa_ft_rrb_lin(tlvs_auth, NULL, NULL, &auth, &auth_len) < 0)
++	if (wpa_ft_rrb_lin(tlvs_auth, NULL, NULL, &auth, &auth_len, NULL) < 0)
+ 		goto out;
+ 
+ 	*packet_len = sizeof(u16) + auth_len + plain_len;
+@@ -719,6 +767,26 @@ static int wpa_ft_get_vlan(struct wpa_authenticator *wpa_auth,
+ }
+ 
+ 
++static int wpa_ft_set_rate_limit(struct wpa_authenticator *wpa_auth,
++				 const u8 *sta_addr,
++				 struct rate_description *rate)
++{
++	if (!wpa_auth->cb->set_rate_limit)
++		return -1;
++	return wpa_auth->cb->set_rate_limit(wpa_auth->cb_ctx, sta_addr, rate);
++}
++
++
++static int wpa_ft_get_rate_limit(struct wpa_authenticator *wpa_auth,
++				 const u8 *sta_addr,
++				 struct rate_description *rate)
++{
++	if (!wpa_auth->cb->get_rate_limit)
++		return -1;
++	return wpa_auth->cb->get_rate_limit(wpa_auth->cb_ctx, sta_addr, rate);
++}
++
++
+ static int
+ wpa_ft_set_identity(struct wpa_authenticator *wpa_auth, const u8 *sta_addr,
+ 		    const u8 *identity, size_t identity_len)
+@@ -1053,7 +1121,7 @@ wpa_ft_rrb_seq_req(struct wpa_authenticator *wpa_auth,
+ 
+ 	if (wpa_ft_rrb_build(key, key_len, NULL, NULL, seq_req_auth, NULL,
+ 			     wpa_ft_rrb_get_aa(wpa_auth), FT_PACKET_R0KH_R1KH_SEQ_REQ,
+-			     &packet, &packet_len) < 0) {
++			     &packet, &packet_len, NULL) < 0) {
+ 		item = NULL; /* some other seq resp might still accept this */
+ 		goto err;
+ 	}
+@@ -1236,6 +1304,7 @@ struct wpa_ft_pmk_r0_sa {
+ 	u8 spa[ETH_ALEN];
+ 	int pairwise; /* Pairwise cipher suite, WPA_CIPHER_* */
+ 	struct vlan_description *vlan;
++	struct rate_description *rate;
+ 	os_time_t expiration; /* 0 for no expiration */
+ 	u8 *identity;
+ 	size_t identity_len;
+@@ -1254,6 +1323,7 @@ struct wpa_ft_pmk_r1_sa {
+ 	u8 spa[ETH_ALEN];
+ 	int pairwise; /* Pairwise cipher suite, WPA_CIPHER_* */
+ 	struct vlan_description *vlan;
++	struct rate_description *rate;
+ 	u8 *identity;
+ 	size_t identity_len;
+ 	u8 *radius_cui;
+@@ -1282,6 +1352,7 @@ static void wpa_ft_free_pmk_r0(struct wpa_ft_pmk_r0_sa *r0)
+ 
+ 	os_memset(r0->pmk_r0, 0, PMK_LEN_MAX);
+ 	os_free(r0->vlan);
++	os_free(r0->rate);
+ 	os_free(r0->identity);
+ 	os_free(r0->radius_cui);
+ 	os_free(r0);
+@@ -1336,6 +1407,7 @@ static void wpa_ft_free_pmk_r1(struct wpa_ft_pmk_r1_sa *r1)
+ 
+ 	os_memset(r1->pmk_r1, 0, PMK_LEN_MAX);
+ 	os_free(r1->vlan);
++	os_free(r1->rate);
+ 	os_free(r1->identity);
+ 	os_free(r1->radius_cui);
+ 	os_free(r1);
+@@ -1388,7 +1460,8 @@ static int wpa_ft_store_pmk_r0(struct wpa_authenticator *wpa_auth,
+ 			       const struct vlan_description *vlan,
+ 			       int expires_in, int session_timeout,
+ 			       const u8 *identity, size_t identity_len,
+-			       const u8 *radius_cui, size_t radius_cui_len)
++			       const u8 *radius_cui, size_t radius_cui_len,
++			       struct rate_description *rate)
+ {
+ 	struct wpa_authenticator *primary_auth = wpa_get_primary_auth(wpa_auth);
+ 	struct wpa_ft_pmk_cache *cache = primary_auth->ft_pmk_cache;
+@@ -1417,6 +1490,14 @@ static int wpa_ft_store_pmk_r0(struct wpa_authenticator *wpa_auth,
+ 		}
+ 		*r0->vlan = *vlan;
+ 	}
++	if (rate && (rate->rx || rate->tx)) {
++		r0->rate = os_zalloc(sizeof(*rate));
++		if (!r0->rate) {
++			bin_clear_free(r0, sizeof(*r0));
++			return -1;
++		}
++		*r0->rate = *rate;
++	}
+ 	if (identity) {
+ 		r0->identity = os_malloc(identity_len);
+ 		if (r0->identity) {
+@@ -1477,7 +1558,8 @@ static int wpa_ft_store_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 			       const struct vlan_description *vlan,
+ 			       int expires_in, int session_timeout,
+ 			       const u8 *identity, size_t identity_len,
+-			       const u8 *radius_cui, size_t radius_cui_len)
++			       const u8 *radius_cui, size_t radius_cui_len,
++			       struct rate_description *rate)
+ {
+ 	struct wpa_authenticator *primary_auth = wpa_get_primary_auth(wpa_auth);
+ 	struct wpa_ft_pmk_cache *cache = primary_auth->ft_pmk_cache;
+@@ -1508,6 +1590,14 @@ static int wpa_ft_store_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 		}
+ 		*r1->vlan = *vlan;
+ 	}
++	if (rate && (rate->rx || rate->tx)) {
++		r1->rate = os_zalloc(sizeof(*rate));
++		if (!r1->rate) {
++			bin_clear_free(r1, sizeof(*r1));
++			return -1;
++		}
++		*r1->rate = *rate;
++	}
+ 	if (identity) {
+ 		r1->identity = os_malloc(identity_len);
+ 		if (r1->identity) {
+@@ -1544,7 +1634,7 @@ int wpa_ft_fetch_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 			struct vlan_description *vlan,
+ 			const u8 **identity, size_t *identity_len,
+ 			const u8 **radius_cui, size_t *radius_cui_len,
+-			int *session_timeout)
++			int *session_timeout, struct rate_description *rate)
+ {
+ 	struct wpa_authenticator *primary_auth = wpa_get_primary_auth(wpa_auth);
+ 	struct wpa_ft_pmk_cache *cache = primary_auth->ft_pmk_cache;
+@@ -1565,6 +1655,12 @@ int wpa_ft_fetch_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 				*vlan = *r1->vlan;
+ 			if (vlan && !r1->vlan)
+ 				os_memset(vlan, 0, sizeof(*vlan));
++			if (rate) {
++				if (r1->rate)
++					*rate = *r1->rate;
++				else
++					os_memset(rate, 0, sizeof(*rate));
++			}
+ 			if (identity && identity_len) {
+ 				*identity = r1->identity;
+ 				*identity_len = r1->identity_len;
+@@ -2115,7 +2211,7 @@ static int wpa_ft_pull_pmk_r1(struct wpa_state_machine *sm,
+ 
+ 	if (wpa_ft_rrb_build(key, key_len, req_enc, NULL, req_auth, NULL,
+ 			     wpa_ft_rrb_get_aa(wpa_auth), FT_PACKET_R0KH_R1KH_PULL,
+-			     &packet, &packet_len) < 0)
++			     &packet, &packet_len, NULL) < 0)
+ 		return -1;
+ 
+ 	ft_pending_req_ies = wpabuf_alloc_copy(ies, ies_len);
+@@ -2147,6 +2243,7 @@ int wpa_ft_store_pmk_fils(struct wpa_state_machine *sm,
+ 	const u8 *identity, *radius_cui;
+ 	size_t identity_len, radius_cui_len;
+ 	int session_timeout;
++	struct rate_description rate;
+ 	size_t pmk_r0_len = wpa_key_mgmt_sha384(sm->wpa_key_mgmt) ?
+ 		SHA384_MAC_LEN : PMK_LEN;
+ 
+@@ -2156,6 +2253,7 @@ int wpa_ft_store_pmk_fils(struct wpa_state_machine *sm,
+ 		return -1;
+ 	}
+ 
++	wpa_ft_get_rate_limit(sm->wpa_auth, sm->addr, &rate);
+ 	identity_len = wpa_ft_get_identity(sm->wpa_auth, sm->addr, &identity);
+ 	radius_cui_len = wpa_ft_get_radius_cui(sm->wpa_auth, sm->addr,
+ 					       &radius_cui);
+@@ -2164,7 +2262,7 @@ int wpa_ft_store_pmk_fils(struct wpa_state_machine *sm,
+ 	return wpa_ft_store_pmk_r0(sm->wpa_auth, sm->addr, pmk_r0, pmk_r0_len,
+ 				   pmk_r0_name, sm->pairwise, &vlan, expires_in,
+ 				   session_timeout, identity, identity_len,
+-				   radius_cui, radius_cui_len);
++				   radius_cui, radius_cui_len, &rate);
+ }
+ 
+ 
+@@ -2228,6 +2326,7 @@ void wpa_auth_ft_store_keys(struct wpa_state_machine *sm, const u8 *pmk_r0,
+ 	struct wpa_authenticator *wpa_auth = wpa_get_primary_auth(sm->wpa_auth);
+ 	int psk_local, expires_in;
+ 	struct vlan_description vlan;
++	struct rate_description rate;
+ 	const u8 *identity, *radius_cui;
+ 	size_t identity_len, radius_cui_len;
+ 	int session_timeout;
+@@ -2249,15 +2348,16 @@ void wpa_auth_ft_store_keys(struct wpa_state_machine *sm, const u8 *pmk_r0,
+ 	radius_cui_len = wpa_ft_get_radius_cui(wpa_auth, sm->addr,
+ 						&radius_cui);
+ 	session_timeout = wpa_ft_get_session_timeout(wpa_auth, sm->addr);
++	wpa_ft_get_rate_limit(wpa_auth, sm->addr, &rate);
+ 	wpa_ft_store_pmk_r0(wpa_auth, sm->addr, pmk_r0, key_len,
+ 			    pmk_r0_name,
+ 			    sm->pairwise, &vlan, expires_in,
+ 			    session_timeout, identity, identity_len,
+-			    radius_cui, radius_cui_len);
++			    radius_cui, radius_cui_len, &rate);
+ 	wpa_ft_store_pmk_r1(wpa_auth, sm->addr, pmk_r1, key_len,
+ 			    sm->pmk_r1_name, sm->pairwise, &vlan,
+ 			    expires_in, session_timeout, identity,
+-			    identity_len, radius_cui, radius_cui_len);
++			    identity_len, radius_cui, radius_cui_len, &rate);
+ }
+ 
+ 
+@@ -3337,7 +3437,8 @@ static int wpa_ft_local_derive_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 				      const u8 **radius_cui,
+ 				      size_t *radius_cui_len,
+ 				      int *out_session_timeout,
+-				      size_t *pmk_r1_len)
++				      size_t *pmk_r1_len,
++				      struct rate_description *rate)
+ {
+ 	struct wpa_auth_config *conf = &wpa_auth->conf;
+ 	const struct wpa_ft_pmk_r0_sa *r0;
+@@ -3373,7 +3474,7 @@ static int wpa_ft_local_derive_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 			    out_pmk_r1_name,
+ 			    sm->pairwise, r0->vlan, expires_in, session_timeout,
+ 			    r0->identity, r0->identity_len,
+-			    r0->radius_cui, r0->radius_cui_len);
++			    r0->radius_cui, r0->radius_cui_len, r0->rate);
+ 
+ 	*out_pairwise = sm->pairwise;
+ 	if (vlan) {
+@@ -3383,6 +3484,13 @@ static int wpa_ft_local_derive_pmk_r1(struct wpa_authenticator *wpa_auth,
+ 			os_memset(vlan, 0, sizeof(*vlan));
+ 	}
+ 
++	if (rate) {
++		if (r0->rate)
++			*rate = *r0->rate;
++		else
++			os_memset(rate, 0, sizeof(*rate));
++	}
++
+ 	if (identity && identity_len) {
+ 		*identity = r0->identity;
+ 		*identity_len = r0->identity_len;
+@@ -3417,6 +3525,7 @@ static int wpa_ft_process_auth_req(struct wpa_state_machine *sm,
+ 	u8 *pos, *end;
+ 	int pairwise, session_timeout = 0;
+ 	struct vlan_description vlan;
++	struct rate_description rate = {};
+ 	const u8 *identity, *radius_cui;
+ 	size_t identity_len = 0, radius_cui_len = 0;
+ 	size_t pmk_r1_len, kdk_len, len;
+@@ -3518,7 +3627,7 @@ static int wpa_ft_process_auth_req(struct wpa_state_machine *sm,
+ 					pmk_r1, &pmk_r1_len, &pairwise, &vlan,
+ 					&identity, &identity_len, &radius_cui,
+ 					&radius_cui_len,
+-					&session_timeout) == 0) {
++					&session_timeout, &rate) == 0) {
+ 			wpa_printf(MSG_DEBUG,
+ 				   "FT: Found PMKR1Name (using SHA%zu) from local cache",
+ 				   pmk_r1_len * 8);
+@@ -3534,7 +3643,7 @@ static int wpa_ft_process_auth_req(struct wpa_state_machine *sm,
+ 				       pmk_r1_name, pmk_r1, &pairwise,
+ 				       &vlan, &identity, &identity_len,
+ 				       &radius_cui, &radius_cui_len,
+-				       &session_timeout, &pmk_r1_len) == 0) {
++				       &session_timeout, &pmk_r1_len, &rate) == 0) {
+ 		wpa_printf(MSG_DEBUG,
+ 			   "FT: Generated PMK-R1 based on local PMK-R0");
+ 		goto pmk_r1_derived;
+@@ -3636,6 +3745,7 @@ pmk_r1_derived:
+ 		wpa_printf(MSG_DEBUG, "FT: Failed to configure VLAN");
+ 		goto out;
+ 	}
++	wpa_ft_set_rate_limit(sm->wpa_auth, sm->addr, &rate);
+ 	if (wpa_ft_set_identity(sm->wpa_auth, sm->addr,
+ 				identity, identity_len) < 0 ||
+ 	    wpa_ft_set_radius_cui(sm->wpa_auth, sm->addr,
+@@ -4317,7 +4427,7 @@ static int wpa_ft_rrb_build_r0(const u8 *key, const size_t key_len,
+ 
+ 	ret = wpa_ft_rrb_build(key, key_len, tlvs, sess_tlv, tlv_auth,
+ 			       pmk_r0->vlan, src_addr, type,
+-			       packet, packet_len);
++			       packet, packet_len, pmk_r0->rate);
+ 
+ 	forced_memzero(pmk_r1, sizeof(pmk_r1));
+ 
+@@ -4457,7 +4567,7 @@ static int wpa_ft_rrb_rx_pull(struct wpa_authenticator *wpa_auth,
+ 		ret = wpa_ft_rrb_build(key, key_len, resp, NULL, resp_auth,
+ 				       NULL, wpa_ft_rrb_get_aa(wpa_auth),
+ 				       FT_PACKET_R0KH_R1KH_RESP,
+-				       &packet, &packet_len);
++				       &packet, &packet_len, NULL);
+ 	} else {
+ 		ret = wpa_ft_rrb_build_r0(key, key_len, resp, r0, f_r1kh_id,
+ 					  f_s1kh_id, resp_auth, wpa_ft_rrb_get_aa(wpa_auth),
+@@ -4515,6 +4625,10 @@ static int wpa_ft_rrb_rx_r1(struct wpa_authenticator *wpa_auth,
+ 	int session_timeout;
+ 	struct vlan_description vlan;
+ 	size_t pmk_r1_len;
++	const u8 *f_rate;
++	size_t f_rate_len;
++	struct rate_description rate;
++	int has_rate = 0;
+ 
+ 	RRB_GET_AUTH(FT_RRB_R0KH_ID, r0kh_id, msgtype, -1);
+ 	wpa_hexdump(MSG_DEBUG, "FT: R0KH-ID", f_r0kh_id, f_r0kh_id_len);
+@@ -4641,11 +4755,18 @@ static int wpa_ft_rrb_rx_r1(struct wpa_authenticator *wpa_auth,
+ 		session_timeout = 0;
+ 	wpa_printf(MSG_DEBUG, "FT: session_timeout %d", session_timeout);
+ 
++	RRB_GET_OPTIONAL(FT_RRB_RATE_LIMIT, rate, msgtype, 2 * sizeof(le32));
++	if (f_rate) {
++		rate.rx = WPA_GET_LE32(f_rate);
++		rate.tx = WPA_GET_LE32(f_rate + sizeof(le32));
++		has_rate = 1;
++	}
++
+ 	ret = wpa_ft_store_pmk_r1(wpa_auth, f_s1kh_id, f_pmk_r1, pmk_r1_len,
+ 				  f_pmk_r1_name,
+ 				  pairwise, &vlan, expires_in, session_timeout,
+ 				  f_identity, f_identity_len, f_radius_cui,
+-				  f_radius_cui_len);
++				  f_radius_cui_len, has_rate ? &rate : NULL);
+ 	if (ret < 0)
+ 		goto out;
+ 
+@@ -4984,7 +5105,7 @@ static int wpa_ft_rrb_rx_seq_req(struct wpa_authenticator *wpa_auth,
+ 
+ 	if (wpa_ft_rrb_build(key, key_len, NULL, NULL, seq_resp_auth, NULL,
+ 			     wpa_ft_rrb_get_aa(wpa_auth), FT_PACKET_R0KH_R1KH_SEQ_RESP,
+-			     &packet, &packet_len) < 0)
++			     &packet, &packet_len, NULL) < 0)
+ 		goto out;
+ 
+ 	wpa_ft_rrb_oui_send(wpa_auth, src_addr,
+@@ -5486,7 +5607,7 @@ static void wpa_ft_sta_roamed_notify_per_r1kh(struct wpa_state_machine *sm,
+ 
+ 	if (wpa_ft_rrb_build(r1kh->key, sizeof(r1kh->key), clear, NULL, clear_auth, NULL,
+ 			     wpa_ft_rrb_get_aa(sm->wpa_auth), FT_PACKET_R1KH_STA_ROAMED_NOTIFY,
+-			     &packet, &packet_len) < 0)
++			     &packet, &packet_len, NULL) < 0)
+ 		return;
+ 
+ 	wpa_ft_rrb_oui_send(wpa_auth, r1kh->addr, FT_PACKET_R1KH_STA_ROAMED_NOTIFY,
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -3230,7 +3230,7 @@ static void hapd_pasn_update_params(struct hostapd_data *hapd,
+ 				    rsn_data.pmkid,
+ 				    pasn->pmk_r1, &pasn->pmk_r1_len, NULL,
+ 				    NULL, NULL, NULL,
+-				    NULL, NULL, NULL);
++				    NULL, NULL, NULL, NULL);
+ #endif /* CONFIG_IEEE80211R_AP */
+ 	}
+ #ifdef CONFIG_FILS

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -304,6 +304,10 @@
 		"dynamic_own_ip_addr": {
 			"type": "boolean"
 		},
+		"dynamic_probe_resp": {
+			"description": "Keep responding to broadcast/wildcard probe requests even when ignore_broadcast_ssid is set (allows a controller to probe hidden SSIDs on demand)",
+			"type": "boolean"
+		},
 		"dynamic_vlan": {
 			"description": "Allow RADIUS authentication server to decide which VLAN is used for the stations (0 = disabled, 1 = optional, 2 = required)",
 			"type": "number",
@@ -354,6 +358,10 @@
 		"fils_dhcp": {
 			"description": "DHCP server for FILS HLP. Set to '*' for automatic lookup.",
 			"type": "string"
+		},
+		"ft_l2_refresh": {
+			"description": "Interval in seconds for broadcasting an FT RRB request so R0KH/R1KH peers keep each other's L2 address fresh in distributed FT setups (0 = disabled)",
+			"type": "number"
 		},
 		"ft_over_ds": {
 			"description": "Whether to enable FT-over-DS",
@@ -1045,6 +1053,10 @@
 			"description": "WMM-PS Unscheduled Automatic Power Save Delivery [U-APSD]",
 			"type": "boolean",
 			"default": true
+		},
+		"uci_section": {
+			"description": "Name of the originating UCI wireless section for this BSS; reported by hostapd over ubus so the controller (uCentral) can map a running BSS back to its configuration",
+			"type": "string"
 		},
 		"uesa": {
 			"description": "Unauthenticated emergency service accessible",

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -57,7 +57,7 @@ function iface_setup(config) {
 	append_vars(config, [
 		'ctrl_interface', 'ap_isolate', 'max_num_sta', 'ap_max_inactivity', 'airtime_bss_weight',
 		'airtime_bss_limit', 'airtime_sta_weight', 'bss_load_update_period', 'chan_util_avg_period',
-		'disassoc_low_ack', 'skip_inactivity_poll', 'ignore_broadcast_ssid', 'uapsd_advertisement_enabled',
+		'disassoc_low_ack', 'skip_inactivity_poll', 'ignore_broadcast_ssid', 'dynamic_probe_resp', 'uci_section', 'uapsd_advertisement_enabled',
 		'utf8_ssid', 'multi_ap', 'multi_ap_vlanid', 'multi_ap_profile', 'tdls_prohibit', 'bridge',
 		'wds_sta', 'wds_bridge', 'snoop_iface', 'vendor_elements', 'nas_identifier', 'radius_acct_interim_interval',
 		'ocv', 'multicast_to_unicast', 'preamble', 'proxy_arp', 'per_sta_vif', 'mbo',
@@ -375,6 +375,7 @@ function iface_roaming(config) {
 	set_default(config, 'mobility_domain', substr(md5(config.ssid), 0, 4));
 	set_default(config, 'ft_psk_generate_local', config.auth_type == 'psk');
 	set_default(config, 'ft_iface', config.network_ifname);
+	set_default(config, 'ft_l2_refresh', 30);
 
 	if (!config.ft_psk_generate_local) {
 		if (!config.r0kh || !config.r1kh) {
@@ -398,7 +399,7 @@ function iface_roaming(config) {
 
 	append_vars(config, [
 		'mobility_domain', 'ft_psk_generate_local', 'ft_over_ds', 'reassociation_deadline',
-		'ft_iface'
+		'ft_iface', 'ft_l2_refresh'
 	]);
 }
 


### PR DESCRIPTION
Ported the missing hostapd patches from the branch staging-for-v4.2.0-LTS
The patch descriptions and the source patches are listed below.

0264: uci_section bss config option (from 901-cfg-section.patch)
0265: dynamic_probe_resp config option (from 999-probe-request.patch)
0266: fix ap-sta channel setup failed (from 800-fix-ap-sta-channel-setup-failed.patch)
0267: RADIUS DAS CoA + Proxy-State (from 900-coa.patch and 999-das-proxy-state.patch)
0268: ft_l2_refresh support (from t00-010-ft_refresh.patch)
0269: dynamic VLAN on wired driver (from 790-wired-dynamic-vlan.patch and t00-012-hostapd-Fix-DVLAN-802.1x-issue.patch)
0270: notify ubus on rssi-ignored probe (from zzz-ignore-probe-event.patch)
0271: CoA/Disconnect approval via ubus (from 901-coa-ubus.patch)
0272: EWMA management-frame signal (from 999-ssi_signal.patch)
0273: reuse FT ANonce during roaming (from 999-ft-anonce.patch and zzzz-001-fix-assoc-reject-during-roaming.patch)
0274: report roaming origin/target over ubus (from 999-re-assoc-event.patch)
0275: carry WISPr rate-limit across FT roaming (from 751-wispr-ft.patch)

wifi-scripts: added "dynamic_probe_resp", "ft_l2_refresh", and "uci_section".

Fixes: WIFI-15605