### PR TITLE
Staging wifi 15680 support strict fwd

### DIFF
--- a/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t06-hostapd-ubus-export-uci_section.patch
+++ b/feeds/qca-wifi-7/hostapd/wlan-app-extns/hostapd/patches/zzz-t06-hostapd-ubus-export-uci_section.patch
@@ -1,0 +1,23 @@
+#
+# Export the uci_section BSS config parameter added by
+# zzz-901-cfg-section.patch in the hostapd.<bss> get_status ubus reply.
+#
+# ucentral-event and rrmd use it to locate the UCI section a BSS was
+# generated from (uci.get_all('wireless', <uci_section>)). Without it
+# hapd.config stays undefined, which silently disables strict forwarding,
+# the strict forwarding static FDB updates, the DHCP relay option-82
+# ssid/vlan-id formats and per-BSS RRM configuration.
+#
+diff --git a/src/ap/ubus.c b/src/ap/ubus.c
+--- a/src/ap/ubus.c
++++ b/src/ap/ubus.c
+@@ -416,6 +416,9 @@
+ 			hapd->iface->cac_started ? hapd->iface->dfs_cac_ms / 1000 - now.sec : 0);
+ 	blobmsg_close_table(&b, dfs_table);
+ 
++	if (hapd->conf->uci_section)
++		blobmsg_add_string(&b, "uci_section", hapd->conf->uci_section);
++
+ 	ubus_send_reply(ctx, req, b.head);
+ 
+ 	return 0;

