### PR TITLE
qca-wifi-6: fix uneven CPU load from packet steering on ipq50xx

### DIFF
--- a/feeds/qca-wifi-6/ipq50xx/base-files/etc/uci-defaults/35-packet-steering
+++ b/feeds/qca-wifi-6/ipq50xx/base-files/etc/uci-defaults/35-packet-steering
@@ -1,0 +1,21 @@
+#!/bin/sh
+# QCA IPQ platforms: default packet_steering to disabled.
+# Hardware acceleration (PPE/NSS/SFE) handles packet distribution;
+# software RPS provides no benefit and may cause uneven CPU load.
+# Only set defaults if not already configured (preserves user settings).
+
+changed=0
+
+if [ -z "$(uci -q get network.globals.packet_steering)" ]; then
+    uci set network.globals.packet_steering='0'
+    changed=1
+fi
+
+if [ -z "$(uci -q get network.globals.steering_flows)" ]; then
+    uci set network.globals.steering_flows='0'
+    changed=1
+fi
+
+[ "$changed" = "1" ] && uci commit network
+
+exit 0


### PR DESCRIPTION
Root cause:
QCA IPQ50xx platforms (qca-wifi-6) ship with network.globals.packet_steering enabled by default. Hardware acceleration (PPE/NSS/SFE) already handles packet distribution on these platforms, so software RPS (packet_steering) provides no benefit and instead causes uneven CPU load distribution across cores during throughput testing.

Solution:
Add a uci-defaults script that sets network.globals.packet_steering and network.globals.steering_flows to '0' by default. The defaults are only applied when not already configured, so any existing user settings are preserved across upgrades.

Fixes: WIFI-14504