### PR TITLE
profiles: select smp_util for EAP115 and EAP115a

### DIFF
--- a/profiles/edgecore_eap115.yml
+++ b/profiles/edgecore_eap115.yml
@@ -14,5 +14,6 @@ include:
 packages:
   - kmod-mt798x-2p5g-phy
   - mt798x-2p5g-phy-firmware-internal
+  - smp_util
 diffconfig: |
   CONFIG_WIFI_SCRIPTS_UCODE=y

--- a/profiles/edgecore_eap115a.yml
+++ b/profiles/edgecore_eap115a.yml
@@ -14,5 +14,6 @@ include:
 packages:
   - kmod-mt798x-2p5g-phy
   - mt798x-2p5g-phy-firmware-internal
+  - smp_util
 diffconfig: |
   CONFIG_WIFI_SCRIPTS_UCODE=y


### PR DESCRIPTION
Add smp_util to the EAP115 and EAP115a profiles. This installs /sbin/smp-mt76.sh along with the package's flowtable helper, init script and hotplug hook.

Fixes: WIFI-15614