### PR TITLE
Staging wifi 15609: Update Edgecore AP LED behavior (EAP104, EAP105, OAP101/OAP101e)

### DIFF
--- a/feeds/qca-wifi-6/ipq50xx/base-files/etc/board.d/01_leds
+++ b/feeds/qca-wifi-6/ipq50xx/base-files/etc/board.d/01_leds
@@ -13,8 +13,8 @@ wallys,dr5018)
 edgecore,eap104)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wifi2" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wifi5" "phy1tpt"
-	ucidef_set_led_netdev "wan" "wan" "yellow:uplink" "eth0"
-        ucidef_set_led_default "power" "POWER" "green:power" "on"
+	ucidef_set_led_netdev "wan" "wan" "green:uplink" "eth0"
+	ucidef_set_led_default "power" "POWER" "green:power" "on"
 	;;
 indio,um-325ax-v2|\
 indio,um-335ax|\
@@ -48,8 +48,8 @@ sonicfi,rap630e)
 	;;
 edgecore,oap101|\
 edgecore,oap101e)
-	ucidef_set_led_netdev "wan" "wan" "red:ethernet" "eth1"
-        ucidef_set_led_default "power" "POWER" "blue:management" "on"
+	ucidef_set_led_netdev "wan" "wan" "orange:ethernet" "eth0"
+	ucidef_set_led_default "power" "POWER" "green:system" "on"
 	;;
 emplus,wap385c)
 	ucidef_set_led_default "ledr" "LEDR" "sys:red" "on"

--- a/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
+++ b/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-eap104.dts
@@ -690,7 +690,7 @@
 			default-state = "off";
 		};
 		led@43 {
-			label = "yellow:uplink";
+			label = "green:uplink";
 			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};

--- a/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-oap101.dts
+++ b/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-oap101.dts
@@ -450,20 +450,20 @@
 		compatible = "gpio-leds";
 
 		led@0 {
-			label = "red:ethernet";
+			label = "orange:ethernet";
 			gpios = <&tca9539 0 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
-		led@1 {
+		led_power: led@1 {
 			label = "green:system";
 			gpios = <&tca9539 1 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-		led_power: led@2 {
-			label = "blue:management";
-			gpios = <&tca9539 2 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 			linux,default-trigger = "heartbeat";
+		};
+		led@2 {
+			label = "blue:cloud";
+			gpios = <&tca9539 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
 		};
 	};
 

--- a/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-oap101e.dts
+++ b/feeds/qca-wifi-6/ipq50xx/files/arch/arm64/boot/dts/qcom/qcom-ipq5018-oap101e.dts
@@ -450,20 +450,20 @@
 		compatible = "gpio-leds";
 
 		led@0 {
-			label = "red:ethernet";
+			label = "orange:ethernet";
 			gpios = <&tca9539 0 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
-		led@1 {
+		led_power: led@1 {
 			label = "green:system";
 			gpios = <&tca9539 1 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-		led_power: led@2 {
-			label = "blue:management";
-			gpios = <&tca9539 2 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 			linux,default-trigger = "heartbeat";
+		};
+		led@2 {
+			label = "blue:cloud";
+			gpios = <&tca9539 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
 		};
 	};
 

--- a/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-edgecore-eap105.dts
+++ b/feeds/qca-wifi-7/ipq53xx/dts/ipq5332-edgecore-eap105.dts
@@ -282,12 +282,12 @@
 				default-state = "off";
 			};
 			led_power: led@38 {
-				label = "blue:status";
+				label = "green:system";
 				gpios = <&tlmm 38 GPIO_ACTIVE_HIGH>;
 				default-state = "off";
 			};
 			led@39 {
-				label = "green:system";
+				label = "blue:cloud";
 				gpios = <&tlmm 39 GPIO_ACTIVE_HIGH>;
 				default-state = "off";
 			};


### PR DESCRIPTION
| Commit | Ticket | Subject |
|---|---|---|
| `5f0a020a` | WIFI-15636 |  `qca-wifi-6/ipq50xx: update Edgecore EAP104, OAP101 and OAP101e LED behavior`: EAP104 `yellow:uplink` → `green:uplink` on gpio43 and wired as the wan netdev LED; OAP101/e `red:ethernet` → `orange:ethernet`, `blue:management` → `blue:cloud`, `led_power` alias moved from `led@2` to `led@1` so boot blinks green, and uplink activity rebound from `eth1` (lan) to `eth0` (wan) |
| `a747da37` | WIFI-15610 | `qca-wifi-7/ipq53xx: correct Edgecore EAP105 LED labels` — `led@38` `blue:status` → `green:system` (gpio38 is green) and `led@39` → `blue:cloud`, so power and boot share the green LED |

**Affected targets / boards**
- `qca-wifi-6` / `ipq50xx` — EAP104, OAP101, OAP101e
- `qca-wifi-7` / `ipq53xx` — EAP105

**Note:** `board.d/01_leds` is shared, but only the `edgecore,eap104` and `edgecore,oap101|edgecore,oap101e` cases are touched; no other board's LED configuration changes.

Test outcome: https://telecominfraproject.atlassian.net/browse/WIFI-15609?focusedCommentId=64909