### PR TITLE
certificates: restore certs on udaya-a6-id2/od2 A/B slot switch

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -112,7 +112,9 @@ hfcl,ion4xi_HMR|\
 hfcl,ion4x|\
 hfcl,ion4x_2|\
 hfcl,ion4xi_wp|\
-hfcl,ion4xe)
+hfcl,ion4xe|\
+udaya,a6-id2|\
+udaya,a6-od2)
 	if grep -q rootfs_1 /proc/cmdline; then
 		PART_NAME=rootfs
 	else


### PR DESCRIPTION
certificates: restore certs from previous slot on udaya-a6-id2/od2 A/B switch
    Problem:
    
    After a firmware upgrade that switches the active A/B boot slot,
    udaya-a6-id2 and udaya-a6-od2 fail to restore device certificates.
    The device boots into the newly-active slot with no valid certificates
    volume of its own, never reconnects to the uCentral controller, and
    requires manual re-upload of certificates into /certificates before it
    comes back online -- repeating on every subsequent upgrade.
    
    Root Cause: mount_certs has no inactive-slot recovery fallback for udaya,a6-id2 or
    udaya,a6-od2. Both boards fell through to the default case (check
    only, no recovery), unlike other A/B boards (e.g. hfcl,ion4x* and the
    edgecore,eap10x family) which already reach into the inactive slot to
    recover certificates when the primary lookup fails.
    
    Fix: Join udaya,a6-id2 and udaya,a6-od2 into the existing hfcl,ion4x*
    fallback case, which checks /proc/cmdline for the active rootfs/
    rootfs_1 slot and attaches the other one to recover the certificates
    volume from it.
    
    Tests: Tested on udaya-a6-id2, verified certificates are recovered
    and the device reconnects to uCentral after an upgrade that switches
    the active boot slot.
    
    
    Fixes: WIFI-15567
    Signed-off-by: Sujeet Kumar <sujeet.kumar@inventum.net>