### PR TITLE
patches-25.12: add uboot-envtools support for Edgecore EAP112

### DIFF
--- a/patches-25.12/0185-mediatek-add-support-for-Edgecore-EAP112.patch
+++ b/patches-25.12/0185-mediatek-add-support-for-Edgecore-EAP112.patch
@@ -5,14 +5,27 @@ Subject: [PATCH] mediatek: add Edgecore EAP112 support
 
 Signed-off-by: Sebastian Huang <sebastian_huang@accton.com>
 ---
+ .../uboot-envtools/files/mediatek_filogic        |   1 +
  .../mediatek/dts/mt7981a-edgecore-eap112.dts     | 252 ++++++++++++++++++
  .../filogic/base-files/etc/board.d/02_network    |   1 +
  .../base-files/etc/board.d/03_gpio_switches      |   4 +
  .../lib/preinit/05_set_edgecore_netdev           |   1 +
  target/linux/mediatek/image/filogic.mk           |  18 ++
- 5 files changed, 276 insertions(+)
+ 6 files changed, 277 insertions(+)
  create mode 100644 target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
 
+diff --git a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+index fd89a211d8..465296e90a 100644
+--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
++++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+@@ -71,6 +71,7 @@ asiarf,ap7986-003|\
+ cetron,ct3003|\
+ comfast,cf-wr632ax|\
+ edgecore,eap111|\
++edgecore,eap112|\
+ edgecore,eap115|\
+ edgecore,eap115a|\
+ emplus,wap588m|\
 diff --git a/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts b/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
 new file mode 100644
 index 0000000000..93cdf70822


### PR DESCRIPTION
Allow the envtool config to be generated on EAP112.

Fixes: WIFI-15369