### PR TITLE
MPSKD: fix vlan assignment 

### DIFF
--- a/feeds/qca-wifi-6/hostapd/patches/800-multi-psk-roaming-vlan.patch
+++ b/feeds/qca-wifi-6/hostapd/patches/800-multi-psk-roaming-vlan.patch
@@ -1,0 +1,55 @@
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -153,6 +153,7 @@ struct hostapd_sta_wpa_psk_short {
+ 	unsigned int is_passphrase:1;
+ 	u8 psk[PMK_LEN];
+ 	char passphrase[MAX_PASSPHRASE_LEN + 1];
++	int vlan_id;
+ 	int ref; /* (number of references held) - 1 */
+ };
+ 
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -2404,6 +2404,42 @@ int ieee802_11_set_radius_info(struct ho
+ 			       vlan_id->tagged[0] ? "+" : "");
+ 		return -1;
+ 	}
++
++	/* Store VLAN ID with cached PSK for MPSK roaming support */
++	if (hapd->conf->ssid.dynamic_vlan && psk && vlan_id->notempty &&
++	    vlan_id->untagged > 0) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++
++		for (psk_entry = psk; psk_entry; psk_entry = psk_entry->next) {
++			psk_entry->vlan_id = vlan_id->untagged;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Stored VLAN %d with PSK for "
++				   MACSTR, vlan_id->untagged,
++				   MAC2STR(sta->addr));
++		}
++	}
++
++	/* Restore VLAN from cached PSK if not provided by RADIUS */
++	if (hapd->conf->ssid.dynamic_vlan && !vlan_id->notempty && sta->psk) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++		int cached_vlan = 0;
++
++		for (psk_entry = sta->psk; psk_entry; psk_entry = psk_entry->next) {
++			if (psk_entry->vlan_id > 0) {
++				cached_vlan = psk_entry->vlan_id;
++				break;
++			}
++		}
++
++		if (cached_vlan > 0) {
++			vlan_id->notempty = 1;
++			vlan_id->untagged = cached_vlan;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Restored VLAN %d from cached PSK for " MACSTR,
++				   cached_vlan, MAC2STR(sta->addr));
++		}
++	}
++
+ 	if (ap_sta_set_vlan(hapd, sta, vlan_id) < 0)
+ 		return -1;
+ 	if (sta->vlan_id)

--- a/feeds/qca-wifi-7/hostapd/files/mpskd
+++ b/feeds/qca-wifi-7/hostapd/files/mpskd
@@ -252,14 +252,34 @@ function sta_auth_psk(ifname, addr) {
 	return ssid_psk(ssid, addr);
 }
 
