### PR TITLE
mediatek: mt76: enable wed_enable=1 for mt7915e on sonicfi_rap630w_211g

### DIFF
--- a/patches-25.12/0118-Fix-Sonicfi_RAP630W-211G-RVR-test-shows-low-5G-TX-power.patch
+++ b/patches-25.12/0118-Fix-Sonicfi_RAP630W-211G-RVR-test-shows-low-5G-TX-power.patch
@@ -1,0 +1,26 @@
+From 4b31378553a7d433945772bd2c28689d072ef39a Mon Sep 17 00:00:00 2001
+From: lyc-cybertan <yuanchongli@cybertan.com.tw>
+Date: Thu, 23 Jul 2026 15:10:57 +0800
+Subject: [PATCH] Fix Sonicfi_RAP630W-211G RVR test shows low 5G TX power
+
+---
+ package/kernel/mt76/Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/package/kernel/mt76/Makefile b/package/kernel/mt76/Makefile
+index 2272546c0e..5d21e1519f 100644
+--- a/package/kernel/mt76/Makefile
++++ b/package/kernel/mt76/Makefile
+@@ -238,6 +238,9 @@ define KernelPackage/mt7915e
+   DEPENDS+=@PCI_SUPPORT +kmod-mt76-connac +kmod-hwmon-core +kmod-thermal +@DRIVER_11AX_SUPPORT +@KERNEL_RELAY
+   FILES:= $(PKG_BUILD_DIR)/mt7915/mt7915e.ko
+   AUTOLOAD:=$(call AutoProbe,mt7915e)
++  ifeq ($(CONFIG_TARGET_PROFILE), "DEVICE_sonicfi_rap630w_211g")
++  	MODPARAMS.mt7915e:=wed_enable=1
++  endif
+ endef
+ 
+ define KernelPackage/mt7916-firmware
+-- 
+2.34.1
+


### PR DESCRIPTION
After adapting to the MTDK platform WiFi6 firmware, hardware acceleration failed to offload traffic because the WED function was not enabled. During 5G RvR testing, the LAN to WiFi forwarding rate was too low to meet specs.

In the upstream MT76 driver, WED is an optional hardware acceleration component and is disabled by default. The wed_enable module parameter must be manually configured to initialize the hardware offloading path, reducing CPU soft forwarding performance loss.

Modify package/kernel/mt76/Makefile to inject the mt7915e module parameter wed_enable=1 specifically for the VNet sonicfi_rap630w_211g target model. This enables the hardware traffic offloading path during firmware compilation, allowing LAN to WiFi traffic to be handled by WED.

Fixes: WIFI-15621

Test Results:
After compiling and deploying the firmware, retesting showed a significant improvement in LAN → WiFi direction transmission rate in the 5G RvR scenario, and all performance indicators met the testing requirements