### PR TITLE
Previously GCMP-256 was enabled for both HE and EHT on 6GHz band.

### DIFF
--- a/patches/0104-netifd-limit-gcmp-256-to-EHT-only.patch
+++ b/patches/0104-netifd-limit-gcmp-256-to-EHT-only.patch
@@ -1,0 +1,37 @@
+From 386e28bccf11978022a461abdc438af2e4eb691b Mon Sep 17 00:00:00 2001
+From: ruanyaoyu <ruanyaoyu@actiontec.com>
+Date: Wed, 29 Jul 2026 18:28:43 +0800
+Subject: [PATCH] netifd: limit GCMP-256 cipher to EHT only on 6GHz
+
+Previously GCMP-256 was enabled for both HE and EHT on 6GHz band.
+This change limits it to EHT only, as HE does not require GCMP-256.
+
+Tested on WF196 with 6GHz radio, verified GCMP-256 is only applied under
+EHT mode and not under HE mode.
+
+Fixes: WIFI-15627
+Signed-off-by: ruanyaoyu <ruanyaoyu@actiontec.com>
+---
+ .../config/netifd/patches/201-gcmp-256-eht-only.patch | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+ create mode 100644 package/network/config/netifd/patches/201-gcmp-256-eht-only.patch
+
+diff --git a/package/network/config/netifd/patches/201-gcmp-256-eht-only.patch b/package/network/config/netifd/patches/201-gcmp-256-eht-only.patch
+new file mode 100644
+--- /dev/null
++++ b/package/network/config/netifd/patches/201-gcmp-256-eht-only.patch
+@@ -0,0 +1,12 @@
++Index: netifd-2023-09-19-8587c074/scripts/netifd-wireless.sh
++===================================================================
++--- netifd-2023-09-19-8587c074.orig/scripts/netifd-wireless.sh
+++++ netifd-2023-09-19-8587c074/scripts/netifd-wireless.sh
++@@ -75,7 +75,7 @@
++ 			hwmode=a;
++ 			case "$htmode" in
++-				HE*|EHT*) wpa3_cipher="GCMP-256 ";;
+++				EHT*) wpa3_cipher="GCMP-256 ";;
++ 				*) wpa3_cipher="";;
++ 			esac
++ 		;;
+-- 
+2.43.0


### PR DESCRIPTION
This change limits it to EHT only, as HE does not require GCMP-256.

Tested on WF196 with 6GHz radio, verified GCMP-256 is only applied under EHT mode and not under HE mode.

Fixes: WIFI-15627