### PR TITLE
hostapd/mpskd: preserve RADIUS MPSK VLAN across band roaming incl. 6 GHz

### DIFF
--- a/feeds/ipq807x_v5.4/hostapd/patches/800-multi-psk-roaming-vlan.patch
+++ b/feeds/ipq807x_v5.4/hostapd/patches/800-multi-psk-roaming-vlan.patch
@@ -1,0 +1,55 @@
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -153,6 +153,7 @@ struct hostapd_sta_wpa_psk_short {
+ 	unsigned int is_passphrase:1;
+ 	u8 psk[PMK_LEN];
+ 	char passphrase[MAX_PASSPHRASE_LEN + 1];
++	int vlan_id;
+ 	int ref; /* (number of references held) - 1 */
+ };
+ 
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -2404,6 +2404,42 @@ int ieee802_11_set_radius_info(struct ho
+ 			       vlan_id->tagged[0] ? "+" : "");
+ 		return -1;
+ 	}
++
++	/* Store VLAN ID with cached PSK for MPSK roaming support */
++	if (hapd->conf->ssid.dynamic_vlan && psk && vlan_id->notempty &&
++	    vlan_id->untagged > 0) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++
++		for (psk_entry = psk; psk_entry; psk_entry = psk_entry->next) {
++			psk_entry->vlan_id = vlan_id->untagged;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Stored VLAN %d with PSK for "
++				   MACSTR, vlan_id->untagged,
++				   MAC2STR(sta->addr));
++		}
++	}
++
++	/* Restore VLAN from cached PSK if not provided by RADIUS */
++	if (hapd->conf->ssid.dynamic_vlan && !vlan_id->notempty && sta->psk) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++		int cached_vlan = 0;
++
++		for (psk_entry = sta->psk; psk_entry; psk_entry = psk_entry->next) {
++			if (psk_entry->vlan_id > 0) {
++				cached_vlan = psk_entry->vlan_id;
++				break;
++			}
++		}
++
++		if (cached_vlan > 0) {
++			vlan_id->notempty = 1;
++			vlan_id->untagged = cached_vlan;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Restored VLAN %d from cached PSK for " MACSTR,
++				   cached_vlan, MAC2STR(sta->addr));
++		}
++	}
++
+ 	if (ap_sta_set_vlan(hapd, sta, vlan_id) < 0)
+ 		return -1;
+ 	if (sta->vlan_id)

--- a/feeds/qca-wifi-7/hostapd/files/mpskd
+++ b/feeds/qca-wifi-7/hostapd/files/mpskd
@@ -252,14 +252,34 @@ function sta_auth_psk(ifname, addr) {
 	return ssid_psk(ssid, addr);
 }
 
