### PR TITLE
qca-wifi-7: Fix version_le logic and firmware build date in anti-rollback for RAP750W-311a

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
@@ -60,7 +60,7 @@ version_le() {
 
 	[ -z "$ver1" ] || [ -z "$ver2" ] && return 1
 
-	[ "$(printf '%s\n' "$ver1" "$ver2" | sort -V | head -n1)" = "$ver1" ]
+	[ "$(printf '%s\n' "$ver1" "$ver2" | sort -Vr | head -n1)" != "$ver1" ]
 }
 
 find_mmc_part() {

--- a/patches-25.12/0120-base-filies-Modify-the-build-date-to-the-latest.patch
+++ b/patches-25.12/0120-base-filies-Modify-the-build-date-to-the-latest.patch
@@ -1,0 +1,23 @@
+From e723664f8d33da9b8ef15ad719300865ff57b84e Mon Sep 17 00:00:00 2001
+From: "jemmy.lin" <jemmy.lin@cybertan.com.tw>
+Date: Mon, 10 Aug 2026 09:59:09 +0800
+Subject: [PATCH] Modify the build date to the latest
+
+---
+ scripts/get_source_date_epoch.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/get_source_date_epoch.sh b/scripts/get_source_date_epoch.sh
+index 727cb0372b..02a226cd02 100755
+--- a/scripts/get_source_date_epoch.sh
++++ b/scripts/get_source_date_epoch.sh
+@@ -31,5 +31,5 @@ try_mtime() {
+ 	[ -n "$SOURCE_DATE_EPOCH" ]
+ }
+ 
+-try_version || try_git || try_hg || try_mtime || SOURCE_DATE_EPOCH=""
++try_git || try_hg || try_mtime || SOURCE_DATE_EPOCH=""
+ echo "$SOURCE_DATE_EPOCH"
+-- 
+2.34.1
+


### PR DESCRIPTION
Fix version_le logic and firmware build date in anti-rollback for RAP750W-311a

root cause:
    1. The version_le function incorrectly evaluates version comparisons, preventing firmware upgrades when the firmware version is equal to the version limit: v4.2.6.

    2. The firmware build date is incorrect. Starting from TIP 5.1 (OpenWrt 25.12.3), OpenWrt added a version date file (openwrt/version.date) that fixed the build date to 2026-05-04. This fixed date exceeds our LIMIT_BUILD_DATE: 20270717 causing the build date check to fail

Solutions:

   1. Modify the version_le function to allow upgrades for firmware versions that are greater than or equal to the version limit (>= version_limit).

   2. Update openwrt/scripts/get_source_date_epoch.sh to ignore the timestamp from version.date and retrieve the current date instead.

Fixes: WIFI-15645