### PR TITLE
qca-wifi-6/hostapd: FT: update cached PMK-R0/PMK-R1 VLAN when VLAN is assigned late

### DIFF
--- a/feeds/qca-wifi-6/hostapd/patches/zzzz-002-FT-update-cached-PMK-R0-R1-VLAN-on-late-assignment.patch
+++ b/feeds/qca-wifi-6/hostapd/patches/zzzz-002-FT-update-cached-PMK-R0-R1-VLAN-on-late-assignment.patch
@@ -1,0 +1,151 @@
+hostapd: FT: update cached PMK-R0/PMK-R1 VLAN when VLAN is assigned late
+
+On platforms using the ucode/mpskd multi-PSK handler, the PSK of a
+station is matched from the per-STA PSK list supplied via the
+"sta_auth" notification (force_psk).  In that path
+hostapd_wpa_auth_get_psk() reports vlan_id=0, so when the FT key
+hierarchy is stored after EAPOL-Key msg 2/4 MIC validation
+(wpa_auth_ft_store_keys()), the PMK-R0/PMK-R1 cache entries are created
+without VLAN information.  The VLAN is only applied afterwards, when
+mpskd answers the "sta_connected" notification and the ucode glue calls
+ap_sta_set_vlan()/ap_sta_bind_vlan().
+
+As a result, any FT roam served from these cache entries - a local
+PMK-R1 lookup on this AP or an RRB pull/push response handed to another
+AP of the mobility domain - carried no VLAN, and the station ended up
+in the default VLAN after roaming (multi-psk client with vlan-id roams
+from a QCA AP to an MTK AP and gets an IP from the default network).
+
+Fix this by refreshing the VLAN of all stored PMK-R0/PMK-R1 entries of
+the station at the moment the late VLAN assignment happens.  A
+successful update is logged at INFO level:
+
+  FT: Updated stored PMK-R0/PMK-R1 VLAN <id> for <sta>
+
+diff -urN a/src/ap/ucode.c b/src/ap/ucode.c
+--- a/src/ap/ucode.c	2026-07-22 17:04:58.487502400 +0800
++++ b/src/ap/ucode.c	2026-07-22 17:05:38.343545400 +0800
+@@ -4,6 +4,7 @@
+ #include "utils/common.h"
+ #include "utils/ucode.h"
+ #include "hostapd.h"
++#include "wpa_auth.h"
+ #include "beacon.h"
+ #include "hw_features.h"
+ #include "ap_drv_ops.h"
+@@ -807,6 +808,15 @@
+ 
+ 		ap_sta_set_vlan(hapd, sta, &vdesc);
+ 		ap_sta_bind_vlan(hapd, sta);
++
++		/* The VLAN of a multi-PSK STA is assigned only now (via
++		 * ucode/mpskd), after the 4-way handshake has completed and
++		 * the FT key hierarchy (PMK-R0/PMK-R1) has already been
++		 * stored without VLAN information.  Refresh the stored
++		 * entries so that FT roaming (local PMK-R1 lookup and RRB
++		 * pull/push responses served to other APs) carries the
++		 * correct VLAN. */
++		wpa_auth_ft_update_sta_vlan(sta->wpa_sm);
+ 	}
+ 
+ out:
+diff -urN a/src/ap/wpa_auth.h b/src/ap/wpa_auth.h
+--- a/src/ap/wpa_auth.h	2026-07-22 17:04:58.571308800 +0800
++++ b/src/ap/wpa_auth.h	2026-07-22 17:05:40.576050700 +0800
+@@ -494,6 +494,13 @@
+ 			const u8 **identity, size_t *identity_len,
+ 			const u8 **radius_cui, size_t *radius_cui_len,
+ 			int *session_timeout, struct rate_description *rate);
++void wpa_auth_ft_update_sta_vlan(struct wpa_state_machine *sm);
++
++#else /* CONFIG_IEEE80211R_AP */
++
++static inline void wpa_auth_ft_update_sta_vlan(struct wpa_state_machine *sm)
++{
++}
+ 
+ #endif /* CONFIG_IEEE80211R_AP */
+ 
+diff -urN a/src/ap/wpa_auth_ft.c b/src/ap/wpa_auth_ft.c
+--- a/src/ap/wpa_auth_ft.c	2026-07-22 17:04:58.657822900 +0800
++++ b/src/ap/wpa_auth_ft.c	2026-07-22 17:05:49.970249900 +0800
+@@ -1390,6 +1390,79 @@
+ }
+ 
+ 
++/*
++ * Update the VLAN stored in the PMK-R0/PMK-R1 cache entries of a STA whose
++ * VLAN was assigned only after the initial 4-way handshake (e.g., by the
++ * ucode/mpskd multi-PSK handler).  Without this, RRB responses and local
++ * PMK-R1 lookups would hand out the entries without VLAN information and
++ * the station would land in the default VLAN after FT roaming.
++ */
++void wpa_auth_ft_update_sta_vlan(struct wpa_state_machine *sm)
++{
++	struct wpa_ft_pmk_cache *cache;
++	struct wpa_ft_pmk_r0_sa *r0;
++	struct wpa_ft_pmk_r1_sa *r1;
++	struct vlan_description vlan;
++	int updated = 0;
++
++	if (!sm || !sm->wpa_auth || !sm->wpa_auth->ft_pmk_cache)
++		return;
++
++	if (!wpa_key_mgmt_ft(sm->wpa_key_mgmt))
++		return;
++
++	if (wpa_ft_get_vlan(sm->wpa_auth, sm->addr, &vlan) < 0)
++		return;
++
++	cache = sm->wpa_auth->ft_pmk_cache;
++
++	dl_list_for_each(r0, &cache->pmk_r0, struct wpa_ft_pmk_r0_sa, list) {
++		if (os_memcmp(r0->spa, sm->addr, ETH_ALEN) != 0)
++			continue;
++		if (!vlan.notempty) {
++			os_free(r0->vlan);
++			r0->vlan = NULL;
++			continue;
++		}
++		if (!r0->vlan)
++			r0->vlan = os_zalloc(sizeof(vlan));
++		if (!r0->vlan) {
++			wpa_printf(MSG_ERROR,
++				   "FT: Failed to allocate VLAN for stored PMK-R0 entry of "
++				   MACSTR, MAC2STR(sm->addr));
++			continue;
++		}
++		*r0->vlan = vlan;
++		updated++;
++	}
++
++	dl_list_for_each(r1, &cache->pmk_r1, struct wpa_ft_pmk_r1_sa, list) {
++		if (os_memcmp(r1->spa, sm->addr, ETH_ALEN) != 0)
++			continue;
++		if (!vlan.notempty) {
++			os_free(r1->vlan);
++			r1->vlan = NULL;
++			continue;
++		}
++		if (!r1->vlan)
++			r1->vlan = os_zalloc(sizeof(vlan));
++		if (!r1->vlan) {
++			wpa_printf(MSG_ERROR,
++				   "FT: Failed to allocate VLAN for stored PMK-R1 entry of "
++				   MACSTR, MAC2STR(sm->addr));
++			continue;
++		}
++		*r1->vlan = vlan;
++		updated++;
++	}
++
++	if (updated)
++		wpa_printf(MSG_INFO,
++			   "FT: Updated stored PMK-R0/PMK-R1 VLAN %d for "
++			   MACSTR, vlan.untagged, MAC2STR(sm->addr));
++}
++
++
+ static int wpa_ft_store_pmk_r0(struct wpa_authenticator *wpa_auth,
+ 			       const u8 *spa, const u8 *pmk_r0,
+ 			       size_t pmk_r0_len,


### PR DESCRIPTION
On platforms using the ucode/mpskd multi-PSK handler, the PSK of a station is matched from the per-STA PSK list supplied via the "sta_auth" notification (force_psk).  In that path hostapd_wpa_auth_get_psk() reports vlan_id=0, so when the FT key hierarchy is stored after EAPOL-Key msg 2/4 MIC validation (wpa_auth_ft_store_keys()), the PMK-R0/PMK-R1 cache entries are created without VLAN information.  The VLAN is only applied afterwards, when mpskd answers the "sta_connected" notification and the ucode glue calls ap_sta_set_vlan()/ap_sta_bind_vlan().

As a result, any FT roam served from these cache entries - a local PMK-R1 lookup on this AP or an RRB pull/push response handed to another AP of the mobility domain - carried no VLAN, and the station ended up in the default VLAN after roaming (multi-psk client with vlan-id roams from a QCA AP to an MTK AP and gets an IP from the default network).

Fix this by refreshing the VLAN of all stored PMK-R0/PMK-R1 entries of the station at the moment the late VLAN assignment happens.  A successful update is logged at INFO level:

  FT: Updated stored PMK-R0/PMK-R1 VLAN <id> for <sta>

This PR is same as this: https://github.com/Telecominfraproject/wlan-ap/pull/1201
Fixes: WIFI-15185