-function sta_auth_cache(ifname, addr, idx, phrase) {
+function cache_reply(cache) {
+	if (!cache.vlan)
+		return cache.data;
+	let d = {};
+	for (let k, v in cache.data)
+		d[k] = v;
+	d.vlan = cache.vlan;
+	return d;
+}
+
+function sta_auth_cache(ifname, addr, idx, phrase, vlan) {
 	let ssid = iface_ssid(ifname);
 	if (!ssid)
 		return;
 
+	/*
+	 * Learn (and clear) the RADIUS VLAN only on the bands that carry it
+	 * (2.4/5 GHz). On 6 GHz there is no RADIUS, so keep the value learned
+	 * earlier instead of wiping it when the event carries no VLAN.
+	 */
+	let learn_vlan = interfaces[ifname]?.band != '6g';
+
 	let cache = sta_cache_entry_get(ssid, addr);
-	if (cache)
-		return cache.data;
+	if (cache) {
+		if (learn_vlan)
+			cache.vlan = vlan;
+		return cache_reply(cache);
+	}
 
 	let psk = ssid_psk(ssid, addr);
 	if (!psk)
@@ -276,17 +296,20 @@ function sta_auth_cache(ifname, addr, idx, phrase) {
 	if (!cache)
 		return;
 
+	if (learn_vlan)
+		cache.vlan = vlan;
+
 	let ssid_data = ssids[ssid];
 	if (!ssid_data)
-		return cache.data;
+		return cache_reply(cache);
 
 	let target_ifname = ssid_data.bands['6g'];
 	if (!target_ifname)
-		return cache.data;
+		return cache_reply(cache);
 
 	let target_iface = interfaces[target_ifname];
 	if (!target_iface)
-		return cache.data;
+		return cache_reply(cache);
 
 	cache.timer = uloop.timer(30 * 1000, () => {
 		let msg = {
@@ -302,7 +325,7 @@ function sta_auth_cache(ifname, addr, idx, phrase) {
 		delete cache.timer;
 	});
 
-	return cache.data;
+	return cache_reply(cache);
 }
 
 function auth_cb(msg) {
@@ -321,7 +344,7 @@ function auth_cb(msg) {
 	case 'sta_connected':
 		if (data.psk_idx == null || !is_ssid_mpsk(data.iface))
 			return;
-		return sta_auth_cache(data.iface, data.sta, data.psk_idx, data.psk);
+		return sta_auth_cache(data.iface, data.sta, data.psk_idx, data.psk, data.vlan);
 	case 'reload':
 		netifd_reload();
 		reload_timer.set(5000);

--- a/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0080-multi-psk-roaming-vlan.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0080-multi-psk-roaming-vlan.patch
@@ -1,0 +1,69 @@
+From: Marek Kwaczynski <marek@shasta.cloud>
+Subject: [PATCH] qca-wifi-7: hostapd: port MPSK roaming VLAN fix to WiFi-7
+
+WiFi-7 counterpart of John Crispin commit 55691669 ("hostapd: fix VLAN
+assignment lost on MPSK roaming between bands"), which fixed WiFi-6 only.
+Cache the RADIUS-assigned VLAN with the per-STA PSK entry and restore it
+when RADIUS does not resend it on a PMK-cached roam.
+
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -160,5 +160,6 @@
+ 	unsigned int is_passphrase:1;
+ 	u8 psk[PMK_LEN];
+ 	char passphrase[MAX_PASSPHRASE_LEN + 1];
++	int vlan_id;
+ 	int ref; /* (number of references held) - 1 */
+ };
+
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -2449,6 +2449,48 @@
+ 			       vlan_id->tagged[0] ? "+" : "");
+ 		return -1;
+ 	}
++
++	/* Store VLAN ID with cached PSK for MPSK roaming support */
++	if (hapd->conf->ssid.dynamic_vlan && psk && vlan_id->notempty &&
++	    vlan_id->untagged > 0) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++
++		for (psk_entry = psk; psk_entry; psk_entry = psk_entry->next) {
++			psk_entry->vlan_id = vlan_id->untagged;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Stored VLAN %d with PSK for "
++				   MACSTR, vlan_id->untagged,
++				   MAC2STR(sta->addr));
++		}
++	}
++
++	/* Restore VLAN from cached PSK if not provided by RADIUS */
++	if (hapd->conf->ssid.dynamic_vlan && !vlan_id->notempty && sta->psk) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++		int cached_vlan = 0;
++
++		for (psk_entry = sta->psk; psk_entry; psk_entry = psk_entry->next) {
++			if (psk_entry->vlan_id > 0) {
++				cached_vlan = psk_entry->vlan_id;
++				break;
++			}
++		}
++
++		if (cached_vlan > 0) {
++			vlan_id->notempty = 1;
++			vlan_id->untagged = cached_vlan;
++
++			/* Re-persist so it survives the psk-list swap below */
++			for (psk_entry = psk; psk_entry;
++			     psk_entry = psk_entry->next)
++				psk_entry->vlan_id = cached_vlan;
++
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Restored VLAN %d from cached PSK for " MACSTR,
++				   cached_vlan, MAC2STR(sta->addr));
++		}
++	}
++
+ 	if (ap_sta_set_vlan(hapd, sta, vlan_id) < 0)
+ 		return -1;
+ 	if (sta->vlan_id)

--- a/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0081-mpsk-6g-radius-vlan.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0081-mpsk-6g-radius-vlan.patch
@@ -1,0 +1,20 @@
+From: Marek Kwaczynski <marek@shasta.cloud>
+Subject: [PATCH] qca-wifi-7: hostapd: emit sta VLAN in sta_connected ucode event
+
+Include the RADIUS-assigned VLAN (sta->vlan_id) in the ucode sta_connected
+event so mpskd can learn a client's VLAN on 2.4/5G and re-apply it when the
+same client (E-MPSK) later joins the 6 GHz SAE BSS (where there is no RADIUS).
+Pairs with mpskd returning the cached VLAN, which hostapd applies via the
+existing ap_sta_set_vlan() path in hostapd_ucode_sta_connected().
+
+--- a/src/ap/ucode.c
++++ b/src/ap/ucode.c
+@@ -804,6 +804,8 @@
+ 		ucv_object_add(val, "psk_idx", ucv_int64_new(sta->psk_idx - 1));
+ 	if (sta->psk)
+ 		ucv_object_add(val, "psk", ucv_string_new(sta->psk->passphrase));
++	if (sta->vlan_id)
++		ucv_object_add(val, "vlan", ucv_int64_new(sta->vlan_id));
+ 	uc_value_push(ucv_get(val));
+ 
+ 	val = wpa_ucode_call(3);


### PR DESCRIPTION
Fixes WIFI-14179.

Branch renamed to follow guideline A1 (`staging-WIFI-<number>-<short-hyphenated-description>`).

This supersedes #1202, which contains the identical commits (head `c460941c9a6f`) and was already approved by @venkatchimata and @SebastianHuang-ec. Only the branch name differs, no code changes.