### PR TITLE
filogic: enable WED offload on RAP630W-211G

### DIFF
--- a/feeds/ucentral/bridger/patches/001-renderer-enable-bridger-hardware-offload-on-WED-capa.patch
+++ b/feeds/ucentral/bridger/patches/001-renderer-enable-bridger-hardware-offload-on-WED-capa.patch
@@ -1,0 +1,92 @@
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/interface/ssid.uc ucentral-schema-2026.08.26~d1e90a04/renderer/templates/interface/ssid.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/interface/ssid.uc	2026-09-03 14:29:15.338389105 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/renderer/templates/interface/ssid.uc	2026-09-03 14:39:10.167216528 +0800
+@@ -85,6 +85,10 @@
+ 		return ssid.rate_limit && (ssid.rate_limit.ingress_rate || ssid.rate_limit.egress_rate);
+ 	}
+ 
++	function needs_offload_exclude() {
++		return capab.wed && has_rate_limit();
++	}
++
+ 	// is_ functions - boolean checks/validation
+ 	function is_6g_band(band) {
+ 		return band == "6G";
+@@ -423,6 +427,8 @@
+ 	function calculate_ifname(name) {
+ 		if ('captive' in ssid.services)
+ 			return 'wlanc' + captive.get(name);
++		if (needs_offload_exclude())
++			return 'wlanr' + captive.next++;
+ 		return '';
+ 	}
+ 
+@@ -483,7 +489,7 @@
+ 		uci_set_string(output, `wireless.${section}.uci_section`, section);
+ 		uci_set_string(output, `wireless.${section}.device`, phy.section);
+ 
+-		if (has_captive_service())
++		if (has_captive_service() || needs_offload_exclude())
+ 			uci_set_string(output, `wireless.${section}.ifname`, ifname);
+ 
+ 		return uci_output(output);
+@@ -502,6 +508,19 @@
+ 		return uci_output(output);
+ 	}
+ 
++	function generate_offload_exclude_integration(ifname) {
++		if (!needs_offload_exclude() || ifname == '')
++			return '';
++
++		let output = [];
++
++		uci_comment(output, '### exclude rate-limited iface from bridger HW offload (WED on)');
++		uci_list_string(output, 'bridger.@defaults[0].blacklist', ifname);
++
++		return uci_output(output);
++	}
++
++
+ 	function generate_owe_transition_config(section) {
+ 		if (ssid?.encryption?.proto != 'owe-transition')
+ 			return '';
+@@ -1081,6 +1100,7 @@
+ {%   if (!(band == "HaLow" && bss_mode == 'mesh')): %}
+ {{ generate_base_wireless_config(section, phy, ifname, bss_mode) }}
+ {{ generate_captive_integration(section, basename, ifname) }}
++{{ generate_offload_exclude_integration(ifname) }
+ {{ generate_owe_transition_config(section) }}
+ {{ generate_owe_config(section, ssidname, owe) }}
+ {{ generate_mesh_config(section, bss_mode) }}
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/toplevel.uc ucentral-schema-2026.08.26~d1e90a04/renderer/templates/toplevel.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/toplevel.uc	2026-09-03 14:29:15.340389105 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/renderer/templates/toplevel.uc	2026-09-03 14:41:02.251473426 +0800
+@@ -281,5 +281,5 @@
+ 		include("config_raw.uc", { location: '/config_raw', config_raw: state.config_raw });
+ 
+ 	latency.write();
+-	services.set_enabled("bridger", false);
++	services.set_enabled("bridger", capab.wed ? 'no-restart' : false);
+ %}
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/system/capabilities.uc ucentral-schema-2026.08.26~d1e90a04/system/capabilities.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/system/capabilities.uc	2026-09-03 14:29:15.343389106 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/system/capabilities.uc	2026-09-03 14:43:14.842800241 +0800
+@@ -170,6 +170,18 @@
+ if (length(wifi))
+ 	capa.wifi = wifi;
+ 
++for (let path in fs.glob('/sys/module/*/parameters/wed_enable')) {
++	let wedfile = fs.open(path, 'r');
++	if (!wedfile)
++		continue;
++	let wed_enable = trim(wedfile.read('all'));
++	wedfile.close();
++	if (wed_enable == '1' || wed_enable == 'Y') {
++		capa.wed = true;
++		break;
++	}
++}
++
+ capa.compress_cmd = true;
+ 
+ fs.writefile('/etc/ucentral/capabilities.json', capa);

--- a/feeds/ucentral/ucentral-schema/patches/001-renderer-enable-bridger-hardware-offload-on-WED-capa.patch
+++ b/feeds/ucentral/ucentral-schema/patches/001-renderer-enable-bridger-hardware-offload-on-WED-capa.patch
@@ -1,0 +1,92 @@
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/interface/ssid.uc ucentral-schema-2026.08.26~d1e90a04/renderer/templates/interface/ssid.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/interface/ssid.uc	2026-09-03 14:29:15.338389105 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/renderer/templates/interface/ssid.uc	2026-09-03 14:39:10.167216528 +0800
+@@ -85,6 +85,10 @@
+ 		return ssid.rate_limit && (ssid.rate_limit.ingress_rate || ssid.rate_limit.egress_rate);
+ 	}
+ 
++	function needs_offload_exclude() {
++		return capab.wed && has_rate_limit();
++	}
++
+ 	// is_ functions - boolean checks/validation
+ 	function is_6g_band(band) {
+ 		return band == "6G";
+@@ -423,6 +427,8 @@
+ 	function calculate_ifname(name) {
+ 		if ('captive' in ssid.services)
+ 			return 'wlanc' + captive.get(name);
++		if (needs_offload_exclude())
++			return 'wlanr' + captive.next++;
+ 		return '';
+ 	}
+ 
+@@ -483,7 +489,7 @@
+ 		uci_set_string(output, `wireless.${section}.uci_section`, section);
+ 		uci_set_string(output, `wireless.${section}.device`, phy.section);
+ 
+-		if (has_captive_service())
++		if (has_captive_service() || needs_offload_exclude())
+ 			uci_set_string(output, `wireless.${section}.ifname`, ifname);
+ 
+ 		return uci_output(output);
+@@ -502,6 +508,19 @@
+ 		return uci_output(output);
+ 	}
+ 
++	function generate_offload_exclude_integration(ifname) {
++		if (!needs_offload_exclude() || ifname == '')
++			return '';
++
++		let output = [];
++
++		uci_comment(output, '### exclude rate-limited iface from bridger HW offload (WED on)');
++		uci_list_string(output, 'bridger.@defaults[0].blacklist', ifname);
++
++		return uci_output(output);
++	}
++
++
+ 	function generate_owe_transition_config(section) {
+ 		if (ssid?.encryption?.proto != 'owe-transition')
+ 			return '';
+@@ -1081,6 +1100,7 @@
+ {%   if (!(band == "HaLow" && bss_mode == 'mesh')): %}
+ {{ generate_base_wireless_config(section, phy, ifname, bss_mode) }}
+ {{ generate_captive_integration(section, basename, ifname) }}
++{{ generate_offload_exclude_integration(ifname) }
+ {{ generate_owe_transition_config(section) }}
+ {{ generate_owe_config(section, ssidname, owe) }}
+ {{ generate_mesh_config(section, bss_mode) }}
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/toplevel.uc ucentral-schema-2026.08.26~d1e90a04/renderer/templates/toplevel.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/renderer/templates/toplevel.uc	2026-09-03 14:29:15.340389105 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/renderer/templates/toplevel.uc	2026-09-03 14:41:02.251473426 +0800
+@@ -281,5 +281,5 @@
+ 		include("config_raw.uc", { location: '/config_raw', config_raw: state.config_raw });
+ 
+ 	latency.write();
+-	services.set_enabled("bridger", false);
++	services.set_enabled("bridger", capab.wed ? 'no-restart' : false);
+ %}
+diff -Nur ucentral-schema-2026.08.26~d1e90a04-orig/system/capabilities.uc ucentral-schema-2026.08.26~d1e90a04/system/capabilities.uc
+--- ucentral-schema-2026.08.26~d1e90a04-orig/system/capabilities.uc	2026-09-03 14:29:15.343389106 +0800
++++ ucentral-schema-2026.08.26~d1e90a04/system/capabilities.uc	2026-09-03 14:43:14.842800241 +0800
+@@ -170,6 +170,18 @@
+ if (length(wifi))
+ 	capa.wifi = wifi;
+ 
++for (let path in fs.glob('/sys/module/*/parameters/wed_enable')) {
++	let wedfile = fs.open(path, 'r');
++	if (!wedfile)
++		continue;
++	let wed_enable = trim(wedfile.read('all'));
++	wedfile.close();
++	if (wed_enable == '1' || wed_enable == 'Y') {
++		capa.wed = true;
++		break;
++	}
++}
++
+ capa.compress_cmd = true;
+ 
+ fs.writefile('/etc/ucentral/capabilities.json', capa);

--- a/patches-25.12/0123-mediatek-mt76-enable-wed_enable-1-for-sonicfi_rap630w_211g.patch
+++ b/patches-25.12/0123-mediatek-mt76-enable-wed_enable-1-for-sonicfi_rap630w_211g.patch
@@ -1,0 +1,40 @@
+From 1b90994b2ed92973c107db7198bc631b9f88f2cb Mon Sep 17 00:00:00 2001
+From: lyc-cybertan <Yuanchong.li@cybertan.com.tw>
+Date: Thu, 3 Sep 2026 15:18:36 +0800
+Subject: [PATCH] Subject: [PATCH] mediatek: mt76: enable wed_enable=1 for
+ mt7915e on sonicfi_rap630w_211g
+
+After adapting to the MTDK platform WiFi6 firmware, hardware acceleration
+failed to offload traffic because the WED function was not enabled. During
+5G RvR testing, the LAN to WiFi forwarding rate was too low to meet specs.
+
+In the upstream mt76 driver WED is an optional hardware acceleration
+component and is disabled by default. The wed_enable module parameter has
+to be set for the driver to initialise the hardware offload path, which
+removes the CPU soft forwarding bottleneck.
+
+Inject the mt7915e module parameter wed_enable=1 from
+package/kernel/mt76/Makefile for the sonicfi_rap630w_211g target profile
+only, so the hardware offload path is available on that board and every
+other mt7915e board keeps the upstream default.
+---
+ package/kernel/mt76/Makefile | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/package/kernel/mt76/Makefile b/package/kernel/mt76/Makefile
+index 169b70bb69..d6ccf690db 100644
+--- a/package/kernel/mt76/Makefile
++++ b/package/kernel/mt76/Makefile
+@@ -238,6 +238,9 @@ define KernelPackage/mt7915e
+   DEPENDS+=@PCI_SUPPORT +kmod-mt76-connac +kmod-hwmon-core +kmod-thermal +@DRIVER_11AX_SUPPORT +@KERNEL_RELAY
+   FILES:= $(PKG_BUILD_DIR)/mt7915/mt7915e.ko
+   AUTOLOAD:=$(call AutoProbe,mt7915e)
++  ifeq ($(CONFIG_TARGET_PROFILE), "DEVICE_sonicfi_rap630w_211g")
++      MODPARAMS.mt7915e:=wed_enable=1
++  endif
+ endef
+ 
+ define KernelPackage/mt7916-firmware
+-- 
+2.34.1
+


### PR DESCRIPTION
The Sonicfi RAP630W-211G (MT7981B + MT7976) probes mt7915e without wed_enable, so the Wireless Ethernet Dispatch offload path is never initialised and the bridged LAN->WLAN path is forwarded by the CPU. 5G RvR LAN-to-WiFi throughput does not meet spec.

Setting wed_enable=1: the frames of a hardware offloaded flow never traverse the tc qdisc of the wireless netdev, so an SSID carrying a rate_limit silently stops being shaped. WED is therefore turned on here together with the two changes that keep the rate limiter working.

Three patches, in the order they take effect:

1. ucentral-schema 0001-renderer-*: report capa.wed when a loaded wireless module was probed with wed_enable=1, so the renderer keys off the platform really having the offload engine rather than off a board name. Default bridger to 'no-restart' instead of stopped when capab.wed is set; set_enabled() keeps the first state written, so an SSID with strict_forwarding still promotes bridger to 'early' and a platform without WED is unchanged. Give a rate-limited SSID an explicit wlanr<n> ifname and add it to bridger.@defaults[0].blacklist, the same exclusion captive portal interfaces already use.

2. bridger 002-bridger-fix-mtk-*: bridger only consults the blacklist for the device it attaches the BPF classifier to. A flow is learned from its ingress device, so a flow whose egress device is blacklisted was still given a tc-flower rule with SKIP_SW and redirected into that device purely in hardware, bypassing the HTB qdisc that enforces the per-SSID egress rate. Skip only the hardware binding, so a blacklisted egress device is still bridged by bridger's BPF fast path.

3. patches-25.12/0123-mediatek-mt76-*: set MODPARAMS.mt7915e:=wed_enable=1 for the DEVICE_sonicfi_rap630w_211g profile only, so every other mt7915e board keeps the upstream default of WED disabled.

Fixes: WIFI-15633

RVR test:
before add ucentral-schema 0001-renderer-* and patches-25.12/0123-mediatek-mt76-*
<img width="405" height="143" alt="image" src="https://github.com/user-attachments/assets/db3690f2-63c3-48a6-bd34-335609aa60ec" />
already add:
<img width="1351" height="459" alt="image" src="https://github.com/user-attachments/assets/d61a833d-aa7b-4dab-b036-96e98ffcdef0" />

Sanity test:
before add those three patches
<img width="879" height="799" alt="image" src="https://github.com/user-attachments/assets/78149212-4447-4548-97bf-4adf2c1f40a0" />
already add:
<img width="822" height="766" alt="image" src="https://github.com/user-attachments/assets/e9b63e2a-2716-4af4-a0e7-b6d228f7c632" />
