### PR TITLE
mediatek: wifi-scripts: add psk2-radius encryption

### DIFF
--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -931,6 +931,12 @@
 			"description": "Request Chargeable-User-Identity (RFC 4372)",
 			"type": "boolean"
 		},
+		"radius_require_message_authenticator": {
+			"description": "Require the Message-Authenticator attribute in received RADIUS packets (CVE-2024-3596 mitigation). Disabled by default to interoperate with RADIUS servers that omit it on non-EAP (MAC/PSK) responses",
+			"type": "number",
+			"enum": [ 0, 1 ],
+			"default": 0
+		},
 		"reassociation_deadline": {
 			"description": "Reassociation deadline in time units",
 			"type": "number",

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -63,6 +63,7 @@ function iface_setup(config) {
 		'ocv', 'multicast_to_unicast', 'preamble', 'proxy_arp', 'per_sta_vif', 'mbo',
 		'bss_transition', 'wnm_sleep_mode', 'wnm_sleep_mode_no_keys', 'qos_map_set', 'max_listen_int',
 		'dtim_period', 'wmm_enabled', 'start_disabled', 'na_mcast_to_ucast',
+		'radius_require_message_authenticator',
 	]);
 }
 
@@ -175,7 +176,7 @@ function iface_auth_type(config) {
 
 		if (config.radius_das_client && config.radius_das_secret) {
 			set_default(config, 'radius_das_port', 3799);
-			set_default(config, 'radius_das_client', `${config.radius_das_client} ${config.radius_das_secret}`);
+			config.radius_das_client = `${config.radius_das_client} ${config.radius_das_secret}`;
 		}
 
 		set_default(config, 'eapol_version', config.wpa & 1);
@@ -184,6 +185,23 @@ function iface_auth_type(config) {
 		append('eapol_key_index_workaround', '1');
 		append('ieee8021x', '1');
 
+		break;
+
+	case 'psk2-radius':
+		/* WPA2-PSK, but the PSK is fetched from the RADIUS server during
+		 * the 4-way handshake so clients can be centrally tracked. */
+		set_default(config, 'ieee80211w', 1);
+		set_default(config, 'radius_require_message_authenticator', 0);
+		config.vlan_possible = 1;
+		config.wpa_psk_radius = 3;
+		config.macaddr_acl = 2;
+
+		iface_authentication_server(config);
+
+		if (config.radius_das_client && config.radius_das_secret) {
+			set_default(config, 'radius_das_port', 3799);
+			config.radius_das_client = `${config.radius_das_client} ${config.radius_das_secret}`;
+		}
 		break;
 	}
 

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -47,6 +47,11 @@ export function parse_encryption(config, dev_config) {
 		wpa3_pairwise = null;
 		break;
 
+	case 'psk2-radius':
+		/* WPA2-PSK with the PSK fetched from RADIUS (client tracking) */
+		wpa3_pairwise = null;
+		break;
+
 	case 'sae':
 	case 'psk3':
 		config.auth_type = 'sae';
@@ -155,6 +160,12 @@ export function wpa_key_mgmt(config) {
 			append_value(config, 'wpa_key_mgmt', 'FT-PSK');
 		if (config.ieee80211w)
 			append_value(config, 'wpa_key_mgmt', 'WPA-PSK-SHA256');
+		break;
+
+	case 'psk2-radius':
+		append_value(config, 'wpa_key_mgmt', 'WPA-PSK');
+		if (config.ieee80211r)
+			append_value(config, 'wpa_key_mgmt', 'FT-PSK');
 		break;
 
 	case 'eap':


### PR DESCRIPTION
Add the support for psk2-radius encryption.
Also set "radius_require_message_authenticator" to 0 by default.

Fixes: WIFI-15603