### PR TITLE
Staging wifi 15461 test ba recovery 0814

### DIFF
--- a/feeds/qca-wifi-7/mac80211/patches-tip/pending/a-101-ath12k-fix-ampdu-stop-tid.patch
+++ b/feeds/qca-wifi-7/mac80211/patches-tip/pending/a-101-ath12k-fix-ampdu-stop-tid.patch
@@ -1,0 +1,44 @@
+From: Reshma Immaculate Rajkumar <reshma.rajkumar@oss.qualcomm.com>
+Date: Fri, 27 Feb 2026 16:31:23 +0530
+Subject: [PATCH] wifi: ath12k: Pass the correct value of each TID during a stop AMPDU session
+
+With traffic ongoing for data TID [TID 0], an DELBA request to
+stop AMPDU for the BA session was received on management TID [TID 4].
+The corresponding TID number was incorrectly passed to stop the BA session,
+resulting in the BA session for data TIDs being stopped and the BA size
+being reduced to 1, causing an overall dip in TCP throughput.
+
+Fix this issue by passing the correct argument from
+ath12k_dp_rx_ampdu_stop() to ath12k_dp_arch_peer_rx_tid_reo_update()
+during an AMPDU stop session. Instead of passing peer->dp_peer->rx_tid,
+which is the base address of the array, corresponding to TID 0, pass
+the value of &peer->dp_peer->rx_tid[params->tid]. With this, the
+different TID numbers are accounted for.
+
+Tested-on: QCN9274 hw2.0 PCI WLAN.WBE.1.5-01651-QCAHKSWPL_SILICONZ-1
+
+Fixes: d889913205cf ("wifi: ath12k: driver for Qualcomm Wi-Fi 7 devices")
+Signed-off-by: Reshma Immaculate Rajkumar <reshma.rajkumar@oss.qualcomm.com>
+---
+--- a/drivers/net/wireless/ath/ath12k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath12k/dp_rx.c
+@@ -1280,6 +1280,7 @@ int ath12k_dp_rx_ampdu_stop(struct ath12
+ 	struct ath12k_base *ab = ar->ab;
+ 	struct ath12k_peer *peer;
+ 	struct ath12k_sta *ahsta = ath12k_sta_to_ahsta(params->sta);
++	struct ath12k_dp_rx_tid *rx_tid;
+ 	struct ath12k_link_sta *arsta;
+ 	int vdev_id;
+ 	bool active;
+@@ -1307,7 +1308,8 @@ int ath12k_dp_rx_ampdu_stop(struct ath12
+ 		return 0;
+ 	}
+
+-	ret = ath12k_peer_rx_tid_reo_update(ab, peer, peer->rx_tid, 1, 0, false);
++	rx_tid = &peer->rx_tid[params->tid];
++	ret = ath12k_peer_rx_tid_reo_update(ab, peer, rx_tid, 1, 0, false);
+ 	spin_unlock_bh(&ab->base_lock);
+ 	if (ret) {
+ 		ath12k_warn(ab, "failed to update reo for rx tid %d: %d\n",
+--
+2.34.1

--- a/feeds/ucentral/ucentral-event/Makefile
+++ b/feeds/ucentral/ucentral-event/Makefile
@@ -12,6 +12,7 @@ define Package/ucentral-event
   SECTION:=ucentral
   CATEGORY:=uCentral
   TITLE:=uCentral event gathering daemon
+  DEPENDS:=+iw
 endef
 
 define Build/Compile
@@ -19,11 +20,13 @@ define Build/Compile
 endef
 
 define Package/ucentral-event/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config
 	$(INSTALL_BIN) ./files/ucentral-event $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/ucentral-wifiscan $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/ba-recovery $(1)/usr/bin/
 	$(INSTALL_BIN) ./files/ucentral-event.init $(1)/etc/init.d/ucentral-event
 	$(INSTALL_BIN) ./files/ucentral-wifiscan.init $(1)/etc/init.d/ucentral-wifiscan
+	$(INSTALL_BIN) ./files/ba-recovery.init $(1)/etc/init.d/ba-recovery
 	$(INSTALL_DATA) ./files/event $(1)/etc/config/
 	$(INSTALL_DATA) ./files/events.json $(1)/etc/
 endef

--- a/feeds/ucentral/ucentral-event/files/ba-recovery
+++ b/feeds/ucentral/ucentral-event/files/ba-recovery
@@ -1,0 +1,288 @@
+#!/bin/sh
+# ba-recovery: detect and recover broken BA sessions after cross-band roaming
+#
+# ROOT CAUSE:
+# QCN9274 firmware (WLAN.WBE.1.4.1) maintains internal BA/TX aggregation
+# state indexed by STA MAC across both 5G and 6G MACs. When the same STA
+# re-appears on a different MAC after a band-hop roam, the firmware does
+# NOT reset this state. The PHY rate stays high but actual throughput
+# collapses to 0-5 Mbps because the firmware's BA window tracking is stale.
+#
+# This script is a pure userspace workaround and is currently the ONLY
+# mitigation in the tree for this firmware bug.
+#
+# A kernel-side attempt (ath12k: force fresh TID on ampdu_start) was tried
+# and dropped. It freed the REO queue descriptor synchronously from
+# ath12k_dp_rx_peer_tid_setup(), bypassing ath12k's deferred-free protocol
+# (REO UPDATE_RX_QUEUE vld=0 -> reo_cmd_cache_flush_list -> aged flush ->
+# free). The REO hardware can still DMA into the descriptor after it has
+# been kfree()d back to the general slab, which corrupted unrelated
+# structures and panicked the AP. Do not reintroduce that approach without
+# routing the teardown through ath12k_peer_rx_tid_delete_handler() and
+# letting ath12k_dp_rx_tid_del_func() own the free.
+#
+# Consequence for tuning: with no kernel-side mitigation, every stuck
+# band-hop is handled here, so this script now kicks in more often than it
+# did when the kernel patch was carrying most of the cases.
+#
+# FLOW:
+# 1. Subscribes to nl80211 netlink events ("iw event") and watches for
+#    NL80211_CMD_NEW_STATION, which mac80211 emits from sta_info_insert()
+#    once hostapd has added the STA after a successful association
+# 2. Detects band-hops (STA moves between phy5g-apX and phy6g-apX)
+# 3. Only acts if STA was previously passing real traffic (>= PKT_THRESHOLD)
+# 4. After CHECK_DELAY seconds, samples RX packet count twice (1s apart)
+# 5. If delta < PKT_THRESHOLD -> disassociates STA to force clean reconnect
+# 6. Stops kicking after MAX_KICKS consecutive failures per STA
+#
+# WHY NETLINK INSTEAD OF SYSLOG:
+# The first version of this script parsed "logread -f" for hostapd's
+# "IEEE 802.11: associated (aid N)" message. That has several problems:
+#   - it depends on hostapd log level and on the exact wording of a log
+#     string that is not an API and changes between hostapd versions
+#   - every single syslog line on the box has to be piped and matched by
+#     the shell, and events are silently lost if syslogd rate-limits or
+#     the ring buffer wraps under load (exactly the situation we care about)
+#   - it needs a running/attachable syslogd
+# nl80211 NEW_STATION comes straight from cfg80211, is the authoritative
+# "STA is now on this interface" event, carries the ifindex and MAC as
+# structured attributes, and is delivered on a dedicated multicast group.
+#
+# Usage: ba-recovery [CHECK_DELAY_SEC] [PKT_THRESHOLD]
+# Defaults: CHECK_DELAY=2, PKT_THRESHOLD=2000
+#
+# Install as init.d service for persistent background operation.
+
+CHECK_DELAY="${1:-2}"
+PKT_THRESHOLD="${2:-2000}"
+MAX_KICKS=5
+
+# Only run on EAP105 — this workaround is specific to QCN9274 FW bug
+BOARD=$(cat /tmp/sysinfo/board_name 2>/dev/null)
+case "$BOARD" in
+	edgecore,eap105) ;;
+	*)
+		logger -t ba-recovery "board '$BOARD' is not EAP105, exiting"
+		exit 0
+		;;
+esac
+
+log() {
+	logger -t ba-recovery "$*"
+	echo "[$(date +%s)] $*"
+}
+
+get_rx_pkts() {
+	local mac="$1"
+	local iface="$2"
+	local mac_upper pkts
+
+	mac_upper=$(echo "$mac" | tr 'a-f' 'A-F')
+
+	pkts=$(iwinfo "$iface" assoc 2>/dev/null | \
+		grep -A2 "$mac_upper" | \
+		grep "RX:" | \
+		head -1 | \
+		sed -n 's/.*[[:space:]]\([0-9]*\) Pkts\..*/\1/p')
+
+	[ -z "$pkts" ] && pkts="0"
+	echo "$pkts"
+}
+
+do_recover() {
+	local mac="$1"
+	local iface="$2"
+	local delta="$3"
+	local kicks last_kick now elapsed
+
+	# Increment kick counter
+	kicks=0
+	[ -f "$STATE_DIR/${mac}.kicks" ] && kicks=$(cat "$STATE_DIR/${mac}.kicks")
+	
+	# Reset counter if last kick was more than 30 seconds ago (not a rapid-fire loop)
+	now=$(date +%s)
+	last_kick=0
+	[ -f "$STATE_DIR/${mac}.last_kick" ] && last_kick=$(cat "$STATE_DIR/${mac}.last_kick")
+	elapsed=$((now - last_kick))
+	if [ "$elapsed" -gt 30 ]; then
+		kicks=0
+	fi
+	
+	kicks=$((kicks + 1))
+	echo "$kicks" > "$STATE_DIR/${mac}.kicks"
+	echo "$now" > "$STATE_DIR/${mac}.last_kick"
+
+	if [ "$kicks" -gt "$MAX_KICKS" ]; then
+		log "SKIP: $mac rapid-fire kicks=$kicks > max=$MAX_KICKS within 30s, backing off"
+		return
+	fi
+
+	log "RECOVER: $mac on $iface pkt_delta=${delta} < threshold=${PKT_THRESHOLD} (kick $kicks/$MAX_KICKS)"
+	log "RECOVER: disassociating $mac from $iface"
+	hostapd_cli -i "$iface" disassociate "$mac" reason=4 tx=0
+}
+
+check_sta_pkts() {
+	local mac="$1"
+	local iface="$2"
+	local pkts1 pkts2 delta
+
+	pkts1=$(get_rx_pkts "$mac" "$iface")
+	if [ "$pkts1" = "0" ]; then
+		log "check: $mac on $iface — STA not found in assoc table"
+		return
+	fi
+
+	sleep 1
+
+	pkts2=$(get_rx_pkts "$mac" "$iface")
+	if [ "$pkts2" = "0" ]; then
+		log "check: $mac on $iface — STA gone after 1s"
+		return
+	fi
+
+	delta=$((pkts2 - pkts1))
+
+	# Skip truly idle STAs (no traffic at all) — they aren't broken, just inactive
+	if [ "$delta" -eq 0 ] && [ ! -f "$STATE_DIR/${mac}.active" ]; then
+		log "SKIP: $mac on $iface — idle STA (delta=0, never active), ignoring"
+		return
+	fi
+
+	if [ "$delta" -lt "$PKT_THRESHOLD" ]; then
+		do_recover "$mac" "$iface" "$delta"
+	else
+		log "OK: $mac on $iface pkt_delta=${delta}/s (healthy)"
+		# Reset kick counter on success
+		rm -f "$STATE_DIR/${mac}.kicks"
+		# Mark as active for future reference
+		echo "$delta" > "$STATE_DIR/${mac}.active"
+	fi
+}
+
+update_active_state() {
+	local mac="$1"
+	local iface="$2"
+	local pkts1 pkts2 delta
+
+	pkts1=$(get_rx_pkts "$mac" "$iface")
+	[ "$pkts1" = "0" ] && return
+
+	sleep 1
+
+	pkts2=$(get_rx_pkts "$mac" "$iface")
+	[ "$pkts2" = "0" ] && return
+
+	delta=$((pkts2 - pkts1))
+	if [ "$delta" -ge "$PKT_THRESHOLD" ]; then
+		echo "$delta" > "$STATE_DIR/${mac}.active"
+	fi
+}
+
+# --- Main ---
+log "=== ba-recovery daemon starting (pid=$$) ==="
+log "CONFIG: CHECK_DELAY=${CHECK_DELAY}s, PKT_THRESHOLD=${PKT_THRESHOLD}pkts/s, MAX_KICKS=${MAX_KICKS}"
+
+# nl80211 event source — required
+IW=$(command -v iw 2>/dev/null)
+if [ -z "$IW" ]; then
+	log "ERROR: iw not found, cannot subscribe to nl80211 events"
+	exit 1
+fi
+
+# Discover interfaces (retry up to 30 times waiting for hostapd).
+# Informational only — the nl80211 event stream does not depend on hostapd
+# being up, and the band is derived per-event from the netlink ifname. So a
+# timeout here is not fatal: radios may be disabled at boot and enabled
+# later, and we still want to be listening when that happens.
+IFACE_5G=""
+IFACE_6G=""
+RETRIES=30
+while [ "$RETRIES" -gt 0 ]; do
+	for obj in $(ubus list 2>/dev/null | grep "^hostapd\\."); do
+		iface="${obj#hostapd.}"
+		case "$iface" in
+			*5g*) IFACE_5G="$iface" ;;
+			*6g*) IFACE_6G="$iface" ;;
+		esac
+	done
+	[ -n "$IFACE_5G" ] && [ -n "$IFACE_6G" ] && break
+	RETRIES=$((RETRIES - 1))
+	sleep 2
+done
+
+if [ -z "$IFACE_5G" ] && [ -z "$IFACE_6G" ]; then
+	log "WARN: no hostapd interfaces found after 60s, listening anyway"
+fi
+[ -n "$IFACE_5G" ] && log "  5G interface: $IFACE_5G"
+[ -n "$IFACE_6G" ] && log "  6G interface: $IFACE_6G"
+
+# State tracking
+STATE_DIR="/tmp/ba-recovery-state"
+rm -rf "$STATE_DIR"
+mkdir -p "$STATE_DIR"
+
+cleanup() {
+	rm -rf "$STATE_DIR"
+	kill $(jobs -p) 2>/dev/null
+	exit 0
+}
+trap cleanup INT TERM
+
+log "=== ready, subscribed to nl80211 events ==="
+
+# Watch nl80211 (netlink) for NEW_STATION events.
+# "iw event" line format (it fflush()es stdout after every event, so this
+# streams line by line through the pipe):
+#   "phy5g-ap0 (phy #1): new station aa:bb:cc:dd:ee:ff"
+# Events without an ifindex (wdev-only) are ignored — we need a netdev to
+# map to a band and to talk to hostapd_cli.
+# stderr is left attached so netlink setup failures land in syslog via procd.
+"$IW" event | while IFS= read -r line; do
+	case "$line" in
+		*": new station "*)
+			# Prefix up to the first ':' is "<ifname> (phy #N)" or "<ifname>"
+			iface="${line%%:*}"
+			iface="${iface%% *}"
+			# iw formats MACs with %02x, so this is always lowercase
+			# and matches the state-file naming used below.
+			mac="${line##*new station }"
+
+			[ -z "$mac" ] && continue
+			[ -z "$iface" ] && continue
+
+			# Determine band from interface name. This also drops
+			# wdev-only / phy-only events, which have no band.
+			band=""
+			case "$iface" in
+				*5g*) band="5g" ;;
+				*6g*) band="6g" ;;
+				*) continue ;;
+			esac
+
+			# Check for band hop
+			prev_band=""
+			[ -f "$STATE_DIR/$mac" ] && prev_band=$(cat "$STATE_DIR/$mac")
+			echo "$band" > "$STATE_DIR/$mac"
+
+			if [ -n "$prev_band" ] && [ "$prev_band" != "$band" ]; then
+				log "BAND-HOP: $mac moved $prev_band -> $band ($iface)"
+				(
+					sleep "$CHECK_DELAY"
+					check_sta_pkts "$mac" "$iface"
+				) &
+			else
+				# Same band or first association — sample traffic to track active state
+				# Do this in background to not block the log reader
+				(
+					sleep 1
+					update_active_state "$mac" "$iface"
+				) &
+			fi
+			;;
+	esac
+done
+
+# "iw event" only returns on netlink socket error or SIGPIPE; procd respawns us.
+log "ERROR: nl80211 event stream ended, exiting for respawn"
+exit 1

