### PR TITLE
.github/workflows: warn when a PR has no milestone

### DIFF
--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -4,7 +4,9 @@ name: PR Guidelines
 # on every feature/general-fix PR targeting main (and the LTS staging branch).
 #
 # 'edited' is included so re-running after a PR description fix works
-# without a force-push.
+# without a force-push. 'milestoned'/'demilestoned' are included because
+# milestone changes do not raise an 'edited' event, and the milestone check
+# below needs to re-evaluate when one is set or cleared.
 #
 # One job runs all checks, aggregates their findings into a single sticky PR
 # comment (so the author is informed directly), then fails if any hard rule was
@@ -12,7 +14,7 @@ name: PR Guidelines
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, milestoned, demilestoned]
     branches:
       - main
       - staging-for-v4.2.0-LTS
@@ -49,6 +51,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          # Empty when no milestone is assigned.
+          PR_MILESTONE: ${{ github.event.pull_request.milestone.title }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -113,7 +117,23 @@ jobs:
           run_check "PR description (ticket link)" check_pr_desc
 
           # ------------------------------------------------------------------
-          # 4. Report: aggregate all findings into one sticky PR comment,
+          # 4. Milestone: the author must attach their PR to the target release
+          #    milestone so the change is tracked in the right release notes.
+          #    Reported as a warning (not a hard failure) so an otherwise-good PR
+          #    isn't blocked - but it is the author's job to set it.
+          # ------------------------------------------------------------------
+          check_milestone() {
+            if [ -n "${PR_MILESTONE:-}" ]; then
+              echo "Milestone: $PR_MILESTONE"
+              return 0
+            fi
+            echo "::warning::No milestone set. Assign the target release milestone to this PR so the change is tracked in the release notes."
+            return 0
+          }
+          run_check "Milestone" check_milestone
+
+          # ------------------------------------------------------------------
+          # 5. Report: aggregate all findings into one sticky PR comment,
           #    then fail last so the comment is always posted first.
           # ------------------------------------------------------------------
           {
@@ -125,7 +145,7 @@ jobs:
             else
               echo "## ✅ PR & Commit Guidelines — all checks passed"
               echo ""
-              echo "Commits, PR description, and C style all look good. Thanks!"
+              echo "Commits, PR description, C style, and milestone all look good. Thanks!"
             fi
             echo ""
             cat sections.md


### PR DESCRIPTION
Add a milestone check to the PR guidelines job, reading the title from github.event.pull_request.milestone. It reports through the existing run_check aggregator, so a missing milestone shows up as an inline annotation and a bullet in the sticky PR comment. It is emitted as a warning rather than a hard failure, so an otherwise-good PR is not blocked.

Also add the milestoned and demilestoned trigger types. GitHub does not raise an 'edited' event for milestone changes, so without them the warning would persist in the comment until the next push.