### PR TITLE
yuncore_ax820: enable pstore

### DIFF
--- a/patches/0104-yuncore_ax820-enable-pstore.patch
+++ b/patches/0104-yuncore_ax820-enable-pstore.patch
@@ -1,0 +1,58 @@
+From: Firas Shaari <firas.shaari@shaariconsultancy.com>
+Date: Mon, 3 Aug 2026 19:30:00 -0400
+Subject: [PATCH] yuncore_ax820: enable pstore
+
+The AX820 device tree has no reserved-memory/ramoops node, so ramoops
+comes up with mem_size=0/mem_address=0 and crash logs are never saved.
+Reserve 512 KB for ramoops and map it uncached.
+
+The mapping type matters on MT7621. With a cached mapping the 12-byte
+ramoops zone header (sig/start/size) is a single dirty cache line that
+is still in the D-cache when the SoC resets, while the record itself is
+large enough to be written back by capacity eviction through the 32 KB
+D-cache. The record therefore survives the reset in DRAM but its length
+reads back as 0, so persistent_ram_post_init() treats the zone as empty
+and discards a perfectly good crash dump.
+
+Verified on hardware by instrumenting persistent_ram_post_init() to
+print each zone's recovered state before any zap:
+
+  mem-type = <2>:  size=0     start=0     -> dump discarded
+  mem-type = <1>:  size=6909  start=6909  -> dump recovered
+
+With the uncached mapping the full chain works: panic -> ramoops ->
+pstore -> ucentral-pstore -> controller rebootLog (type crashlog).
+
+Fixes: WIFI-15350
+Signed-off-by: Firas Shaari <firas.shaari@shaariconsultancy.com>
+---
+ .../ramips/dts/mt7621_yuncore_ax820.dts            | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
++++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+@@ -79,6 +79,21 @@
+ 			linux,code = <KEY_RESTART>;
+ 		};
+ 	};
++
++	reserved-memory {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		ranges;
++
++		ramoops: ramoops@f000000 {
++			compatible = "ramoops";
++			reg = <0x0f000000 0x80000>;
++			record-size = <0x20000>;
++			console-size = <0x20000>;
++			pmsg-size = <0x20000>;
++			mem-type = <1>;
++		};
++	};
+ };
+
+ &spi0 {
+--
+2.34.1


### PR DESCRIPTION
Fixes: WIFI-15350

Root Cause:

The AX820 device tree has no `reserved-memory/ramoops` node, so ramoops comes up with `mem_size=0`/`mem_address=0` and crash logs are never saved. Kernel-side pstore itself is already enabled globally by `patches/0052-generic-enable-pstore-support.patch`.

Adding the node alone is not sufficient, and this is the part that is easy to miss. With a cached mapping the crash record does reach DRAM and does survive the reset, but the zone's 12-byte header (sig/start/size) does not. The header is a single dirty cache line still sitting in the 32 KB MIPS D-cache when the SoC resets, while the record itself is large enough to be written back by capacity eviction on its way through. On the next boot `persistent_ram_post_init()` reads `size == 0`, treats the zone as empty, and discards an otherwise perfectly intact dump. The signature and the payload both look healthy — only the length is lost, which is why this is effectively invisible from userspace.

Solution:

Add the `reserved-memory/ramoops` node reserving 512 KB at 0x0f000000 (240 MB, leaving 16 MB of headroom on the 256 MB AX820) and map it uncached with `mem-type = <1>`.

Confirmed by instrumenting `persistent_ram_post_init()` to print each zone's recovered state before any zap. That step is what makes the result unambiguous: `persistent_ram_zap()` clears start/size but leaves the data behind, so "the length was never written" and "the zone was zapped at boot" are otherwise indistinguishable after the fact.

```
mem-type = <2> (cached):    size=0     start=0     -> dump discarded
mem-type = <1> (uncached):  size=6909  start=6909  -> dump recovered
```

Scope:

This touches a single file, `target/linux/ramips/dts/mt7621_yuncore_ax820.dts`, which is compiled only into the AX820 device tree. No shared kernel config, no feed, and no other board is affected.

Testing:

Built for ramips/mt7621 and verified on a YunCore AX820 running a clean production image — no debug kernel, no instrumentation, just this DTS change. After `echo c > /proc/sysrq-trigger` and the reboot, the panic is captured, decoded and uploaded to the controller:

```
"method":"rebootLog","params":{"type":"crashlog","date":1785798601,
 "info":["Panic#1 Part1","<5>[    0.000000] Linux version 5.15.132 ..."
```

and the AP re-registers with `"reason":"crashlog"`. Note that an empty `/sys/fs/pstore` is expected on success — `/usr/sbin/ucentral-pstore` consumes the record and ships it to the controller, so capture should be confirmed in `logread` rather than on the filesystem.

Possible related issue on another board:

`patches/0100-sonicfi_rap63xc-211g-enable-pstore.patch` (same MT7621 SoC) specifies no `mem-type` property at all, so it defaults to write-combined and is likely affected by the same problem. It was the template this patch was originally modelled on. Since pstore silently not working looks identical to "the device never crashed", this may not have been noticed. Worth validating on that board with a real crash — not changed here, as I have no RAP63XC to test on.
