### PR TITLE
.github/workflows: retry build on transient feed clone failures

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -55,12 +55,45 @@ jobs:
       run: |
         docker rmi `docker images -q` || true
 
+    # `make` runs build.sh in docker, which clones the openwrt tree and then the
+    # feeds (luci, routing, ...) from git.openwrt.org. Those clones intermittently
+    # fail with HTTP 5xx, taking the whole build down. gen_config.py wipes feeds/,
+    # feeds.conf and .config at the start of every run, so re-running make after a
+    # feed failure is safe. Retry up to 3 times with exponential backoff, but only
+    # when the log shows a network failure, so real compile errors still fail fast.
     - name: Build image for ${{ matrix.target }}
       id: build
+      shell: bash
       run: |
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
-        make -j TARGET=${{ matrix.target }}
+
+        LOG="${RUNNER_TEMP}/build-${{ matrix.target }}.log"
+        NET_ERRORS='The requested URL returned error: 5|unable to access|Could not resolve host|Connection timed out|Failed to connect|Error updating feeds|Error setting up feeds|Cloning the tree failed|Fetching the tree failed|RPC failed|early EOF'
+
+        for attempt in 1 2 3; do
+          echo "::group::Build attempt ${attempt}/3 for ${{ matrix.target }}"
+          if make -j TARGET=${{ matrix.target }} 2>&1 | tee "${LOG}"; then
+            echo "::endgroup::"
+            echo "Build succeeded on attempt ${attempt}"
+            exit 0
+          fi
+          echo "::endgroup::"
+
+          if ! grep -qE "${NET_ERRORS}" "${LOG}"; then
+            echo "Build failed for a non-network reason, not retrying"
+            exit 1
+          fi
+
+          if [ "${attempt}" -lt 3 ]; then
+            delay=$((30 * attempt))
+            echo "Feed/network failure detected. Retrying in ${delay} seconds..."
+            sleep "${delay}"
+          fi
+        done
+
+        echo "Build failed after 3 attempts due to feed/network errors"
+        exit 1
 
     - name: Package and upload image for ${{ matrix.target }}
       id: package_and_upload_image

--- a/.github/workflows/x64_vm-build-test.yml
+++ b/.github/workflows/x64_vm-build-test.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
-        make -j TARGET=${{ matrix.target }}        make -j TARGET=${{ matrix.target }}
+        make -j TARGET=${{ matrix.target }}
 
     - name: Package and upload image for ${{ matrix.target }}
       id: package_and_upload_image


### PR DESCRIPTION
Builds fail regularly when git.openwrt.org returns HTTP 5xx while gen_config.py clones the feeds, e.g. "unable to access 'https://git.openwrt.org/project/luci.git/': The requested URL returned error: 504". The tree is fine, the mirror is just unavailable for a moment, but the whole matrix entry is lost.

Retry the build up to 3 times with a 30s/60s backoff, only when the captured log matches a network failure so compile errors still fail fast. gen_config.py wipes feeds/, feeds.conf and .config on every run, so a retry restarts from a clean feed state.

While here, drop the duplicated make invocation in the x64_vm build test, where the line repeats itself and make aborts with "No rule to make target 'make'".