### PR TITLE
Staging update eap115 eap115a codebase 0723

### DIFF
--- a/feeds/mediatek/hostapd/patches/0276-owf-hostapd-increase-netlink-socket-receive-buffer.patch
+++ b/feeds/mediatek/hostapd/patches/0276-owf-hostapd-increase-netlink-socket-receive-buffer.patch
@@ -1,0 +1,37 @@
+From a1b2c3d4e5f60718293a4b5c6d7e8f90123456789 Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Thu, 24 Jul 2026 15:00:00 +0800
+Subject: [PATCH] mtk: hostapd: increase netlink socket receive buffer size
+
+Increase the dynamic VLAN netlink socket receive buffer to 256KB to
+prevent dropped messages during heavy RADIUS exchanges (e.g. OpenRoaming
+with large certificate chains and vendor-specific attributes). Without
+this, the netlink socket used by full_dynamic_vlan_init() can hit
+"No buffer space available" on recvmsg and lose RADIUS-assigned VLAN
+events.
+
+Signed-off-by: Tanya Singh <tanya_singh@accton.com>
+---
+ src/ap/vlan_full.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/ap/vlan_full.c b/src/ap/vlan_full.c
+index 1a2b3c4d5..6e7f8a9b0 100644
+--- a/src/ap/vlan_full.c
++++ b/src/ap/vlan_full.c
+@@ -772,6 +772,7 @@ full_dynamic_vlan_init(struct hostapd_data *hapd)
+ {
+ 	struct sockaddr_nl local;
+ 	struct full_dynamic_vlan *priv;
++	int rxbuf = 262144;
+ 
+ 	priv = os_zalloc(sizeof(*priv));
+ 	if (priv == NULL)
+@@ -790,6 +791,7 @@ full_dynamic_vlan_init(struct hostapd_data *hapd)
+ 		os_free(priv);
+ 		return NULL;
+ 	}
++	setsockopt(priv->s, SOL_SOCKET, SO_RCVBUF, &rxbuf, sizeof(rxbuf));
+ 
+ 	os_memset(&local, 0, sizeof(local));
+ 	local.nl_family = AF_NETLINK;

--- a/feeds/mediatek/mt76/Makefile
+++ b/feeds/mediatek/mt76/Makefile
@@ -324,7 +324,12 @@ define KernelPackage/mt7996e
   	   +@KERNEL_RELAY +@DRIVER_11BE_SUPPORT
   FILES:= $(PKG_BUILD_DIR)/mt7996/mt7996e.ko
   AUTOLOAD:=$(call AutoProbe,mt7996e)
-  MODPARAMS.mt7996e:=wed_enable=1
+  ifneq ($(filter "DEVICE_edgecore_eap115" "DEVICE_edgecore_eap115a",$(CONFIG_TARGET_PROFILE)),)
+    # Disable WED (flow offload) on EAP115/EAP115a to avoid data-path regression
+    MODPARAMS.mt7996e:=wed_enable=0
+  else
+    MODPARAMS.mt7996e:=wed_enable=1
+  endif
 endef
 
 define KernelPackage/mt7992-firmware

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -456,6 +456,39 @@
 			"description": "WAN Metrics",
 			"type": "string"
 		},
