### PR TITLE
mediatek: enable USB host and fix LTE GPIOs on Edgecore EAP112

### DIFF
--- a/patches-25.12/0190-mediatek-enable-usb-host-for-Edgecore-EAP112.patch
+++ b/patches-25.12/0190-mediatek-enable-usb-host-for-Edgecore-EAP112.patch
@@ -1,0 +1,77 @@
+From d4e5f60718293a4b5c6d7e8f90123456789abcde Mon Sep 17 00:00:00 2001
+From: Ian Chen <ian77_chen@accton.com>
+Date: Fri, 7 Aug 2026 15:30:00 +0800
+Subject: [PATCH] mediatek: enable USB host and fix LTE GPIOs on Edgecore EAP112
+
+The EAP112 has its LTE modem on the SoC USB port, but that port was
+never brought up: mt7981b.dtsi defaults &xhci and &usb_phy to disabled
+and the board DTS did not override them, and Device/edgecore_eap112 did
+not select kmod-usb3, so the MediaTek xHCI driver was not built.
+
+The USB function drivers (qmi_wwan, cdc_mbim, option) still loaded, so
+nothing looked broken, but without a host controller there was no bus to
+enumerate on: /sys/bus/usb/devices stayed empty and the wwan proto
+handler always failed with No valid device was found'.
+
+The modem power and reset lines were unreachable as well. Their sysfs
+GPIO numbers date back to a kernel 5.4 tree, where gpiolib picked a chip
+base by counting down from ARCH_NR_GPIOS, placing the 57-pin mt7981
+controller at 455 so that pio pins 2 and 3 showed up as 457 and 458.
+Current kernels count up from GPIO_DYNAMIC_BASE (512) instead, so the
+exports failed with invalid GPIO 457' / invalid GPIO 458'. Renumber
+them to 514 and 515, which are the same two pins.
+
+Signed-off-by: Ian Chen <ian77_chen@accton.com>
+---
+ target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts          | 8 ++++++++
+ .../mediatek/filogic/base-files/etc/board.d/03_gpio_switches   | 4 ++--
+ target/linux/mediatek/image/filogic.mk                         | 2 +-
+ 3 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts b/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
+--- a/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
++++ b/target/linux/mediatek/dts/mt7981a-edgecore-eap112.dts
+@@ -78,6 +78,14 @@
+ 	status = "okay";
+ };
+ 
++&usb_phy {
++	status = "okay";
++};
++
++&xhci {
++	status = "okay";
++};
++
+ &pio {
+ 	spi0_flash_pins: spi0-pins {
+ 		mux {
+diff --git a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
++++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+@@ -6,8 +6,8 @@ board=$(board_name)
+ 
+ case "$board" in
+ edgecore,eap112)
+-	ucidef_add_gpio_switch "gpio_lte_reset" "LTE_reset" "457" "1"
+-	ucidef_add_gpio_switch "gpio_lte_power" "LTE_power" "458" "1"
++	ucidef_add_gpio_switch "gpio_lte_reset" "LTE_reset" "514" "1"
++	ucidef_add_gpio_switch "gpio_lte_power" "LTE_power" "515" "1"
+ 	;;
+ huasifei,wh3000-pro)
+ 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "0"
+diff --git a/target/linux/mediatek/image/filogic.mk b/target/linux/mediatek/image/filogic.mk
+--- a/target/linux/mediatek/image/filogic.mk
++++ b/target/linux/mediatek/image/filogic.mk
+@@ -1388,7 +1388,7 @@ define Device/edgecore_eap112
+   IMAGES := sysupgrade.bin factory.bin
+   IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
++  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
+ endef
+ TARGET_DEVICES += edgecore_eap112
+
+-- 
+2.43.0
+

--- a/profiles/edgecore_eap112.yml
+++ b/profiles/edgecore_eap112.yml
@@ -15,6 +15,7 @@ packages:
   - kmod-phy-airoha-an8801sb
   - kmod-i2c-core
   - kmod-mii
+  - kmod-usb3
   - kmod-usb-net
   - kmod-usb-net-cdc-mbim
   - kmod-usb-net-cdc-ncm


### PR DESCRIPTION
To support LTE functions on Edgecore EAP112.

The EAP112 has its LTE modem on the SoC USB port, but that port was never brought up: mt7981b.dtsi defaults &xhci and &usb_phy to disabled and the board DTS did not override them, and Device/edgecore_eap112 did not select kmod-usb3, so the MediaTek xHCI driver was not built.

The USB function drivers (qmi_wwan, cdc_mbim, option) still loaded, so nothing looked broken, but without a host controller there was no bus to enumerate on: /sys/bus/usb/devices stayed empty and the wwan proto handler always failed with `No valid device was found'.

The modem power and reset lines were unreachable as well. Their sysfs GPIO numbers date back to a kernel 5.4 tree, where gpiolib picked a chip base by counting down from ARCH_NR_GPIOS, placing the 57-pin mt7981 controller at 455 so that pio pins 2 and 3 showed up as 457 and 458. Current kernels count up from GPIO_DYNAMIC_BASE (512) instead, so the exports failed with invalid GPIO 457 and 458. Renumber them to 514 and 515, which are the same two pins.

Fixes: WIFI-15594