--- a/feeds/ucentral/ucentral-event/files/ba-recovery
+++ b/feeds/ucentral/ucentral-event/files/ba-recovery
@@ -30,10 +30,40 @@
 #    NL80211_CMD_NEW_STATION, which mac80211 emits from sta_info_insert()
 #    once hostapd has added the STA after a successful association
 # 2. Detects band-hops (STA moves between phy5g-apX and phy6g-apX)
-# 3. Only acts if STA was previously passing real traffic (>= PKT_THRESHOLD)
-# 4. After CHECK_DELAY seconds, samples RX packet count twice (1s apart)
-# 5. If delta < PKT_THRESHOLD -> disassociates STA to force clean reconnect
-# 6. Stops kicking after MAX_KICKS consecutive failures per STA
+# 3. After CHECK_DELAY seconds, samples the AP-side RX packet counter for
+#    that STA twice, 1s apart, giving a pkts/s rate
+# 4. Any sample >= SEEN_FLOOR refreshes the activity marker, then the rate is
+#    classified:
+#      >= ACTIVE_FLOOR    healthy, stop here
+#      >  DEAD_THRESHOLD  passing traffic but not healthy. Never kicked.
+#      <= DEAD_THRESHOLD  candidate for the stuck-BA signature
+# 5. A candidate is kicked only if it carried traffic within ACTIVE_TTL and a
+#    second confirming sample still reads dead. The confirm absorbs post-roam
+#    TCP ramp-up, which at a single sample point is indistinguishable from a
+#    stuck session: measured runs show the first sample reading 0 pkts/s on
+#    links that go on to reach 9400 pkts/s as well as on genuinely stuck ones.
+# 6. Stops kicking after MAX_KICKS failures per STA within 30s
+# 7. A settled-rate sample is logged SETTLED_DELAY later, purely so each roam
+#    is self-contained evidence of where the link ended up.
+#
+# WHY SEEN_FLOOR IS SEPARATE FROM ACTIVE_FLOOR:
+# The marker used to be refreshed only by a healthy sample, which deadlocks: a
+# stuck STA can never produce one, so once the marker expired it could never be
+# recovered again. A run on 2026-08-17 showed exactly that, 9 consecutive
+# band-hops at 0-213 pkts/s with LANforge pushing traffic throughout, every one
+# skipped as "not seen active" and no kick ever attempted. Refreshing at
+# SEEN_FLOOR instead means a stuck session keeps its own eligibility alive, since
+# the stuck rate is far above SEEN_FLOOR while idle chatter is far below it.
+#
+# WHY THE RATE BANDS ARE WHERE THEY ARE:
+# An earlier version skipped only when the rate was exactly 0 and kicked
+# anything below a single 2000 pkts/s threshold. In practice that kicked
+# idle clients passing 1 pkt/s of background chatter, and each kick forced
+# a reassociation that produced another band-hop and another check. It also
+# kicked a STA measured at 1378 pkts/s (~16 Mbps), which is nothing like
+# the 0-5 Mbps signature this works around. The "was active" marker was
+# only ever written at >= 2000 pkts/s, so it never armed and the
+# previously-active precondition was dead code.
 #
 # WHY NETLINK INSTEAD OF SYSLOG:
 # The first version of this script parsed "logread -f" for hostapd's
