### PR TITLE
patches-25.12: increase ramoops size for EAP111 and EAP112

### DIFF
--- a/patches-25.12/0186-mediatek-increase-ramoops-size-for-Edgecore-EAP111-EAP112.patch
+++ b/patches-25.12/0186-mediatek-increase-ramoops-size-for-Edgecore-EAP111-EAP112.patch
@@ -1,0 +1,61 @@
+From 78b34822a012ac5fcba547e825467950e3439f91 Mon Sep 17 00:00:00 2001
+From: Sebastian Huang <sebastian_huang@accton.com>
+Date: Sat, 25 Jul 2026 00:36:20 +0800
+Subject: [PATCH] mediatek: increase the ramoops size to 512KB for Edgecore
+ EAP111/EAP112
+
+Signed-off-by: Sebastian Huang <sebastian_huang@accton.com>
+---
+ .../linux/mediatek/dts/mt7981a-edgecore-eap111.dts   | 12 ++++++++++++
+ .../linux/mediatek/dts/mt7981a-edgecore-eap112.dts   | 12 ++++++++++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts b/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
+index bfe72bd87a..378ca13b5f 100644
+--- a/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
++++ b/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
+@@ -53,6 +53,18 @@
+ 			function = LED_FUNCTION_INDICATOR;
+ 		};
+ 	};
++
++	reserved-memory {
++		/delete-node/ ramoops@42ff0000;  // Delete the original node
++
++		ramoops: ramoops@42f80000 {
++			compatible = "ramoops";
++			reg = <0x0 0x42f80000 0x0 0x80000>;
++			record-size = <0x25000>;
++			console-size = <0x25000>;
++			pmsg-size = <0x25000>;
++		};
++	};
+ };
+ 
+ &uart0 {
+diff --git a/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts b/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
+index 93cdf70822..8298e1aa72 100644
+--- a/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
++++ b/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
+@@ -53,6 +53,18 @@
+ 			function = LED_FUNCTION_INDICATOR;
+ 		};
+ 	};
++
++	reserved-memory {
++		/delete-node/ ramoops@42ff0000;  // Delete the original node
++
++		ramoops: ramoops@42f80000 {
++			compatible = "ramoops";
++			reg = <0x0 0x42f80000 0x0 0x80000>;
++			record-size = <0x25000>;
++			console-size = <0x25000>;
++			pmsg-size = <0x25000>;
++		};
++	};
+ };
+ 
+ &uart0 {
+-- 
+2.34.1
+


### PR DESCRIPTION
Increase the ramoops size to 512KiB

Fixes: WIFI-15307