### PR TITLE
certificates: mount_certs: skip ubiattach -d 3 if ubi0 is attached

### DIFF
--- a/feeds/tip/certificates/files/usr/bin/mount_certs
+++ b/feeds/tip/certificates/files/usr/bin/mount_certs
@@ -131,13 +131,21 @@ udaya,a6-od2)
 		PART_NAME=rootfs_1
 	fi	
 	;;
-cig,wf186w|\
 cig,wf189|\
+cig,wf189h)
+	if grep -q rootfs_1 /proc/cmdline || grep -q "ubi.mtd=rootfs_1" /proc/cmdline; then
+		PART_NAME=rootfs
+	else
+		PART_NAME=rootfs_1
+	fi
+	;;
+cig,wf186w|\
 cig,wf189w|\
-cig,wf189h|\
 cig,wf186h|\
 cig,wf196|\
-cig,wf188n|\
+cig,wf188n)
+	PART_NAME=rootfs_1
+	;;
 emplus,wap380c|\
 emplus,wap385c|\
 emplus,wap386v2|\
@@ -170,6 +178,9 @@ esac
 MTD=$(find_mtd_index $PART_NAME)
 
 [ -z "$MTD" ] && return 1
+
+# Skip secondary ubiattach if partition is already attached as ubi0
+[ -e /sys/class/ubi/ubi0/mtd_num ] && [ "$MTD" = "$(cat /sys/class/ubi/ubi0/mtd_num)" ] && return 0
 
 ubiattach -m $MTD -d 3
 if [ -e /dev/ubi3 ] ; then


### PR DESCRIPTION
Commit b4e1583fa (WIFI-15591) added early-boot certificate restoration. On single-NAND IPQ53xx targets (e.g. cig_wf189, cig_wf189h), partition 'fs' / 'rootfs_1' is attached by U-Boot as ubi0. Calling ubiattach -m $MTD -d 3 forces the kernel to attach the primary UBI partition as a secondary device, corrupting the UBI volume table (dropping 'kernel' and 'ubi_rootfs' volumes) and dropping the AP into U-Boot on reboot.

Check if /dev/ubi0 exists before calling ubiattach -d 3. If ubi0 is already attached, mount_certs returns safely without mutating primary UBI headers.

Fixes: WIFI-15659