@@ -48,14 +78,44 @@
 # "STA is now on this interface" event, carries the ifindex and MAC as
 # structured attributes, and is delivered on a dedicated multicast group.
 #
-# Usage: ba-recovery [CHECK_DELAY_SEC] [PKT_THRESHOLD]
-# Defaults: CHECK_DELAY=2, PKT_THRESHOLD=2000
+# Usage: ba-recovery [CHECK_DELAY_SEC] [DEAD_THRESHOLD] [ACTIVE_FLOOR]
+# Defaults: CHECK_DELAY=3, DEAD_THRESHOLD=800, ACTIVE_FLOOR=1000
+#
+# Measured rates on EAP105, uplink, 1500-byte frames:
+#
+#   idle client                    0-1 pkts/s
+#   stuck BA session         195-560 pkts/s   (~2.5-7 Mbps)
+#   healthy after a roam    1643-9482 pkts/s  (~20-115 Mbps)
+#
+# DEAD_THRESHOLD sits at 800, inside the empty gap between the top of the
+# observed stuck range (560) and the lowest healthy reading (1643). An earlier
+# value of 300 bisected the stuck range and let 400, 414, 513 and 556 pkts/s
+# sessions through uncorrected. SEEN_FLOOR at 100 sits in the equally wide gap
+# below the stuck range.
 #
 # Install as init.d service for persistent background operation.
 
