### PR TITLE
ucentral-schema: update to latest HEAD (9dc64a8)

### DIFF
--- a/feeds/ucentral/ucentral-schema/Makefile
+++ b/feeds/ucentral/ucentral-schema/Makefile
@@ -4,10 +4,10 @@ PKG_NAME:=ucentral-schema
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL=https://github.com/Telecominfraproject/wlan-ucentral-schema.git
-PKG_MIRROR_HASH:=5b9083215abf13501b3219d8a6f1e8c66668bf102430ea593d899d87ad1565fd
+PKG_MIRROR_HASH:=da774b1a81eaa38ab4774ff14bc497f4ec177bd57b01deae3582127334b09e4f
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2026-05-11
-PKG_SOURCE_VERSION:=6fe9800e22802d89ca50ca319169c254035495d7
+PKG_SOURCE_DATE:=2026-07-21
+PKG_SOURCE_VERSION:=9dc64a8686f80018ec5862c1256463776bf4228e
 PKG_MAINTAINER:=John Crispin <john@phrozen.org>
 PKG_LICENSE:=BSD-3-Clause
 
@@ -46,6 +46,7 @@ define Package/ucentral-schema/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/system/reboot_cause.uc $(1)/usr/share/ucentral
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/system/state.uc $(1)/usr/share/ucentral
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/system/telemetry.uc $(1)/usr/share/ucentral
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/ujq $(1)/usr/bin
 	$(LN) /usr/share/ucentral/schemareader.uc $(1)/usr/share/ucode
 	$(LN) /usr/share/ucentral/ucentral.uc $(1)/usr/bin/ucentral_apply
 	$(CP) ./files/* $(1)


### PR DESCRIPTION
9dc64a8 renderer: fall back to interface wiphy when the link object has none
ae4c485 health: match captive/custom-named SSIDs to their radio by band
37557a1 state: fix HaLow center frequency in state message
4c7afdd captive: add walled-garden firewall allow rules before drop rule
5712780 state: fix HaLow interface frequency report in the state message
aa68005 network: add switch_vlan settings for models with LAN Ethernet ports
818569f health: add per-radio health check to detect failed SSIDs
d48b896 renderer/templates: Only force auto-channel when STA is on the same radio
eed1a4a tests: drop the suite
16bb4ee radius_proxy: wire private_key_password into radsec TLS config
5621b44 radius_proxy: add status_server knob to radsec realm
df5a753 switch: align port-mirror schema with controller as a list
b973d73 trace: add snaplen and filter expression support
9ac65f7 tools: add ujq helper for pretty printing json
8facc23 radio: skip htmode matching for HaLow band
8c5b891 wifi: fix 2.4G/5G radios showing empty when a HaLow radio is present
d3b4d2c network: keep downstream bridge alive when it has only wlan members
f7db117 renderer: allow dhcpinject service to be disabled
96e4e5e renderer: skip 160MHz fallback on 5G when DFS is disabled
382515a (origin/WIFI-15494-lightweight-JSON-formatter) renderer: wait for netifd wireless to settle before promoting config
f1fe3a3 renderer: isolate UCI savedir to avoid races with netifd
561628e network: aggregate network ports from multiple sources
c1f069c network: null-safety check