### PR TITLE
certificates: mount_certs: skip ubiattach -d 3 if ubi0 is already attached

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -171,6 +171,9 @@ MTD=$(find_mtd_index $PART_NAME)
 
 [ -z "$MTD" ] && return 1
 
+# Skip secondary ubiattach if partition is already attached as ubi0
+[ -e /dev/ubi0 ] && return 0
+
 ubiattach -m $MTD -d 3
 if [ -e /dev/ubi3 ] ; then
 	if mount -t ubifs ubi3:certificates /certificates; then


### PR DESCRIPTION


Commit b4e1583fa (WIFI-15591) added early-boot certificate restoration. On single-NAND IPQ53xx targets (e.g. cig_wf189, cig_wf189h), partition 'fs' / 'rootfs_1' is attached by U-Boot as ubi0. Calling ubiattach -m $MTD -d 3 forces the kernel to attach the primary UBI partition as a secondary device, corrupting the UBI volume table (dropping 'kernel' and 'ubi_rootfs' volumes) and dropping the AP into U-Boot on reboot.

Check if /dev/ubi0 exists before calling ubiattach -d 3. If ubi0 is already attached, mount_certs returns safely without mutating primary UBI headers.

Fixes: WIFI-15659