### PR TITLE
mediatek: wifi-scripts: support secondary RADIUS servers

### DIFF
--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -42,6 +42,19 @@
 			"description": "Shared accounting RADIUS secret",
 			"type": "string"
 		},
+		"acct_server_secondary": {
+			"description": "Backup RADIUS accounting server, used if the primary is unreachable",
+			"type": "string"
+		},
+		"acct_port_secondary": {
+			"description": "Backup RADIUS accounting port",
+			"type": "number",
+			"default": 1813
+		},
+		"acct_secret_secondary": {
+			"description": "Shared secret for the backup RADIUS accounting server",
+			"type": "string"
+		},
 		"airtime_bss_limit": {
 			"description": "Whether the current BSS should be limited (when airtime_mode=3)",
 			"type": "boolean"
@@ -160,6 +173,19 @@
 		},
 		"auth_server_shared_secret": {
 			"description": "Shared authentication RADIUS secret",
+			"type": "string"
+		},
+		"auth_server_secondary": {
+			"description": "Backup RADIUS authentication server, used if the primary is unreachable",
+			"type": "string"
+		},
+		"auth_port_secondary": {
+			"description": "Backup RADIUS authentication port",
+			"type": "number",
+			"default": 1812
+		},
+		"auth_secret_secondary": {
+			"description": "Shared secret for the backup RADIUS authentication server",
 			"type": "string"
 		},
 		"basic_rate": {

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -73,6 +73,12 @@ function iface_authentication_server(config) {
 		append_vars(config, [ 'auth_server_port', 'auth_server_shared_secret' ]);
 	}
 
+	if (config.auth_server_secondary) {
+		append('auth_server_addr', config.auth_server_secondary);
+		append('auth_server_port', config.auth_port_secondary);
+		append('auth_server_shared_secret', config.auth_secret_secondary);
+	}
+
 	append_vars(config, [ 'radius_auth_req_attr' ]);
 }
 
@@ -80,6 +86,12 @@ function iface_accounting_server(config) {
 	for (let server in config.acct_server_addr) {
 		append('acct_server_addr', server);
 		append_vars(config, [ 'acct_server_port', 'acct_server_shared_secret' ]);
+	}
+
+	if (config.acct_server_secondary) {
+		append('acct_server_addr', config.acct_server_secondary);
+		append('acct_server_port', config.acct_port_secondary);
+		append('acct_server_shared_secret', config.acct_secret_secondary);
 	}
 
 	append_vars(config, [ 'radius_acct_req_attr' ]);


### PR DESCRIPTION
Add the settings for the secondary RADIUS authentication and accounting server.

Fixes: WIFI-15576