### PR TITLE
hostapd: Remove the unsupported configuration options and also disable offload when WDS is turned on 

### DIFF
--- a/feeds/qca-wifi-6/hostapd/files/wpa_supplicant.uc
+++ b/feeds/qca-wifi-6/hostapd/files/wpa_supplicant.uc
@@ -33,6 +33,33 @@ function iface_stop(iface)
 	iface.running = false;
 }
 
+function disable_wds_offload(phydev, ifname, config)
+{
+	if (!config["4addr"])
+		return null;
+	/*
+	 * phydev.name may be phy0.0;
+	 * debugfs is actually always phydev.phy, for example phy0.
+	 */
+	let path =
+		`/sys/kernel/debug/ieee80211/${phydev.phy}/netdev:${ifname}/disable_offload`;
+
+	let fp = open(path, "w");
+	if (!fp)
+		return `unable to open ${path}`;
+
+	let written = fp.write("1\n");
+	let closed = fp.close();
+	let value = readfile(path);
+
+	if (written != 2 || !closed || 
+	    value == null || trim(value) != "1")
+		return `unable to set ${path}`;
+
+	wpas.printf(`WDS: disable_offload=1 on ${ifname}`);
+	return null;
+}
+
 function iface_start(phydev, iface, macaddr_list)
 {
 	let phy = phydev.name;
@@ -50,8 +77,19 @@ function iface_start(phydev, iface, macaddr_list)
 	wpas.data.iface_phy[ifname] = phy;
 	wdev_remove(ifname);
 	let ret = phydev.wdev_add(ifname, wdev_config);
-	if (ret)
+	if (ret) {
 		wpas.printf(`Failed to create device ${ifname}: ${ret}`);
+		delete wpas.data.iface_phy[ifname];
+		return;
+	}
+
+	ret = disable_wds_offload(phydev, ifname, wdev_config);
+	if (ret) {
+		wpas.printf(`WDS setup failed for ${ifname}: ${ret}`);
+		delete wpas.data.iface_phy[ifname];
+		wdev_remove(ifname);
+		return;
+	}
 	wdev_set_up(ifname, true);
 	wpas.add_iface(iface.config);
 	iface.running = true;

--- a/patches-25.12/0118-hostapd-remove-unsupported-config-and-disable-hairpin.patch
+++ b/patches-25.12/0118-hostapd-remove-unsupported-config-and-disable-hairpin.patch
@@ -1,0 +1,105 @@
+From f8485a4d06944477c5ec3caec46009775fbe8505 Mon Sep 17 00:00:00 2001
+From: "huimin.he" <huimin.he@cybertan.com.tw>
+Date: Wed, 29 Jul 2026 18:06:04 +0800
+Subject: [PATCH] test
+
+---
+ .../wifi-scripts/files/lib/netifd/hostapd.sh  | 11 +------
+ .../files/lib/netifd/wireless-device.uc       | 29 +++++++++++++++----
+ 2 files changed, 24 insertions(+), 16 deletions(-)
+
+diff --git a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+index 5df4a58578..e93b815859 100644
+--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
++++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+@@ -1425,7 +1425,7 @@ wpa_supplicant_add_network() {
+ 	wireless_vif_parse_encryption
+ 
+ 	json_get_vars \
+-		ssid bssid key rsn_override \
++		ssid bssid key \
+ 		mcast_rate \
+ 		ieee80211w ieee80211r fils ocv beacon_prot \
+ 		multi_ap \
+@@ -1433,8 +1433,6 @@ wpa_supplicant_add_network() {
+ 
+ 	json_get_values basic_rate_list basic_rate
+ 
+-	set_default rsn_override 0
+-
+ 	case "$auth_type" in
+ 		sae|owe|eap2|eap192)
+ 			set_default ieee80211w 2
+@@ -1487,12 +1485,6 @@ wpa_supplicant_add_network() {
+ 	[ -n "$ocv" ] && append network_data "ocv=$ocv" "$N$T"
+ 	[ -n "$beacon_prot" ] && append network_data "beacon_prot=$beacon_prot" "$N$T"
+ 
+-	rsn_overriding=0
+-	case "$htmode" in
+-	EHT*|HE*) [ "$rsn_override" -gt 0 ] && rsn_overriding=1;;
+-	esac
+-	append network_data "rsn_overriding=$rsn_overriding" "$N$T"
+-
+ 	case "$auth_type" in
+ 		none) ;;
+ 		owe)
+@@ -1734,7 +1726,6 @@ network={
+ 	$scan_ssid
+ 	ssid="$ssid"
+ 	key_mgmt=$key_mgmt
+-	sae_pwe=$sae_pwe
+ 	$network_data
+ }
+ EOF
+diff --git a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+index 339ad9ea0b..8a396695cf 100644
+--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
++++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+@@ -46,9 +46,12 @@ function delete_wdev(name)
+ function handle_link(dev, data, up)
+ {
+ 	let config = data.config;
+-	let bridge_isolate;
++	let main = dev == data.ifname;
++	let sta_child =
++		!main && !!match(dev, /[.]sta.+/);
+ 	let ap = false;
+-	if (dev == data.ifname)
++
++	if (main)
+ 		ap = data.type == "vlan" ||
+ 		     (data.type == "vif" && config.mode == "ap");
+ 
+@@ -61,11 +64,25 @@ function handle_link(dev, data, up)
+ 	};
+ 
+ 	if (ap && config.multicast_to_unicast != null)
+-		dev_data.multicast_to_unicast = config.multicast_to_unicast;
+-
+-	if (data.type == "vif" && config.mode == "ap") {
+-		dev_data.wireless_proxyarp = !!config.proxy_arp;
++		dev_data.multicast_to_unicast =
++			config.multicast_to_unicast ? 1 : 0;
++	if (main && data.type == "vif") {
+ 		dev_data.wireless_isolate = !!config.isolate;
++		dev_data.wireless_proxyarp =
++			config.mode == "ap" && !!config.proxy_arp;
++	}
++
++	if (sta_child) {
++		dev_data.multicast_to_unicast = 0;
++		dev_data.wireless_proxyarp = false;
++		dev_data.wireless_isolate = false;
++	}
++
++	if (main && data.type == "vif" &&
++	    config.mode == "sta" && !!config.wds) {
++		dev_data.multicast_to_unicast = 0;
++		dev_data.wireless_proxyarp = false;
++		dev_data.wireless_isolate = true;
+ 	}
+ 
+ 	if (up)
+-- 
+2.34.1
+


### PR DESCRIPTION

After updating to OpenWrt 25.12, hostapd.sh added two new configurations (sae_pwe and rsn_overriding) for wpa_supplicant 
The hostapd for QCA WiFi 6 cannot recognize them, causing the WiFi STA mode to fail to start.

The original QCA proprietary wifi-scripts have been replaced with the standard OpenWrt wifi-scripts.
This causes the wireless offload feature to remain enabled when WDS is turned on
which prevents the device operating in STA mode from obtaining an IP address from the AP.
In addition, the standard wifi-scripts also fail to disable hairpin on the WDS sub‑interface
resulting in a network loop between the STA and the AP.

Fixes: WIFI-15620

Signed-off-by: huimin.he <huimin.he@cybertan.com.tw>
