### PR TITLE
ucentral-state: fix leds_off handling and stale state after locate-blink

### DIFF
--- a/feeds/ucentral/ucentral-state/files/ucentral-state
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state
@@ -214,13 +214,13 @@ function led_find(alias) {
 function factory_reset_timeout() {
 	let led = led_find('led-running');
 	if (led)
-		led_write(led, 'trigger', leds-off ? 'none' : 'default-on');
+		led_write(led, 'trigger', leds_off ? 'none' : 'default-on');
 }
 
 let blink_timer;
 function blink_timeout() {
 	if (current_state == 'blink') {
-		current_state = 'online';
+		current_state = online ? 'online' : 'offline';
 	}
 	system('/etc/init.d/led turnon');
 	if (!blink_timer)


### PR DESCRIPTION
(same as https://github.com/Telecominfraproject/wlan-ap/pull/1235)
Two defects in the state daemon found:

1. factory_reset_timeout() misspelled leds_off with a hyphen, so it parsed as arithmetic on two undeclared identifiers. Under 'use strict' that either raises a reference error or yields NaN, which is falsy and always selects 'default-on' -> so a unit with leds_off=1 lit its status LED 6 seconds after a factory-reset indication instead of staying dark. This function guards only 'if (led)', so the inline ternary was its only leds_off check.

2. blink_timeout() forced current_state to 'online' regardless of actual connectivity. If a locate-blink was requested while offline, the next genuine online transition hit the early return in the 'set' method, so led-running was never set to default-on and online_handler() never ran, leaving the offline admin_ui interface up after the AP connected. Use the 'online' flag, which the state handlers maintain.

Fixes: WIFI-15644