-CHECK_DELAY="${1:-2}"
-PKT_THRESHOLD="${2:-2000}"
+CHECK_DELAY="${1:-3}"
+DEAD_THRESHOLD="${2:-800}"
+ACTIVE_FLOOR="${3:-1000}"
 MAX_KICKS=5
+
+# Any sample at or above this refreshes the activity marker. It sits well below
+# DEAD_THRESHOLD on purpose: a stuck STA still pushes 195-560 pkts/s, so it keeps
+# its own eligibility alive and stays recoverable across consecutive stuck roams.
+# Observed idle traffic is 0-1 pkts/s, so the margin either side is large.
+SEEN_FLOOR=100
+
+# How long an activity observation stays trustworthy. Past this the STA is
+# treated as idle and will not be kicked, so a client that finished its transfer
+# is left alone.
+ACTIVE_TTL=120
+
+# Delay before the confirming sample when a candidate is found.
+CONFIRM_DELAY=3
+
+# Delay before the observational settled-rate sample.
+SETTLED_DELAY=10
 
 # Only run on EAP105 — this workaround is specific to QCN9274 FW bug
 BOARD=$(cat /tmp/sysinfo/board_name 2>/dev/null)
@@ -70,6 +130,33 @@ esac
 log() {
 	logger -t ba-recovery "$*"
 	echo "[$(date +%s)] $*"
+}
+
+# Milliseconds since the AP last saw a frame from this STA, from the
+# "<mac> ... <N> ms ago" line of "iwinfo <iface> assoc". Echoes -1 if unreadable.
+#
+# Logged for diagnosis only, NOT used to make decisions. It was tried as an
+# idle-vs-stuck discriminator on the theory that mac80211 derives it from
+# rx_stats.last_rx (ieee80211_sta_last_active), updated on reception ahead of
+# reorder/BA release, so a stalled-but-transmitting STA would read low. Hardware
+# refuted that: in the window right after a roam it reads 1700-3700ms on links
+# that go on to push 9400 pkts/s seconds later, because the client simply has not
+# resumed transmitting yet. It measures "has not started again", not "has nothing
+# to send", so it cannot separate the two cases at the point we sample.
+get_inactive_ms() {
+	local mac="$1"
+	local iface="$2"
+	local mac_upper ms
+
+	mac_upper=$(echo "$mac" | tr 'a-f' 'A-F')
+
+	ms=$(iwinfo "$iface" assoc 2>/dev/null | \
+		grep "$mac_upper" | \
+		head -1 | \
+		sed -n 's/.*[[:space:]]\([0-9]\{1,\}\) ms ago.*/\1/p')
+
+	[ -z "$ms" ] && ms="-1"
+	echo "$ms"
 }
 
 get_rx_pkts() {
@@ -87,6 +174,51 @@ get_rx_pkts() {
 
 	[ -z "$pkts" ] && pkts="0"
 	echo "$pkts"
+}
+
+# Record that this STA was observed passing real traffic, with a timestamp.
+mark_active() {
+	date +%s > "$STATE_DIR/${1}.active"
+}
+
+# Purely observational: sample once more after SETTLED_DELAY and log the rate
+# the link actually ended up at. Without this a "recovered on its own" line is
+# ambiguous, since a confirm of 500/s (~6 Mbps) looks the same whether the link
+# then climbed to 100 Mbps or stayed at 6. Takes no action.
+log_settled() {
+	local mac="$1" iface="$2" p1 p2 rate
+
+	sleep "$SETTLED_DELAY"
+
+	p1=$(get_rx_pkts "$mac" "$iface")
+	[ "$p1" = "0" ] && return
+	sleep 1
+	p2=$(get_rx_pkts "$mac" "$iface")
+	[ "$p2" = "0" ] && return
+
+	rate=$((p2 - p1))
+	[ "$rate" -ge "$SEEN_FLOOR" ] && mark_active "$mac"
+	if [ "$rate" -ge "$ACTIVE_FLOOR" ]; then
+		log "SETTLED: $mac on $iface ${rate}/s (healthy)"
+	else
+		log "SETTLED: $mac on $iface ${rate}/s (still below ${ACTIVE_FLOOR}/s) inactive=$(get_inactive_ms "$mac" "$iface")ms"
+	fi
+}
+
+# True if the STA was seen healthy within ACTIVE_TTL seconds. Anything older
+# is stale: the client may simply have finished what it was doing.
+was_recently_active() {
+	local mac="$1" ts age
+
+	[ -f "$STATE_DIR/${mac}.active" ] || return 1
+
+	ts=$(cat "$STATE_DIR/${mac}.active" 2>/dev/null)
+	case "$ts" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+
+	age=$(( $(date +%s) - ts ))
+	[ "$age" -le "$ACTIVE_TTL" ]
 }
 
 do_recover() {
@@ -117,15 +249,20 @@ do_recover() {
 		return
 	fi
 
-	log "RECOVER: $mac on $iface pkt_delta=${delta} < threshold=${PKT_THRESHOLD} (kick $kicks/$MAX_KICKS)"
+	log "RECOVER: $mac on $iface pkt_delta=${delta}/s <= dead=${DEAD_THRESHOLD} (kick $kicks/$MAX_KICKS)"
 	log "RECOVER: disassociating $mac from $iface"
-	hostapd_cli -i "$iface" disassociate "$mac" reason=4 tx=0
+	# hostapd_cli prints "OK" on stdout, which procd forwards to syslog.
+	if hostapd_cli -i "$iface" disassociate "$mac" reason=4 tx=0 >/dev/null 2>&1; then
+		log "RECOVER: disassociate accepted for $mac"
+	else
+		log "RECOVER: disassociate FAILED for $mac on $iface"
+	fi
 }
 
 check_sta_pkts() {
 	local mac="$1"
 	local iface="$2"
-	local pkts1 pkts2 delta
+	local pkts1 pkts2 delta confirm inact
 
 	pkts1=$(get_rx_pkts "$mac" "$iface")
 	if [ "$pkts1" = "0" ]; then
@@ -143,21 +280,73 @@ check_sta_pkts() {
 
 	delta=$((pkts2 - pkts1))
 
-	# Skip truly idle STAs (no traffic at all) — they aren't broken, just inactive
-	if [ "$delta" -eq 0 ] && [ ! -f "$STATE_DIR/${mac}.active" ]; then
-		log "SKIP: $mac on $iface — idle STA (delta=0, never active), ignoring"
+	# The RX counter is cumulative per association and resets to zero when the
+	# STA reassociates. A negative delta means that happened between the two
+	# samples, so the reading is meaningless rather than low. Abort instead of
+	# clamping to 0: clamping would look like "no traffic" and could kick a STA
+	# that is fine. The next band-hop re-evaluates.
+	if [ "$delta" -lt 0 ]; then
+		log "check: $mac on $iface — RX counter reset mid-sample (reassociated), no reading"
 		return
 	fi
 
-	if [ "$delta" -lt "$PKT_THRESHOLD" ]; then
-		do_recover "$mac" "$iface" "$delta"
-	else
+	# Any real traffic keeps the STA eligible for recovery, including the low
+	# rates a stuck session produces. See SEEN_FLOOR.
+	[ "$delta" -ge "$SEEN_FLOOR" ] && mark_active "$mac"
+
+	# Healthy: nothing to do.
+	if [ "$delta" -ge "$ACTIVE_FLOOR" ]; then
 		log "OK: $mac on $iface pkt_delta=${delta}/s (healthy)"
-		# Reset kick counter on success
 		rm -f "$STATE_DIR/${mac}.kicks"
-		# Mark as active for future reference
-		echo "$delta" > "$STATE_DIR/${mac}.active"
+		return
 	fi
+
+	# Passing real traffic but below the healthy bar. Degraded is not the
+	# failure mode this works around, so never kick here.
+	if [ "$delta" -gt "$DEAD_THRESHOLD" ]; then
+		log "SKIP: $mac on $iface pkt_delta=${delta}/s — degraded but passing, not the stuck-BA signature"
+		return
+	fi
+
+	# At or below DEAD_THRESHOLD. Only act if this STA has carried traffic
+	# recently, otherwise it is just idle. Because SEEN_FLOOR is low enough that a
+	# stuck session refreshes the marker itself, this does not lock out a STA that
+	# stays stuck across several roams.
+	inact=$(get_inactive_ms "$mac" "$iface")
+
+	if ! was_recently_active "$mac"; then
+		log "SKIP: $mac on $iface pkt_delta=${delta}/s inactive=${inact}ms — no traffic within ${ACTIVE_TTL}s, treating as idle"
+		return
+	fi
+
+	# Confirm before kicking. TCP can take a few seconds to ramp back up
+	# after a roam, which looks identical to a stuck BA session at T+3s.
+	sleep "$CONFIRM_DELAY"
+
+	pkts1=$(get_rx_pkts "$mac" "$iface")
+	[ "$pkts1" = "0" ] && { log "check: $mac on $iface — STA gone before confirm"; return; }
+	sleep 1
+	pkts2=$(get_rx_pkts "$mac" "$iface")
+	[ "$pkts2" = "0" ] && { log "check: $mac on $iface — STA gone during confirm"; return; }
+
+	confirm=$((pkts2 - pkts1))
+
+	if [ "$confirm" -lt 0 ]; then
+		log "check: $mac on $iface — RX counter reset mid-confirm (reassociated), no reading"
+		return
+	fi
+
+	[ "$confirm" -ge "$SEEN_FLOOR" ] && mark_active "$mac"
+
+	if [ "$confirm" -gt "$DEAD_THRESHOLD" ]; then
+		log "SKIP: $mac on $iface recovered on its own (first=${delta}/s confirm=${confirm}/s inactive=${inact}ms)"
+		log_settled "$mac" "$iface"
+		return
+	fi
+
+	log "STUCK: $mac on $iface first=${delta}/s confirm=${confirm}/s inactive=${inact}ms"
+	do_recover "$mac" "$iface" "$confirm"
+	log_settled "$mac" "$iface"
 }
 
 update_active_state() {
@@ -174,14 +363,14 @@ update_active_state() {
 	[ "$pkts2" = "0" ] && return
 
 	delta=$((pkts2 - pkts1))
-	if [ "$delta" -ge "$PKT_THRESHOLD" ]; then
-		echo "$delta" > "$STATE_DIR/${mac}.active"
+	if [ "$delta" -ge "$SEEN_FLOOR" ]; then
+		mark_active "$mac"
 	fi
 }
 
 # --- Main ---
 log "=== ba-recovery daemon starting (pid=$$) ==="
-log "CONFIG: CHECK_DELAY=${CHECK_DELAY}s, PKT_THRESHOLD=${PKT_THRESHOLD}pkts/s, MAX_KICKS=${MAX_KICKS}"
+log "CONFIG: CHECK_DELAY=${CHECK_DELAY}s DEAD_THRESHOLD=${DEAD_THRESHOLD}pkts/s ACTIVE_FLOOR=${ACTIVE_FLOOR}pkts/s SEEN_FLOOR=${SEEN_FLOOR}pkts/s ACTIVE_TTL=${ACTIVE_TTL}s CONFIRM_DELAY=${CONFIRM_DELAY}s SETTLED_DELAY=${SETTLED_DELAY}s MAX_KICKS=${MAX_KICKS}"
 
 # nl80211 event source — required
 IW=$(command -v iw 2>/dev/null)

--- a/feeds/ucentral/ucentral-event/files/ba-recovery.init
+++ b/feeds/ucentral/ucentral-event/files/ba-recovery.init
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/bin/ba-recovery 2 2000
+	procd_set_param respawn 3600 5 5
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}

--- a/feeds/ucentral/ucentral-event/files/ba-recovery.init
+++ b/feeds/ucentral/ucentral-event/files/ba-recovery.init
@@ -5,7 +5,10 @@ USE_PROCD=1
 
 start_service() {
 	procd_open_instance
-	procd_set_param command /usr/bin/ba-recovery 2 2000
+	# No args: the script's own defaults are the single source of truth for
+	# CHECK_DELAY / DEAD_THRESHOLD / ACTIVE_FLOOR. Passing them here too
+	# just creates two places to keep in sync.
+	procd_set_param command /usr/bin/ba-recovery
 	procd_set_param respawn 3600 5 5
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
## Summary

Fixes the uplink throughput collapse that follows a 5G↔6G roam on EAP105
(QCN9274 / WLAN.WBE.1.4.1). Two independent problems are addressed:

1. A real ath12k bug where a DELBA on the management TID tore down the BA
   session for data TIDs (upstream backport).
2. A QCN9274 firmware defect where internal BA/TX aggregation state is not
   reset when a STA re-appears on a different MAC after a band-hop. The PHY
   rate stays high while actual throughput drops to ~1–8 Mbps. There is no
   driver-side fix available, so this is mitigated in userspace.

## Commits

**`ad66567a` ath12k: pass the correct value of each TID during a stop AMPDU session**
Backport of the upstream fix
(https://lore.kernel.org/all/20260227110123.3726354-1-reshma.rajkumar@oss.qualcomm.com/).
`ath12k_dp_rx_ampdu_stop()` passed `peer->dp_peer->rx_tid` (the array base,
i.e. TID 0) instead of `&peer->dp_peer->rx_tid[params->tid]`, so a DELBA
received on TID 4 stopped the BA session for TID 0 and dropped BA size to 1.
New file: `feeds/qca-wifi-7/mac80211/patches-tip/pending/a-101-ath12k-fix-ampdu-stop-tid.patch`

**`37495b6f` ucentral-event: add BA session recovery for cross-band roaming**
Adds `ba-recovery`, a procd-managed userspace watchdog. It subscribes to
nl80211 `NL80211_CMD_NEW_STATION` via `iw event`, detects a STA hopping
between the 5G and 6G interfaces, samples that STA's AP-side RX packet rate,
and disassociates it (`reason=4`) when the rate matches the stuck-BA
signature so it reconnects cleanly. Kicks back off after 5 attempts per STA
within 30s. Exits immediately on any board other than `edgecore,eap105`.

Netlink rather than `logread -f`: hostapd's `"IEEE 802.11: associated (aid N)"`
string is not an API, depends on log level and hostapd version, requires every
syslog line to be piped through the shell, and is silently lost when syslogd
rate-limits or the ring buffer wraps — precisely the load condition this
targets. Adds `DEPENDS:=+iw`.

**`814f3df7` ucentral-event: ba-recovery: detect stuck sessions, not idle clients**
Replaces the original single-sample / single-threshold detection, which kicked
idle clients passing background chatter and had a dead "was previously active"
precondition. Three rate bands are used instead, chosen from measured
populations on EAP105 uplink with 1500-byte frames:

| population | rate | throughput |
|---|---|---|
| idle client | 0–1 pkts/s | — |
| stuck BA session | ~90–700 pkts/s | ~1–8 Mbps |
| healthy after roam | ~1200–9500 pkts/s | ~15–115 Mbps |

`DEAD_THRESHOLD=800` sits in the empty gap above the stuck range;
`ACTIVE_FLOOR=1000`; `SEEN_FLOOR=100` sits in the gap below it. `SEEN_FLOOR`
is deliberately separate from `ACTIVE_FLOOR` — refreshing the activity marker
only on healthy samples deadlocks, since a stuck STA can never produce one and
becomes permanently unrecoverable once the marker expires. A confirming sample
is required before kicking because at T+3s a stuck session and TCP ramping
back up both read near zero. A negative RX delta (counter reset by a
reassociation mid-sample) aborts the reading rather than clamping to 0, which
would read as "no traffic" and could kick a healthy STA.

## Affected targets / boards / drivers

- Target: `ipq53xx` (qca-wifi-7 / ath12k, `patches-tip/pending`)
- Board: Edgecore EAP105 (`edgecore,eap105`) — `ba-recovery` is board-gated and
  no-ops elsewhere
- Package: `ucentral-event`
- The ath12k patch is target-wide; the userspace workaround is EAP105-only

## Test evidence

https://telecominfraproject.atlassian.net/browse/WIFI-15461?focusedCommentId=66728

Edgecore EAP105, ipq53xx, QCN9274, firmware WLAN.WBE.1.4.1. LANforge client,
continuous TCP uplink, scripted 5G↔6G roam every ~33s.

Best validation run, 18 roams over ~10 minutes:
- 17 of 18 roams ended in a healthy link
- 8 STAs matched the stuck signature and were kicked; all 8 recovered
  (settled rate 9382–9476 pkts/s)
- 5 were healthy at the first sample; 5 recovered on their own during the
  confirm window and were correctly left alone
- 1 was left degraded (`confirm=1365 → settled=323`) and self-corrected at the
  next band-hop
- 18-minute idle tail with zero kicks — idle guard holds
- No kernel panic; daemon stable for ~34 minutes, memory flat

Control run with the disassociation suppressed (detection and logging
unchanged): 8 of 8 roams stuck, **zero** self-recovery, settling at
128–457 pkts/s. This confirms the firmware does not self-heal and that the
degradation compounds across consecutive roams.

Fixes: WIFI-15461