### PR TITLE
qca-wifi-7: fix version_le logic for v4.2.6

### DIFF
--- a/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
+++ b/feeds/qca-wifi-7/ipq53xx/base-files/lib/upgrade/platform.sh
@@ -61,7 +61,7 @@ version_le() {
 
 	[ -z "$ver1" ] || [ -z "$ver2" ] && return 1
 
-	[ "$(printf '%s\n' "$ver1" "$ver2" | sort -V | head -n1)" = "$ver1" ]
+	[ "$(printf '%s\n' "$ver1" "$ver2" | sort -Vr | head -n1)" != "$ver1" ]
 }
 
 


### PR DESCRIPTION
Problem:
The version_le function incorrectly evaluates version comparisons, preventing firmware upgrades when the firmware version is equal to the version limit: v4.2.6.

Root Cause:
The version_le function uses incorrect version comparison logic. When the running firmware version equals the anti-rollback version limit v4.2.6, firmware upgrade will be blocked.

Solution:
Modify the version_le function to allow upgrades for firmware versions that are greater than or equal to the version limit (>= version_limit). This resolves the issue tracked in WIFI-15654.

Tests: 
Successfully verified upgrade with version 4.2.6 firmware.

Fixed: WIFI-15654