### PR TITLE
netifd-morse: fix HaLow Mesh broken

### DIFF
--- a/feeds/morse/netifd-morse/lib/netifd/wireless/morse.sh
+++ b/feeds/morse/netifd-morse/lib/netifd/wireless/morse.sh
@@ -246,6 +246,7 @@ drv_morse_setup() {
 	json_get_vars \
 		phy macaddr path \
 		country \
+		channel \
 		txpower \
 		frag rts htmode \
 		ampdu \
@@ -689,6 +690,14 @@ morse_vap_cleanup() {
 
 morse_interface_cleanup() {
 	local phy="$1"
+
+	# Removing an interface mid-scan wedges the chip: rm_if and the scan's
+	# cfg_scan(false) both wait on a firmware command while holding mors->lock,
+	# and every command afterwards fails with -110. Abort scans first.
+	local _wdev
+	for _wdev in $(_list_phy_interfaces "$phy"); do
+		iw dev "$_wdev" scan abort >/dev/null 2>&1
+	done
 
 	morse_vap_cleanup hostapd_s1g "$(uci -q -P /var/state get wireless._${phy}.aplist)"
 	morse_vap_cleanup wpa_supplicant_s1g "$(uci -q -P /var/state get wireless._${phy}.splist)"


### PR DESCRIPTION
root casue:
netifd re-runs drv_morse_setup while the first bring-up is still settling. The second run's morse_interface_cleanup() removes interfaces while the mesh interface is mid-scan.

In the driver, both morse_mac_ops_remove_interface() (mac.c:2785) and morse_mac_ops_sw_scan_complete() (mac.c:3680) hold mors->lock while waiting on a firmware command (600ms x 2 retries). They stall each other. The firmware stops responding after receiving the teardown sequence while still in scan mode, every subsequent command returns -110, and halow_mesh can never be brought up.

solution:
morse_interface_cleanup(): abort any in-progress scan before removing interfaces, so sw_scan_complete releases mors->lock immediately and rm_if no longer overlaps with it.

drv_morse_setup(): add the missing 'channel' to json_get_vars. $channel was empty in _get_regulatory() and the hostapd conf.

Fixes: WIFI-15668