### PR TITLE
ucentral-client/ucentral-state: indicate controller connection state via LEDs

### DIFF
--- a/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
+++ b/feeds/ucentral/ucentral-client/files/etc/init.d/ucentral
@@ -13,6 +13,10 @@ reload_service() {
 	restart
 }
 
+stop_service() {
+	[ -x /usr/libexec/ucentral-led.sh ] && /usr/libexec/ucentral-led.sh off
+}
+
 start_service() {
 	[ -s /etc/ucentral/capabilities.json ] || rm /etc/ucentral/capabilities.json
 	[ -f /etc/ucentral/capabilities.json ] || /usr/share/ucentral/capabilities.uc
@@ -48,7 +52,11 @@ start_service() {
 	[ -f /etc/ucentral/gateway.json ] && server=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["server"]')
 	port=
 	[ -f /etc/ucentral/gateway.json ] && port=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["port"]')
-	[ -n "$server" -a -n "$port" ] || return 0
+	[ -n "$server" -a -n "$port" ] || {
+		# No gateway configured: the AP cannot be controller-managed
+		[ -x /usr/libexec/ucentral-led.sh ] && /usr/libexec/ucentral-led.sh off
+		return 0
+	}
 
 	cert=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["cert"]')
 	ca=$(cat /etc/ucentral/gateway.json | jsonfilter -e '@["ca"]')

--- a/feeds/ucentral/ucentral-client/files/usr/libexec/ucentral-led.sh
+++ b/feeds/ucentral/ucentral-client/files/usr/libexec/ucentral-led.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# ucentral-led.sh - drive the cloud/controller-managed indicator LED.
+#
+# Called with "on" or "off" by:
+#   - /etc/init.d/ucentral   on service stop, and when no gateway is configured
+#   - ucentral-state         on online/offline transitions (real connection state)
+#
+# Boards without a cloud LED, or with LEDs disabled globally, are a no-op.
+#
+
+. /lib/functions.sh
+
+case "$(board_name)" in
+edgecore,eap104)
+	LED_PATH="/sys/class/leds/green:cloud"
+	;;
+edgecore,eap105|\
+edgecore,oap101|\
+edgecore,oap101e|\
+edgecore,eap111|\
+edgecore,eap111e|\
+edgecore,eap115|\
+edgecore,eap115a)
+	LED_PATH="/sys/class/leds/blue:cloud"
+	;;
+*)
+	exit 0
+	;;
+esac
+
+# The LED may be absent on a board variant that shares a board_name.
+[ -d "$LED_PATH" ] || exit 0
+
+# Respect the global LED kill switch, as ucentral-state does for led-running.
+[ "$(uci -q get system.@system[-1].leds_off)" = "1" ] && set -- off
+
+echo none > "$LED_PATH/trigger"
+
+case "$1" in
+on)
+	cat "$LED_PATH/max_brightness" > "$LED_PATH/brightness"
+	;;
+off|*)
+	echo 0 > "$LED_PATH/brightness"
+	;;
+esac