+		"hs20_oper_friendly_name": {
+			"description": "Operator Friendly Name (one entry per language, e.g. 'eng:Example')",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"osu_ssid": {
+			"description": "SSID used for all OSU connections",
+			"type": "string"
+		},
+		"osu_provider": {
+			"description": "List of osu-provider section names to advertise",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"operator_icon": {
+			"description": "List of operator icon names (referencing hs20-icon section names)",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"radius_server_clients": {
+			"description": "Path to RADIUS client configuration for the integrated RADIUS server",
+			"type": "string"
+		},
+		"radius_server_auth_port": {
+			"description": "UDP port for the integrated RADIUS authentication server",
+			"type": "number"
+		},
 		"identity": {
 			"description": "Identity string for EAP",
 			"type": "string"
@@ -561,7 +594,7 @@
 			"type": "alias",
 			"default": "qos_map_set"
 		},
-		"roaming_consortium": {
+		"iw_roaming_consortium": {
 			"type": "alias",
 			"default": "roaming_consortium"
 		},

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -395,6 +395,7 @@ function iface_eap_server(config) {
 	append_vars(config, [
 		'eap_server', 'eap_server_erp', 'eap_user_file', 'ca_cert', 'server_cert',
 		'private_key', 'private_key_passwd', 'server_id',
+		'radius_server_clients', 'radius_server_auth_port',
 	]);
 }
 
@@ -472,15 +473,58 @@ function iface_key_caching(config) {
 	]);
 }
 
+function iface_hs20_icons(uci) {
+	uci.foreach('wireless', 'hs20-icon', (s) => {
+		append_raw(`hs20_icon=${s.width}:${s.height}:${s.lang}:${s.type}:${s['.name']}:${s.path}`);
+	});
+}
+
+function iface_osu_provider(uci, name) {
+	let s = uci.get_all('wireless', name);
+	if (!s || s['.type'] != 'osu-provider')
+		return;
+
+	append_raw('# provider ' + name);
+	append('osu_server_uri', s.osu_server_uri);
+	append('osu_nai', s.osu_nai);
+	append('osu_nai2', s.osu_nai2);
+	append('osu_method_list', s.osu_method);
+
+	for (let desc in s.osu_service_desc)
+		append('osu_service_desc', desc);
+	for (let name in s.osu_friendly_name)
+		append('osu_friendly_name', name);
+	for (let icon in s.osu_icon)
+		append('osu_icon', icon);
+
+	append_raw('');
+}
+
 function iface_hs20(config) {
 	if (!config.hs20)
 		return;
 
+	set_default(config, 'disable_dgaf', config.hs20);
+
 	append_vars(config, [
 		'hs20', 'disable_dgaf', 'anqp_domain_id', 'hs20_deauth_req_timeout',
 		'hs20_wan_metrics', 'hs20_operating_class', 'hs20_t_c_filename', 'hs20_t_c_timestamp',
-		'hs20_t_c_server_url', 'hs20_conn_capab'
+		'hs20_t_c_server_url', 'osu_ssid'
 	]);
+
+	/* repeated keys: one line per entry */
+	for (let name in config.hs20_oper_friendly_name)
+		append('hs20_oper_friendly_name', name);
+	for (let capab in config.hs20_conn_capab)
+		append('hs20_conn_capab', capab);
+	for (let icon in config.operator_icon)
+		append('operator_icon', icon);
+
+	/* hs20-icon and osu-provider live in separate wireless sections */
+	let uci = libuci.cursor();
+	iface_hs20_icons(uci);
+	for (let name in config.osu_provider)
+		iface_osu_provider(uci, name);
 }
 
 function iface_interworking(config) {
@@ -488,18 +532,31 @@ function iface_interworking(config) {
 		return;
 	
 	config.interworking = true;
-	
+
+	/* domain_name is a single comma-separated directive */
 	if (config.domain_name)
 		config.domain_name = join(',', config.domain_name);
 
+	/* 3GPP cellular network info is a single semicolon-separated directive */
 	if (config.anqp_3gpp_cell_net)
-		config.domain_name = join(',', config.anqp_3gpp_cell_net);
+		config.anqp_3gpp_cell_net = join(';', config.anqp_3gpp_cell_net);
 
 	append_vars(config, [
 		'interworking', 'internet', 'asra', 'uesa', 'access_network_type', 'hessid', 'venue_group',
-		'venue_type', 'network_auth_type', 'gas_address3', 'roaming_consortium', 'anqp_elem', 'nai_realm',
-		'venue_name', 'venue_url', 'domain_name', 'anqp_3gpp_cell_net',
+		'venue_type', 'network_auth_type', 'gas_address3', 'domain_name', 'anqp_3gpp_cell_net',
 	]);
+
+	/* these keys must be emitted once per list entry */
+	for (let oi in config.roaming_consortium)
+		append('roaming_consortium', oi);
+	for (let elem in config.anqp_elem)
+		append('anqp_elem', elem);
+	for (let realm in config.nai_realm)
+		append('nai_realm', realm);
+	for (let name in config.venue_name)
+		append('venue_name', name);
+	for (let url in config.venue_url)
+		append('venue_url', url);
 }
 
 function iface_rates(config, dev_config) {

--- a/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/feeds/mediatek/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -16,6 +16,10 @@ export function parse_encryption(config, dev_config) {
 	if (!config.wpa)
 		config.wpa_pairwise = null;
 
+	/* OSEN (OSU Server-only authenticated L2 Encryption Network) */
+	if (wildcard(config.encryption, '*osen*'))
+		config.auth_osen = true;
+
 	config.wpa_pairwise = (config.hw_mode == 'ad') ? 'GCMP' : 'CCMP';
 	config.auth_type = encryption[0] ?? 'none';
 
@@ -149,8 +153,12 @@ export function parse_encryption(config, dev_config) {
 };
 
 export function wpa_key_mgmt(config) {
-	if (!config.wpa)
+	if (!config.wpa) {
+		/* OSEN can be used on an otherwise open OSU BSS */
+		if (config.auth_osen)
+			config.wpa_key_mgmt = 'OSEN';
 		return;
+	}
 
 	switch(config.auth_type) {
 	case 'psk':
@@ -306,6 +314,9 @@ export function wpa_key_mgmt(config) {
 			break;
 		}
 	}
+
+	if (config.auth_osen)
+		append_value(config, 'wpa_key_mgmt', 'OSEN');
 
 	if (config.rsn_override && config.rsn_override_key_mgmt_2)
 		config.key_mgmt = config.rsn_override_key_mgmt_2;

--- a/feeds/mediatek/wifi-scripts/files/etc/hotplug.d/ieee80211/12-mtk-sr-scene-cond
+++ b/feeds/mediatek/wifi-scripts/files/etc/hotplug.d/ieee80211/12-mtk-sr-scene-cond
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+board=$(board_name)
+
+phy_dir="/sys/kernel/debug/ieee80211"
+# Count the number of phyX
+phy_count=$(ls -d $phy_dir/phy* 2>/dev/null | wc -l)
+echo "$phy_count" > /tmp/phy_count
+
+case "$board" in
+    "edgecore,eap112")
+        phy1_file=$phy_dir/phy1/mt76/sr_enable
+        phy2_file=$phy_dir/phy2/mt76/sr_enable
+
+        if [ -f "$phy1_file" ]; then
+            check_phy1=$(cat $phy1_file)
+            [ "$check_phy1" = 0 ] && echo 1 > $phy1_file
+        fi
+
+        if [ -f "$phy2_file" ]; then
+            check_phy2=$(cat $phy2_file)
+            [ "$check_phy2" = 0 ] && echo 1 > $phy2_file
+        fi
+
+        # note: phy0 is HaLow
+        ln -sf $phy_dir/phy1/mt76/sr_scene_cond /tmp/sr_scene_cond_phy2g
+        ln -sf $phy_dir/phy2/mt76/sr_scene_cond /tmp/sr_scene_cond_phy5g
+    ;;
+    "edgecore,eap111")
+        phy0_file=$phy_dir/phy0/mt76/sr_enable
+        phy1_file=$phy_dir/phy1/mt76/sr_enable
+
+        if [ -f "$phy0_file" ]; then
+            check_phy0=$(cat $phy0_file)
+            [ "$check_phy0" = 0 ] && echo 1 > $phy0_file
+        fi
+
+        if [ -f "$phy1_file" ]; then
+            check_phy1=$(cat $phy1_file)
+            [ "$check_phy1" = 0 ] && echo 1 > $phy1_file
+        fi
+
+        ln -sf $phy_dir/phy0/mt76/sr_scene_cond /tmp/sr_scene_cond_phy2g
+        ln -sf $phy_dir/phy1/mt76/sr_scene_cond /tmp/sr_scene_cond_phy5g
+    ;;
+    "edgecore,eap115"|\
+    "edgecore,eap115a")
+        band0_file=$phy_dir/phy0/mt76/band0/sr_enable
+        band1_file=$phy_dir/phy0/mt76/band1/sr_enable
+
+        if [ -f "$band0_file" ]; then
+            check_band0=$(cat $band0_file)
+            [ "$check_band0" = 0 ] && echo 1 > $band0_file
+        fi
+
+        if [ -f "$band1_file" ]; then
+            check_band1=$(cat $band1_file)
+            [ "$check_band1" = 0 ] && echo 1 > $band1_file
+        fi
+
+        ln -sf $phy_dir/phy0/mt76/band0/sr_scene_cond /tmp/sr_scene_cond_phy2g
+        ln -sf $phy_dir/phy0/mt76/band1/sr_scene_cond /tmp/sr_scene_cond_phy5g
+    ;;
+esac

--- a/feeds/mediatek/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/feeds/mediatek/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -114,9 +114,10 @@ for (let phy_name, phy in board.wlan) {
 			num_global_macaddr = board.wlan.defaults.ssids?.[band_name]?.mac_count;
 		}
 
-		if (length(info.radios) > 0)
+		if (length(info.radios) > 0) {
 			id += `\nset ${s}.radio='${radio.index}'`;
-
+			id += `\nset ${s}.sku_idx='${radio.index}'`;
+		}
 		if (has_mlo)
 			init_mld = true;
 

--- a/feeds/mtk-app/smp_util/files/smp-mt76.sh
+++ b/feeds/mtk-app/smp_util/files/smp-mt76.sh
@@ -371,7 +371,7 @@ setup_model()
 	elif [[ $board == *"bpi-r4"* ]]; then
 		dbg "setup_model: bpi-r4 NUM_WIFI_CARD=$num_of_wifi"
 		MT7988 $num_of_wifi
-	elif [[ $board == *"7987"* ]]; then
+	elif [[ $board == *"7987"* || $board == "edgecore,eap115" || $board == "edgecore,eap115a" ]]; then
 		dbg "setup_model: MT7987 NUM_WIFI_CARD=$num_of_wifi"
 		MT7988 $num_of_wifi
 	fi
@@ -437,6 +437,16 @@ set_rps_cpus()
 			fi
 		fi
 	done
+
+	board=$(board_name)
+	case $board in
+	edgecore,eap115|\
+	edgecore,eap115a)
+		# for EAP115, change CPU loading of ethter traffic on Core0 and Core2
+		echo 4 > /sys/class/net/eth0/queues/rx-0/rps_cpus
+		echo 4 > /sys/class/net/eth1/queues/rx-0/rps_cpus
+		;;
+	esac
 }
 
 set_smp_affinity()

--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/policy_chanutil.uc
@@ -1,4 +1,6 @@
 let board_info = global.ubus.conn.call('system', 'board');
+let math = require('math');
+
 let config = {
     /* Channel utilization threshold: When Utilization of the current channel or adjacent channel reaches the configured threshold (in %), the AP switches to a different Channel.
     Set this field to 0 to disable this feature. Range: 0-99 */
@@ -45,13 +47,35 @@ case 'edgecore,eap112':
     break;
 }
 
+// MTK board capability flags — add new boards here instead of scattering checks
+let mtk_caps = {
+    single_phy_multi_band: (board_name == 'edgecore,eap115' || board_name == 'edgecore,eap115a'),
+    uses_sr_scene_cond: (board_name == 'edgecore,eap111' || board_name == 'edgecore,eap112' ||
+                         board_name == 'edgecore,eap115' || board_name == 'edgecore,eap115a'),
+    has_halow: (board_name == 'edgecore,eap112' && phy_count == 3),
+};
+
+function get_phy_id(iface) {
+    let iface_num = replace(iface, /[^0-9]/g, '');
+    let phy_id = 'phy' + iface_num;
+
+    if (board_name == 'edgecore,eap105') {
+        phy_id = 'phy00';
+    } else if (mtk_caps.single_phy_multi_band) {
+        phy_id = 'phy0';
+    }
+
+    return phy_id;
+}
+
 function cool_down_check(iface, cool_down_period) {
     let now_t = time();
-    let cool_down_f= 0;
+    let cool_down_f = 0;
 
     // check cool_down_period passed or not
-    let deltaTS = now_t - stats_info_read("/tmp/chan_switch_time_" + iface);
-    ulog_info(`[%s] Cool down check: current_time=%d, chan_switch_time=%d, deltaTS(time passed)=%d \n`, iface, now_t, stats_info_read("/tmp/chan_switch_time_" + iface), deltaTS);
+    let chan_switch_time = stats_info_read("/tmp/chan_switch_time_" + iface);
+    let deltaTS = now_t - chan_switch_time;
+    ulog_info(`[%s] Cool down check: current_time=%d, chan_switch_time=%d, deltaTS(time passed)=%d \n`, iface, now_t, chan_switch_time, deltaTS);
 
     if (deltaTS < (cool_down_period/1000)) {
         ulog_info(`[%s] Need to cool down (%d seconds hasn't passed) before switching channel \n`, iface, cool_down_period/1000);
@@ -261,7 +285,7 @@ function interface_status_check(iface) {
     let radio_status = 'DISABLED';
     let radio_down_f = 1;
 
-    if (board_info.board_name == 'edgecore,eap112' && phy_count == 3) {
+    if (mtk_caps.has_halow) {
         //  hostapd_cli_s1g status | grep 'Selected interface'| awk -F "\'" '{print $2}'
         let check_HaLow_iface_cmd = sprintf('hostapd_cli_s1g status | grep \'Selected interface\'| awk -F "\'" \'{print $2}\'');
         let check_HaLow_iface = fs.popen(check_HaLow_iface_cmd);
@@ -348,6 +372,9 @@ function hostapd_switch_channel(msg) {
 }
 
 function switch_status_check(iface, dfs_enabled_5g_flag) {
+    // add a 5 sec delay regardless of DFS being enabled or not
+    sleep(5000);
+
     // need to wait for radio 5GHz interface to be UP, when DFS is enabled
     if (dfs_enabled_5g_flag == 1) {
         ulog_info(`[%s] 5G radio might need some time to be UP (DFS enabled) \n`, iface);
@@ -394,11 +421,7 @@ function switch_status_check(iface, dfs_enabled_5g_flag) {
 }
 
 function dfs_chan_check(iface, rcs_channel) {
-    let iface_num = replace(iface, /[^0-9]/g, '');
-    let phy_id = 'phy' + iface_num;
-    if (board_name == 'edgecore,eap105') {
-        phy_id = 'phy00';
-    }
+    let phy_id = get_phy_id(iface);
     let dfs_enabled_5g_f = 0;
     let dfs_chan_list = global.phy.phys[phy_id].dfs_channels;
 
@@ -438,18 +461,18 @@ function fixed_channel_config(iface, iface_num, fixed_channel_f, auto_channel_f,
 }
 
 function get_chan_util(radio_band, sleep_time) {
-	let pdev_stats = {};
-	let chan_util = 0;
+    let pdev_stats = {};
+    let chan_util = 0;
     let total_usage = 0;
 
     let prev_values = {
-		txFrameCount: null,
-		rxFrameCount: null,
-		rxClearCount: null,
+        txFrameCount: null,
+        rxFrameCount: null,
+        rxClearCount: null,
         chanBusyTime: null,
-		cycleCount: null,
+        cycleCount: null,
         chanActiveTime: null,
-	};
+    };
 
     for (let c = 0; c < 2; c++) {
         // Check tx and tx stats for wlanX interface
@@ -464,11 +487,23 @@ function get_chan_util(radio_band, sleep_time) {
             chanActiveTime: null,
         };
 
-        if (board_info.board_name == 'edgecore,eap111' || board_info.board_name == 'edgecore,eap112') {
-            // for EAP111 and EAP112 (only 2.4G and 5G radio bands)
+        if (mtk_caps.uses_sr_scene_cond) {
+            // for MTK based APs (only 2.4G and 5G radio bands)
+            // Trigger the kernel to log SR scene condition for this band
             system(`cat /tmp/sr_scene_cond_phy${radio_band}`);
-            // logread -e "Congestion Ratio" | tail -n 1  | awk -F'= ' '{print $2}' | tr -d '%'
-            let cmd = sprintf('logread -e \"Congestion Ratio\" | tail -n 1  | awk -F\'= \' \'{print $2}\' | tr -d \'\%\'');
+
+            let cmd;
+            if (mtk_caps.single_phy_multi_band) {
+                // EAP115/115a: single phy with band0=2g, band1=5g
+                // The kernel logs "Band index = X" followed by "Congestion Ratio = YY.Y%"
+                // Filter by band index to get the correct band's congestion ratio
+                let band_idx = (radio_band == '2g') ? 0 : 1;
+                cmd = sprintf('logread | grep -E "(Band index = %d|Congestion Ratio)" | grep -A1 "Band index = %d" | grep "Congestion Ratio" | tail -n 1 | awk -F\'= \' \'{print $2}\' | tr -d \' %%\'', band_idx, band_idx);
+            } else {
+                // EAP111/EAP112: separate phys, each logs "Band index = 0"; each phy is independent
+                cmd = sprintf('logread -e \"Congestion Ratio\" | tail -n 1 | awk -F\'= \' \'{print $2}\' | tr -d \' %%\'');
+            }
+
             let chan_util_cmd = fs.popen(cmd);
             let _chan_util = chan_util_cmd.read('all');
             chan_util_cmd.close();
@@ -536,13 +571,8 @@ function get_chan_util(radio_band, sleep_time) {
 }
 
 function random_channel_selection(iface, band, htmode, chan_list_valid, exclude_dfs) {
-    let math = require('math');
     let bw = replace(htmode, /[^0-9]/g, '');
-    let iface_num = replace(iface, /[^0-9]/g, '');
-    let phy_id = 'phy' + iface_num;
-    if (board_name == 'edgecore,eap105') {
-        phy_id = 'phy00';
-    }
+    let phy_id = get_phy_id(iface);
 
     // channel list from the driver based on the country code
     let chan_list_cc = uniq(sort(global.phy.phys[phy_id].channels, (a, b) => a - b));
@@ -820,11 +850,12 @@ function channel_optimize() {
 
     ulog_info(`Interval for checking Channel Utilization = %d seconds; Interval for cooling down = %d seconds \n`, config.interval/1000, cool_down_period/1000);
 
+    // get wireless interface uci config from "ubus call network.wireless status"
+    let wireless_status = global.ubus.conn.call('network.wireless', 'status');
+
     for (let j = 0; j < num_radios; j++) {
         let radio_id = "radio" + j;
 
-        // get wireless interface uci config from "ubus call network.wireless status"
-        let wireless_status = global.ubus.conn.call('network.wireless', 'status');
         radio_disabled[j] = wireless_status[radio_id].disabled;
         radio_band[j] = wireless_status[radio_id].config.band;
 
@@ -971,7 +1002,6 @@ function channel_optimize() {
                         /* Collect the chan util info of #max_chan channels*/
                         for (let num_chan = 0; num_chan < max_chan; num_chan++) {
                             ulog_info(`[%s] Channel utilization check ROUND#%d \n`, radio_iface[l], num_chan);
-
                             if (num_chan == 0) {
                                 curr_chan_list[num_chan] = current_channel[l];
                                 chan_util_list[num_chan] = chan_util_value[l];
@@ -984,7 +1014,6 @@ function channel_optimize() {
                                 // call RCS for multiple random chan
                                 let chan_scan = algo_rcs(radio_iface[l], curr_chan_list[num_chan-1], radio_band[l], htmode[l], selected_channels[l], acs_exclude_dfs[l]);
                                 curr_chan_list[num_chan] = stats_info_read("/tmp/rrm_random_channel_" + radio_iface[l]);
-
                                 if (chan_scan == 1) {
                                     // assign channel from RCS to interface
                                     init_payload = {

--- a/patches-25.12/0186-mediatek-add-thermal-protection-init-for-EAP115-EAP115a.patch
+++ b/patches-25.12/0186-mediatek-add-thermal-protection-init-for-EAP115-EAP115a.patch
@@ -1,0 +1,35 @@
+From a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Thu, 23 Jul 2026 00:00:00 +0000
+Subject: [PATCH] mediatek: add thermal protection init for EAP115/EAP115a
+
+Add a boot-time init script that programs hwmon thermal trip points for
+Edgecore EAP boards. On EAP115/EAP115a the 2.4G sensor trips at 105C and
+restores at 95C.
+---
+ .../filogic/base-files/etc/init.d/thermal_protection | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+ create mode 100755 target/linux/mediatek/filogic/base-files/etc/init.d/thermal_protection
+
+diff --git a/target/linux/mediatek/filogic/base-files/etc/init.d/thermal_protection b/target/linux/mediatek/filogic/base-files/etc/init.d/thermal_protection
+new file mode 100755
+index 0000000000..84030929c6
+--- /dev/null
++++ b/target/linux/mediatek/filogic/base-files/etc/init.d/thermal_protection
+@@ -0,0 +1,14 @@
++#!/bin/sh /etc/rc.common
++
++START=99
++
++boot() {
++	case $(board_name) in
++	edgecore,eap115|\
++	edgecore,eap115a)
++		# Only set for 2.4G, trigger temp 105, restore temp 95
++		echo 95000 > /sys/class/hwmon/hwmon1/temp1_crit
++		echo 105000 > /sys/class/hwmon/hwmon1/temp1_max
++		;;
++	esac
++}
+-- 
+2.45.2

--- a/patches-25.12/0187-mediatek-eap115-move-ramoops-to-dts-log-to-pmsg.patch
+++ b/patches-25.12/0187-mediatek-eap115-move-ramoops-to-dts-log-to-pmsg.patch
@@ -1,0 +1,86 @@
+From b2c3d4e5f6071829304a5b6c7d8e9f0123456789 Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Thu, 23 Jul 2026 00:00:00 +0000
+Subject: [PATCH] mediatek: eap115: move ramoops reserved-memory to DTS and
+ store logread to pmsg
+
+u-boot should remove PSTORE support and let the runtime
+firmware handle it via its own DTS file.
+
+The current firmware ramoops size is too small and may not capture enough
+information for debug. The reserved memory size needs to be increased, but
+it is currently defined in the u-boot configuration. Move the settings from
+u-boot to the runtime device tree file, which is easier to maintain. After
+testing, the ramoops reserved memory can only live in 0x5ffa0000 ~
+0x5ffbffff.
+
+Also store logread output to /dev/pmsg0 so log data survives into the
+ramoops pstore region.
+
+---
+ package/system/ubox/files/log.init                     | 19 +++++++++++++++++++
+ target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi | 12 ++++++++++++
+ 2 files changed, 31 insertions(+)
+
+diff --git a/package/system/ubox/files/log.init b/package/system/ubox/files/log.init
+index 040a550e15..25e533fbe9 100644
+--- a/package/system/ubox/files/log.init
++++ b/package/system/ubox/files/log.init
+@@ -68,6 +68,24 @@ start_service_file()
+ 	procd_close_instance
+ }
+ 
++start_service_pmsg()
++{
++	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
++	local pid_file="/var/run/logread.${PIDCOUNT}.pid"
++	local pmsg_file="/dev/pmsg0"
++
++	[ "$2" = 0 ] || {
++		echo "validation failed"
++		return 1
++	}
++	[ -e "${pmsg_file}" ] || return
++
++	procd_open_instance pmsgfile
++	procd_set_param command "$PROG" -f -F "$pmsg_file" -p "$pid_file"
++	procd_append_param command -S "128"
++	procd_close_instance
++}
++
+ start_service_remote()
+ {
+ 	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
+@@ -110,6 +128,7 @@ start_service()
+ 	config_load system
+ 	config_foreach validate_log_daemon system start_service_daemon
+ 	config_foreach validate_log_section system start_service_file
++	config_foreach validate_log_section system start_service_pmsg
+ 	config_foreach validate_log_section system start_service_remote
+ }
+ 
+diff --git a/target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi b/target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi
+index d0a4a5b5bb..ba67e05354 100644
+--- a/target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi
++++ b/target/linux/mediatek/dts/mt7987a-edgecore-eap115.dtsi
+@@ -60,6 +60,18 @@
+ 		always-running;
+ 	};
+ 
++	reserved-memory {
++		/* 128 KiB reserved for ramoops/pstore */
++		ramoops@5ffa0000 {
++			compatible = "ramoops";
++			reg = <0 0x5ffa0000 0 0x20000>;
++			ecc-size = <0x0>;
++			record-size = <0x4000>;
++			console-size = <0x4000>;
++			pmsg-size = <0x4000>;
++			ftrace-size = <0x0>;
++		};
++	};
+ };
+ 
+ &eth {
+-- 
+2.45.2

--- a/patches-25.12/0188-busybox-enable-mpstat-by-default.patch
+++ b/patches-25.12/0188-busybox-enable-mpstat-by-default.patch
@@ -1,0 +1,24 @@
+From c3d4e5f60718293a4b5c6d7e8f90123456789abc Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Thu, 23 Jul 2026 00:00:00 +0000
+Subject: [PATCH] busybox: enable mpstat by default
+
+---
+ package/utils/busybox/Config-defaults.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package/utils/busybox/Config-defaults.in b/package/utils/busybox/Config-defaults.in
+index da6b7d6b58..d80956f101 100644
+--- a/package/utils/busybox/Config-defaults.in
++++ b/package/utils/busybox/Config-defaults.in
+@@ -2822,7 +2822,7 @@ config BUSYBOX_DEFAULT_LSOF
+ 	default n
+ config BUSYBOX_DEFAULT_MPSTAT
+ 	bool
+-	default n
++	default y
+ config BUSYBOX_DEFAULT_NMETER
+ 	bool
+ 	default n
+-- 
+2.34.1


### PR DESCRIPTION
Multiple updates for Edgecore EAP115, EAP115a:

| Ticket | Commit | Summary |
|--------|--------|---------|
| WIFI-15614 | ba2623cd | Update smp_util for EAP115, EAP115a |
| WIFI-15615 | 878c83a1 | Unable to configure tx-power on EAP115, EAP115a |
| WIFI-15616 | fe8966c1 | [EAP115] Disable HW acceleration (flow offload) |
| WIFI-15617 | 4156847b | [EAP115] Enable thermal protection |
| WIFI-15618 | 95aab529 | [EAP115] Move ramoops reserved-memory to DTS and store logread to pmsg |
| WIFI-15619 | 1ee9b95a | [EAP115] Enable mpstat for monitoring CPU usage |
| WIFI-15625 | 703cb9cb | [EAP115] Support Openroaming |
| WIFI-15486 | 6c8591d9 | RRM support on EAP115, EAP115a |