--- a/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/feeds/qca-wifi-7/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -435,6 +435,8 @@ hostapd_common_add_bss_config() {
 	config_add_string rsn_override_key_mgmt_2 rsn_override_pairwise_2
 
 	config_add_int wps_cred_add_sae
+
+	config_add_string uci_section
 }
 
 hostapd_set_vlan_file() {
@@ -696,7 +698,8 @@ hostapd_set_bss_options() {
 		eap_server eap_user_file ca_cert server_cert private_key private_key_passwd server_id radius_server_clients radius_server_auth_port \
 		vendor_elements fils ocv apup dpp ssid_protection \
 		rsn_override_key_mgmt rsn_override_pairwise rsn_override_mfp \
-		rsn_override_key_mgmt_2 rsn_override_pairwise_2 rsn_override_mfp_2
+		rsn_override_key_mgmt_2 rsn_override_pairwise_2 rsn_override_mfp_2 \
+		uci_section
 
 
 	json_get_values sae_groups sae_groups
@@ -1355,6 +1358,8 @@ hostapd_set_bss_options() {
 			append bss_conf "apup_peer_ifname_prefix=$apup_peer_ifname_prefix" "$N"
 		fi
 	fi
+
+	[ -n "$uci_section" ] && append bss_conf "uci_section=$uci_section" "$N"
 
 	json_get_values opts hostapd_bss_options
 	for val in $opts; do

--- a/feeds/ucentral/ucentral-event/files/ucentral-event
+++ b/feeds/ucentral/ucentral-event/files/ucentral-event
@@ -125,6 +125,75 @@ function get_bridge_pvid(ifname) {
 	return null;
 }
 
+/*
+ * Resolve the one port strict forwarding lets traffic through from.
+ *
+ * The schema defines strict forwarding as isolating the BSS from every other
+ * member of its bridge apart from the first wired port. bridger takes a single
+ * target port and it has to sit in the BSS's own bridge: the policy is derived
+ * from the target's VLAN output and the bridge MAC, and bridger_output() only
+ * passes frames whose ingress port is that target or which the AP itself
+ * sourced. Naming a port in a different bridge therefore drops everything the
+ * clients send instead of isolating them, which is what an SSID on a
+ * downstream interface used to get, since the WAN is not a member of the
+ * downstream bridge.
+ *
+ * Returns null while the BSS is not bridged yet. The redirect is re-asserted on
+ * client association, so that case resolves itself and is not worth reporting.
+ */
+function strict_fwd_redirect_port(ifname) {
+	let master = fs.readlink(`/sys/class/net/${ifname}/master`);
+	if (!master)
+		return null;
+
+	let bridge = fs.basename(master);
+	let members = fs.lsdir(`/sys/class/net/${bridge}/brif`);
+	if (!members)
+		return null;
+
+	/* keep using the uplink whenever it shares the BSS's bridge */
+	for (let wan in wan_ports)
+		if (index(members, wan) >= 0)
+			return wan;
+
+	/* otherwise the first wired member, lsdir() sorts so this is stable */
+	for (let member in members)
+		if (!fs.access(`/sys/class/net/${member}/phy80211`))
+			return member;
+
+	warn(`ucentral-event: no wired port in ${bridge}, cannot enable strict forwarding on ${ifname}\n`);
+
+	return null;
+}
+
+/*
+ * Push the strict forwarding redirect for a BSS into bridger.
+ *
+ * This has to be re-asserted rather than set once: bridger drops
+ * dev->redirect_dev whenever the netdev detaches from the bridge
+ * (device_set_attached() -> device_set_redirect(dev, 0)), and it rejects
+ * set_device_config for a netdev it has not learned via netlink yet. Both
+ * cases are silent, so a single call at BSS start can be lost with no way
+ * to notice. device_set_redirect() is a no-op when the value is unchanged,
+ * so repeating the call is cheap.
+ */
+function strict_fwd_set_redirect(hapd) {
+	if (!+hapd?.config?.strict_forwarding)
+		return;
+
+	let port = strict_fwd_redirect_port(hapd.ifname);
+	if (!port)
+		return;
+
+	let ret = ubus.call('bridger', 'set_device_config', {
+		name: hapd.ifname,
+		redirect: port
+	});
+
+	if (ret == null)
+		warn(`ucentral-event: failed to enable strict forwarding on ${hapd.ifname} via ${port}: ${ubus.error()}\n`);
+}
+
 function strict_fwd_update_fdb(hapd, address) {
 	if (!+hapd?.config?.strict_forwarding)
 		return;
@@ -256,6 +325,7 @@ handlers = {
 			ubus.call('ratelimit', 'client_set', msg);
 		}
 
+		strict_fwd_set_redirect(hapd);
 		strict_fwd_update_fdb(hapd, notify.data.address);
 	},
 
@@ -420,11 +490,7 @@ function hostapd_add(path, obj) {
 
 	printf('%.J\n', hostapd[ifname]);
 
-	if (+hostapd[ifname].config?.strict_forwarding)
-		ubus.call('bridger', 'set_device_config', {
-			name: ifname,
-			redirect: wan_ports[0]
-		});
+	strict_fwd_set_redirect(hostapd[ifname]);
 
 	if (hostapd[ifname].op_class >= 81 &&
 	    hostapd[ifname].op_class <= 84)

--- a/patches-25.12/0122-wifi-scripts-pass-uci_section-through-to-hostapd.patch
+++ b/patches-25.12/0122-wifi-scripts-pass-uci_section-through-to-hostapd.patch
@@ -1,0 +1,95 @@
+From 43e910ff217b0ca3c156936f7cec41a301156f69 Mon Sep 17 00:00:00 2001
+From: Tanya Singh <tanya_singh@accton.com>
+Date: Tue, 25 Aug 2026 20:09:41 +0800
+Subject: [PATCH] wifi-scripts: pass uci_section through to hostapd
+
+The hostapd C side already knows about the uci_section BSS config
+parameter (zzz-0012-cfg-section.patch) and exports it in the get_status
+ubus reply, but nothing ever writes it into the generated BSS config, so
+hapd->conf->uci_section stays NULL and the field is silently omitted.
+
+Every consumer keys off that field to find the wifi-iface section that
+produced the BSS:
+
+ - ucentral-event does uci.get_all('wireless', <uci_section>), so
+   hapd.config is undefined. That breaks strict_forwarding (bridger
+   set_device_config is never called), the strict forwarding static FDB
+   updates, and the DHCP relay option-82 ssid/vlan-id circuit-id and
+   remote-id formats.
+ - rrmd local.uc does uci.get_all('rrmd', status.uci_section), so
+   per-BSS RRM configuration falls back to defaults.
+
+ucentral-schema already emits 'option uci_section' for every wifi-iface,
+so plumbing it through the config generator is all that is needed. Do it
+for both the shell and the ucode generator so the config does not break
+again when WIFI_SCRIPTS_UCODE is enabled.
+
+Signed-off-by: Tanya Singh <tanya_singh@accton.com>
+---
+ .../files-ucode/usr/share/schema/wireless.wifi-iface.json  | 4 ++++
+ .../wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc    | 1 +
+ .../config/wifi-scripts/files/lib/netifd/hostapd.sh        | 7 ++++++-
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+index 75ec3a3bdb..9b3fc42695 100644
+--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
++++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+@@ -1038,6 +1038,10 @@
+ 			"type": "boolean",
+ 			"default": true
+ 		},
++		"uci_section": {
++			"description": "Name of the UCI section this BSS was generated from, exported via the hostapd get_status ubus call",
++			"type": "string"
++		},
+ 		"uesa": {
+ 			"description": "Unauthenticated emergency service accessible",
+ 			"type": "boolean",
+diff --git a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+index 0629e70409..2cd635f22c 100644
+--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
++++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+@@ -60,6 +60,7 @@ function iface_setup(config) {
+ 		'ocv', 'beacon_prot', 'spp_amsdu', 'multicast_to_unicast', 'preamble', 'proxy_arp', 'per_sta_vif', 'mbo',
+ 		'bss_transition', 'wnm_sleep_mode', 'wnm_sleep_mode_no_keys', 'qos_map_set', 'max_listen_int',
+ 		'dtim_period', 'wmm_enabled', 'start_disabled', 'na_mcast_to_ucast', 'no_probe_resp_if_max_sta',
++		'uci_section',
+ 	]);
+ }
+ 
+diff --git a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+index 5df4a58578..917e930339 100644
+--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
++++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+@@ -469,6 +469,8 @@ hostapd_common_add_bss_config() {
+ 	config_add_string apup_peer_ifname_prefix
+ 
+ 	config_add_int rssi_reject_assoc_rssi rssi_ignore_probe_request
++
++	config_add_string uci_section
+ }
+ 
+ hostapd_set_vlan_file() {
+@@ -629,7 +631,8 @@ hostapd_set_bss_options() {
+ 		multicast_to_unicast_all proxy_arp per_sta_vif na_mcast_to_ucast \
+ 		eap_server eap_user_file ca_cert server_cert private_key private_key_passwd server_id radius_server_clients radius_server_auth_port \
+ 		vendor_elements fils ocv beacon_prot spp_amsdu apup rsn_override \
+-		rssi_reject_assoc_rssi rssi_ignore_probe_request
++		rssi_reject_assoc_rssi rssi_ignore_probe_request \
++		uci_section
+ 
+ 	set_default rsn_override 0
+ 	set_default fils 0
+@@ -1286,6 +1289,8 @@ hostapd_set_bss_options() {
+ 		fi
+ 	fi
+ 
++	[ -n "$uci_section" ] && append bss_conf "uci_section=$uci_section" "$N"
++
+ 	json_get_values opts hostapd_bss_options
+ 	for val in $opts; do
+ 		append bss_conf "$val" "$N"
+-- 
+2.34.1
+


### PR DESCRIPTION
Strict forwarding does not work on this branch for any model. Two independent
defects, both silent:

1. hostapd never reported which UCI section a BSS came from, so every consumer
   that keys off `uci_section` no-oped. The 23.05 -> 25.12 port brought across
   the C halves of the TIP `uci_section` patch (0070, 0078) but not the three
   shell lines that emit it, because `/lib/netifd/hostapd.sh` moved from the
   hostapd package into `wifi-scripts`, and the qca-wifi-7 feed ships its own
   copy of both packages.
2. Even with that fixed, the bridger redirect that enforces the isolation was
   pushed once at BSS start and could be lost without a trace, so with two
   strict-forwarding SSIDs the second one stayed unenforced.

**Commits:**
- **`hostapd: restore uci_section plumbing lost in the 25.12 port`**
  Adds the three generator lines to base `wifi-scripts` (new
  `patches-25.12/0122`) plus the ucode generator, mirrors them into the
  qca-wifi-7 feed's own `hostapd.sh`, and exports `uci_section` in `get_status`
  for that feed's hostapd (`zzz-t06`), which patch 0078 only did for the base
  hostapd this feed overrides.
  Restores strict forwarding, its static FDB updates, DHCP relay option-82
  `ssid`/`vlan-id`, and per-BSS RRM.

- **`ucentral-event: make the strict forwarding redirect stick`**
  Re-asserts the redirect on client association instead of only at BSS start,
  and stops discarding the ubus return. bridger rejects a netdev it has not
  learned yet, and clears `dev->redirect_dev` on any bridge detach; nothing
  re-applied it.
  Also resolves the redirect target from the BSS's own bridge instead of
  assuming `wan_port[0]`. bridger takes one target port and derives the policy
  from that port's VLAN output and the bridge MAC, so a port in another bridge
  drops everything the clients send. That is what an SSID on a `downstream`
  interface got. The uplink is still preferred when it shares the BSS's bridge,
  so upstream SSIDs behave exactly as before.

Tested on EAP101 (QCA WiFi6) and EAP105 (QCA WiFi7): https://telecominfraproject.atlassian.net/browse/WIFI-15680?focusedCommentId=66834

Fixes: WIFI-15680