### PR TITLE
build-dev.yml:

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -10,8 +10,11 @@ env:
 
 on:
   push:
-    branches: [ main, next, staging-* ]
+    branches: [ staging-*, next ]
     tags: [ v* ]
+  schedule:
+    - cron: '0 22 * * *'      # daily main build (22:00 UTC)
+  workflow_dispatch:          # manual "build main now"
 
 # Only one run per ref at a time; cancel superseded runs so rapid pushes to the
 # same branch don't stack up parallel full-matrix builds and waste CI minutes.
@@ -24,23 +27,41 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       targets: ${{ steps.pick.outputs.targets }}
+      should_run: ${{ steps.pick.outputs.should_run }}
     steps:
-    # staging-* branches build only the staging DUTs; main/next/tags build all targets
+    - uses: actions/checkout@v4          # needed for the commit-age guard below
+
+    # staging-*/next build only the staging DUTs; main daily / dispatch / tags build all targets
     - name: Select build targets
       id: pick
       run: |
         FULL="[ 'cig_wf189h', 'cig_wf189w', 'cig_wf660a', 'cig_wf672', 'cig_wf186h', 'cig_wf186w', 'cig_wf188n', 'cig_wf189', 'cig_wf196', 'cig_wf197', 'cybertan_eww631-a1', 'cybertan_eww631-b1','sonicfi_rap63xc-211g', 'sonicfi_rap630w-312g', 'sonicfi_rap630c-311g', 'sonicfi_rap630w-311g', 'sonicfi_rap650c', 'sonicfi_rap7110c-341x', 'sonicfi_rap750e-h', 'sonicfi_rap750e-s', 'sonicfi_rap750w-311a', 'sonicfi_rap630w-211g', 'edgecore_eap101', 'edgecore_eap102', 'edgecore_eap104', 'edgecore_eap105', 'edgecore_eap111', 'edgecore_eap115', 'edgecore_oap101', 'edgecore_oap101e', 'edgecore_oap103', 'hfcl_ion4xe', 'hfcl_ion4xi', 'hfcl_ion4x', 'hfcl_ion4x_2', 'hfcl_ion4x_3', 'hfcl_ion4xi_w', 'hfcl_ion4x_w', 'indio_um-305ax', 'udaya_a6-id2', 'udaya_a6-od2', 'yuncore_ax820', 'yuncore_ax840', 'yuncore_fap640', 'yuncore_fap650', 'yuncore_fap655', 'sercomm_ap72tip-v4', 'asterfusion_ap7330']"
         STAGING="[ 'edgecore_eap101', 'edgecore_eap102', 'edgecore_eap105', 'edgecore_eap111', 'cig_wf189', 'sonicfi_rap630c-311g', 'sonicfi_rap630w-311g', 'sonicfi_rap7110c-341x', 'udaya_a6-id2' ]"
-        if [[ ${GITHUB_REF} == refs/heads/staging-* ]]; then
+        if [[ ${GITHUB_REF} == refs/heads/staging-* || ${GITHUB_REF} == refs/heads/next ]]; then
           TARGETS="${STAGING}"
         else
           TARGETS="${FULL}"
         fi
         echo "targets=$(echo "${TARGETS}" | tr \' \")" >> $GITHUB_OUTPUT
 
+        # Daily scheduled build skips when main had no commits in ~25h
+        # (25h, not 24h, absorbs GitHub cron jitter). Non-schedule events always run.
+        if [[ "${{ github.event_name }}" == "schedule" ]]; then
+          AGE=$(( $(date +%s) - $(git log -1 --format=%ct) ))
+          if [ "$AGE" -lt 90000 ]; then
+            echo "should_run=true"  >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "No commits in last 25h — skipping daily build."
+          fi
+        else
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        fi
+
   build:
     runs-on: ubuntu-22.04
     needs: set-matrix
+    if: needs.set-matrix.outputs.should_run == 'true'
     outputs:
       x64_vm_image_name: ${{ steps.package_and_upload_image.outputs.x64_vm_image_name }}
     strategy:


### PR DESCRIPTION
Build main once nightly and keep per-push builds only on the lighter staging/next branches.
- Drop main from push triggers; add a daily schedule (22:00 UTC) and workflow_dispatch.
- Route next to the smaller staging target set, alongside staging-*; nightly/tags/dispatch build the full matrix.
- Skip the nightly run when main had no commits in ~25h. Fixes: WIFI-15660