### PR TITLE
mtk: Fix RAP630W-211G Factory partition corruption breaks wireless

### DIFF
--- a/patches-25.12/0121-Fix-sonicfi-rap630w-211g-Factory-partition-corruptio.patch
+++ b/patches-25.12/0121-Fix-sonicfi-rap630w-211g-Factory-partition-corruptio.patch
@@ -1,0 +1,49 @@
+From b8254e0f957bb01fbcc2dcb9c54452687f1cdbd3 Mon Sep 17 00:00:00 2001
+From: "niko.lei" <niko.lei@cybertan.com.tw>
+Date: Wed, 12 Aug 2026 18:43:45 +0800
+Subject: [PATCH] Fix sonicfi rap630w-211g Factory partition corruption breaks
+ wireless
+
+---
+ package/kernel/mt76/Makefile                     |   5 +++++
+ .../mt76/sonicfi_rap630w_211g_eeprom_dbdc.bin    | Bin 0 -> 4096 bytes
+ 2 files changed, 5 insertions(+)
+ create mode 100644 package/kernel/mt76/sonicfi_rap630w_211g_eeprom_dbdc.bin
+
+diff --git a/package/kernel/mt76/Makefile b/package/kernel/mt76/Makefile
+index 2272546c0e..169b70bb69 100644
+--- a/package/kernel/mt76/Makefile
++++ b/package/kernel/mt76/Makefile
+@@ -644,6 +644,11 @@ ifeq ($(CONFIG_TARGET_PROFILE), "DEVICE_edgecore_eap111")
+ 	cp ./edgecore_eap111_eeprom_dbdc.bin \
+ 		$(1)/lib/firmware/mediatek/mt7981_eeprom_mt7976_dbdc.bin
+ endif
++
++ifeq ($(CONFIG_TARGET_PROFILE), "DEVICE_sonicfi_rap630w_211g")
++	cp ./sonicfi_rap630w_211g_eeprom_dbdc.bin \
++		$(1)/lib/firmware/mediatek/mt7981_eeprom_mt7976_dbdc.bin
++endif
+ endef
+ 
+ define KernelPackage/mt7986-firmware/install
+diff --git a/package/kernel/mt76/sonicfi_rap630w_211g_eeprom_dbdc.bin b/package/kernel/mt76/sonicfi_rap630w_211g_eeprom_dbdc.bin
+new file mode 100644
+index 0000000000000000000000000000000000000000..1774b9d6baa6b36b31c8ab1767fead3c585258d5
+GIT binary patch
+literal 4096
+zcmeHJKTpCy6n~gFkT4P0#DNHb*}=7mQyC0xg~7?M;Y6>0E=`#H2=ED<TwL1Tm03Oj
+zi7TrKn<T#WIEw}(3PMc!d*R;ie(&DB>uY*}+yOx0vVQx5KEuH~P`pu9XaF2PAN(jk
+zKEQwshl6{Nwlcr4Qq9Ca?m)3vT&_?>oPUGmwHtV?)@;^4qY+~{?F<o@T<4e9#@sZ`
+zFbsu?+%$v041<Iqmyxeo|99T&^~U4LWICPAa=CoIT$Z!>eA8^(hdz0I+jfgAe}^47
+zIz<Dti{BYkVKj;&761=9j>LBGQxcvp1lN_4>!#W&7DbrKImgkm9qAckLI|ZoY06}f
+z(zq_Bxt^Cs*D~BRKBY}*%Hm6aSdK%fWm%3(J+I$SqpR2s-^78odceBzkBIuY#Bq3x
+zJR$6RRP}BL0WDpN0WG7`MS$AAO6IE8zDD3&#8q8uBLKaK>zatmbw&~Z)i87fV7^$d
+z>0+I(8Hjy9rmUCVyroj5BGt?vsspwIz&OM2p9DPOc#MGIg+vGm7Jm@7JDL9^Oo@E%
+jGoL9;i4<fC^Ftps1r7BNwyv5o+RoPPo9S5x{;~t_J!52F
+
+literal 0
+HcmV?d00001
+
+-- 
+2.34.1
+


### PR DESCRIPTION
Root cause:
The Factory partition stores RF calibration data and is read-only. If this partition gets corrupted due to something other than a software issue, the wireless interface won't start properly.

Solution:
Store the backup RF calibration file at
/lib/firmware/mediatek/mt7981_eeprom_mt7976_dbdc.bin to avoid the above‑mentioned issue.

Fixes: WIFI-15655