### PR TITLE
qca-wifi-7: update anti-rollback limit ver for 750W-311A/750E-S/750E-H

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
@@ -225,8 +225,8 @@ platform_check_image() {
 		local info_output=$(get_firmware_info "$1")
 		FW_VER="${info_output%%|*}"
 		FW_BUILD_DATE="${info_output#*|}"
-		local LIMIT_VER="5.0.0"
-		local LIMIT_BUILD_DATE="20260603"
+		local LIMIT_VER="4.2.6"
+		local LIMIT_BUILD_DATE="20260717"
 
 		echo "Checking version for $board..."
 		echo "Current: v$CURRENT_VER, Firmware: v$FW_VER, Limit: <= v$LIMIT_VER"


### PR DESCRIPTION
set anti-rollback limit to LIMIT_VER=4.2.6 / LIMIT_BUILD_DATE=20260717 (the first UBIFS release for these boards, per https://github.com/Telecominfraproject/wlan-ap/pull/1153)

Test Results:

Upgrading to firmware versions lower than the restricted version, or firmware without version information but built earlier than the cutoff build date, will fail. Upgrades to firmware versions higher than the restricted version will succeed. Firmware without version information but with a build date later than the cutoff build date can also be upgraded successfully.

Fixes: WIFI-15401
