### PR TITLE
luci-mod-ucentral: fix uplink config not applied in Maverick mode

### DIFF
--- a/feeds/tip/luci/luci-mod-ucentral/root/sbin/profileupdate
+++ b/feeds/tip/luci/luci-mod-ucentral/root/sbin/profileupdate
@@ -11,5 +11,8 @@ else
 	/etc/init.d/firstcontact enable 
 	/etc/init.d/ucentral disable    
 fi
+if [ -L /etc/ucentral/ucentral.active ] && [ "$(readlink /etc/ucentral/ucentral.active 2>/dev/null)" = "/etc/ucentral/ucentral.cfg.0000000001" ]; then 
+	rm /etc/ucentral/ucentral.active; 
+fi
 
 exit 0


### PR DESCRIPTION
Problem:
The uplink config is not set in the /etc/config/network in Maverick mode.

Root Cause:
If /etc/ucentral/ucentral.active exists,
/usr/share/ucentral/ucentral.uc /etc/ucentral/ucentral.cfg.0000000001 is not executed. As a result, after configuring PPPoE in Maverick mode, ucentral does not read /etc/ucentral/profile.json and does not update the UCI configuration.

Solution:
After configuring the network in Maverick mode, profileupdate is triggered. Add a step to remove the symbolic link so that the UCI configuration can be updated after the AP reboots.

Tests: Successfully verified on RAP7110C-341X

Fixes: WIFI-15336