### PR TITLE
rrmd: scan: restrict off-channel scan to the target frequency

### DIFF
--- a/feeds/ucentral/rrmd/files/usr/share/rrmd/scan.uc
+++ b/feeds/ucentral/rrmd/files/usr/share/rrmd/scan.uc
@@ -12,7 +12,7 @@ let scan_blocked_cnt = 0;
 function scan(phy, params) {
 	if (params.wiphy_freq) {
 		params.center_freq1 = (int) (params.wiphy_freq) + (int) (phys[phy].offset);
-		params.scan_ssids = [ '' ];
+		params.scan_frequencies = [ (int) (params.wiphy_freq) ];
 	}
 
 	params.scan_flags = SCAN_FLAG_AP;


### PR DESCRIPTION
The periodic RRM scan set wiphy_freq/center_freq1 on the TRIGGER_SCAN request but never populated scan_frequencies, so nl80211 fell back to scanning the whole band on every off-channel dwell.

Limit the request to the single target frequency via scan_frequencies and drop the active scan_ssids probe, so the off-channel visit is a short passive dwell bounded by the existing measurement_duration.

Fixes: WIFI-14822

(cherry picked from commit e7244b2f460fcfd9c89299cca60dd47047fd7c8f)