### PR TITLE
patches-25.12: fix led default brightness being cleared by the trigge…

### DIFF
--- a/patches-25.12/0190-base-files-led-apply-default-brightness-after-setting.patch
+++ b/patches-25.12/0190-base-files-led-apply-default-brightness-after-setting.patch
@@ -1,0 +1,58 @@
+From a299b1c784252a43f094dd2ee1f0536b910b5ccc Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Thu, 13 Aug 2026 19:41:40 +0800
+Subject: [PATCH] base-files: led: apply the led default brightness after
+ setting the trigger
+
+ucidef_set_led_default() never lit its LED. load_led() wrote the default
+brightness first and set the trigger afterwards, but writing 'none' to
+trigger reaches led_trigger_remove() in the kernel, which ends in
+led_set_brightness(led_cdev, LED_OFF) and zeroes the value just written.
+Every board declaring a power LED this way came up dark unless something
+else lit it, so the breakage was easy to miss.
+
+Move both default-brightness branches below the trigger write so the
+value sticks, and keep them above the $ret check so a default is still
+applied when the trigger cannot be set for want of a kernel module - the
+LED is then in its configured state rather than off.
+
+Signed-off-by: Tanya Singh <tanya_singh@accton.com>
+---
+ package/base-files/files/etc/init.d/led | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/package/base-files/files/etc/init.d/led b/package/base-files/files/etc/init.d/led
+index 79f9388705..3926cd782a 100755
+--- a/package/base-files/files/etc/init.d/led
++++ b/package/base-files/files/etc/init.d/led
+@@ -103,6 +103,16 @@ load_led() {
+ 		}
+ 		printf "\n" >> /var/run/led.state
+ 
++		led_color_set "$1" "$sysfs"
++
++		echo $trigger > /sys/class/leds/${sysfs}/trigger 2> /dev/null
++		ret="$?"
++
++		# Apply the configured default brightness *after* the trigger has been
++		# written. Writing to 'trigger' runs led_trigger_remove() in the kernel,
++		# which calls led_set_brightness(LED_OFF) and would otherwise clobber
++		# the value we just set, leaving the LED dark. Done before the $ret
++		# check so the default is still honoured when the trigger is missing.
+ 		[ "$default" = 0 ] &&
+ 			echo 0 >/sys/class/leds/${sysfs}/brightness
+ 
+@@ -111,10 +121,6 @@ load_led() {
+ 			echo "$brightness" > /sys/class/leds/${sysfs}/brightness
+ 		}
+ 
+-		led_color_set "$1" "$sysfs"
+-
+-		echo $trigger > /sys/class/leds/${sysfs}/trigger 2> /dev/null
+-		ret="$?"
+ 		[ $ret = 0 ] || {
+ 			echo >&2 "Skipping trigger '$trigger' for led '$name' due to missing kernel module"
+ 			return 1
+-- 
+2.34.1
+


### PR DESCRIPTION
…r write

ucidef_set_led_default() has no effect: load_led() in /etc/init.d/led applied the configured brightness before setting the trigger, and writing 'none' to trigger reaches led_trigger_remove() in the kernel LED core, which calls led_set_brightness(led_cdev, LED_OFF) and zeroes the value just written. Since ucidef_set_led_default() sets no trigger, load_led() falls back to 'none' and the LED is switched off every time.

This affects every target that declares a solid-on indicator this way, 10 entries in mediatek/filogic 01_leds alone. It went unnoticed because most such LEDs sit on the led-running GPIO, where /etc/diag.sh set_state done or ucentral-state lights them independently; only boards without a second owner are visibly dark.

Add patch 0190, which moves the default-brightness block below the trigger write. It stays above the $ret check so a default is still applied when the trigger is unavailable for want of a kernel module, leaving the LED plain on rather than off.

The preceding commit gives EAP111, EAP112 and EAP115 a power LED via ucidef_set_led_default, so none of them would light without this.

Fixes: WIFI-15656