### PR TITLE
patches-25.12: enable EHT capability detection on non-QCA targets

### DIFF
--- a/patches-25.12/0191-ucode-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-6.patch
+++ b/patches-25.12/0191-ucode-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-6.patch
@@ -1,0 +1,90 @@
+From deabfec9ff102a044cd51ef5fac50ec67c8bf9bf Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Mon, 17 Aug 2026 20:00:00 +0800
+Subject: [PATCH] ucode: limit EHT iftype attribute stubs to QCA wifi-6
+
+The EHT iftype attribute stubs added by 0001-fixes.patch sit in the #else
+arm of the QCA_WIFI_7 conditional, so they apply to every target that is
+not ipq95xx or ipq53xx. Only the QCA wifi-6 header lacks these
+attributes: qca-wifi-7-nl80211.h defines both, and so does the bundled
+upstream nl80211_copy.h that every other target uses.
+
+So on mediatek and any other non-QCA target,
+NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC and _PHY were mapped to
+NL80211_ATTR_NOT_IMPLEMENTED and the parser never populated
+iftype_data[].eht_cap_phy. wifi-detect.uc gates EHT detection on that
+field, so it always took the early continue and /etc/board.json carried
+no eht flag and no EHT modes, even where the driver advertised full EHT
+support. On EAP115 (mt7992) 'iw phy0 info' listed EHT capabilities while
+board.json showed only ht/vht/he, leaving the controller unable to
+configure any Wi-Fi 7 channel width.
+
+Add a package patch moving the two stubs into the QCA_WIFI_6 block, which
+is the only build whose header lacks them and which has no EHT to report
+in any case. ipq95xx and ipq53xx are unaffected, having never had them.
+
+Signed-off-by: Tanya Singh <tanya_singh@accton.com>
+---
+ ...-iftype-attribute-stubs-to-QCA-wifi-.patch | 50 +++++++++++++++++++
+ 1 file changed, 50 insertions(+)
+ create mode 100644 package/utils/ucode/patches/0002-nl80211-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-.patch
+
+diff --git a/package/utils/ucode/patches/0002-nl80211-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-.patch b/package/utils/ucode/patches/0002-nl80211-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-.patch
+new file mode 100644
+index 0000000000..d5ec1c3f13
+--- /dev/null
++++ b/package/utils/ucode/patches/0002-nl80211-limit-EHT-iftype-attribute-stubs-to-QCA-wifi-.patch
+@@ -0,0 +1,50 @@
++From: Tanya Singh <tanya_singh@accton.com>
++Subject: [PATCH] nl80211: limit EHT iftype attribute stubs to QCA wifi-6
++
++The EHT iftype attribute stubs were placed in the #else arm of the
++QCA_WIFI_7 conditional, so they applied to every target that is not
++ipq95xx or ipq53xx. Only the QCA wifi-6 header is missing these
++attributes; qca-wifi-7-nl80211.h defines both, and so does the bundled
++upstream nl80211_copy.h that every other target uses.
++
++The result was that on mediatek and any other non-QCA target,
++NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC and _PHY were mapped to
++NL80211_ATTR_NOT_IMPLEMENTED, so the parser never populated
++iftype_data[].eht_cap_phy. wifi-detect.uc reads that field to decide
++whether a band supports EHT:
++
++	if (!ift.eht_cap_phy)
++		continue;
++	band_info.eht = true;
++
++so it always took the early continue and /etc/board.json reported no eht
++flag and no EHT modes, even where the driver advertised full EHT support.
++On EAP115 (mt7992) 'iw phy0 info' listed EHT capabilities while board.json
++showed only ht/vht/he.
++
++Move the two stubs into the QCA_WIFI_6 block, which is the only build
++whose header lacks them and which has no EHT to report in any case.
++
++Signed-off-by: Tanya Singh <tanya_singh@accton.com>
++---
++--- a/lib/nl80211.c
+++++ b/lib/nl80211.c
++@@ -141,6 +141,8 @@
++ #define NL80211_ATTR_MLO_LINK_DISABLED NL80211_ATTR_NOT_IMPLEMENTED
++ #define NL80211_ATTR_MLO_TTLM_DLINK NL80211_ATTR_NOT_IMPLEMENTED
++ #define NL80211_ATTR_MLO_TTLM_ULINK NL80211_ATTR_NOT_IMPLEMENTED
+++#define NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC NL80211_ATTR_NOT_IMPLEMENTED
+++#define NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PHY NL80211_ATTR_NOT_IMPLEMENTED
++ #endif
++ 
++ #ifdef QCA_WIFI_7
++@@ -148,9 +150,6 @@
++ #define NL80211_MNTR_FLAG_SKIP_TX NL80211_ATTR_NOT_IMPLEMENTED
++ #define NL80211_ATTR_MLO_TTLM_DLINK NL80211_ATTR_NOT_IMPLEMENTED
++ #define NL80211_ATTR_MLO_TTLM_ULINK NL80211_ATTR_NOT_IMPLEMENTED
++-#else
++-#define NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC NL80211_ATTR_NOT_IMPLEMENTED
++-#define NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PHY NL80211_ATTR_NOT_IMPLEMENTED
++ #endif
++ 
++ 
+-- 
+2.34.1
+


### PR DESCRIPTION
ucode's nl80211 binding maps netlink attribute numbers to the field names its callers read. 0043 added QCA header workarounds to that binding via package/utils/ucode/patches/0001-fixes.patch, which stubs the attributes the QCA nl80211.h lacks by pointing them at NL80211_ATTR_NOT_IMPLEMENTED (0x10000) - a value no real attribute uses, so the table entry compiles but can never match an incoming message.

The EHT iftype stubs were placed in the #else arm of the QCA_WIFI_7 conditional, which covers every target that is not ipq95xx or ipq53xx. Only the QCA wifi-6 header is missing them: qca-wifi-7-nl80211.h defines both, and non-QCA targets include the toolchain's linux/nl80211.h, which defines both as well. So mediatek received a workaround for a problem it does not have, and NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC and _PHY were discarded there.

`wifi-detect.uc` gates EHT detection on that field:
```
	if (!ift.eht_cap_phy)
		continue;
	band_info.eht = true;
```
so it always took the early continue and /etc/board.json carried no eht flag and no EHT modes, leaving the controller unable to configure any Wi-Fi 7 channel width. On EAP115 'iw phy0 info' lists EHT capabilities while board.json reports only ht/vht/he.

Add a ucode package patch moving the two stubs into the QCA_WIFI_6 block, the only build whose header lacks them and which has no EHT to report in any case. ipq95xx and ipq53xx never had them. Mediatek wifi-6 boards are unaffected: the attribute is now looked up, but mt7981 never sends it, so the same early continue applies and board.json is unchanged.

This did not affect 24.10, where the QCA binding shipped as a whole replacement lib/nl80211.c copied in only for QCA targets, so the stubs never reached mediatek. The 25.12 rework moved the guards into the shared source and carried the #else over unchanged.

FW has been verified: 

- EAP115: https://telecominfraproject.atlassian.net/browse/WIFI-15662?focusedCommentId=66724
- EAP112: https://telecominfraproject.atlassian.net/browse/WIFI-15662?focusedCommentId=66761

Fixes: WIFI-15662