-function sta_auth_cache(ifname, addr, idx, phrase) {
+function cache_reply(cache) {
+	if (!cache.vlan)
+		return cache.data;
+	let d = {};
+	for (let k, v in cache.data)
+		d[k] = v;
+	d.vlan = cache.vlan;
+	return d;
+}
+
+function sta_auth_cache(ifname, addr, idx, phrase, vlan) {
 	let ssid = iface_ssid(ifname);
 	if (!ssid)
 		return;
 
+	/*
+	 * Learn (and clear) the RADIUS VLAN only on the bands that carry it
+	 * (2.4/5 GHz). On 6 GHz there is no RADIUS, so keep the value learned
+	 * earlier instead of wiping it when the event carries no VLAN.
+	 */
+	let learn_vlan = interfaces[ifname]?.band != '6g';
+
 	let cache = sta_cache_entry_get(ssid, addr);
-	if (cache)
-		return cache.data;
+	if (cache) {
+		if (learn_vlan)
+			cache.vlan = vlan;
+		return cache_reply(cache);
+	}
 
 	let psk = ssid_psk(ssid, addr);
 	if (!psk)
@@ -276,17 +296,20 @@ function sta_auth_cache(ifname, addr, idx, phrase) {
 	if (!cache)
 		return;
 
+	if (learn_vlan)
+		cache.vlan = vlan;
+
 	let ssid_data = ssids[ssid];
 	if (!ssid_data)
-		return cache.data;
+		return cache_reply(cache);
 
 	let target_ifname = ssid_data.bands['6g'];
 	if (!target_ifname)
-		return cache.data;
+		return cache_reply(cache);
 
 	let target_iface = interfaces[target_ifname];
 	if (!target_iface)
-		return cache.data;
+		return cache_reply(cache);
 
 	cache.timer = uloop.timer(30 * 1000, () => {
 		let msg = {
@@ -302,7 +325,7 @@ function sta_auth_cache(ifname, addr, idx, phrase) {
 		delete cache.timer;
 	});
 
-	return cache.data;
+	return cache_reply(cache);
 }
 
 function auth_cb(msg) {
@@ -321,7 +344,7 @@ function auth_cb(msg) {
 	case 'sta_connected':
 		if (data.psk_idx == null || !is_ssid_mpsk(data.iface))
 			return;
-		return sta_auth_cache(data.iface, data.sta, data.psk_idx, data.psk);
+		return sta_auth_cache(data.iface, data.sta, data.psk_idx, data.psk, data.vlan);
 	case 'reload':
 		netifd_reload();
 		reload_timer.set(5000);

--- a/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0080-multi-psk-roaming-vlan.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0080-multi-psk-roaming-vlan.patch
@@ -1,0 +1,69 @@
+From: Marek Kwaczynski <marek@shasta.cloud>
+Subject: [PATCH] qca-wifi-7: hostapd: port MPSK roaming VLAN fix to WiFi-7
+
+WiFi-7 counterpart of John Crispin commit 55691669 ("hostapd: fix VLAN
+assignment lost on MPSK roaming between bands"), which fixed WiFi-6 only.
+Cache the RADIUS-assigned VLAN with the per-STA PSK entry and restore it
+when RADIUS does not resend it on a PMK-cached roam.
+
+--- a/src/ap/ap_config.h
++++ b/src/ap/ap_config.h
+@@ -160,5 +160,6 @@
+ 	unsigned int is_passphrase:1;
+ 	u8 psk[PMK_LEN];
+ 	char passphrase[MAX_PASSPHRASE_LEN + 1];
++	int vlan_id;
+ 	int ref; /* (number of references held) - 1 */
+ };
+
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -2449,6 +2449,48 @@
+ 			       vlan_id->tagged[0] ? "+" : "");
+ 		return -1;
+ 	}
++
++	/* Store VLAN ID with cached PSK for MPSK roaming support */
++	if (hapd->conf->ssid.dynamic_vlan && psk && vlan_id->notempty &&
++	    vlan_id->untagged > 0) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++
++		for (psk_entry = psk; psk_entry; psk_entry = psk_entry->next) {
++			psk_entry->vlan_id = vlan_id->untagged;
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Stored VLAN %d with PSK for "
++				   MACSTR, vlan_id->untagged,
++				   MAC2STR(sta->addr));
++		}
++	}
++
++	/* Restore VLAN from cached PSK if not provided by RADIUS */
++	if (hapd->conf->ssid.dynamic_vlan && !vlan_id->notempty && sta->psk) {
++		struct hostapd_sta_wpa_psk_short *psk_entry;
++		int cached_vlan = 0;
++
++		for (psk_entry = sta->psk; psk_entry; psk_entry = psk_entry->next) {
++			if (psk_entry->vlan_id > 0) {
++				cached_vlan = psk_entry->vlan_id;
++				break;
++			}
++		}
++
++		if (cached_vlan > 0) {
++			vlan_id->notempty = 1;
++			vlan_id->untagged = cached_vlan;
++
++			/* Re-persist so it survives the psk-list swap below */
++			for (psk_entry = psk; psk_entry;
++			     psk_entry = psk_entry->next)
++				psk_entry->vlan_id = cached_vlan;
++
++			wpa_printf(MSG_DEBUG,
++				   "RADIUS MPSK: Restored VLAN %d from cached PSK for " MACSTR,
++				   cached_vlan, MAC2STR(sta->addr));
++		}
++	}
++
+ 	if (ap_sta_set_vlan(hapd, sta, vlan_id) < 0)
+ 		return -1;
+ 	if (sta->vlan_id)

--- a/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0081-mpsk-6g-radius-vlan.patch
+++ b/feeds/qca-wifi-7/hostapd/patches/zzzz-x-0081-mpsk-6g-radius-vlan.patch
@@ -1,0 +1,170 @@
+From: Marek Kwaczynski <marek@shasta.cloud>
+Subject: [PATCH] qca-wifi-7: hostapd: add ucode station hooks for MPSK
+
+The WiFi-7 hostapd tree ships mpskd, but its ucode glue only exposes the
+bss_add/bss_reload/bss_remove hooks, so mpskd never sees a station and
+its sta_auth/sta_connected handlers are dead code. Port the two station
+hooks from the WiFi-6 tree:
+
+ - sta_auth lets mpskd hand hostapd the per-station PSK list and force it
+   over the BSS-wide passphrase (use_sta_psk). The selected passphrase
+   also gets its own SAE PT, otherwise H2E, which is mandatory on 6 GHz,
+   cannot be used with a per-station PSK.
+ - sta_connected reports the matched PSK index, the passphrase and the
+   RADIUS-assigned VLAN, and applies the VLAN that mpskd returns via
+   ap_sta_set_vlan()/ap_sta_bind_vlan().
+
+psk_idx is tracked in hostapd_wpa_auth_get_psk() and sae_get_password()
+so mpskd can tell which MPSK entry a station matched. Together with mpskd
+caching the VLAN it learns on 2.4/5 GHz, this restores the RADIUS VLAN
+for the same client when it later joins the 6 GHz SAE BSS, where there is
+no RADIUS exchange.
+
+The hook bodies live in the package src/ overlay (src/ap/ucode.{c,h}),
+same as in the WiFi-6 tree.
+
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -632,11 +632,14 @@
+ 			      const struct sae_pk **s_pk)
+ {
+ 	const char *password = NULL;
+-	struct sae_password_entry *pw;
++	struct sae_password_entry *pw = NULL;
+ 	struct sae_pt *pt = NULL;
+ 	const struct sae_pk *pk = NULL;
+ 	struct hostapd_sta_wpa_psk_short *psk = NULL;
+ 
++	if (sta && sta->use_sta_psk)
++		goto use_sta_psk;
++
+ 	/* With sae_track_password functionality enabled, try to first find the
+ 	 * next viable wildcard-address password if a password identifier was
+ 	 * not used. Select an wildcard-addr entry if the STA is known to have
+@@ -697,12 +700,30 @@
+ 		pt = hapd->conf->ssid.pt;
+ 	}
+ 
+-	if (!password && sta && !rx_id) {
++use_sta_psk:
++	if (!password && sta && (!rx_id || sta->use_sta_psk)) {
++		sta->psk_idx = 0;
+ 		for (psk = sta->psk; psk; psk = psk->next) {
+-			if (psk->is_passphrase) {
+-				password = psk->passphrase;
++			if (!psk->is_passphrase)
++				continue;
++
++			password = psk->passphrase;
++			if (!sta->use_sta_psk)
++				break;
++
++			sta->psk_idx = 1;
++			if (sta->sae_pt) {
++				pt = sta->sae_pt;
+ 				break;
+ 			}
++
++			pt = sae_derive_pt(hapd->conf->sae_groups,
++					   hapd->conf->ssid.ssid,
++					   hapd->conf->ssid.ssid_len,
++					   (const u8 *) password,
++					   os_strlen(password), NULL);
++			sta->sae_pt = pt;
++			break;
+ 		}
+ 	}
+ 
+@@ -3465,6 +3486,12 @@
+ 		goto fail;
+ 	}
+ 
++	res = hostapd_ucode_sta_auth(hapd, sta);
++	if (res) {
++		resp = res;
++		goto fail;
++	}
++
+ 	sta->flags &= ~WLAN_STA_PREAUTH;
+ 	ieee802_1x_notify_pre_auth(sta->eapol_sm, 0);
+ 
+--- a/src/ap/sta_info.c
++++ b/src/ap/sta_info.c
+@@ -474,6 +474,9 @@
+ 	forced_memzero(sta->last_tk, WPA_TK_MAX_LEN);
+ #endif /* CONFIG_TESTING_OPTIONS */
+ 
++	if (sta->sae_pt)
++		sae_deinit_pt(sta->sae_pt);
++
+ 	os_free(sta);
+ }
+ 
+@@ -1558,6 +1561,9 @@
+ 		sta->flags &= ~WLAN_STA_AUTHORIZED;
+ 	}
+ 
++	if (authorized)
++		hostapd_ucode_sta_connected(hapd, sta);
++
+ 	return true;
+ }
+ 
+--- a/src/ap/sta_info.h
++++ b/src/ap/sta_info.h
+@@ -180,6 +180,9 @@
+ 	int vlan_id_bound; /* updated by ap_sta_bind_vlan() */
+ 	 /* PSKs from RADIUS authentication server */
+ 	struct hostapd_sta_wpa_psk_short *psk;
++	struct sae_pt *sae_pt;
++	int use_sta_psk;
++	int psk_idx;
+ 
+ 	char *identity; /* User-Name from RADIUS */
+ 	char *radius_cui; /* Chargeable-User-Identity from RADIUS */
+--- a/src/ap/wpa_auth_glue.c
++++ b/src/ap/wpa_auth_glue.c
+@@ -412,6 +412,9 @@
+ 	}
+ #endif /* CONFIG_SAE */
+ 
++	if (sta)
++		sta->psk_idx = 0;
++
+ #ifdef CONFIG_OWE
+ 	if ((hapd->conf->wpa_key_mgmt & WPA_KEY_MGMT_OWE) &&
+ 	    sta && sta->owe_pmk) {
+@@ -438,13 +441,18 @@
+ 	 * returned psk which should not be returned again.
+ 	 * logic list (all hostapd_get_psk; all sta->psk)
+ 	 */
++	if (sta && sta->use_sta_psk)
++		psk = NULL;
+ 	if (sta && sta->psk && !psk) {
+ 		struct hostapd_sta_wpa_psk_short *pos;
++		int psk_idx = 1;
+ 
+ 		if (vlan_id)
+ 			*vlan_id = 0;
+ 		psk = sta->psk->psk;
+-		for (pos = sta->psk; pos; pos = pos->next) {
++		if (vlan_id)
++			sta->psk_idx = psk_idx;
++		for (pos = sta->psk; pos; pos = pos->next, psk_idx++) {
+ 			if (pos->is_passphrase) {
+ 				if (pbkdf2_sha1(pos->passphrase,
+ 						hapd->conf->ssid.ssid,
+@@ -458,9 +466,13 @@
+ 			}
+ 			if (pos->psk == prev_psk) {
+ 				psk = pos->next ? pos->next->psk : NULL;
++				if (vlan_id)
++					sta->psk_idx = psk_idx + 1;
+ 				break;
+ 			}
+ 		}
++		if (vlan_id && !psk)
++			sta->psk_idx = 0;
+ 	}
+ 	return psk;
+ }

--- a/feeds/qca-wifi-7/hostapd/src/src/ap/ucode.c
+++ b/feeds/qca-wifi-7/hostapd/src/src/ap/ucode.c
@@ -6,6 +6,7 @@
 #include "hostapd.h"
 #include "beacon.h"
 #include "hw_features.h"
+#include "ieee802_11_auth.h"
 #include "ap_drv_ops.h"
 #include "dfs.h"
 #include "acs.h"
@@ -703,6 +704,121 @@ out:
 		interfaces->ctrl_iface_init(hapd);
 
 	return ret ? NULL : ucv_boolean_new(true);
+}
+
+
+int hostapd_ucode_sta_auth(struct hostapd_data *hapd, struct sta_info *sta)
+{
+	char addr[sizeof(MACSTR)];
+	uc_value_t *val, *cur;
+	int ret = 0;
+
+	if (wpa_ucode_call_prepare("sta_auth"))
+		return 0;
+
+	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface)));
+
+	snprintf(addr, sizeof(addr), MACSTR, MAC2STR(sta->addr));
+	val = ucv_string_new(addr);
+	uc_value_push(ucv_get(val));
+
+	val = wpa_ucode_call(2);
+
+	cur = ucv_object_get(val, "psk", NULL);
+	if (ucv_type(cur) == UC_ARRAY) {
+		struct hostapd_sta_wpa_psk_short *p, **next;
+		size_t len = ucv_array_length(cur);
+
+		next = &sta->psk;
+		hostapd_free_psk_list(*next);
+		*next = NULL;
+
+		for (size_t i = 0; i < len; i++) {
+			uc_value_t *cur_psk;
+			const char *str;
+			size_t str_len;
+
+			cur_psk = ucv_array_get(cur, i);
+			str = ucv_string_get(cur_psk);
+			if (!str)
+				continue;
+			str_len = strlen(str);
+			if (str_len < 8 || str_len > 64)
+				continue;
+
+			p = os_zalloc(sizeof(*p));
+			if (!p)
+				continue;
+
+			if (str_len == 64) {
+				if (hexstr2bin(str, p->psk, PMK_LEN) < 0) {
+					os_free(p);
+					continue;
+				}
+			} else {
+				p->is_passphrase = 1;
+				os_memcpy(p->passphrase, str, str_len + 1);
+			}
+
+			*next = p;
+			next = &p->next;
+		}
+	}
+
+	cur = ucv_object_get(val, "force_psk", NULL);
+	sta->use_sta_psk = ucv_is_truish(cur);
+
+	cur = ucv_object_get(val, "status", NULL);
+	if (ucv_type(cur) == UC_INTEGER)
+		ret = ucv_int64_get(cur);
+
+	ucv_put(val);
+	ucv_gc(vm);
+
+	return ret;
+}
+
+void hostapd_ucode_sta_connected(struct hostapd_data *hapd, struct sta_info *sta)
+{
+	char addr[sizeof(MACSTR)];
+	uc_value_t *val, *cur;
+
+	if (wpa_ucode_call_prepare("sta_connected"))
+		return;
+
+	uc_value_push(ucv_get(ucv_string_new(hapd->conf->iface)));
+
+	snprintf(addr, sizeof(addr), MACSTR, MAC2STR(sta->addr));
+	val = ucv_string_new(addr);
+	uc_value_push(ucv_get(val));
+
+	val = ucv_object_new(vm);
+	if (sta->psk_idx)
+		ucv_object_add(val, "psk_idx", ucv_int64_new(sta->psk_idx - 1));
+	if (sta->psk)
+		ucv_object_add(val, "psk", ucv_string_new(sta->psk->passphrase));
+	if (sta->vlan_id)
+		ucv_object_add(val, "vlan", ucv_int64_new(sta->vlan_id));
+	uc_value_push(ucv_get(val));
+
+	val = wpa_ucode_call(3);
+	if (ucv_type(val) != UC_OBJECT)
+		goto out;
+
+	cur = ucv_object_get(val, "vlan", NULL);
+	if (ucv_type(cur) == UC_INTEGER) {
+		struct vlan_description vdesc = {
+			.notempty = 1,
+			.untagged = ucv_int64_get(cur),
+		};
+
+		ap_sta_set_vlan(hapd, sta, &vdesc);
+		ap_sta_bind_vlan(hapd, sta);
+	}
+
+out:
+	ucv_put(val);
+	ucv_gc(vm);
 }
 
 

