### PR TITLE
hostapd: MLO ACL - do not reject STA on external-RADIUS PENDING (WIFI…

### DIFF
--- a/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/patches/z002-hostapd-MLO-ACL-do-not-reject-STA-on-external-RADIUS-PENDING.patch
+++ b/feeds/qca-wifi-7/hostapd/openwrt-patches/services/hostapd/patches/z002-hostapd-MLO-ACL-do-not-reject-STA-on-external-RADIUS-PENDING.patch
@@ -1,0 +1,37 @@
+From: Henry Haller <hbh@rgnets.com>
+Subject: [PATCH] hostapd: MLO ACL - do not reject STA on external-RADIUS PENDING
+
+hostapd_check_ml_acl() (added by s010-02) rejects a STA at association
+whenever hostapd_check_acl() returns anything other than HOSTAPD_ACL_ACCEPT
+in its non-MLD branch. With macaddr_acl=2 (USE_EXTERNAL_RADIUS_AUTH -
+uCentral radius.authentication.mac-filter=true) hostapd_check_acl() returns
+HOSTAPD_ACL_PENDING unconditionally, so on an MLD AP (mld_ap=1, i.e. any
+EHT/6 GHz BSS) a client using RADIUS MAC authentication can never associate
+("STA <mac> not allowed to connect", reason=1). RADIUS itself accepts
+(Access-Accept, VLAN returned) - the reject is hostapd-internal.
+
+RADIUS authorization is already enforced at authentication time; this
+assoc-time gate only needs to honour the static accept/deny lists. Reject
+only on an explicit HOSTAPD_ACL_REJECT, matching the MLD-link branch below
+which already tolerates macaddr_acl=2.
+
+Reproduced + fixed on CIG WF189 (ipq5332/qcn9274, OpenWrt 25.12, hostapd
+2025-03-10 95ad711): 100% assoc failure without the change; associates +
+4-way + dynamic VLAN with it. Static deny_mac / DENY_UNLESS_ACCEPTED
+blocking preserved.
+
+JIRA: WIFI-15628
+Signed-off-by: Henry Haller <hbh@rgnets.com>
+---
+--- a/src/ap/ieee802_11_auth.c
++++ b/src/ap/ieee802_11_auth.c
+@@ -357,7 +357,8 @@
+ 	int acl_res, acl_res_linkaddr, accept = 0;
+ 
+ 	if (!ap_sta_is_mld(hapd, sta)) {
+-		if (hostapd_check_acl(hapd, sta->addr, NULL) != HOSTAPD_ACL_ACCEPT) {
++		acl_res = hostapd_check_acl(hapd, sta->addr, NULL);
++		if (acl_res != HOSTAPD_ACL_ACCEPT && acl_res != HOSTAPD_ACL_PENDING) {
+ 			wpa_printf(MSG_INFO, "STA " MACSTR " not allowed to connect",
+ 				   MAC2STR(sta->addr));
+ 			return HOSTAPD_ACL_REJECT;


### PR DESCRIPTION
See JIRA: WIFI-15628

hostapd_check_ml_acl() (added by s010-02) rejects a STA at association
whenever hostapd_check_acl() returns anything other than HOSTAPD_ACL_ACCEPT
in its non-MLD branch. With macaddr_acl=2 (USE_EXTERNAL_RADIUS_AUTH -
uCentral radius.authentication.mac-filter=true) hostapd_check_acl() returns
HOSTAPD_ACL_PENDING unconditionally, so on an MLD AP (mld_ap=1, i.e. any
EHT/6 GHz BSS) a client using RADIUS MAC authentication can never associate
("STA <mac> not allowed to connect", reason=1). RADIUS itself accepts
(Access-Accept, VLAN returned) - the reject is hostapd-internal.

RADIUS authorization is already enforced at authentication time; this
assoc-time gate only needs to honour the static accept/deny lists. Reject
only on an explicit HOSTAPD_ACL_REJECT, matching the MLD-link branch below
which already tolerates macaddr_acl=2.

Reproduced + fixed on CIG WF189 (ipq5332/qcn9274, OpenWrt 25.12, hostapd
2025-03-10 95ad711): 100% assoc failure without the change; associates +
4-way + dynamic VLAN with it. Static deny_mac / DENY_UNLESS_ACCEPTED
blocking preserved.