--- a/feeds/ucentral/ucentral-state/files/ucentral-state
+++ b/feeds/ucentral/ucentral-state/files/ucentral-state
@@ -188,8 +188,12 @@ function config_load() {
 	if (status?.connected) {
 		online_handler();
 		online = true;
-	} else if (config.ui.offline_trigger)
-		offline_timer = uloop.timer(config.ui.offline_trigger * 1000, offline_handler);
+		system('/usr/libexec/ucentral-led.sh on');
+	} else {
+		system('/usr/libexec/ucentral-led.sh off');
+		if (config.ui.offline_trigger)
+			offline_timer = uloop.timer(config.ui.offline_trigger * 1000, offline_handler);
+	}
 }
 
 function led_write(led, property, value) {
@@ -223,6 +227,13 @@ function blink_timeout() {
 		current_state = online ? 'online' : 'offline';
 	}
 	system('/etc/init.d/led turnon');
+	/*
+	 * 'led turnon' blanks every LED and then restores only the ones
+	 * configured in board.json. The cloud LED is driven purely from
+	 * userspace, so re-assert it here or it stays dark until the next
+	 * online/offline transition.
+	 */
+	system('/usr/libexec/ucentral-led.sh ' + (online ? 'on' : 'off'));
 	if (!blink_timer)
 		return;
 	blink_timer.cancel();
@@ -235,6 +246,7 @@ let state_handler = {
 		let led = led_find('led-running');
 		if (!leds_off && led)
 			led_write(led, 'trigger', 'heartbeat');
+		system('/usr/libexec/ucentral-led.sh off');
 		if (config.ui.offline_trigger) {
 			if (offline_timer)
 				offline_timer.cancel();
@@ -248,6 +260,7 @@ let state_handler = {
 		let led = led_find('led-running');
 		if (!leds_off && led)
 			led_write(led, 'trigger', 'default-on');
+		system('/usr/libexec/ucentral-led.sh on');
 		online_handler();
 		return 0;
 	},
@@ -279,8 +292,16 @@ let ubus_methods = {
 	set: {
 		call: function(req) {
 			ulog(LOG_INFO, 'state %s -> %s\n', current_state, req.args.state);
-			if (current_state == req.args.state && req.args.state != 'blink')
+			if (current_state == req.args.state && req.args.state != 'blink') {
+				/*
+				 * State is unchanged, so the handlers are skipped.
+				 * The cloud LED lives outside board.json and may have
+				 * been cleared meanwhile (ucentral restart, or a
+				 * 'led turnon'), so re-assert it here.
+				 */
+				system('/usr/libexec/ucentral-led.sh ' + (online ? 'on' : 'off'));
 				return;
+			}
 			if (!state_handler[req.args.state])
 				return ubus.STATUS_INVALID_ARGUMENT;
 			if (current_state != req.args.state)


### PR DESCRIPTION
The QSGs for several Edgecore APs define a cloud / controller-managed
indicator, and the LEDs are labelled in DTS, but nothing drove them — the
cloud LED stayed dark whether or not the AP had reached its controller.

board.d cannot express this. Every `ucidef_set_led_*` helper maps to a kernel
LED trigger and there is no trigger for "ucentral is connected", so this is
driven from userspace and deliberately kept out of `board.json` so
`/etc/init.d/led` does not reset it mid-session.

Adds `ucentral-led.sh`, which maps `board_name` to that board's cloud LED,
honours the global `leds_off` kill switch, and is a no-op where the LED is
absent. `ucentral-state` calls it from the online/offline handlers, where the
real connection state is already known.

The LED is asserted from every point that knows the true state rather than on
transitions alone, so it repairs itself:

- `config_load()`: a `ucentral-state` restart while connected relights it
- `blink_timeout()`: `led turnon` blanks every LED but restores only the
  board.json-configured ones
- the ubus `set` early return: a `ucentral` restart clears the LED and the
  client then re-sends an unchanged `online` that would otherwise be skipped

The init script clears the LED on service stop and when no gateway is
configured, since in both cases the client cannot report its own state. It is
**not** lit on service start: ucentral already reports true state via
`ubus_set_client_status()` from `LWS_CALLBACK_CLIENT_ESTABLISHED`, so a
timer-based "on" would show "managed" on an AP that never connects.

## Affected packages, targets and boards

| Package | Change |
|---|---|
| `ucentral-client` | new `usr/libexec/ucentral-led.sh`; `init.d/ucentral` stop + no-gateway hooks |
| `ucentral-state` | 6 assertion points |

| LED | Boards |
|---|---|
| `green:cloud` | EAP104 |
| `blue:cloud` | EAP105, OAP101, OAP101e, EAP111, EAP111e, EAP115, EAP115a |

**Integration test:** https://telecominfraproject.atlassian.net/browse/WIFI-15643?focusedCommentId=65751

**Coverage:**
- dark before connect, lit on connect, cleared on a real disconnect with the
  client left running (`nft insert` drop on the controller IP), relit on
  reconnect
- all four self-repair paths: `ucentral` restart, `ucentral-state` restart, and
  locate-blink expiry while **online** and while **offline** (the offline case
  is the one that would regress if the re-assert trusted `current_state`)
- `leds-active: false` pushed from the controller turns it off, and the setting
  cannot be overridden by a direct helper call or a state transition
- service stop and missing `gateway.json` both clear it
- no regression on the power or uplink LEDs
- helper is idempotent and fails safe with no argument

Fixes: WIFI-15643