--- a/feeds/qca-wifi-7/hostapd/src/src/ap/ucode.h
+++ b/feeds/qca-wifi-7/hostapd/src/src/ap/ucode.h
@@ -23,6 +23,8 @@ int hostapd_ucode_init(struct hapd_interfaces *ifaces);
 
 void hostapd_ucode_free(void);
 void hostapd_ucode_free_iface(struct hostapd_iface *iface);
+int hostapd_ucode_sta_auth(struct hostapd_data *hapd, struct sta_info *sta);
+void hostapd_ucode_sta_connected(struct hostapd_data *hapd, struct sta_info *sta);
 void hostapd_ucode_add_bss(struct hostapd_data *hapd);
 void hostapd_ucode_free_bss(struct hostapd_data *hapd);
 void hostapd_ucode_reload_bss(struct hostapd_data *hapd);
@@ -40,6 +42,13 @@ static inline void hostapd_ucode_free_iface(struct hostapd_iface *iface)
 {
 }
 static inline void hostapd_ucode_reload_bss(struct hostapd_data *hapd)
+{
+}
+static inline int hostapd_ucode_sta_auth(struct hostapd_data *hapd, struct sta_info *sta)
+{
+	return 0;
+}
+static inline void hostapd_ucode_sta_connected(struct hostapd_data *hapd, struct sta_info *sta)
 {
 }
 static inline void hostapd_ucode_add_bss(struct hostapd_data *hapd)


### PR DESCRIPTION
hostapd, mpskd: fix VLAN assignment lost on MPSK roaming between bands
When a client roams between bands (2.4/5/6 GHz) using RADIUS-based
Multi-PSK (MPSK), the VLAN assignment is lost and the client gets
placed on the default VLAN 1.

Fixes: WIFI-14179