### PR TITLE
ucentral:add -i flag for QA certificates to fix connection failure

### DIFF
--- a/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
+++ b/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
@@ -44,6 +44,12 @@ start_service() {
 		[ "${selfsigned}" == "true" ] && insecure=1
 	fi
 
+	if [ -f /etc/ucentral/cert.pem ]; then
+		case "$(openssl x509 -in /etc/ucentral/cert.pem -noout -issuer 2>/dev/null)" in
+			*"OpenLAN Demo"*) insecure=1 ;;
+	esac
+	fi
+
 	server=
 	[ -f /etc/ucentral/gateway.json ] && server=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["server"]')
 	port=


### PR DESCRIPTION
WIFI-15602
Bug Phenomenon
When using QA certificates to connect to uCentral, the connection fails with OpenSSL error X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN (19). This error indicates that during certificate chain construction, a self-signed certificate was encountered that is not present in the local trusted CA certificate store.

In v4.2.1, the -i parameter was always added when using QA certificates, allowing the connection to succeed. 
However, in v5.0.0, the following change was introduced:

[ "$insecure" = "true" ] && insecure=1 || insecure=0

This logic fixed insecure mode being enabled by default when allow-self-signed is unset, but broke QA certificate connections.

Fix
Add a conditional check to detect QA certificates and explicitly add the -i parameter when a QA certificate is being used.

Fixes: WIFI-15602-QA certificates are unable to connect to controller

Testing
- Verified that QA certificate connections work correctly with the fix
  applied
- Confirmed that production certificates continue to work without the
  -i parameter