### PR TITLE
ath11k: fix wrong TID passed when stopping AMPDU session WIFI-15627

### DIFF
--- a/feeds/ipq807x_v5.4/mac80211/patches/pending/a-106-ath11k-fix-ampdu-stop-wrong-tid.patch
+++ b/feeds/ipq807x_v5.4/mac80211/patches/pending/a-106-ath11k-fix-ampdu-stop-wrong-tid.patch
@@ -1,0 +1,31 @@
+From: Pablo Martin-Gomez <pmartin-gomez@freebox.fr>
+Subject: [PATCH] wifi: ath11k: fix wrong TID passed when stopping AMPDU session
+
+When handling a DELBA request, ath11k_dp_rx_ampdu_stop() calls
+ath11k_peer_rx_tid_reo_update() to tear down the BA session for the
+specified TID. However, it currently passes peer->rx_tid instead of the
+entry corresponding to params->tid. Since peer->rx_tid is an array, this
+decays to a pointer to the first element, effectively operating on TID 0
+regardless of the TID in the DELBA request. This leads to incorrect BA
+session state and may significantly reduce RX throughput, as traffic
+falls back to a BA window size of 1 on TID 0.
+
+Backported from ath-current:
+https://lore.kernel.org/all/20260126174049.1370659-1-pmartin-gomez@freebox.fr/
+
+Signed-off-by: Pablo Martin-Gomez <pmartin-gomez@freebox.fr>
+Signed-off-by: Firas Shaari <firas.shaari@shaariconsultancy.com>
+
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1217,7 +1217,9 @@
+ 		return 0;
+ 	}
+ 
+-	ret = ath11k_peer_rx_tid_reo_update(ar, peer, peer->rx_tid, 1, 0, false);
++	ret = ath11k_peer_rx_tid_reo_update(ar, peer,
++					    &peer->rx_tid[params->tid],
++					    1, 0, false);
+ 	spin_unlock_bh(&ab->base_lock);
+ 	if (ret) {
+ 		ath11k_warn(ab, "failed to update reo for rx tid %d: %d\n",


### PR DESCRIPTION
Backport of the upstream ath-current fix by Pablo Martin-Gomez (Freebox):
https://lore.kernel.org/all/20260126174049.1370659-1-pmartin-gomez@freebox.fr/

`ath11k_dp_rx_ampdu_stop()` passes `peer->rx_tid` (array base, i.e. TID 0) to `ath11k_peer_rx_tid_reo_update()` instead of the entry for `params->tid`. A DELBA on any TID therefore collapses the data TID 0 BA window to 1, causing episodic uplink throughput collapse (wire rate → ~400 Mbps with client MCS thrashing) that self-recovers only when the client re-ADDBAs TID 0.

This is the ath11k twin of the ath12k bug being addressed for WIFI-15461 on the WiFi-7 targets (upstream: https://lore.kernel.org/all/20260227110123.3726354-1-reshma.rajkumar@oss.qualcomm.com/).

**Verified on CIG WF196** (QCN9074 6 GHz radio, Intel BE200 STA, 3-minute monitored runs):
- Before: 943 Mbps uplink collapses to ~350–620 Mbps for ~150 s with client rate thrash (MCS 3–11), then self-recovers, repeating.
- After (this one-line fix only): 983 Mbps average (1 GbE wire rate), steady 2SS MCS10, no collapse episodes.

Fixes: WIFI-15627
